### PR TITLE
feat: Add native OpenRouter support with provider ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changes
 
-- Remove map-reduce summarization; reject inputs that exceed the model’s context window.
+- Add native OpenRouter support via `OPENROUTER_API_KEY` with optional provider ordering (`OPENROUTER_PROVIDERS`).
+- Remove map-reduce summarization; reject inputs that exceed the model's context window.
 - Preflight text prompts with the GPT tokenizer and the model’s max input tokens.
 - Reject text files over 10 MB before tokenization.
 - Reject too-small numeric `--length` and `--max-output-tokens` values.

--- a/README.md
+++ b/README.md
@@ -160,9 +160,23 @@ Set the key matching your chosen `--model`:
 
 OpenRouter (OpenAI-compatible):
 
-- Set `OPENAI_BASE_URL=https://openrouter.ai/api/v1`
-- Prefer `OPENROUTER_API_KEY=...` (instead of reusing `OPENAI_API_KEY`)
-- Use OpenRouter models via the `openai/...` prefix, e.g. `--model openai/xiaomi/mimo-v2-flash:free`
+- Set `OPENROUTER_API_KEY=...` to route `openai/...` models through OpenRouter
+- Use OpenRouter models via the `openai/...` prefix, e.g. `--model openai/openai/gpt-oss-20b`
+- Optional: `OPENROUTER_PROVIDERS=...` to specify provider fallback order (e.g. `groq,google-vertex`)
+
+Example:
+
+```bash
+OPENROUTER_API_KEY=sk-or-... summarize "https://example.com" --model openai/openai/gpt-oss-20b
+```
+
+With provider ordering (falls back through providers in order):
+
+```bash
+OPENROUTER_API_KEY=sk-or-... OPENROUTER_PROVIDERS="groq,google-vertex" summarize "https://example.com"
+```
+
+Legacy: `OPENAI_BASE_URL=https://openrouter.ai/api/v1` with `OPENAI_API_KEY` also works.
 
 Optional services:
 

--- a/src/llm/html-to-markdown.ts
+++ b/src/llm/html-to-markdown.ts
@@ -43,6 +43,7 @@ export function createHtmlToMarkdownConverter({
   googleApiKey,
   openaiApiKey,
   anthropicApiKey,
+  openrouterApiKey,
   fetchImpl,
   onUsage,
 }: {
@@ -52,6 +53,7 @@ export function createHtmlToMarkdownConverter({
   openaiApiKey: string | null
   fetchImpl: typeof fetch
   anthropicApiKey: string | null
+  openrouterApiKey: string | null
   onUsage?: (usage: {
     model: string
     provider: 'xai' | 'openai' | 'google' | 'anthropic'
@@ -70,7 +72,7 @@ export function createHtmlToMarkdownConverter({
 
     const result = await generateTextWithModelId({
       modelId,
-      apiKeys: { xaiApiKey, googleApiKey, openaiApiKey, anthropicApiKey },
+      apiKeys: { xaiApiKey, googleApiKey, openaiApiKey, anthropicApiKey, openrouterApiKey },
       system,
       prompt,
       timeoutMs,


### PR DESCRIPTION
## Summary

- Detect OpenRouter via `OPENROUTER_API_KEY` environment variable (no need to set `OPENAI_BASE_URL`)
- Support provider ordering via `OPENROUTER_PROVIDERS` env var (e.g., `groq,google-vertex`)
- Send `X-OpenRouter-Provider-Order` header when providers are configured
- Add `openrouterApiKey` to LLM API keys type and validation logic

## Usage

```bash
# Simple usage
OPENROUTER_API_KEY=sk-or-... summarize "https://example.com" --model openai/openai/gpt-oss-20b

# With provider ordering (fallback order)
OPENROUTER_API_KEY=sk-or-... OPENROUTER_PROVIDERS="groq,google-vertex" summarize "https://example.com"
```

## Test plan

- [x] Build passes
- [x] `OPENROUTER_API_KEY=... --model openai/openai/gpt-oss-20b` works
- [x] `OPENROUTER_PROVIDERS=groq,clarifai/fp4,google-vertex` sends correct header
- [x] Without `OPENROUTER_API_KEY`, `openai/...` uses direct OpenAI API
- [x] YouTube summarization works via OpenRouter

🤖 Generated with [Claude Code](https://claude.com/claude-code)