### PR TITLE
feat: Add --model auto for context-aware model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 ### Changes
 
 - Add native OpenRouter support via `OPENROUTER_API_KEY` with optional provider ordering (`OPENROUTER_PROVIDERS`).
+- Add `--model auto` for context-aware model selection via OpenRouter (smaller inputs use cheaper models).
+  - Configurable via `OPENROUTER_MODEL_SMALL`, `OPENROUTER_MODEL_LARGE`, `OPENROUTER_THRESHOLD_*`, `OPENROUTER_PROVIDERS_*`
 - Remove map-reduce summarization; reject inputs that exceed the model's context window.
 - Preflight text prompts with the GPT tokenizer and the model’s max input tokens.
 - Reject text files over 10 MB before tokenization.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,30 @@ OPENROUTER_API_KEY=sk-or-... OPENROUTER_PROVIDERS="groq,google-vertex" summarize
 
 Legacy: `OPENAI_BASE_URL=https://openrouter.ai/api/v1` with `OPENAI_API_KEY` also works.
 
+### Context-aware model selection (`--model auto`)
+
+Use `--model auto` to automatically select models based on input token count. Smaller inputs use cheaper/faster models, larger inputs use models with bigger context windows.
+
+```bash
+OPENROUTER_API_KEY=sk-or-... summarize "https://example.com" --model auto
+```
+
+Default configuration (same as chatpod-backend):
+- **< 95K tokens**: `openai/gpt-oss-20b` via `groq,clarifai/fp4,google-vertex`
+- **95K-950K tokens**: `google/gemini-2.5-flash-lite-preview-09-2025` via `google-ai-studio,google-vertex`
+- **> 950K tokens**: Error (no truncation)
+
+Customize via environment variables:
+
+| Variable | Default |
+|----------|---------|
+| `OPENROUTER_MODEL_SMALL` | `openai/gpt-oss-20b` |
+| `OPENROUTER_MODEL_LARGE` | `google/gemini-2.5-flash-lite-preview-09-2025` |
+| `OPENROUTER_THRESHOLD_SMALL` | `95000` |
+| `OPENROUTER_THRESHOLD_MAX` | `950000` |
+| `OPENROUTER_PROVIDERS_SMALL` | `groq,clarifai/fp4,google-vertex` |
+| `OPENROUTER_PROVIDERS_LARGE` | `google-ai-studio,google-vertex` |
+
 Optional services:
 
 - `FIRECRAWL_API_KEY` (website extraction fallback)


### PR DESCRIPTION
## Summary

Adds `--model auto` for automatic model selection based on input token count via OpenRouter. Smaller inputs use cheaper/faster models, larger inputs use models with bigger context windows.

## Usage

```bash
OPENROUTER_API_KEY=sk-or-... summarize "https://example.com" --model auto
```

## Default Configuration

| Token Count | Model | Providers |
|-------------|-------|-----------|
| < 95K | `openai/gpt-oss-20b` | groq, clarifai/fp4, google-vertex |
| 95K - 950K | `google/gemini-2.5-flash-lite-preview-09-2025` | google-ai-studio, google-vertex |
| > 950K | Error (no truncation) | - |

## Customization

All thresholds, models, and provider orders are configurable via environment variables:

| Variable | Default |
|----------|---------|
| `OPENROUTER_MODEL_SMALL` | `openai/gpt-oss-20b` |
| `OPENROUTER_MODEL_LARGE` | `google/gemini-2.5-flash-lite-preview-09-2025` |
| `OPENROUTER_THRESHOLD_SMALL` | `95000` |
| `OPENROUTER_THRESHOLD_MAX` | `950000` |
| `OPENROUTER_PROVIDERS_SMALL` | `groq,clarifai/fp4,google-vertex` |
| `OPENROUTER_PROVIDERS_LARGE` | `google-ai-studio,google-vertex` |

## Token Estimation

Token counts are estimated using `gpt-tokenizer` (GPT's BPE tokenizer). This is an approximation since different models have different tokenizers, but provides a reasonable baseline and is consistent with the existing input validation logic in the codebase.

## Test Plan

- [x] `--model auto` without `OPENROUTER_API_KEY` → error
- [x] Small input → uses small model with small providers
- [x] Large input → uses large model with large providers  
- [x] Input exceeding max threshold → error
- [x] Custom env vars override defaults
- [x] Verbose output shows resolved model and providers
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)