### PR TITLE
fix: prioritize manual captions over auto-generated

### DIFF
--- a/src/content/link-preview/transcript/providers/youtube/captions.ts
+++ b/src/content/link-preview/transcript/providers/youtube/captions.ts
@@ -339,11 +339,12 @@ const extractTranscriptFromPlayerPayload = async (
     const bTrack = b as CaptionTrackRecord
     const aKind = typeof aTrack.kind === 'string' ? aTrack.kind : ''
     const bKind = typeof bTrack.kind === 'string' ? bTrack.kind : ''
+    // Prefer manual captions over auto-generated (ASR)
     if (aKind === 'asr' && bKind !== 'asr') {
-      return -1
+      return 1
     }
     if (bKind === 'asr' && aKind !== 'asr') {
-      return 1
+      return -1
     }
     const aLang = typeof aTrack.languageCode === 'string' ? aTrack.languageCode : ''
     const bLang = typeof bTrack.languageCode === 'string' ? bTrack.languageCode : ''


### PR DESCRIPTION
## Summary

The sort logic for YouTube caption tracks was backwards - ASR (auto-generated) tracks were being prioritized over manually-uploaded captions.

Manual captions are typically higher quality with proper punctuation, speaker identification, and accurate transcription.

## Changes

Swapped the return values in the caption track sort comparator to prefer manual captions:

**Priority order is now:**
1. Manual/native captions (no `kind: 'asr'`)
2. Auto-generated captions (`kind: 'asr'`)
3. English preferred within each category

## Test plan

- Existing tests pass
- Videos with both manual and auto-generated captions will now use manual first

🤖 Generated with [Claude Code](https://claude.com/claude-code)