### PR TITLE
feat: add twitter subcommand for user timeline summarization

### DIFF
--- a/src/run/cli-preflight.ts
+++ b/src/run/cli-preflight.ts
@@ -1,7 +1,8 @@
 import type { Command } from 'commander'
 import { handleDaemonRequest } from '../daemon/cli.js'
 import { refreshFree } from '../refresh-free.js'
-import { attachRichHelp, buildDaemonHelp, buildProgram, buildRefreshFreeHelp } from './help.js'
+import { handleTwitterRequest } from '../twitter/cli.js'
+import { attachRichHelp, buildDaemonHelp, buildProgram, buildRefreshFreeHelp, buildTwitterHelp } from './help.js'
 
 type HelpContext = {
   normalizedArgv: string[]
@@ -24,6 +25,10 @@ export function handleHelpRequest({
   }
   if (topic === 'daemon') {
     stdout.write(`${buildDaemonHelp()}\n`)
+    return true
+  }
+  if (topic === 'twitter') {
+    stdout.write(`${buildTwitterHelp()}\n`)
     return true
   }
 
@@ -125,6 +130,16 @@ export async function handleRefreshFreeRequest({
 
 export async function handleDaemonCliRequest(ctx: RefreshContext): Promise<boolean> {
   return handleDaemonRequest({
+    normalizedArgv: ctx.normalizedArgv,
+    envForRun: ctx.envForRun,
+    fetchImpl: ctx.fetchImpl,
+    stdout: ctx.stdout,
+    stderr: ctx.stderr,
+  })
+}
+
+export async function handleTwitterCliRequest(ctx: RefreshContext): Promise<boolean> {
+  return handleTwitterRequest({
     normalizedArgv: ctx.normalizedArgv,
     envForRun: ctx.envForRun,
     fetchImpl: ctx.fetchImpl,

--- a/src/run/help.ts
+++ b/src/run/help.ts
@@ -201,3 +201,30 @@ export function buildDaemonHelp(): string {
     '  --token <token>  (required for install)',
   ].join('\n')
 }
+
+export function buildTwitterHelp(): string {
+  return [
+    'Usage: summarize twitter --user <handle> [--since YYYY-MM-DD] [--until YYYY-MM-DD] [options]',
+    '',
+    'Fetch and summarize tweets from a Twitter/X user within a date range.',
+    'Requires the bird CLI to be installed and authenticated.',
+    '',
+    'Options:',
+    '  --user <handle>     Twitter username (with or without @)',
+    '  --since <date>      Start date in YYYY-MM-DD format',
+    '  --until <date>      End date in YYYY-MM-DD format',
+    '  -n, --count <n>     Number of tweets to fetch (default: 20, max: 100)',
+    '  --extract           Output tweets without summarization',
+    '  --json              Output as JSON',
+    '',
+    'Examples:',
+    '  summarize twitter --user steipete --since 2025-01-01 --until 2025-01-31',
+    '  summarize twitter --user @elonmusk --since 2025-01-01 -n 50',
+    '  summarize twitter --user steipete --since 2025-01-01 --extract',
+    '  summarize twitter --user steipete --since 2025-01-01 --extract --json',
+    '',
+    'Prerequisites:',
+    '  Install bird CLI: https://github.com/steipete/bird',
+    '  Authenticate: bird check',
+  ].join('\n')
+}

--- a/src/run/runner.ts
+++ b/src/run/runner.ts
@@ -30,6 +30,7 @@ import {
   handleDaemonCliRequest,
   handleHelpRequest,
   handleRefreshFreeRequest,
+  handleTwitterCliRequest,
 } from './cli-preflight.js'
 import { parseCliProviderArg } from './env.js'
 import { handleFileInput, handleUrlAsset } from './flows/asset/input.js'
@@ -81,6 +82,17 @@ export async function runCli(
   }
   if (
     await handleDaemonCliRequest({
+      normalizedArgv,
+      envForRun,
+      fetchImpl: fetch,
+      stdout,
+      stderr,
+    })
+  ) {
+    return
+  }
+  if (
+    await handleTwitterCliRequest({
       normalizedArgv,
       envForRun,
       fetchImpl: fetch,

--- a/src/twitter/cli.ts
+++ b/src/twitter/cli.ts
@@ -1,0 +1,365 @@
+import { execFile } from 'node:child_process'
+
+import { generateTextWithModelId } from '../llm/generate-text.js'
+import { buildTwitterHelp } from '../run/help.js'
+
+export type TwitterCliContext = {
+  normalizedArgv: string[]
+  envForRun: Record<string, string | undefined>
+  fetchImpl: typeof fetch
+  stdout: NodeJS.WritableStream
+  stderr: NodeJS.WritableStream
+}
+
+export type TweetData = {
+  id: string
+  text: string
+  author: {
+    username: string
+    name: string
+  }
+  authorId?: string
+  createdAt?: string
+  replyCount?: number
+  retweetCount?: number
+  likeCount?: number
+  conversationId?: string
+  inReplyToStatusId?: string
+}
+
+function readArgValue(argv: string[], name: string): string | null {
+  const eq = argv.find((a) => a.startsWith(`${name}=`))
+  if (eq) return eq.slice(`${name}=`.length).trim() || null
+  const index = argv.indexOf(name)
+  if (index === -1) return null
+  const next = argv[index + 1]
+  if (!next || next.startsWith('-')) return null
+  return next.trim() || null
+}
+
+function wantHelp(argv: string[]): boolean {
+  return argv.includes('--help') || argv.includes('-h')
+}
+
+function hasArg(argv: string[], name: string): boolean {
+  return argv.includes(name) || argv.some((a) => a.startsWith(`${name}=`))
+}
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+function validateDateFormat(value: string, flagName: string): void {
+  if (!DATE_PATTERN.test(value)) {
+    throw new Error(`${flagName} must be in YYYY-MM-DD format (got: ${value})`)
+  }
+}
+
+function normalizeUsername(user: string): string {
+  return user.startsWith('@') ? user.slice(1) : user
+}
+
+async function searchTweetsWithBird(args: {
+  user: string
+  since?: string
+  until?: string
+  count: number
+  timeoutMs: number
+  env: Record<string, string | undefined>
+}): Promise<{ success: true; tweets: TweetData[] } | { success: false; error: string }> {
+  const queryParts: string[] = [`from:${args.user}`]
+  if (args.since) queryParts.push(`since:${args.since}`)
+  if (args.until) queryParts.push(`until:${args.until}`)
+  const query = queryParts.join(' ')
+
+  // Support BIRD_PATH environment variable for custom bird binary location
+  const birdPath = args.env.BIRD_PATH || 'bird'
+
+  return new Promise((resolve) => {
+    execFile(
+      birdPath,
+      ['search', query, '--json', '-n', String(args.count)],
+      {
+        timeout: args.timeoutMs,
+        env: { ...process.env, ...args.env },
+        maxBuffer: 10 * 1024 * 1024, // 10MB for large tweet sets
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const code = (error as NodeJS.ErrnoException).code
+          if (code === 'ENOENT') {
+            resolve({
+              success: false,
+              error: 'bird CLI not found. Install from https://github.com/steipete/bird',
+            })
+            return
+          }
+          const detail = stderr?.trim()
+          const suffix = detail ? `: ${detail}` : ''
+          resolve({ success: false, error: `bird search failed${suffix}` })
+          return
+        }
+
+        const trimmed = stdout.trim()
+        if (!trimmed) {
+          resolve({ success: true, tweets: [] })
+          return
+        }
+
+        try {
+          const parsed = JSON.parse(trimmed) as TweetData[]
+          if (!Array.isArray(parsed)) {
+            resolve({ success: false, error: 'bird search returned invalid JSON (expected array)' })
+            return
+          }
+          resolve({ success: true, tweets: parsed })
+        } catch (parseError) {
+          const message = parseError instanceof Error ? parseError.message : String(parseError)
+          resolve({ success: false, error: `bird search returned invalid JSON: ${message}` })
+        }
+      }
+    )
+  })
+}
+
+function formatDateForDisplay(dateStr: string): string {
+  try {
+    const date = new Date(dateStr)
+    return date.toLocaleDateString('en-US', {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  } catch {
+    return dateStr
+  }
+}
+
+function formatTweetsForContext(tweets: TweetData[], user: string): string {
+  if (tweets.length === 0) return ''
+
+  const lines: string[] = []
+
+  // Group tweets by date
+  const tweetsByDate = new Map<string, TweetData[]>()
+  for (const tweet of tweets) {
+    const dateKey = tweet.createdAt ? formatDateForDisplay(tweet.createdAt) : 'Unknown date'
+    const existing = tweetsByDate.get(dateKey) || []
+    existing.push(tweet)
+    tweetsByDate.set(dateKey, existing)
+  }
+
+  lines.push(`# Tweets from @${user}`)
+  lines.push('')
+
+  for (const [date, dateTweets] of tweetsByDate) {
+    lines.push(`## ${date}`)
+    lines.push('')
+    for (const tweet of dateTweets) {
+      lines.push(tweet.text)
+      lines.push('')
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function formatTweetsForExtract(tweets: TweetData[], json: boolean): string {
+  if (json) {
+    return JSON.stringify(tweets, null, 2)
+  }
+
+  const lines: string[] = []
+  for (const tweet of tweets) {
+    const date = tweet.createdAt ? formatDateForDisplay(tweet.createdAt) : ''
+    lines.push(`@${tweet.author.username} (${date}):`)
+    lines.push(tweet.text)
+    lines.push(`https://x.com/${tweet.author.username}/status/${tweet.id}`)
+    lines.push('---')
+  }
+  return lines.join('\n')
+}
+
+async function summarizeTweetsWithLLM(args: {
+  context: string
+  user: string
+  tweetCount: number
+  env: Record<string, string | undefined>
+  fetchImpl: typeof fetch
+}): Promise<{ success: true; summary: string } | { success: false; error: string }> {
+  const { context, user, tweetCount, env, fetchImpl } = args
+
+  // Check for API keys
+  const openrouterApiKey = env.OPENROUTER_API_KEY ?? null
+  const openaiApiKey = env.OPENAI_API_KEY ?? null
+  const anthropicApiKey = env.ANTHROPIC_API_KEY ?? null
+  const xaiApiKey = env.XAI_API_KEY ?? null
+  const googleApiKey = env.GEMINI_API_KEY ?? null
+
+  if (!openrouterApiKey && !openaiApiKey && !anthropicApiKey && !xaiApiKey && !googleApiKey) {
+    return {
+      success: false,
+      error: 'No LLM API key found. Set OPENROUTER_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, XAI_API_KEY, or GEMINI_API_KEY.',
+    }
+  }
+
+  // Select model based on available keys
+  // When using OpenRouter, we use openai/ prefix with forceOpenRouter=true
+  // OpenRouter routes through the OpenAI-compatible API
+  let modelId: string
+  const useOpenRouter = Boolean(openrouterApiKey)
+  if (useOpenRouter) {
+    // Use openai/ prefix for OpenRouter - it routes to any model
+    // Using Claude 3.5 Sonnet via OpenRouter (specify as openai/ model)
+    modelId = 'openai/anthropic/claude-3.5-sonnet'
+  } else if (anthropicApiKey) {
+    modelId = 'anthropic/claude-3-5-sonnet-20241022'
+  } else if (openaiApiKey) {
+    modelId = 'openai/gpt-4o-mini'
+  } else if (xaiApiKey) {
+    modelId = 'xai/grok-2-latest'
+  } else {
+    modelId = 'google/gemini-2.0-flash-exp'
+  }
+
+  const prompt = `You are analyzing ${tweetCount} tweets from Twitter user @${user}.
+
+Provide a concise summary of what this user has been tweeting about. Include:
+1. Main topics and themes
+2. Notable announcements or updates
+3. Key interactions or discussions
+4. Overall tone and sentiment
+
+Here are the tweets:
+
+${context}
+
+Provide a well-structured summary in markdown format.`
+
+  try {
+    const result = await generateTextWithModelId({
+      modelId,
+      apiKeys: {
+        xaiApiKey,
+        openaiApiKey,
+        googleApiKey,
+        anthropicApiKey,
+        openrouterApiKey,
+      },
+      forceOpenRouter: useOpenRouter,
+      prompt,
+      temperature: 0.3,
+      maxOutputTokens: 2000,
+      timeoutMs: 120_000,
+      fetchImpl,
+      retries: 1,
+    })
+
+    return { success: true, summary: result.text }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { success: false, error: `LLM summarization failed: ${message}` }
+  }
+}
+
+export async function handleTwitterRequest(ctx: TwitterCliContext): Promise<boolean> {
+  const { normalizedArgv, envForRun, stdout, stderr } = ctx
+
+  if (normalizedArgv[0]?.toLowerCase() !== 'twitter') {
+    return false
+  }
+
+  if (wantHelp(normalizedArgv)) {
+    stdout.write(`${buildTwitterHelp()}\n`)
+    return true
+  }
+
+  // Parse arguments
+  const userRaw = readArgValue(normalizedArgv, '--user')
+  const since = readArgValue(normalizedArgv, '--since')
+  const until = readArgValue(normalizedArgv, '--until')
+  const countRaw = readArgValue(normalizedArgv, '-n') || readArgValue(normalizedArgv, '--count')
+  const extractMode = hasArg(normalizedArgv, '--extract')
+  const jsonMode = hasArg(normalizedArgv, '--json')
+
+  // Validate required arguments
+  if (!userRaw) {
+    throw new Error('--user is required. Example: summarize twitter --user steipete --since 2025-01-01')
+  }
+
+  const user = normalizeUsername(userRaw)
+
+  // Validate date formats
+  if (since) validateDateFormat(since, '--since')
+  if (until) validateDateFormat(until, '--until')
+
+  // Parse count
+  const count = countRaw ? parseInt(countRaw, 10) : 20
+  if (isNaN(count) || count < 1) {
+    throw new Error('--count must be a positive number')
+  }
+  if (count > 100) {
+    throw new Error('--count cannot exceed 100')
+  }
+
+  // Fetch tweets
+  const timeoutMs = 60_000 // 1 minute timeout for bird
+  const result = await searchTweetsWithBird({
+    user,
+    since: since ?? undefined,
+    until: until ?? undefined,
+    count,
+    timeoutMs,
+    env: envForRun,
+  })
+
+  if (!result.success) {
+    throw new Error(result.error)
+  }
+
+  const tweets = result.tweets
+  if (tweets.length === 0) {
+    const range = since && until ? ` from ${since} to ${until}` : since ? ` since ${since}` : until ? ` until ${until}` : ''
+    throw new Error(`No tweets found for @${user}${range}`)
+  }
+
+  // Extract mode: output tweets without summarization
+  if (extractMode) {
+    const output = formatTweetsForExtract(tweets, jsonMode)
+    stdout.write(`${output}\n`)
+    return true
+  }
+
+  // Summarization mode: format and summarize
+  const context = formatTweetsForContext(tweets, user)
+
+  stderr.write(`Found ${tweets.length} tweets from @${user}, summarizing...\n`)
+
+  const summaryResult = await summarizeTweetsWithLLM({
+    context,
+    user,
+    tweetCount: tweets.length,
+    env: envForRun,
+    fetchImpl: ctx.fetchImpl,
+  })
+
+  if (!summaryResult.success) {
+    throw new Error(summaryResult.error)
+  }
+
+  if (jsonMode) {
+    const jsonOutput = {
+      user,
+      tweetCount: tweets.length,
+      since,
+      until,
+      summary: summaryResult.summary,
+      tweets,
+    }
+    stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`)
+  } else {
+    stdout.write(summaryResult.summary)
+    stdout.write('\n')
+  }
+
+  return true
+}

--- a/tests/cli.twitter.test.ts
+++ b/tests/cli.twitter.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Writable } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+
+import { runCli } from '../src/run.js'
+
+function collectStream() {
+  let text = ''
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      text += chunk.toString()
+      callback()
+    },
+  })
+  return { stream, getText: () => text }
+}
+
+function noopStream(): Writable {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback()
+    },
+  })
+}
+
+describe('twitter subcommand', () => {
+  it('shows help with twitter --help', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'summarize-twitter-'))
+    const stdout = collectStream()
+
+    await runCli(['twitter', '--help'], {
+      env: { HOME: root },
+      fetch: globalThis.fetch,
+      stdout: stdout.stream,
+      stderr: noopStream(),
+    })
+
+    const output = stdout.getText()
+    expect(output).toContain('--user')
+    expect(output).toContain('--since')
+    expect(output).toContain('--until')
+    expect(output).toContain('--extract')
+    expect(output).toContain('bird CLI')
+  })
+
+  it('shows help with help twitter', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'summarize-twitter-'))
+    const stdout = collectStream()
+
+    await runCli(['help', 'twitter'], {
+      env: { HOME: root },
+      fetch: globalThis.fetch,
+      stdout: stdout.stream,
+      stderr: noopStream(),
+    })
+
+    const output = stdout.getText()
+    expect(output).toContain('--user')
+    expect(output).toContain('YYYY-MM-DD')
+  })
+
+  it('requires --user flag', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'summarize-twitter-'))
+
+    await expect(
+      runCli(['twitter', '--since', '2025-01-01'], {
+        env: { HOME: root },
+        fetch: globalThis.fetch,
+        stdout: noopStream(),
+        stderr: noopStream(),
+      })
+    ).rejects.toThrow(/--user is required/i)
+  })
+
+  it('validates --since date format', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'summarize-twitter-'))
+
+    await expect(
+      runCli(['twitter', '--user', 'testuser', '--since', 'invalid-date'], {
+        env: { HOME: root },
+        fetch: globalThis.fetch,
+        stdout: noopStream(),
+        stderr: noopStream(),
+      })
+    ).rejects.toThrow(/--since must be in YYYY-MM-DD format/i)
+  })
+
+  it('validates --until date format', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'summarize-twitter-'))
+
+    await expect(
+      runCli(['twitter', '--user', 'testuser', '--until', '01-01-2025'], {
+        env: { HOME: root },
+        fetch: globalThis.fetch,
+        stdout: noopStream(),
+        stderr: noopStream(),
+      })
+    ).rejects.toThrow(/--until must be in YYYY-MM-DD format/i)
+  })
+
+  it('validates --count must be positive', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'summarize-twitter-'))
+
+    await expect(
+      runCli(['twitter', '--user', 'testuser', '-n', '0'], {
+        env: { HOME: root },
+        fetch: globalThis.fetch,
+        stdout: noopStream(),
+        stderr: noopStream(),
+      })
+    ).rejects.toThrow(/--count must be a positive number/i)
+  })
+
+  it('validates --count cannot exceed 100', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'summarize-twitter-'))
+
+    await expect(
+      runCli(['twitter', '--user', 'testuser', '-n', '101'], {
+        env: { HOME: root },
+        fetch: globalThis.fetch,
+        stdout: noopStream(),
+        stderr: noopStream(),
+      })
+    ).rejects.toThrow(/--count cannot exceed 100/i)
+  })
+
+  it('handles bird CLI not found error', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'summarize-twitter-'))
+
+    // Without BIRD_PATH and without bird in PATH, this should fail
+    await expect(
+      runCli(['twitter', '--user', 'testuser', '--since', '2025-01-01', '--extract'], {
+        env: { HOME: root, PATH: '' },
+        fetch: globalThis.fetch,
+        stdout: noopStream(),
+        stderr: noopStream(),
+      })
+    ).rejects.toThrow(/bird CLI not found/i)
+  })
+
+  it('normalizes username with @ prefix', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'summarize-twitter-'))
+
+    // This will fail because bird is not installed, but it validates that
+    // the @ prefix is handled (no error about invalid username)
+    await expect(
+      runCli(['twitter', '--user', '@testuser', '--since', '2025-01-01', '--extract'], {
+        env: { HOME: root, PATH: '' },
+        fetch: globalThis.fetch,
+        stdout: noopStream(),
+        stderr: noopStream(),
+      })
+    ).rejects.toThrow(/bird CLI not found/i)
+  })
+})


### PR DESCRIPTION
## Summary
- Add `twitter` subcommand to summarize tweets from a specific user within a date range
- Integrates with `bird` CLI for Twitter/X API access
- Supports `--extract` mode for tweet extraction without summarization
- LLM-powered summarization using available API keys (OpenRouter, OpenAI, Anthropic, etc.)

## Usage

```bash
# Summarize tweets from a user in a date range
summarize twitter --user steipete --since 2025-01-01 --until 2025-01-31

# Extract only (no LLM summarization)
summarize twitter --user @elonmusk --since 2025-01-01 --extract

# JSON output
summarize twitter --user steipete --since 2025-01-01 --extract --json

# Custom count
summarize twitter --user steipete -n 50
```

## Design Decisions
- Uses existing subcommand pattern (preflight handler, manual arg parsing)
- Aggregates tweets into single context for coherent time-period summary
- Accepts @handle or handle format for flexibility
- Default 20 tweets matches bird's default
- Supports `BIRD_PATH` environment variable for custom bird location

## Test plan
- [x] Run `summarize twitter --help` - verify help text
- [x] Run `summarize twitter --user steipete --since 2025-12-25 --until 2025-12-27`
- [x] Run with `--extract` flag - verify raw tweet output  
- [x] Run with `--json` flag - verify structured output
- [x] Run `pnpm test` - all 766 tests pass (9 new twitter-specific tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)