### PR TITLE
fix: skip OpenRouter fallback for native-only models

### DIFF
--- a/src/model-auto.ts
+++ b/src/model-auto.ts
@@ -37,6 +37,14 @@ export type AutoModelAttempt = {
   debug: string
 }
 
+/**
+ * Models that only work via native API and are not available on OpenRouter.
+ * These models should not be added as OpenRouter fallback attempts.
+ */
+const NATIVE_ONLY_MODELS = new Set([
+  'xai/grok-4-fast-non-reasoning',
+])
+
 const DEFAULT_RULES: AutoRule[] = [
   {
     when: ['video'],
@@ -443,10 +451,12 @@ export function buildAutoModelAttempts(input: AutoSelectionInput): AutoModelAtte
       transport: 'native',
     })
 
+    const slug = normalizeGatewayStyleModelId(modelRaw)
     const canAddOpenRouterFallback =
-      !input.requiresVideoUnderstanding && envHasKey(input.env, 'OPENROUTER_API_KEY')
+      !input.requiresVideoUnderstanding &&
+      envHasKey(input.env, 'OPENROUTER_API_KEY') &&
+      !NATIVE_ONLY_MODELS.has(slug)
     if (canAddOpenRouterFallback) {
-      const slug = normalizeGatewayStyleModelId(modelRaw)
       addAttempt(`openrouter/${slug}`, {
         openrouter: true,
         openrouterProviders: input.openrouterProvidersFromEnv,


### PR DESCRIPTION
## Summary
- Adds `NATIVE_ONLY_MODELS` set for models that only work via native API
- Skips adding OpenRouter fallback attempts for these models
- Fixes 400 errors when `xai/grok-4-fast-non-reasoning` is routed through OpenRouter (it doesn't exist there)

## ⚠️ Note: This is a Showcase Fix

**This PR demonstrates the bug and provides a minimal fix, but a larger architectural fix may be needed.**

The root issue is that `buildAutoModelAttempts()` blindly creates OpenRouter fallback attempts for all models in `DEFAULT_RULES`, assuming they all exist on OpenRouter. A more comprehensive solution might:

1. Validate model availability on OpenRouter at runtime (API call to check model catalog)
2. Maintain a more complete list of native-only models
3. Add provider-specific routing logic to model definitions in `DEFAULT_RULES`

## Test plan
- [x] `tests/model-auto.test.ts` - Added new test for native-only model behavior
- [x] Existing candidate order test updated to avoid the native-only model

🤖 Generated with [Claude Code](https://claude.com/claude-code)