### PR TITLE
fix: resolve short Anthropic model aliases (claude-sonnet-4 → claude-sonnet-4-0)

### DIFF
--- a/tests/model-id.test.ts
+++ b/tests/model-id.test.ts
@@ -14,6 +14,34 @@ describe('model id parsing', () => {
     )
   })
 
+  it('resolves short Anthropic model aliases to versioned form', () => {
+    // Bare alias without provider prefix
+    expect(normalizeGatewayStyleModelId('claude-sonnet-4')).toBe('anthropic/claude-sonnet-4-0')
+    // With provider prefix
+    expect(normalizeGatewayStyleModelId('anthropic/claude-sonnet-4')).toBe(
+      'anthropic/claude-sonnet-4-0'
+    )
+    // Case-insensitive
+    expect(normalizeGatewayStyleModelId('Anthropic/Claude-Sonnet-4')).toBe(
+      'anthropic/claude-sonnet-4-0'
+    )
+    // claude-opus-4 alias
+    expect(normalizeGatewayStyleModelId('claude-opus-4')).toBe('anthropic/claude-opus-4-0')
+    expect(normalizeGatewayStyleModelId('anthropic/claude-opus-4')).toBe(
+      'anthropic/claude-opus-4-0'
+    )
+    // Full model ids must NOT be rewritten
+    expect(normalizeGatewayStyleModelId('anthropic/claude-sonnet-4-20250514')).toBe(
+      'anthropic/claude-sonnet-4-20250514'
+    )
+    expect(normalizeGatewayStyleModelId('anthropic/claude-sonnet-4-0')).toBe(
+      'anthropic/claude-sonnet-4-0'
+    )
+    expect(normalizeGatewayStyleModelId('anthropic/claude-sonnet-4-5')).toBe(
+      'anthropic/claude-sonnet-4-5'
+    )
+  })
+
   it('accepts historical grok aliases', () => {
     expect(normalizeGatewayStyleModelId('grok-4-1-fast-non-reasoning')).toBe(
       'xai/grok-4-fast-non-reasoning'


### PR DESCRIPTION
Closes #52

## Problem

Using `--model anthropic/claude-sonnet-4` returns an empty LLM response because bare generation names like `claude-sonnet-4` are not valid Anthropic API identifiers.

## Root Cause

The Anthropic Messages API requires either a **dated id** (`claude-sonnet-4-20250514`) or a **versioned alias** (`claude-sonnet-4-0`). When the bare name is passed, `tryGetModel()` returns `null`, a synthetic model is created with the invalid id, and the API returns empty content.

## Fix

Added `ANTHROPIC_MODEL_ALIASES` map in `normalizeGatewayStyleModelId()` — same pattern as the existing grok aliases — to resolve bare names to their `-0` versioned aliases:

| User input | Resolved to |
|---|---|
| `claude-sonnet-4` | `anthropic/claude-sonnet-4-0` |
| `anthropic/claude-sonnet-4` | `anthropic/claude-sonnet-4-0` |
| `claude-opus-4` | `anthropic/claude-opus-4-0` |
| `anthropic/claude-opus-4` | `anthropic/claude-opus-4-0` |

The `-0` suffix is Anthropic's standard "latest point-release" pointer, so this is future-proof.

Existing valid model ids (e.g. `claude-sonnet-4-5`, `claude-sonnet-4-20250514`, `claude-sonnet-4-0`) pass through **unchanged**.

## Changes

- **`src/llm/model-id.ts`** — Added alias lookup table and resolution for both bare and prefixed forms
- **`tests/model-id.test.ts`** — 9 new test cases covering bare alias, prefixed alias, case-insensitivity, opus alias, and verification that full model ids are not rewritten

All 1,113 existing tests pass.