### PR TITLE
fix: pass --lang to YouTube transcript→markdown conversion

### DIFF
--- a/src/run/flows/url/flow.ts
+++ b/src/run/flows/url/flow.ts
@@ -726,6 +726,7 @@ export async function runUrlFlow({
           source: extracted.siteName,
           transcript: extracted.content,
           timeoutMs: flags.timeoutMs,
+          outputLanguage: flags.outputLanguage,
         })
         extractedForOutput = {
           ...extracted,


### PR DESCRIPTION
Fixes #46

## Problem

Using `--lang ro` (or any language) with `--extract --format md --markdown-mode llm` on a YouTube URL always returns English output, ignoring the `--lang` flag entirely.

## Root Cause
The transcript-to-markdown LLM prompt had no language instruction. The summary path handled `--lang` correctly, but the extract+markdown path never passed `outputLanguage` through.

## Fix

- Import and use `formatOutputLanguageInstruction` in the transcript-to-markdown converter
- Add `outputLanguage` to the `ConvertTranscriptToMarkdown` type signature
- Pass `flags.outputLanguage` from the URL flow extract path

2 files, +11/-1 lines. Build passes, no new dependencies.