### PR TITLE
fix: resolve symlinks when locating CLI entrypoint for daemon

### DIFF
--- a/src/daemon/cli.ts
+++ b/src/daemon/cli.ts
@@ -239,7 +239,9 @@ async function resolveCliEntrypointPathForService(): Promise<string> {
   const argv1 = process.argv[1]
   if (!argv1) throw new Error('Unable to resolve CLI entrypoint path')
 
-  const normalized = path.resolve(argv1)
+  // Resolve symlinks so that globally-installed bins (npm, bun, nvm, etc.)
+  // point back to the real package directory instead of the symlink location.
+  const normalized = await fs.realpath(path.resolve(argv1))
   const looksLikeDist = /[/\\]dist[/\\].+\.(cjs|js)$/.test(normalized)
   if (looksLikeDist) {
     await fs.access(normalized)


### PR DESCRIPTION
Fixes #50

## Problem

When `summarize` is installed globally via npm/bun/nvm, the bin entry is a symlink. The daemon installer used `process.argv[1]` directly, which resolved to the symlink location (e.g. `~/.bun/bin/summarize`), then looked for `../dist/cli.js` relative to that — pointing to `~/.bun/dist/cli.js` which doesn't exist.

## Fix
Use `fs.realpath()` to follow symlinks before computing the `dist/` path, so resolution finds the actual package directory.

1 file, +3/-1 lines. Build passes.