### PR TITLE
Fix: skips model attempts if API key is not present

### DIFF
--- a/src/daemon/agent.ts
+++ b/src/daemon/agent.ts
@@ -2,7 +2,7 @@ import type { Api, AssistantMessage, Message, Model, Tool } from '@mariozechner/
 import { completeSimple, getModel, streamSimple } from '@mariozechner/pi-ai'
 import { buildPromptHash } from '../cache.js'
 import { createSyntheticModel } from '../llm/providers/shared.js'
-import { buildAutoModelAttempts } from '../model-auto.js'
+import { buildAutoModelAttempts, type AutoModelAttempt } from '../model-auto.js'
 import { resolveRunContextState } from '../run/run-context.js'
 import { resolveModelSelection } from '../run/run-models.js'
 import { resolveRunOverrides } from '../run/run-settings.js'
@@ -46,6 +46,26 @@ Professional, concise, pragmatic. Use "I" for your actions. Match the user's ton
 
 export function buildAgentPromptHash(automationEnabled: boolean): string {
   return buildPromptHash(automationEnabled ? AGENT_PROMPT_AUTOMATION : AGENT_PROMPT_CHAT_ONLY)
+}
+
+function envHasKey(
+  env: Record<string, string | undefined>,
+  requiredEnv: AutoModelAttempt['requiredEnv']
+): boolean {
+  if (requiredEnv === 'GEMINI_API_KEY') {
+    return Boolean(
+      env.GEMINI_API_KEY?.trim() ||
+        env.GOOGLE_GENERATIVE_AI_API_KEY?.trim() ||
+        env.GOOGLE_API_KEY?.trim()
+    )
+  }
+  if (requiredEnv === 'Z_AI_API_KEY') {
+    return Boolean(env.Z_AI_API_KEY?.trim() || env.ZAI_API_KEY?.trim())
+  }
+  if (requiredEnv.startsWith('CLI_')) {
+    return false // CLI models are not supported in daemon
+  }
+  return Boolean(env[requiredEnv]?.trim())
 }
 
 const TOOL_DEFINITIONS: Record<string, Tool> = {
@@ -539,6 +559,7 @@ async function resolveAgentModel({
 
   for (const attempt of attempts) {
     if (attempt.transport === 'cli') continue
+    if (!envHasKey(env, attempt.requiredEnv)) continue
     if (attempt.transport === 'openrouter') {
       const modelId = attempt.userModelId.replace(/^openrouter\//i, '')
       return { model: applyBaseUrlOverride('openrouter', modelId), maxOutputTokens, apiKeys }

--- a/src/daemon/chat.ts
+++ b/src/daemon/chat.ts
@@ -1,7 +1,7 @@
 import type { Context, Message } from '@mariozechner/pi-ai'
 import type { LlmApiKeys } from '../llm/generate-text.js'
 import { streamTextWithContext } from '../llm/generate-text.js'
-import { buildAutoModelAttempts } from '../model-auto.js'
+import { buildAutoModelAttempts, type AutoModelAttempt } from '../model-auto.js'
 import { parseRequestedModelId } from '../model-spec.js'
 import { resolveEnvState } from '../run/run-env.js'
 
@@ -53,6 +53,26 @@ function resolveApiKeys(env: Record<string, string | undefined>): LlmApiKeys {
     anthropicApiKey: envState.anthropicApiKey,
     openrouterApiKey: envState.openrouterApiKey,
   }
+}
+
+function envHasKey(
+  env: Record<string, string | undefined>,
+  requiredEnv: AutoModelAttempt['requiredEnv']
+): boolean {
+  if (requiredEnv === 'GEMINI_API_KEY') {
+    return Boolean(
+      env.GEMINI_API_KEY?.trim() ||
+        env.GOOGLE_GENERATIVE_AI_API_KEY?.trim() ||
+        env.GOOGLE_API_KEY?.trim()
+    )
+  }
+  if (requiredEnv === 'Z_AI_API_KEY') {
+    return Boolean(env.Z_AI_API_KEY?.trim() || env.ZAI_API_KEY?.trim())
+  }
+  if (requiredEnv.startsWith('CLI_')) {
+    return false // CLI models are not supported in daemon
+  }
+  return Boolean(env[requiredEnv]?.trim())
 }
 
 export async function streamChatResponse({
@@ -130,7 +150,10 @@ export async function streamChatResponse({
     cliAvailability: envState.cliAvailability,
   })
 
-  const attempt = attempts.find((entry) => entry.transport !== 'cli' && entry.llmModelId)
+  const attempt = attempts.find(
+    (entry) =>
+      entry.transport !== 'cli' && entry.llmModelId && envHasKey(env, entry.requiredEnv)
+  )
   if (!attempt || !attempt.llmModelId) {
     throw new Error('No model available for chat')
   }


### PR DESCRIPTION
The Daemon Chat and Agent endpoints were selecting the first available model candidate without checking if the required API key exists. This caused immediate failures when a provider was first in the list but missing a key. Both endpoints now check for envHasKey() before selecting a model, allowing for proper fallback.

First clawdtribution :)