### PR TITLE
fix: remove broken reference to steipete/bird repo

### DIFF
--- a/src/run/bird.ts
+++ b/src/run/bird.ts
@@ -200,7 +200,7 @@ export function withBirdTip(
   url: string | null,
   env: Record<string, string | undefined>
 ): Error {
-  if (!url || !isTwitterStatusUrl(url) || hasBirdCli(env)) {
+  if (!url || !isTwitterStatusUrl(url) || hasBirdCli(env) || !BIRD_TIP) {
     return error instanceof Error ? error : new Error(String(error))
   }
   const message = error instanceof Error ? error.message : String(error)

--- a/src/run/constants.ts
+++ b/src/run/constants.ts
@@ -1,7 +1,6 @@
 import type { ModelConfig } from '../config.js'
 
-export const BIRD_TIP =
-  'Tip: Install bird🐦 for better Twitter support: https://github.com/steipete/bird'
+export const BIRD_TIP = ''
 export const UVX_TIP =
   'Tip: Install uv (uvx) for local Markdown conversion: brew install uv (or set UVX_PATH to your uvx binary).'
 export const SUPPORT_URL = 'https://github.com/steipete/summarize'


### PR DESCRIPTION
## Summary

The `steipete/bird` repository is no longer publicly available (returns 404), so the `BIRD_TIP` constant was directing users to a dead link. The homebrew formula (`steipete/tap/bird`) also fails to download (see steipete/homebrew-tap#13).

## Changes

- **`src/run/constants.ts`**: Clear the `BIRD_TIP` string (set to empty)
- **`src/run/bird.ts`**: Skip appending the tip in `withBirdTip()` when `BIRD_TIP` is empty, avoiding a trailing newline in error messages

The bird CLI integration itself remains intact — users who already have `bird` installed will continue to benefit from it. This only removes the broken installation suggestion from error output.

Closes #70