### PR TITLE
fix: use normalized env key checks in daemon auto fallback

### DIFF
--- a/src/model-auto.ts
+++ b/src/model-auto.ts
@@ -258,7 +258,7 @@ function requiredEnvForCandidate(modelId: string): AutoModelAttempt['requiredEnv
           : 'OPENAI_API_KEY'
 }
 
-function envHasKey(
+export function envHasKey(
   env: Record<string, string | undefined>,
   requiredEnv: AutoModelAttempt['requiredEnv']
 ): boolean {


### PR DESCRIPTION
## Summary
- use shared `envHasKey` from `model-auto` for daemon chat/agent key gating
- gate daemon auto attempts against `envForAuto` (normalized OpenRouter legacy mapping)
- add regression tests for legacy OpenRouter mapping in daemon chat + agent

## Why
PR #67 merged from contributor head and did not include this follow-up commit. This PR lands the intended fix and tests.