### PR TITLE
fix: landing and docs overflow in mobile

### DIFF
--- a/docs/site/assets/site.css
+++ b/docs/site/assets/site.css
@@ -62,6 +62,7 @@ body {
   font-family: var(--body);
   letter-spacing: 0.01em;
   line-height: 1.6;
+  overflow-x: hidden;
 }
 
 body::before {
@@ -350,12 +351,17 @@ a:hover {
   padding: 0 6px;
 }
 
+.productGrid > * {
+  min-width: 0;
+}
+
 .productCard {
   border-radius: var(--r2);
   border: 1px solid var(--line);
   background: rgba(255, 255, 255, 0.03);
   padding: 20px 18px;
   box-shadow: var(--shadow2);
+  min-width: 0;
 }
 
 .productCard__head {
@@ -411,16 +417,22 @@ a:hover {
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(0, 0, 0, 0.35);
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 pre {
+  display: block;
   margin: 0;
   padding: 14px 14px 12px;
+  min-width: 0;
+  max-width: 100%;
   color: rgba(247, 242, 231, 0.94);
   font-family: var(--mono);
   font-size: 12.5px;
   line-height: 1.6;
-  overflow-x: auto;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 code {


### PR DESCRIPTION
Hey, just a quick fix for the home page on mobile.

The pre element needed overflow.

### Before
<img width="429" height="513" alt="image" src="https://github.com/user-attachments/assets/efac1a6a-bcd1-4b46-aa2b-d9000a5be46b" />

### Now
<img width="492" height="688" alt="image" src="https://github.com/user-attachments/assets/23830b6b-c407-49ac-b8d7-150d8f4a36df" />
