### PR TITLE
daemon: Support CLI models in chat and agent endpoints

### DIFF
--- a/src/daemon/chat.ts
+++ b/src/daemon/chat.ts
@@ -1,8 +1,11 @@
 import type { Context, Message } from "@mariozechner/pi-ai";
+import type { SummarizeConfig } from "../config.js";
 import type { LlmApiKeys } from "../llm/generate-text.js";
+import { runCliModel } from "../llm/cli.js";
 import { streamTextWithContext } from "../llm/generate-text.js";
 import { buildAutoModelAttempts, envHasKey } from "../model-auto.js";
 import { parseRequestedModelId } from "../model-spec.js";
+import { parseCliUserModelId } from "../run/env.js";
 import { resolveEnvState } from "../run/run-env.js";
 
 type ChatSession = {
@@ -44,8 +47,29 @@ function buildContext({
   return { systemPrompt, messages: normalizeMessages(messages) };
 }
 
-function resolveApiKeys(env: Record<string, string | undefined>): LlmApiKeys {
-  const envState = resolveEnvState({ env, envForRun: env, configForCli: null });
+function flattenChatForCli({
+  systemPrompt,
+  messages,
+}: {
+  systemPrompt: string;
+  messages: Message[];
+}): string {
+  const parts: string[] = [systemPrompt];
+  for (const msg of messages) {
+    const role = msg.role === "user" ? "User" : "Assistant";
+    const content = typeof msg.content === "string" ? msg.content : "";
+    if (content) {
+      parts.push(`${role}: ${content}`);
+    }
+  }
+  return parts.join("\n\n");
+}
+
+function resolveApiKeys(
+  env: Record<string, string | undefined>,
+  configForCli: SummarizeConfig | null,
+): LlmApiKeys {
+  const envState = resolveEnvState({ env, envForRun: env, configForCli });
   return {
     xaiApiKey: envState.xaiApiKey,
     openaiApiKey: envState.apiKey ?? envState.openaiTranscriptionKey,
@@ -58,6 +82,7 @@ function resolveApiKeys(env: Record<string, string | undefined>): LlmApiKeys {
 export async function streamChatResponse({
   env,
   fetchImpl,
+  configForCli = null,
   session: _session,
   pageUrl,
   pageTitle,
@@ -69,6 +94,7 @@ export async function streamChatResponse({
 }: {
   env: Record<string, string | undefined>;
   fetchImpl: typeof fetch;
+  configForCli?: SummarizeConfig | null;
   session: ChatSession;
   pageUrl: string;
   pageTitle: string | null;
@@ -78,7 +104,7 @@ export async function streamChatResponse({
   pushToSession: (event: ChatEvent) => void;
   emitMeta: (patch: Partial<ChatSession["lastMeta"]>) => void;
 }) {
-  const apiKeys = resolveApiKeys(env);
+  const apiKeys = resolveApiKeys(env, configForCli);
   const context = buildContext({ pageUrl, pageTitle, pageContent, messages });
 
   const resolveModel = () => {
@@ -88,12 +114,20 @@ export async function streamChatResponse({
         return null;
       }
       if (requested.transport === "cli") {
-        throw new Error("CLI models are not supported in the daemon");
+        return {
+          userModelId: requested.userModelId,
+          modelId: null,
+          forceOpenRouter: false,
+          transport: "cli" as const,
+          cliProvider: requested.cliProvider,
+          cliModel: requested.cliModel,
+        };
       }
       return {
         userModelId: requested.userModelId,
         modelId: requested.llmModelId,
         forceOpenRouter: requested.forceOpenRouter,
+        transport: "native" as const,
       };
     }
     return null;
@@ -102,8 +136,26 @@ export async function streamChatResponse({
   const resolved = resolveModel();
   if (resolved) {
     emitMeta({ model: resolved.userModelId });
+    if (resolved.transport === "cli") {
+      const prompt = flattenChatForCli({
+        systemPrompt: context.systemPrompt ?? "",
+        messages: context.messages,
+      });
+      const result = await runCliModel({
+        provider: resolved.cliProvider!,
+        prompt,
+        model: resolved.cliModel ?? null,
+        allowTools: false,
+        timeoutMs: 120_000,
+        env,
+        config: configForCli?.cli ?? null,
+      });
+      pushToSession({ event: "content", data: result.text });
+      pushToSession({ event: "metrics" });
+      return;
+    }
     const result = await streamTextWithContext({
-      modelId: resolved.modelId,
+      modelId: resolved.modelId!,
       apiKeys,
       context,
       timeoutMs: 30_000,
@@ -117,7 +169,7 @@ export async function streamChatResponse({
     return;
   }
 
-  const envState = resolveEnvState({ env, envForRun: env, configForCli: null });
+  const envState = resolveEnvState({ env, envForRun: env, configForCli });
   const attempts = buildAutoModelAttempts({
     kind: "text",
     promptTokens: null,
@@ -130,19 +182,45 @@ export async function streamChatResponse({
     cliAvailability: envState.cliAvailability,
   });
 
-  const attempt = attempts.find(
+  const apiAttempt = attempts.find(
     (entry) =>
       entry.transport !== "cli" &&
       entry.llmModelId &&
       envHasKey(envState.envForAuto, entry.requiredEnv),
   );
-  if (!attempt || !attempt.llmModelId) {
+  const cliAttempt = !apiAttempt
+    ? attempts.find((entry) => entry.transport === "cli")
+    : null;
+  const attempt = apiAttempt ?? cliAttempt;
+  if (!attempt) {
     throw new Error("No model available for chat");
   }
 
   emitMeta({ model: attempt.userModelId });
+
+  if (attempt.transport === "cli") {
+    const parsed = parseCliUserModelId(attempt.userModelId);
+    const prompt = flattenChatForCli({
+      systemPrompt: context.systemPrompt ?? "",
+      messages: context.messages,
+    });
+    const result = await runCliModel({
+      provider: parsed.provider,
+      prompt,
+      model: parsed.model,
+      allowTools: false,
+      timeoutMs: 120_000,
+      env,
+      config: configForCli?.cli ?? null,
+    });
+    pushToSession({ event: "content", data: result.text });
+    pushToSession({ event: "metrics" });
+    void _session;
+    return;
+  }
+
   const result = await streamTextWithContext({
-    modelId: attempt.llmModelId,
+    modelId: attempt.llmModelId!,
     apiKeys,
     context,
     timeoutMs: 30_000,


### PR DESCRIPTION
## Summary

- Route CLI-transport model selections (e.g., `cli/claude`) through `runCliModel()` in both the chat and agent daemon endpoints, instead of rejecting them
- During auto-model selection, API-key-based providers are still preferred; CLI is used as fallback when no key-authenticated option is available
- Flatten multi-turn conversation history into a single text prompt for CLI models (they don't support structured message APIs)
- Fix `parseJsonFromOutput` to handle CLI providers (Claude Code ≥2.x) that emit a JSON array instead of a single object or JSONL, extracting the `type: "result"` entry

## Motivation

The daemon rejected any request that resolved to a CLI-transport model, forcing users to have API keys configured even when a local CLI binary (e.g., `claude`) was available. This made the daemon unusable for users who only have a Claude subscription (no API credits) or who prefer using their local CLI session.

## Test plan

- [x] `pnpm build` succeeds
- [x] `/v1/models` lists `cli/claude` when the binary is available
- [x] `POST /v1/agent` with `model: "cli/claude"` returns correct summarization via JSON response
- [x] `POST /v1/agent` with `model: "cli/claude"` returns correct SSE events (chunk → assistant → done)
- [x] Systemd service starts and serves requests correctly
- [x] Browser extension successfully summarizes pages using CLI: Claude model