### PR TITLE
fix(extension): gate native-input debugger bridge behind tab whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Models: preserve model id casing after the provider prefix so OpenAI-compatible proxies can route exact names correctly (#128, thanks @WinnCook).
 - Cache: give extract entries with unavailable transcripts the same short retry TTL as negative transcript cache entries, so transient Apify failures can recover (#115, thanks @gluneau).
 - Daemon: apply the saved env snapshot to `process.env` before `daemon run` starts so child tools inherit the right PATH and API/tool config under launchd/systemd (#99, thanks @heyalchang).
+- Chrome automation: require sidepanel arming before debugger-backed native input can run in a tab, and auto-disarm after browser JS execution ends (#129, thanks @omnicoder9).
 
 ## 0.11.0 - 2026-02-14
 

--- a/apps/chrome-extension/src/automation/native-input-guard.ts
+++ b/apps/chrome-extension/src/automation/native-input-guard.ts
@@ -1,0 +1,44 @@
+export type NativeInputArmMessage = {
+  type: "automation:native-input-arm";
+  tabId: number;
+  enabled: boolean;
+};
+
+export function updateNativeInputArmedTabs(args: {
+  armedTabs: Set<number>;
+  senderHasTab: boolean;
+  tabId?: number;
+  enabled?: boolean;
+}): boolean {
+  const { armedTabs, senderHasTab, tabId, enabled } = args;
+  if (senderHasTab || typeof tabId !== "number") return false;
+  if (enabled) armedTabs.add(tabId);
+  else armedTabs.delete(tabId);
+  return true;
+}
+
+export function getNativeInputGuardError(args: {
+  armedTabs: Set<number>;
+  senderTabId?: number;
+}): string | null {
+  const { armedTabs, senderTabId } = args;
+  if (typeof senderTabId !== "number") return "Missing sender tab";
+  if (!armedTabs.has(senderTabId)) return "Native input not armed for this tab";
+  return null;
+}
+
+export async function withNativeInputArmedTab<T>(args: {
+  enabled: boolean;
+  tabId: number;
+  sendMessage: (message: NativeInputArmMessage) => Promise<unknown>;
+  run: () => Promise<T>;
+}): Promise<T> {
+  const { enabled, tabId, sendMessage, run } = args;
+  if (!enabled) return run();
+  await sendMessage({ type: "automation:native-input-arm", tabId, enabled: true });
+  try {
+    return await run();
+  } finally {
+    void sendMessage({ type: "automation:native-input-arm", tabId, enabled: false });
+  }
+}

--- a/apps/chrome-extension/src/automation/repl.ts
+++ b/apps/chrome-extension/src/automation/repl.ts
@@ -5,6 +5,7 @@ import {
   parseArtifact,
   upsertArtifact,
 } from "./artifacts-store";
+import { withNativeInputArmedTab } from "./native-input-guard";
 import { executeNavigateTool } from "./navigate";
 import { listSkills } from "./skills-store";
 import { buildUserScriptsGuidance, getUserScriptsStatus } from "./userscripts";
@@ -311,41 +312,31 @@ async function runBrowserJs(
     // ignore
   }
 
-  if (nativeInputEnabled) {
-    // Authorise this tab for debugger-backed native input. Background rejects
-    // requests from tabs that have not been armed by an extension page.
-    await chrome.runtime.sendMessage({
-      type: "automation:native-input-arm",
-      tabId: tab.id,
-      enabled: true,
-    });
-  }
-
   try {
-    const results = await userScripts.execute({
-      target: { tabId: tab.id },
-      world: "USER_SCRIPT",
-      worldId: "summarize-browserjs",
-      injectImmediately: true,
-      js: [{ code: wrapperCode }],
-      ...(executionId ? { executionId } : {}),
+    return await withNativeInputArmedTab({
+      enabled: nativeInputEnabled,
+      tabId: tab.id,
+      sendMessage: (message) => chrome.runtime.sendMessage(message),
+      run: async () => {
+        const results = await userScripts.execute({
+          target: { tabId: tab.id },
+          world: "USER_SCRIPT",
+          worldId: "summarize-browserjs",
+          injectImmediately: true,
+          js: [{ code: wrapperCode }],
+          ...(executionId ? { executionId } : {}),
+        });
+
+        if (signal?.aborted) {
+          return { ok: false, error: "Execution aborted" };
+        }
+
+        const result = results?.[0]?.result as BrowserJsResult | undefined;
+        return result ?? { ok: false, error: "No result from browserjs()" };
+      },
     });
-
-    if (signal?.aborted) {
-      return { ok: false, error: "Execution aborted" };
-    }
-
-    const result = results?.[0]?.result as BrowserJsResult | undefined;
-    return result ?? { ok: false, error: "No result from browserjs()" };
   } finally {
     if (abortHandler) signal?.removeEventListener("abort", abortHandler);
-    if (nativeInputEnabled) {
-      void chrome.runtime.sendMessage({
-        type: "automation:native-input-arm",
-        tabId: tab.id,
-        enabled: false,
-      });
-    }
   }
 }
 

--- a/apps/chrome-extension/src/entrypoints/background.ts
+++ b/apps/chrome-extension/src/entrypoints/background.ts
@@ -9,6 +9,10 @@ import {
   parseArtifact,
   upsertArtifact,
 } from "../automation/artifacts-store";
+import {
+  getNativeInputGuardError,
+  updateNativeInputArmedTabs,
+} from "../automation/native-input-guard";
 import { readAgentResponse } from "../lib/agent-response";
 import { buildChatPageContent } from "../lib/chat-context";
 import { buildDaemonRequestBody, buildSummarizeRequestBody } from "../lib/daemon-payload";
@@ -2211,37 +2215,28 @@ export default defineBackground(() => {
 
       const type = (raw as { type: string }).type;
       if (type === "automation:native-input-arm") {
-        // Only extension pages (sidepanel/options) may arm tabs for native
-        // input. Content scripts always carry sender.tab — a property Chrome
-        // sets and web pages cannot suppress — so rejecting any message that
-        // carries it ensures only genuine extension pages reach this branch.
-        if (sender.tab) return;
         const msg = raw as { tabId?: number; enabled?: boolean };
-        if (typeof msg.tabId !== "number") return;
-        if (msg.enabled) nativeInputArmedTabs.add(msg.tabId);
-        else nativeInputArmedTabs.delete(msg.tabId);
+        updateNativeInputArmedTabs({
+          armedTabs: nativeInputArmedTabs,
+          senderHasTab: Boolean(sender.tab),
+          tabId: msg.tabId,
+          enabled: msg.enabled,
+        });
         return;
       }
       if (type === "automation:native-input") {
         const msg = raw as NativeInputRequest;
         void (async () => {
           const tabId = sender.tab?.id;
-          if (!tabId) {
+          const guardError = getNativeInputGuardError({
+            armedTabs: nativeInputArmedTabs,
+            senderTabId: tabId,
+          });
+          if (guardError) {
             try {
               sendResponse({
                 ok: false,
-                error: "Missing sender tab",
-              } satisfies NativeInputResponse);
-            } catch {
-              // ignore
-            }
-            return;
-          }
-          if (!nativeInputArmedTabs.has(tabId)) {
-            try {
-              sendResponse({
-                ok: false,
-                error: "Native input not armed for this tab",
+                error: guardError,
               } satisfies NativeInputResponse);
             } catch {
               // ignore

--- a/tests/chrome.native-input-guard.test.ts
+++ b/tests/chrome.native-input-guard.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getNativeInputGuardError,
+  updateNativeInputArmedTabs,
+  withNativeInputArmedTab,
+} from "../apps/chrome-extension/src/automation/native-input-guard";
+
+describe("chrome native input guard", () => {
+  it("arms and disarms tabs only for extension-page messages", () => {
+    const armedTabs = new Set<number>();
+
+    expect(
+      updateNativeInputArmedTabs({
+        armedTabs,
+        senderHasTab: true,
+        tabId: 7,
+        enabled: true,
+      }),
+    ).toBe(false);
+    expect(armedTabs.has(7)).toBe(false);
+
+    expect(
+      updateNativeInputArmedTabs({
+        armedTabs,
+        senderHasTab: false,
+        tabId: 7,
+        enabled: true,
+      }),
+    ).toBe(true);
+    expect(armedTabs.has(7)).toBe(true);
+
+    expect(
+      updateNativeInputArmedTabs({
+        armedTabs,
+        senderHasTab: false,
+        tabId: 7,
+        enabled: false,
+      }),
+    ).toBe(true);
+    expect(armedTabs.has(7)).toBe(false);
+  });
+
+  it("rejects missing or unarmed sender tabs", () => {
+    const armedTabs = new Set<number>([3]);
+
+    expect(getNativeInputGuardError({ armedTabs, senderTabId: undefined })).toBe("Missing sender tab");
+    expect(getNativeInputGuardError({ armedTabs, senderTabId: 4 })).toBe(
+      "Native input not armed for this tab",
+    );
+    expect(getNativeInputGuardError({ armedTabs, senderTabId: 3 })).toBeNull();
+  });
+
+  it("arms before execution and disarms after success", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const run = vi.fn(async () => "ok");
+
+    await expect(
+      withNativeInputArmedTab({
+        enabled: true,
+        tabId: 9,
+        sendMessage,
+        run,
+      }),
+    ).resolves.toBe("ok");
+
+    expect(sendMessage.mock.calls).toEqual([
+      [{ type: "automation:native-input-arm", tabId: 9, enabled: true }],
+      [{ type: "automation:native-input-arm", tabId: 9, enabled: false }],
+    ]);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("disarms even when execution fails", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const run = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await expect(
+      withNativeInputArmedTab({
+        enabled: true,
+        tabId: 11,
+        sendMessage,
+        run,
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(sendMessage.mock.calls).toEqual([
+      [{ type: "automation:native-input-arm", tabId: 11, enabled: true }],
+      [{ type: "automation:native-input-arm", tabId: 11, enabled: false }],
+    ]);
+  });
+});


### PR DESCRIPTION
The automation.content.ts content script is registered against <all_urls> and, on every page load,
  installs a window.postMessage listener that forwards any message shaped like {source: "summarize-native-input",
  payload: ...} to the background worker as an automation:native-input request. The background handler takes
  sender.tab.id, attaches chrome.debugger to that tab, and dispatches trusted Input.dispatchMouseEvent /
  Input.dispatchKeyEvent commands — with no check that an automation session was ever started. Because
  window.postMessage is freely callable by page JavaScript, any site the user has open can send that shape and
  receive a trusted click or keystroke on itself, bypassing user-activation gating for popups, clipboard writes,
  autoplay, and download prompts, and flashing the "extension started debugging this browser" banner at will.
The background now keeps a nativeInputArmedTabs whitelist and refuses to attach the debugger for any tab
  not in it. A new automation:native-input-arm message lets the sidepanel add or remove a tab, but the handler drops
  any request that carries sender.tab — a property Chrome attaches to every content-script message and which page
  code cannot strip — so only genuine extension pages can arm a tab. On the sidepanel side, runBrowserJs sends the
  arm message right before userScripts.execute and disarms in a finally block, so the whitelist entry lives only for
  the duration of a single user-initiated REPL call; stale entries are swept on tabs.onRemoved. A hostile page's
  postMessage now terminates with {ok: false, error: "Native input not armed for this tab"} before any debugger call
  is made.