### PR TITLE
chore: hide windows daemon task window [src/daemon/schtasks.ts]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Windows daemon: keep Scheduled Task startup hidden without breaking `summarize daemon restart` or uninstall by tracking the hidden daemon PID and killing that process tree before reruns/removal (#146, thanks @mathicg).
 - Transcription: add AssemblyAI as a first-class remote provider across direct media, podcast/RSS, and yt-dlp YouTube fallback; refactor remote fallback ordering, expand config/env support (`ASSEMBLYAI_API_KEY`, legacy `apiKeys.assemblyai`), and add AssemblyAI unit + live coverage (#126).
 - X/Twitter: prefer `xurl` for tweet extraction when installed, fall back to `bird`, preserve long-form/article text plus media URLs, add live `xurl` extraction/media coverage, and replace the stale dead-`bird` install tip with a current X CLI recommendation (#70).
 - Models: make daemon agent `artifacts` schemas Gemini-safe, improve Google empty-response handling with preview-to-stable fallback, and switch CLI/auto Gemini defaults away from brittle preview behavior (#82, #96).

--- a/src/daemon/cli.ts
+++ b/src/daemon/cli.ts
@@ -76,7 +76,10 @@ type DaemonService = {
     env: Record<string, string | undefined>;
     stdout: NodeJS.WritableStream;
   }) => Promise<void>;
-  restart: (args: { stdout: NodeJS.WritableStream }) => Promise<void>;
+  restart: (args: {
+    env: Record<string, string | undefined>;
+    stdout: NodeJS.WritableStream;
+  }) => Promise<void>;
   isLoaded: (args: { env: Record<string, string | undefined> }) => Promise<boolean>;
 };
 
@@ -418,7 +421,7 @@ export async function handleDaemonRequest({
       return true;
     }
 
-    await service.restart({ stdout });
+    await service.restart({ env: envForRun, stdout });
     const installedCommand = await readInstalledDaemonCommand(envForRun);
     if (installedCommand?.programArguments?.length) {
       stdout.write(

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -22,6 +22,11 @@ function resolveTaskLauncherPath(env: Record<string, string | undefined>): strin
   return path.join(home, ".summarize", "daemon-run.vbs");
 }
 
+function resolveTaskPidPath(env: Record<string, string | undefined>): string {
+  const home = resolveHomeDir(env);
+  return path.join(home, ".summarize", "daemon.pid");
+}
+
 function quoteCmdArg(value: string): string {
   if (!/[ \t"]/g.test(value)) return value;
   return `"${value.replace(/"/g, '\\"')}"`;
@@ -110,21 +115,56 @@ function buildTaskScript({
   return `${lines.join("\r\n")}\r\n`;
 }
 
-function buildTaskLauncherScript({ scriptPath }: { scriptPath: string }): string {
+function buildTaskLauncherScript({
+  scriptPath,
+  pidPath,
+}: {
+  scriptPath: string;
+  pidPath: string;
+}): string {
   const escapedScriptPath = quoteVbsString(scriptPath);
+  const escapedPidPath = quoteVbsString(pidPath);
   return [
-    "Set shell = CreateObject(\"WScript.Shell\")",
-    `command = ${escapedScriptPath}`,
-    'shell.Run command, 0, False',
+    'Set fso = CreateObject("Scripting.FileSystemObject")',
+    'Set processStartup = GetObject("winmgmts:root\\\\cimv2:Win32_ProcessStartup").SpawnInstance_',
+    "processStartup.ShowWindow = 0",
+    `scriptPath = ${escapedScriptPath}`,
+    `pidPath = ${escapedPidPath}`,
+    'command = "cmd.exe /d /c " & Chr(34) & scriptPath & Chr(34)',
+    "processId = 0",
+    'result = GetObject("winmgmts:root\\\\cimv2:Win32_Process").Create(command, Null, processStartup, processId)',
+    "If result <> 0 Then",
+    "  WScript.Quit result",
+    "End If",
+    "Set pidFile = fso.OpenTextFile(pidPath, 2, True)",
+    "pidFile.Write CStr(processId)",
+    "pidFile.Close",
+    "Do While ProcessExists(processId)",
+    "  WScript.Sleep 1000",
+    "Loop",
+    "If fso.FileExists(pidPath) Then",
+    "  Set currentPidFile = fso.OpenTextFile(pidPath, 1, False)",
+    "  currentPid = Trim(currentPidFile.ReadAll)",
+    "  currentPidFile.Close",
+    "  If currentPid = CStr(processId) Then",
+    "    fso.DeleteFile pidPath, True",
+    "  End If",
+    "End If",
+    "",
+    "Function ProcessExists(pid)",
+    '  Set processes = GetObject("winmgmts:root\\\\cimv2").ExecQuery("SELECT ProcessId FROM Win32_Process WHERE ProcessId = " & pid)',
+    "  ProcessExists = (processes.Count > 0)",
+    "End Function",
     "",
   ].join("\r\n");
 }
 
-async function execSchtasks(
+async function execWindowsCommand(
+  file: string,
   args: string[],
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   try {
-    const { stdout, stderr } = await execFileAsync("schtasks", args, {
+    const { stdout, stderr } = await execFileAsync(file, args, {
       encoding: "utf8",
       windowsHide: true,
     });
@@ -140,11 +180,51 @@ async function execSchtasks(
   }
 }
 
+async function execSchtasks(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return execWindowsCommand("schtasks", args);
+}
+
+async function execTaskkill(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return execWindowsCommand("taskkill", args);
+}
+
 async function assertSchtasksAvailable() {
   const res = await execSchtasks(["/Query"]);
   if (res.code === 0) return;
   const detail = res.stderr || res.stdout;
   throw new Error(`schtasks unavailable: ${detail || "unknown error"}`.trim());
+}
+
+function isMissingProcessError(detail: string): boolean {
+  return /not found|not running|no running instance|does not exist/i.test(detail);
+}
+
+async function stopTrackedTaskProcessTree(env: Record<string, string | undefined>): Promise<void> {
+  const pidPath = resolveTaskPidPath(env);
+  let pid = "";
+  try {
+    pid = (await fs.readFile(pidPath, "utf8")).trim();
+  } catch {
+    return;
+  }
+
+  const pidNumber = Number(pid);
+  if (!Number.isInteger(pidNumber) || pidNumber <= 0) {
+    await fs.unlink(pidPath).catch(() => {});
+    return;
+  }
+
+  const res = await execTaskkill(["/PID", `${pidNumber}`, "/T", "/F"]);
+  const detail = (res.stderr || res.stdout).trim();
+  if (res.code !== 0 && !isMissingProcessError(detail)) {
+    throw new Error(`taskkill failed: ${detail || "unknown error"}`.trim());
+  }
+
+  await fs.unlink(pidPath).catch(() => {});
 }
 
 export async function installScheduledTask({
@@ -161,10 +241,12 @@ export async function installScheduledTask({
   await assertSchtasksAvailable();
   const scriptPath = resolveTaskScriptPath(env);
   const launcherPath = resolveTaskLauncherPath(env);
+  const pidPath = resolveTaskPidPath(env);
   await fs.mkdir(path.dirname(scriptPath), { recursive: true });
   const script = buildTaskScript({ programArguments, workingDirectory });
   await fs.writeFile(scriptPath, script, "utf8");
-  const launcher = buildTaskLauncherScript({ scriptPath });
+  await fs.unlink(pidPath).catch(() => {});
+  const launcher = buildTaskLauncherScript({ scriptPath, pidPath });
   await fs.writeFile(launcherPath, launcher, "utf8");
 
   const quotedLauncher = quoteCmdArg(launcherPath);
@@ -198,10 +280,13 @@ export async function uninstallScheduledTask({
   stdout: NodeJS.WritableStream;
 }): Promise<void> {
   await assertSchtasksAvailable();
+  await stopTrackedTaskProcessTree(env);
+  await execSchtasks(["/End", "/TN", DAEMON_WINDOWS_TASK_NAME]);
   await execSchtasks(["/Delete", "/F", "/TN", DAEMON_WINDOWS_TASK_NAME]);
 
   const scriptPath = resolveTaskScriptPath(env);
   const launcherPath = resolveTaskLauncherPath(env);
+  const pidPath = resolveTaskPidPath(env);
   try {
     await fs.unlink(scriptPath);
     stdout.write(`Removed task script: ${scriptPath}\n`);
@@ -214,14 +299,18 @@ export async function uninstallScheduledTask({
   } catch {
     stdout.write(`Task launcher not found at ${launcherPath}\n`);
   }
+  await fs.unlink(pidPath).catch(() => {});
 }
 
 export async function restartScheduledTask({
+  env,
   stdout,
 }: {
+  env: Record<string, string | undefined>;
   stdout: NodeJS.WritableStream;
 }): Promise<void> {
   await assertSchtasksAvailable();
+  await stopTrackedTaskProcessTree(env);
   await execSchtasks(["/End", "/TN", DAEMON_WINDOWS_TASK_NAME]);
   const res = await execSchtasks(["/Run", "/TN", DAEMON_WINDOWS_TASK_NAME]);
   if (res.code !== 0) {

--- a/tests/daemon.schtasks.test.ts
+++ b/tests/daemon.schtasks.test.ts
@@ -1,0 +1,146 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Writable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({ execFile: mocks.execFile }));
+
+import { DAEMON_WINDOWS_TASK_NAME } from "../src/daemon/constants.js";
+import {
+  installScheduledTask,
+  restartScheduledTask,
+  uninstallScheduledTask,
+} from "../src/daemon/schtasks.js";
+
+function collectStream(): { stream: Writable; getText: () => string } {
+  let text = "";
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      text += chunk.toString();
+      callback();
+    },
+  });
+  return { stream, getText: () => text };
+}
+
+function mockExecFileSuccess() {
+  mocks.execFile.mockImplementation(
+    (
+      file: string,
+      args: string[],
+      _options: { encoding: string; windowsHide: boolean },
+      callback: (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void,
+    ) => {
+      if (file === "taskkill") {
+        callback(null, "SUCCESS: The process was terminated.", "");
+        return {} as never;
+      }
+      if (file === "schtasks" && args[0] === "/Query") {
+        callback(null, "", "");
+        return {} as never;
+      }
+      callback(null, "", "");
+      return {} as never;
+    },
+  );
+}
+
+describe("daemon/schtasks install", () => {
+  beforeEach(() => {
+    mocks.execFile.mockReset();
+  });
+
+  it("writes a hidden launcher that tracks the daemon pid", async () => {
+    mockExecFileSuccess();
+    const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
+    const out = collectStream();
+
+    const { scriptPath } = await installScheduledTask({
+      env: { HOME: home },
+      stdout: out.stream,
+      programArguments: ["node", "dist/cli.js", "daemon", "run"],
+    });
+
+    const launcherPath = path.join(home, ".summarize", "daemon-run.vbs");
+    const pidPath = path.join(home, ".summarize", "daemon.pid");
+    const launcher = readFileSync(launcherPath, "utf8");
+    const script = readFileSync(scriptPath, "utf8");
+
+    expect(script).toContain("node dist/cli.js daemon run");
+    expect(launcher).toContain("processStartup.ShowWindow = 0");
+    expect(launcher).toContain('Win32_Process").Create');
+    expect(launcher).toContain(`pidPath = "${pidPath.replace(/\\/g, "\\\\")}"`);
+    expect(launcher).toContain("fso.DeleteFile pidPath, True");
+    expect(out.getText()).toContain("Installed Scheduled Task");
+
+    const createCall = mocks.execFile.mock.calls.find(
+      (call) => call[0] === "schtasks" && (call[1] as string[])[0] === "/Create",
+    );
+    expect(createCall).toBeTruthy();
+    expect(createCall?.[1]).toContain(path.join(home, ".summarize", "daemon-run.vbs"));
+  });
+});
+
+describe("daemon/schtasks lifecycle", () => {
+  beforeEach(() => {
+    mocks.execFile.mockReset();
+  });
+
+  it("kills the tracked daemon pid before rerunning the task", async () => {
+    mockExecFileSuccess();
+    const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
+    const pidPath = path.join(home, ".summarize", "daemon.pid");
+    mkdirSync(path.dirname(pidPath), { recursive: true });
+    writeFileSync(pidPath, "4242", "utf8");
+    const out = collectStream();
+
+    await restartScheduledTask({
+      env: { HOME: home },
+      stdout: out.stream,
+    });
+
+    const commands = mocks.execFile.mock.calls.map(
+      ([file, args]) => `${file} ${(args as string[]).join(" ")}`,
+    );
+    const taskkillCommand = "taskkill /PID 4242 /T /F";
+    const runCommand = `schtasks /Run /TN ${DAEMON_WINDOWS_TASK_NAME}`;
+    expect(commands).toContain(taskkillCommand);
+    expect(commands).toContain(runCommand);
+    expect(commands.indexOf(taskkillCommand)).toBeLessThan(commands.indexOf(runCommand));
+    expect(out.getText()).toContain("Restarted Scheduled Task");
+  });
+
+  it("removes the tracked pid and launcher on uninstall", async () => {
+    mockExecFileSuccess();
+    const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
+    const summarizeDir = path.join(home, ".summarize");
+    mkdirSync(summarizeDir, { recursive: true });
+    const pidPath = path.join(summarizeDir, "daemon.pid");
+    const launcherPath = path.join(summarizeDir, "daemon-run.vbs");
+    const scriptPath = path.join(summarizeDir, "daemon.cmd");
+    writeFileSync(pidPath, "5252", "utf8");
+    writeFileSync(launcherPath, "launcher", "utf8");
+    writeFileSync(scriptPath, "script", "utf8");
+    const out = collectStream();
+
+    await uninstallScheduledTask({
+      env: { HOME: home },
+      stdout: out.stream,
+    });
+
+    const commands = mocks.execFile.mock.calls.map(
+      ([file, args]) => `${file} ${(args as string[]).join(" ")}`,
+    );
+    expect(commands).toContain("taskkill /PID 5252 /T /F");
+    expect(commands).toContain(`schtasks /Delete /F /TN ${DAEMON_WINDOWS_TASK_NAME}`);
+    expect(out.getText()).toContain("Removed task launcher");
+    expect(existsSync(pidPath)).toBe(false);
+    expect(existsSync(launcherPath)).toBe(false);
+    expect(existsSync(scriptPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Hide the Windows daemon startup popup by launching the Scheduled Task through a hidden VBS wrapper instead of invoking `daemon.cmd` directly.

## Changes
- Add `~/.summarize/daemon-run.vbs` during the task install flow.
- Point the Scheduled Task `/TR` to the VBS launcher.
- Continue writing `~/.summarize/daemon.cmd` unchanged for transparency.
- Remove the VBS launcher during uninstall.

## Why
`summarize daemon install` can show a visible CMD window on Windows when the scheduled task starts.  
Launching through the VBS wrapper prevents the popup.

## Testing
- `pnpm -s build`
- Manual Windows check: install/restart daemon and confirm no visible window appears.