### PR TITLE
fix: reject --firecrawl always on YouTube URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Firecrawl: reject `--firecrawl always` for YouTube URLs with an explicit guidance error instead of silently skipping Firecrawl on the transcript-first path (#145, thanks @steipete).
 - YouTube: keep Gemini-only no-caption runs on the transcription path by forwarding the Google API key from the top-level URL flow into link-preview transcription config (#148, thanks @bytrangle).
 - Daemon tests: expand CORS allowlist edge-case coverage for localhost variants, extension-origin casing, spoofed localhost domains, and full trusted response headers (#142, thanks @sebastiondev).
 

--- a/docs/extract-only.md
+++ b/docs/extract-only.md
@@ -24,7 +24,7 @@ Deprecated alias: `--extract-only`.
 - For non-YouTube URLs with `--format md`, the CLI uses Readability article HTML as the default Markdown input (`--markdown-mode readability`).
   - Use `--markdown-mode auto` to prefer LLM/markitdown conversion without Readability preprocessing.
   - Use `--markdown-mode llm` to force an LLM conversion.
-  - Use `--firecrawl always` to try Firecrawl first.
+  - Use `--firecrawl always` to try Firecrawl first for non-YouTube URLs.
 - For non-YouTube URLs with `--format md`, `--markdown-mode auto` can convert HTML to Markdown via an LLM when configured.
   - Force it with `--markdown-mode llm`.
   - If no LLM is configured, `--markdown-mode auto` may fall back to `uvx markitdown` when available.

--- a/docs/firecrawl.md
+++ b/docs/firecrawl.md
@@ -12,7 +12,8 @@ Firecrawl is a fallback for sites that block direct HTML fetching or don’t ren
 
 - `off`: never use Firecrawl.
 - `auto` (default): use Firecrawl only when HTML extraction looks blocked/thin.
-- `always`: try Firecrawl first (falls back to HTML if Firecrawl is unavailable/empty).
+- `always`: try Firecrawl first for non-YouTube URLs (falls back to HTML if Firecrawl is unavailable/empty).
+  - YouTube URLs reject `--firecrawl always`; use `--youtube auto|web|yt-dlp|apify` instead.
 
 ## Extract default
 

--- a/docs/website.md
+++ b/docs/website.md
@@ -13,10 +13,11 @@ Use this for non-YouTube URLs.
 - Fetches the page HTML.
 - Extracts “article-ish” content and normalizes it into clean text.
 - If extraction looks blocked or too thin, it can retry via Firecrawl (Markdown).
+  - Firecrawl applies to non-YouTube URLs only; YouTube URLs use the `--youtube` transcript path instead.
 - If a page is effectively “video-only”, it may treat it as a video input (see `--video-mode`).
 - `--video-mode transcript` prefers embedded media transcripts on pages with audio/video (captions → yt-dlp/Whisper fallback).
 - With `--format md`, the CLI defaults to `--markdown-mode readability` (Readability article HTML as the Markdown input).
-  - Use `--firecrawl always` to try Firecrawl first.
+  - Use `--firecrawl always` to try Firecrawl first for non-YouTube URLs.
 - With `--format md`, `--markdown-mode auto|llm|readability` can also convert HTML → Markdown via an LLM using the configured `--model` (no provider fallback).
 - With `--format md`, `--markdown-mode auto` may fall back to `uvx markitdown` when available (disable with `--preprocess off`).
 - For podcast URLs (Apple Podcasts, RSS, Spotify episodes), it downloads the episode audio and transcribes via Whisper (prefers local `whisper.cpp` when installed + model available); progress shows “Downloading audio …” then “Transcribing …” (duration uses RSS hints or `ffprobe` when available).

--- a/src/run/flows/url/flow.ts
+++ b/src/run/flows/url/flow.ts
@@ -63,6 +63,11 @@ export async function runUrlFlow({
   });
 
   const markdown = createMarkdownConverters(ctx, { isYoutubeUrl });
+  if (flags.firecrawlMode === "always" && isYoutubeUrl) {
+    throw new Error(
+      "--firecrawl always is not supported for YouTube URLs; use --youtube auto|web|yt-dlp|apify instead",
+    );
+  }
   if (flags.firecrawlMode === "always" && !model.apiStatus.firecrawlConfigured) {
     throw new Error("--firecrawl always requires FIRECRAWL_API_KEY");
   }

--- a/tests/cli.errors.test.ts
+++ b/tests/cli.errors.test.ts
@@ -53,6 +53,22 @@ describe("cli error handling", () => {
     ).rejects.toThrow("--firecrawl always requires FIRECRAWL_API_KEY");
   });
 
+  it("errors when --firecrawl always is set for a YouTube URL", async () => {
+    await expect(
+      runCli(
+        ["--firecrawl", "always", "--extract", "https://www.youtube.com/watch?v=dQw4w9WgXcQ"],
+        {
+          env: { HOME: home, FIRECRAWL_API_KEY: "fc-test" },
+          fetch: vi.fn() as unknown as typeof fetch,
+          stdout: noopStream(),
+          stderr: noopStream(),
+        },
+      ),
+    ).rejects.toThrow(
+      "--firecrawl always is not supported for YouTube URLs; use --youtube auto|web|yt-dlp|apify instead",
+    );
+  });
+
   it("errors when --markdown llm is set without any LLM keys", async () => {
     await expect(
       runCli(["--format", "md", "--markdown-mode", "llm", "--extract", "https://example.com"], {


### PR DESCRIPTION
Fixes #145.

## What changes
- fail loudly when `--firecrawl always` is used with a YouTube URL
- add CLI regression coverage for the explicit error
- clarify docs so Firecrawl is documented as non-YouTube-only

## Verification
- `pnpm vitest run tests/cli.errors.test.ts`
- `pnpm -s check`