### PR TITLE
fix: honor openai.useChatCompletions in agent mode

### DIFF
--- a/src/daemon/agent-model.ts
+++ b/src/daemon/agent-model.ts
@@ -251,6 +251,7 @@ export async function resolveAgentModel({
         },
         openaiBaseUrlOverride: baseUrl,
         forceChatCompletions: openaiUseChatCompletions,
+        allowProcessEnvBaseUrlFallback: false,
       });
       return {
         provider,

--- a/src/llm/providers/openai.ts
+++ b/src/llm/providers/openai.ts
@@ -17,6 +17,7 @@ export type OpenAiClientConfigInput = {
   forceOpenRouter?: boolean;
   openaiBaseUrlOverride?: string | null;
   forceChatCompletions?: boolean;
+  allowProcessEnvBaseUrlFallback?: boolean;
 };
 
 export function resolveOpenAiClientConfig({
@@ -24,10 +25,13 @@ export function resolveOpenAiClientConfig({
   forceOpenRouter,
   openaiBaseUrlOverride,
   forceChatCompletions,
+  allowProcessEnvBaseUrlFallback = true,
 }: OpenAiClientConfigInput): OpenAiClientConfig {
   const baseUrlRaw =
     openaiBaseUrlOverride ??
-    (typeof process !== "undefined" ? process.env.OPENAI_BASE_URL : undefined);
+    (allowProcessEnvBaseUrlFallback && typeof process !== "undefined"
+      ? process.env.OPENAI_BASE_URL
+      : undefined);
   const baseUrl = normalizeBaseUrl(baseUrlRaw);
   const isOpenRouterViaBaseUrl = baseUrl ? isOpenRouterBaseUrl(baseUrl) : false;
   const hasOpenRouterKey = apiKeys.openrouterApiKey != null;

--- a/tests/daemon.agent.test.ts
+++ b/tests/daemon.agent.test.ts
@@ -206,6 +206,38 @@ describe("daemon/agent", () => {
     expect(model.baseUrl).toBe("http://127.0.0.1:1234/v1");
   });
 
+  it("ignores ambient process OPENAI_BASE_URL when agent env snapshot does not set it", async () => {
+    const home = makeTempHome();
+    const originalProcessBaseUrl = process.env.OPENAI_BASE_URL;
+    process.env.OPENAI_BASE_URL = "https://ambient.example/v1";
+
+    try {
+      await completeAgentResponse({
+        env: {
+          HOME: home,
+          OPENAI_API_KEY: "sk-openai",
+        },
+        pageUrl: "https://example.com",
+        pageTitle: null,
+        pageContent: "Hello world",
+        messages: [{ role: "user", content: "Hi" }],
+        modelOverride: "openai/gpt-5-mini",
+        tools: [],
+        automationEnabled: false,
+      });
+    } finally {
+      if (typeof originalProcessBaseUrl === "string") {
+        process.env.OPENAI_BASE_URL = originalProcessBaseUrl;
+      } else {
+        delete process.env.OPENAI_BASE_URL;
+      }
+    }
+
+    const model = mockCompleteSimple.mock.calls[0]?.[0] as { api?: string; baseUrl?: string };
+    expect(model.api).toBe("openai-responses");
+    expect(model.baseUrl).toBe("https://example.com");
+  });
+
   it("throws a helpful error when openrouter key is missing", async () => {
     const home = makeTempHome();
     await expect(


### PR DESCRIPTION
## Summary
- route daemon agent OpenAI models through the shared OpenAI resolver so sidepanel chat honors `openai.useChatCompletions`
- preserve custom `OPENAI_BASE_URL` behavior for OpenAI-compatible servers
- add daemon agent regression coverage for env, config, base URL, and streaming agent paths

Closes #155.

## Validation
- `pnpm -s check`
- full Vitest suite passed during `pnpm -s check` (`345` files passed, `26` skipped)

## Notes
- kept the change scoped to the agent resolver and its tests only
- did not add new user-facing flags or settings
- no reporter follow-up comment posted in this pass