### PR TITLE
fix(cli): surface Codex meta-only output as an error

### DIFF
--- a/src/llm/cli.ts
+++ b/src/llm/cli.ts
@@ -53,23 +53,24 @@ const CODEX_META_ONLY_OUTPUT_ERROR =
   "Codex returned no assistant text; stdout only contained session/meta events.";
 
 const CODEX_FOOTER_LINE_PATTERN = /\bcli\/codex(?:\/\S+)?$/;
+const CODEX_TEXT_PAYLOAD_KEYS = [
+  "result",
+  "response",
+  "output",
+  "message",
+  "text",
+  "content",
+] as const;
+
+function hasTextPayloadValue(value: unknown): boolean {
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.some((entry) => hasTextPayloadValue(entry));
+  if (!value || typeof value !== "object") return false;
+  return hasTextPayload(value as Record<string, unknown>);
+}
 
 function hasTextPayload(payload: Record<string, unknown>): boolean {
-  for (const key of ["result", "response", "output", "message", "text", "content"] as const) {
-    const value = payload[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      return true;
-    }
-    if (
-      value &&
-      typeof value === "object" &&
-      !Array.isArray(value) &&
-      hasTextPayload(value as Record<string, unknown>)
-    ) {
-      return true;
-    }
-  }
-  return false;
+  return CODEX_TEXT_PAYLOAD_KEYS.some((key) => hasTextPayloadValue(payload[key]));
 }
 
 function parseJsonRecord(line: string): Record<string, unknown> | null {

--- a/tests/llm.cli.more-branches.test.ts
+++ b/tests/llm.cli.more-branches.test.ts
@@ -8,6 +8,20 @@ const CODEX_META_ONLY_STDOUT = [
   "2m 0s · 3.1k words · cli/codex/gpt-5.2",
 ].join("\n");
 
+const CODEX_STDOUT_WITH_ARRAY_TEXT = [
+  JSON.stringify({
+    type: "response.completed",
+    response: {
+      output: [
+        {
+          content: [{ type: "output_text", text: "assistant text from array payload" }],
+        },
+      ],
+    },
+  }),
+  "2m 0s · 3.1k words · cli/codex/gpt-5.2",
+].join("\n");
+
 describe("llm/cli extra branches", () => {
   it("parses the last JSON object when stdout includes a preface", async () => {
     const result = await runCliModel({
@@ -103,5 +117,23 @@ describe("llm/cli extra branches", () => {
         },
       }),
     ).rejects.toThrow(/stdout only contained session\/meta events/i);
+  });
+
+  it("keeps raw stdout fallback when Codex stdout includes nested array text", async () => {
+    const result = await runCliModel({
+      provider: "codex",
+      prompt: "hi",
+      model: "gpt-5.2",
+      allowTools: false,
+      timeoutMs: 1000,
+      env: {},
+      config: null,
+      execFileImpl: (_cmd, _args, _opts, cb) => {
+        cb(null, CODEX_STDOUT_WITH_ARRAY_TEXT, "");
+        return { stdin: { write() {}, end() {} } } as unknown as ChildProcess;
+      },
+    });
+
+    expect(result.text).toBe(CODEX_STDOUT_WITH_ARRAY_TEXT);
   });
 });


### PR DESCRIPTION
## Summary
- detect the reported Codex stdout shape where `last-message.txt` is empty or missing and stdout only contains session/meta events plus the Codex footer
- raise a specific Codex error instead of returning `thread.started`-style metadata as if it were assistant text
- add regression coverage for both empty and missing `--output-last-message` cases

Refs #138.

## Validation
- `pnpm test -- llm.cli.more-branches.test.ts llm.cli.test.ts daemon.chat.test.ts`
  - this repo expands that into the full Vitest suite; it passed with `345` files passed and `26` skipped
- `pnpm -s check`

## Notes
- this is diagnosis-first and intentionally Codex-only
- it is based on the issue's reported stdout shape (`thread.started` plus the Codex footer), not a broader event-log parser change
- no CLI flags or user-facing settings were added