### PR TITLE
feat: add copy-to-clipboard button for summary results

### DIFF
--- a/apps/chrome-extension/src/entrypoints/sidepanel/index.html
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/index.html
@@ -15,6 +15,13 @@
         </div>
         <div class="controls">
           <div id="summarizeControlRoot" class="summarizeControlRoot"></div>
+          <button id="copySummary" type="button" class="ghost icon" aria-label="Copy summary" hidden>
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M16 1H4C2.9 1 2 1.9 2 3v14h2V3h12V1zm3 4H8C6.9 5 6 5.9 6 7v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+              />
+            </svg>
+          </button>
           <button id="drawerToggle" type="button" class="ghost icon" aria-label="Settings">
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <path

--- a/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
@@ -170,6 +170,7 @@ const chatDockEl = byId<HTMLDivElement>("chatDock");
 const slideImageLoader = createSlideImageLoader();
 
 const summarizeControlRoot = byId<HTMLElement>("summarizeControlRoot");
+const copySummaryBtn = byId<HTMLButtonElement>("copySummary");
 const drawerToggleBtn = byId<HTMLButtonElement>("drawerToggle");
 const refreshBtn = byId<HTMLButtonElement>("refresh");
 const clearBtn = byId<HTMLButtonElement>("clear");
@@ -1075,6 +1076,7 @@ function resetSummaryView({
   clearSlideGallery(renderSlidesHostEl);
   clearMetricsForMode("summary");
   panelState.summaryMarkdown = null;
+  copySummaryBtn.hidden = true;
   panelState.summaryFromCache = null;
   panelState.slides = null;
   if (clearRunId) {
@@ -1254,6 +1256,7 @@ function renderMarkdownDisplay() {
 
 function renderMarkdown(markdown: string) {
   panelState.summaryMarkdown = markdown;
+  copySummaryBtn.hidden = !markdown;
   updateSlideSummaryFromMarkdown(markdown, {
     preserveIfEmpty: slideSummaryByIndex.size > 0,
     source: "summary",
@@ -4162,6 +4165,14 @@ function sendChatMessage() {
 refreshBtn.addEventListener("click", () => sendSummarize({ refresh: true }));
 clearBtn.addEventListener("click", () => {
   void clearCurrentView();
+});
+copySummaryBtn.addEventListener("click", () => {
+  const md = panelState.summaryMarkdown;
+  if (!md) return;
+  void navigator.clipboard.writeText(md).then(() => {
+    headerController.setStatus("Copied");
+    setTimeout(() => headerController.setStatus(panelState.ui?.status ?? ""), 800);
+  });
 });
 drawerToggleBtn.addEventListener("click", () => toggleDrawer());
 advancedBtn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary

- Adds a **copy button** (clipboard icon) in the header controls area, next to the settings gear
- Copies the full summary markdown to the clipboard with one click
- Shows "Copied" status feedback for 800ms (reuses existing header status pattern)
- Button only appears when a summary is rendered, hides when cleared

Closes #162

## Implementation Details

- **`index.html`**: Added copy button with Material Design clipboard SVG icon using existing `.ghost .icon` button classes
- **`main.ts`**: Wired up click handler using `navigator.clipboard.writeText()`, toggles button visibility via `hidden` attribute in `renderMarkdown()` and the clear function

## Test Plan

- [ ] Summarize a page, verify copy button appears in header
- [ ] Click copy button, paste elsewhere to confirm markdown content is copied
- [ ] Verify "Copied" status flash appears briefly
- [ ] Clear summary, verify copy button disappears
- [ ] Verify button does not appear before a summary is generated