### PR TITLE
Update Homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ YouTube slide screenshots (from the browser):
 
 1. Install the CLI (choose one):
    - **npm** (cross‑platform): `npm i -g @steipete/summarize`
-   - **Homebrew** (macOS arm64): `brew install steipete/tap/summarize`
+   - **Homebrew** (macOS arm64): `brew install summarize`
 2. Install the extension (Chrome Web Store link above) and open the Side Panel.
 3. The panel shows a token + install command. Run it in Terminal:
    - `summarize daemon install --token <TOKEN>`
@@ -112,10 +112,10 @@ npm i @steipete/summarize-core
 import { createLinkPreviewClient } from "@steipete/summarize-core/content";
 ```
 
-- Homebrew (custom tap):
+- Homebrew:
 
 ```bash
-brew install steipete/tap/summarize
+brew install summarize
 ```
 
 Homebrew availability depends on the current tap formula for your architecture.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ Ship is **not done** until:
 - GitHub Release has the Bun tarball asset
 - GitHub Release has the Chrome extension zip
 - GitHub Release has the Firefox extension zip
-- Homebrew tap is bumped + `brew install` verifies
+- Homebrew formula is bumped + `brew install` verifies
 
 ## Version sources (keep in sync)
 
@@ -82,7 +82,7 @@ Ship is **not done** until:
 
    - Verify notes render (real newlines): `gh release view v<ver> --json body --jq .body`
 
-8. Homebrew tap bump + verify
+8. Homebrew formula bump + verify
    - Repo: `~/Projects/homebrew-tap`
    - Update `Formula/summarize.rb`:
      - `url` → GitHub Release asset URL
@@ -92,8 +92,7 @@ Ship is **not done** until:
    - Verify:
      ```bash
      brew uninstall summarize || true
-     brew tap steipete/tap || true
-     brew install steipete/tap/summarize
+     brew install summarize
      summarize --version
      ```
 
@@ -161,7 +160,6 @@ Goal:
 5. Homebrew verification (after formula update)
    ```bash
    brew uninstall summarize || true
-   brew tap steipete/tap || true
    brew install steipete/tap/summarize
    summarize --version
    ```


### PR DESCRIPTION
Summarize is now [available](https://github.com/chrisfinazzo/homebrew-core/commit/42f3681a87e1394a6b947f0b043484e471434c91) directly from [Homebrew](https://brew.sh).

I don't know how exactly you want to handle releasing now that a custom Tap is no longer required. Feel free to tweak those instructions as you see fit.