### PR TITLE
fix: isolate chat history by URL instead of just tabId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - CLI build: mark the generated `dist/cli.js` wrapper executable so `npm link` and global installs can run the binary directly on Unix-like systems (#191, thanks @maciej).
 - CLI providers: use stable default aliases for Gemini (`flash`) and Cursor Agent (`auto`) so installed CLI versions resolve supported models reliably (#193, thanks @mvance).
 - YouTube and cache: make `--no-cache` bypass cached URL extraction, forward `OPENAI_API_KEY` into media transcription, and surface yt-dlp transcription failures in diagnostics (#197, thanks @mvance).
+- Chrome extension chat: isolate side-panel chat history by both tab and URL so navigating within a tab no longer shows another page's conversation (#189, thanks @Youpen-y).
 - Spotify podcasts: skip encrypted Spotify embed audio, fall back to publisher RSS enclosures, and surface podcast transcription failures instead of summarizing a bare URL.
 - CLI progress: show only the active transcription provider/model in status text instead of the full remote fallback chain.
 

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-history-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-history-runtime.ts
@@ -7,18 +7,20 @@ export function createChatHistoryRuntime({
   chatLimits,
   normalizeStoredMessage,
   requestChatHistory,
+  getActiveUrl,
 }: {
   chatController: {
     getMessages: () => ChatMessage[];
     setMessages: (messages: ChatMessage[], opts?: { scroll?: boolean }) => void;
   };
   chatHistoryStore: {
-    clear: (tabId: number | null) => Promise<void>;
-    load: (tabId: number) => Promise<ChatMessage[] | null>;
+    clear: (tabId: number | null, url?: string | null) => Promise<void>;
+    load: (tabId: number, url?: string | null) => Promise<ChatMessage[] | null>;
     persist: (
       tabId: number | null,
       messages: ChatMessage[],
       chatEnabled: boolean,
+      url?: string | null,
     ) => Promise<ChatMessage[]>;
   };
   chatLimits: ChatHistoryLimits;
@@ -26,15 +28,16 @@ export function createChatHistoryRuntime({
   requestChatHistory: (
     summary?: string | null,
   ) => Promise<{ ok: boolean; messages?: unknown[]; error?: string }>;
+  getActiveUrl: () => string | null;
 }) {
   let loadId = 0;
 
   return {
     clear(tabId: number | null) {
-      return chatHistoryStore.clear(tabId);
+      return chatHistoryStore.clear(tabId, getActiveUrl());
     },
     load(tabId: number) {
-      return chatHistoryStore.load(tabId);
+      return chatHistoryStore.load(tabId, getActiveUrl());
     },
     async persist(tabId: number | null, chatEnabled: boolean) {
       if (!chatEnabled || !tabId) return;
@@ -43,13 +46,13 @@ export function createChatHistoryRuntime({
       if (compacted.length !== messages.length) {
         chatController.setMessages(compacted, { scroll: false });
       }
-      await chatHistoryStore.persist(tabId, compacted, chatEnabled);
+      await chatHistoryStore.persist(tabId, compacted, chatEnabled, getActiveUrl());
     },
     async restore(tabId: number | null, summaryMarkdown?: string | null) {
       if (!tabId) return;
       loadId += 1;
       const currentLoadId = loadId;
-      const history = await chatHistoryStore.load(tabId);
+      const history = await chatHistoryStore.load(tabId, getActiveUrl());
       if (currentLoadId !== loadId) return;
       if (history?.length) {
         const compacted = compactChatHistory(history, chatLimits);
@@ -67,7 +70,7 @@ export function createChatHistoryRuntime({
           .map((msg) => normalizeStoredMessage(msg as Record<string, unknown>))
           .filter((msg): msg is ChatMessage => Boolean(msg));
         if (!parsed.length) return;
-        const compacted = await chatHistoryStore.persist(tabId, parsed, true);
+        const compacted = await chatHistoryStore.persist(tabId, parsed, true, getActiveUrl());
         chatController.setMessages(compacted, { scroll: false });
       } catch {
         // ignore

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.ts
@@ -1,8 +1,17 @@
 import type { Message } from "@mariozechner/pi-ai";
 import { compactChatHistory, type ChatHistoryLimits } from "./chat-state";
+import { normalizePanelUrl } from "./session-policy";
 import type { ChatMessage } from "./types";
 
-function getChatHistoryKey(tabId: number) {
+function getChatHistoryKey(tabId: number, url?: string | null) {
+  if (url) {
+    try {
+      const normalized = normalizePanelUrl(url);
+      return `chat:tab:${tabId}:${normalized}`;
+    } catch {
+      // fall through
+    }
+  }
   return `chat:tab:${tabId}`;
 }
 
@@ -78,25 +87,25 @@ export function createChatHistoryStore({
 }) {
   const cache = new Map<number, ChatMessage[]>();
 
-  async function clear(tabId: number | null) {
+  async function clear(tabId: number | null, url?: string | null) {
     if (!tabId) return;
     cache.delete(tabId);
     const store = getStorage();
     if (!store) return;
     try {
-      await store.remove(getChatHistoryKey(tabId));
+      await store.remove(getChatHistoryKey(tabId, url));
     } catch {
       // ignore
     }
   }
 
-  async function load(tabId: number): Promise<ChatMessage[] | null> {
+  async function load(tabId: number, url?: string | null): Promise<ChatMessage[] | null> {
     const cached = cache.get(tabId);
     if (cached) return cached;
     const store = getStorage();
     if (!store) return null;
     try {
-      const key = getChatHistoryKey(tabId);
+      const key = getChatHistoryKey(tabId, url);
       const res = await store.get(key);
       const raw = res?.[key];
       if (!Array.isArray(raw)) return null;
@@ -112,14 +121,14 @@ export function createChatHistoryStore({
     }
   }
 
-  async function persist(tabId: number | null, messages: ChatMessage[], chatEnabled: boolean) {
+  async function persist(tabId: number | null, messages: ChatMessage[], chatEnabled: boolean, url?: string | null) {
     if (!chatEnabled || !tabId) return messages;
     const compacted = compactChatHistory(messages, chatLimits);
     cache.set(tabId, compacted);
     const store = getStorage();
     if (!store) return compacted;
     try {
-      await store.set({ [getChatHistoryKey(tabId)]: compacted });
+      await store.set({ [getChatHistoryKey(tabId, url)]: compacted });
     } catch {
       // ignore
     }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.ts
@@ -85,27 +85,28 @@ export function createChatHistoryStore({
   chatLimits: ChatHistoryLimits;
   getStorage?: () => chrome.storage.StorageArea | undefined;
 }) {
-  const cache = new Map<number, ChatMessage[]>();
+  const cache = new Map<string, ChatMessage[]>();
 
   async function clear(tabId: number | null, url?: string | null) {
     if (!tabId) return;
-    cache.delete(tabId);
+    const key = getChatHistoryKey(tabId, url);
+    cache.delete(key);
     const store = getStorage();
     if (!store) return;
     try {
-      await store.remove(getChatHistoryKey(tabId, url));
+      await store.remove(key);
     } catch {
       // ignore
     }
   }
 
   async function load(tabId: number, url?: string | null): Promise<ChatMessage[] | null> {
-    const cached = cache.get(tabId);
+    const key = getChatHistoryKey(tabId, url);
+    const cached = cache.get(key);
     if (cached) return cached;
     const store = getStorage();
     if (!store) return null;
     try {
-      const key = getChatHistoryKey(tabId, url);
       const res = await store.get(key);
       const raw = res?.[key];
       if (!Array.isArray(raw)) return null;
@@ -114,21 +115,27 @@ export function createChatHistoryStore({
         .map((msg) => normalizeStoredMessage(msg as Record<string, unknown>))
         .filter((msg): msg is ChatMessage => Boolean(msg));
       if (!parsed.length) return null;
-      cache.set(tabId, parsed);
+      cache.set(key, parsed);
       return parsed;
     } catch {
       return null;
     }
   }
 
-  async function persist(tabId: number | null, messages: ChatMessage[], chatEnabled: boolean, url?: string | null) {
+  async function persist(
+    tabId: number | null,
+    messages: ChatMessage[],
+    chatEnabled: boolean,
+    url?: string | null,
+  ) {
     if (!chatEnabled || !tabId) return messages;
+    const key = getChatHistoryKey(tabId, url);
     const compacted = compactChatHistory(messages, chatLimits);
-    cache.set(tabId, compacted);
+    cache.set(key, compacted);
     const store = getStorage();
     if (!store) return compacted;
     try {
-      await store.set({ [getChatHistoryKey(tabId, url)]: compacted });
+      await store.set({ [key]: compacted });
     } catch {
       // ignore
     }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
@@ -631,7 +631,11 @@ const navigationRuntime = createNavigationRuntime({
   },
 });
 
-async function migrateChatHistory(fromTabId: number | null, toTabId: number | null, toUrl: string | null) {
+async function migrateChatHistory(
+  fromTabId: number | null,
+  toTabId: number | null,
+  toUrl: string | null,
+) {
   if (!fromTabId || !toTabId || fromTabId === toTabId) return;
   const messages = chatController.getMessages();
   if (messages.length === 0) return;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
@@ -266,6 +266,7 @@ const chatHistoryRuntime = createChatHistoryRuntime({
   chatLimits,
   normalizeStoredMessage,
   requestChatHistory: (summary) => chatSession.requestChatHistory(summary),
+  getActiveUrl: () => activeTabUrl,
 });
 
 type AutomationNoticeAction = "extensions" | "options";
@@ -630,11 +631,11 @@ const navigationRuntime = createNavigationRuntime({
   },
 });
 
-async function migrateChatHistory(fromTabId: number | null, toTabId: number | null) {
+async function migrateChatHistory(fromTabId: number | null, toTabId: number | null, toUrl: string | null) {
   if (!fromTabId || !toTabId || fromTabId === toTabId) return;
   const messages = chatController.getMessages();
   if (messages.length === 0) return;
-  await chatHistoryStore.persist(toTabId, messages, true);
+  await chatHistoryStore.persist(toTabId, messages, true, toUrl);
 }
 
 const syncWithActiveTab = () => navigationRuntime.syncWithActiveTab();

--- a/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
@@ -54,7 +54,7 @@ type UiStateRuntimeOpts = {
   requestAgentAbort: (reason: string) => void;
   clearChatHistoryForActiveTab: () => void | Promise<void>;
   resetChatState: () => void;
-  migrateChatHistory: (fromTabId: number | null, toTabId: number | null) => void | Promise<void>;
+  migrateChatHistory: (fromTabId: number | null, toTabId: number | null, toUrl: string | null) => void | Promise<void>;
   maybeStartPendingSummaryRunForUrl: (url: string | null) => boolean;
   maybeStartPendingSlidesForUrl: (url: string | null) => void;
   resolveActiveSlidesRunId: () => string | null;
@@ -218,7 +218,7 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
         void opts.clearChatHistoryForActiveTab();
         opts.resetChatState();
       } else if (navigation.shouldMigrateChat) {
-        void opts.migrateChatHistory(previousTabId, nextTabId);
+        void opts.migrateChatHistory(previousTabId, nextTabId, nextTabUrl);
       }
       if (navigation.nextInputMode) {
         opts.setInputMode(navigation.nextInputMode);

--- a/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
@@ -54,7 +54,11 @@ type UiStateRuntimeOpts = {
   requestAgentAbort: (reason: string) => void;
   clearChatHistoryForActiveTab: () => void | Promise<void>;
   resetChatState: () => void;
-  migrateChatHistory: (fromTabId: number | null, toTabId: number | null, toUrl: string | null) => void | Promise<void>;
+  migrateChatHistory: (
+    fromTabId: number | null,
+    toTabId: number | null,
+    toUrl: string | null,
+  ) => void | Promise<void>;
   maybeStartPendingSummaryRunForUrl: (url: string | null) => boolean;
   maybeStartPendingSlidesForUrl: (url: string | null) => void;
   resolveActiveSlidesRunId: () => string | null;

--- a/tests/sidepanel.chat-history-runtime.test.ts
+++ b/tests/sidepanel.chat-history-runtime.test.ts
@@ -18,6 +18,7 @@ describe("sidepanel chat history runtime", () => {
       chatLimits: { maxMessages: 10, maxChars: 100 },
       normalizeStoredMessage: vi.fn(),
       requestChatHistory: vi.fn(),
+      getActiveUrl: vi.fn(() => "https://example.com"),
     });
 
     await runtime.persist(7, true);
@@ -26,6 +27,7 @@ describe("sidepanel chat history runtime", () => {
       7,
       [{ id: "1", role: "user", content: "hello", timestamp: 1 }],
       true,
+      "https://example.com",
     );
     expect(chatController.setMessages).not.toHaveBeenCalled();
   });
@@ -48,6 +50,7 @@ describe("sidepanel chat history runtime", () => {
       chatLimits: { maxMessages: 10, maxChars: 100 },
       normalizeStoredMessage: vi.fn(),
       requestChatHistory,
+      getActiveUrl: vi.fn(() => "https://example.com"),
     });
 
     await runtime.restore(7, "summary");
@@ -82,6 +85,7 @@ describe("sidepanel chat history runtime", () => {
       chatLimits: { maxMessages: 10, maxChars: 100 },
       normalizeStoredMessage: vi.fn((raw) => (raw.role === "user" ? (raw as never) : null)),
       requestChatHistory,
+      getActiveUrl: vi.fn(() => "https://example.com"),
     });
 
     await runtime.restore(7, "summary");
@@ -89,6 +93,7 @@ describe("sidepanel chat history runtime", () => {
       7,
       [{ role: "user", content: "remote", timestamp: 1 }],
       true,
+      "https://example.com",
     );
     expect(chatController.setMessages).toHaveBeenCalledWith(
       [{ role: "user", content: "remote", timestamp: 1 }],

--- a/tests/sidepanel.chat-history-store.test.ts
+++ b/tests/sidepanel.chat-history-store.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { createChatHistoryStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.js";
+import type { ChatMessage } from "../apps/chrome-extension/src/entrypoints/sidepanel/types.js";
+
+function createMemoryStorage(): chrome.storage.StorageArea {
+  const values = new Map<string, unknown>();
+  return {
+    get: async (keys?: string | string[] | Record<string, unknown> | null) => {
+      if (typeof keys === "string") return { [keys]: values.get(keys) };
+      if (Array.isArray(keys)) {
+        return Object.fromEntries(keys.map((key) => [key, values.get(key)]));
+      }
+      return Object.fromEntries(values.entries());
+    },
+    set: async (items: Record<string, unknown>) => {
+      for (const [key, value] of Object.entries(items)) values.set(key, value);
+    },
+    remove: async (keys: string | string[]) => {
+      for (const key of Array.isArray(keys) ? keys : [keys]) values.delete(key);
+    },
+    clear: async () => values.clear(),
+  } as chrome.storage.StorageArea;
+}
+
+describe("sidepanel chat history store", () => {
+  it("isolates cached history by tab and normalized URL", async () => {
+    const storage = createMemoryStorage();
+    const store = createChatHistoryStore({
+      chatLimits: { maxMessages: 10, maxChars: 1_000 },
+      getStorage: () => storage,
+    });
+    const pageA: ChatMessage = { id: "a", role: "user", content: "page a", timestamp: 1 };
+    const pageB: ChatMessage = { id: "b", role: "user", content: "page b", timestamp: 2 };
+
+    await store.persist(7, [pageA], true, "https://example.com/a#first");
+    await store.persist(7, [pageB], true, "https://example.com/b");
+
+    await expect(store.load(7, "https://example.com/a#second")).resolves.toEqual([pageA]);
+    await expect(store.load(7, "https://example.com/b")).resolves.toEqual([pageB]);
+  });
+
+  it("clears only the current URL history for a tab", async () => {
+    const storage = createMemoryStorage();
+    const store = createChatHistoryStore({
+      chatLimits: { maxMessages: 10, maxChars: 1_000 },
+      getStorage: () => storage,
+    });
+    const pageA: ChatMessage = { id: "a", role: "user", content: "page a", timestamp: 1 };
+    const pageB: ChatMessage = { id: "b", role: "user", content: "page b", timestamp: 2 };
+
+    await store.persist(7, [pageA], true, "https://example.com/a");
+    await store.persist(7, [pageB], true, "https://example.com/b");
+    await store.clear(7, "https://example.com/a");
+
+    await expect(store.load(7, "https://example.com/a")).resolves.toBeNull();
+    await expect(store.load(7, "https://example.com/b")).resolves.toEqual([pageB]);
+  });
+});


### PR DESCRIPTION
Fixes #188

## Problem

When users navigate to different URLs within the same browser tab, the chat history was shared across all URLs. This caused conversations from one page to incorrectly appear on a different page.

## Changes

- `chat-history-store`: Use ``${tabId}:${normalizedUrl}`` as storage key
- `chat-history-runtime`: Add `getActiveUrl` option and pass URL to store
- `main.ts`: Provide `activeTabUrl` to `chatHistoryRuntime`
- `ui-state-runtime.ts`: Update `migrateChatHistory` to include URL parameter

## Testing

- All sidepanel unit tests pass (37 files, 178 tests)
- E2E tests pass (50 passed, 3 skipped)
- Format and lint checks pass