### PR TITLE
fix(daemon): repair Windows Scheduled Task launcher and document elevation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - CLI providers: use stable default aliases for Gemini (`flash`) and Cursor Agent (`auto`) so installed CLI versions resolve supported models reliably (#193, thanks @mvance).
 - YouTube and cache: make `--no-cache` bypass cached URL extraction, forward `OPENAI_API_KEY` into media transcription, and surface yt-dlp transcription failures in diagnostics (#197, thanks @mvance).
 - Chrome extension chat: isolate side-panel chat history by both tab and URL so navigating within a tab no longer shows another page's conversation (#189, thanks @Youpen-y).
+- Windows daemon: register the logon Scheduled Task via XML with battery-safe hidden launch settings, fix restart/uninstall process cleanup, and document the Administrator install flow (#192, thanks @ajmeese7).
 - Spotify podcasts: skip encrypted Spotify embed audio, fall back to publisher RSS enclosures, and surface podcast transcription failures instead of summarizing a bare URL.
 - CLI progress: show only the active transcription provider/model in status text instead of the full remote fallback chain.
 

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -67,7 +67,7 @@ The extension talks to a tiny local daemon that runs on your machine. This proce
 2. Open the Side Panel (Chrome) or Sidebar (Firefox). You'll see a **Setup** screen with a token and an install command.
 3. Open Terminal:
    - macOS: Applications → Utilities → Terminal
-   - Windows: Start menu → Terminal (or PowerShell)
+   - Windows: Start menu → Terminal (or PowerShell) — **right-click → Run as administrator**
    - Linux: your Terminal app
 4. Paste the command from the Setup screen and press Enter.
    - Installed binary: `summarize daemon install --token <TOKEN>`

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -42,7 +42,7 @@ Dev (repo checkout):
   - Logs: `~/.summarize/logs/daemon.err.log`
 - Windows install:
   - `summarize daemon install` registers a Scheduled Task via `schtasks /Create /SC ONLOGON`, which requires an **elevated** shell. Run it from an Administrator PowerShell/cmd; otherwise you'll see `schtasks create failed: ERROR: Access is denied.`
-  - The task launcher is `%USERPROFILE%\.summarize\daemon-run.vbs`. If install completes but `/health` is unreachable, run `cscript //nologo %USERPROFILE%\.summarize\daemon-run.vbs` to surface the underlying error.
+  - The task launches `cmd.exe /c %USERPROFILE%\.summarize\daemon.cmd`. If install completes but `/health` is unreachable, run that batch file directly to see the underlying error, then `schtasks /Query /TN "Summarize Daemon" /V /FO LIST` to inspect the task state.
 - macOS `launchctl bootstrap` errors (`Input/output error`, `Domain does not support specified action`):
   - `summarize daemon install` now tries both launchd domains (`gui/<uid>` then `user/<uid>`).
   - Install as your normal user (not root) so HOME + launchd domain match.

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -41,8 +41,8 @@ Dev (repo checkout):
   - `summarize daemon status`
   - Logs: `~/.summarize/logs/daemon.err.log`
 - Windows install:
-  - `summarize daemon install` registers a Scheduled Task via `schtasks /Create /SC ONLOGON`, which requires an **elevated** shell. Run it from an Administrator PowerShell/cmd; otherwise you'll see `schtasks create failed: ERROR: Access is denied.`
-  - The task launches `cmd.exe /c %USERPROFILE%\.summarize\daemon.cmd`. If install completes but `/health` is unreachable, run that batch file directly to see the underlying error, then `schtasks /Query /TN "Summarize Daemon" /V /FO LIST` to inspect the task state.
+  - `summarize daemon install` registers a Scheduled Task via `schtasks /Create /XML`, which requires an **elevated** shell. Run it from an Administrator PowerShell/cmd; otherwise you'll see `schtasks create failed: ERROR: Access is denied.`
+  - The task launches `wscript.exe //B //Nologo %USERPROFILE%\.summarize\daemon-launch.vbs`. If install completes but `/health` is unreachable, run `cscript //nologo %USERPROFILE%\.summarize\daemon-launch.vbs` to surface launcher errors, then `schtasks /Query /TN "Summarize Daemon" /V /FO LIST` to inspect the task state.
 - macOS `launchctl bootstrap` errors (`Input/output error`, `Domain does not support specified action`):
   - `summarize daemon install` now tries both launchd domains (`gui/<uid>` then `user/<uid>`).
   - Install as your normal user (not root) so HOME + launchd domain match.

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -40,6 +40,9 @@ Dev (repo checkout):
 - “Daemon not reachable”:
   - `summarize daemon status`
   - Logs: `~/.summarize/logs/daemon.err.log`
+- Windows install:
+  - `summarize daemon install` registers a Scheduled Task via `schtasks /Create /SC ONLOGON`, which requires an **elevated** shell. Run it from an Administrator PowerShell/cmd; otherwise you'll see `schtasks create failed: ERROR: Access is denied.`
+  - The task launcher is `%USERPROFILE%\.summarize\daemon-run.vbs`. If install completes but `/health` is unreachable, run `cscript //nologo %USERPROFILE%\.summarize\daemon-run.vbs` to surface the underlying error.
 - macOS `launchctl bootstrap` errors (`Input/output error`, `Domain does not support specified action`):
   - `summarize daemon install` now tries both launchd domains (`gui/<uid>` then `user/<uid>`).
   - Install as your normal user (not root) so HOME + launchd domain match.

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -126,13 +126,13 @@ function buildTaskLauncherScript({
   const escapedPidPath = quoteVbsString(pidPath);
   return [
     'Set fso = CreateObject("Scripting.FileSystemObject")',
-    'Set processStartup = GetObject("winmgmts:root\\\\cimv2:Win32_ProcessStartup").SpawnInstance_',
+    'Set processStartup = GetObject("winmgmts:root\\cimv2:Win32_ProcessStartup").SpawnInstance_',
     "processStartup.ShowWindow = 0",
     `scriptPath = ${escapedScriptPath}`,
     `pidPath = ${escapedPidPath}`,
     'command = "cmd.exe /d /c " & Chr(34) & scriptPath & Chr(34)',
     "processId = 0",
-    'result = GetObject("winmgmts:root\\\\cimv2:Win32_Process").Create(command, Null, processStartup, processId)',
+    'result = GetObject("winmgmts:root\\cimv2:Win32_Process").Create(command, Null, processStartup, processId)',
     "If result <> 0 Then",
     "  WScript.Quit result",
     "End If",
@@ -152,7 +152,7 @@ function buildTaskLauncherScript({
     "End If",
     "",
     "Function ProcessExists(pid)",
-    '  Set processes = GetObject("winmgmts:root\\\\cimv2").ExecQuery("SELECT ProcessId FROM Win32_Process WHERE ProcessId = " & pid)',
+    '  Set processes = GetObject("winmgmts:root\\cimv2").ExecQuery("SELECT ProcessId FROM Win32_Process WHERE ProcessId = " & pid)',
     "  ProcessExists = (processes.Count > 0)",
     "End Function",
     "",
@@ -263,7 +263,11 @@ export async function installScheduledTask({
     quotedLauncher,
   ]);
   if (create.code !== 0) {
-    throw new Error(`schtasks create failed: ${create.stderr || create.stdout}`.trim());
+    const detail = (create.stderr || create.stdout).trim();
+    const hint = /access is denied/i.test(detail)
+      ? " (run `summarize daemon install` from an elevated PowerShell/cmd — schtasks /SC ONLOGON requires Administrator)"
+      : "";
+    throw new Error(`schtasks create failed: ${detail}${hint}`);
   }
 
   await execSchtasks(["/Run", "/TN", DAEMON_WINDOWS_TASK_NAME]);

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -2,7 +2,8 @@ import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
-import { DAEMON_WINDOWS_TASK_NAME } from "./constants.js";
+import { readDaemonConfig } from "./config.js";
+import { DAEMON_HOST, DAEMON_WINDOWS_TASK_NAME } from "./constants.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -17,12 +18,12 @@ function resolveTaskScriptPath(env: Record<string, string | undefined>): string 
   return path.join(home, ".summarize", "daemon.cmd");
 }
 
-function resolveTaskLauncherPath(env: Record<string, string | undefined>): string {
+function resolveLegacyLauncherPath(env: Record<string, string | undefined>): string {
   const home = resolveHomeDir(env);
   return path.join(home, ".summarize", "daemon-run.vbs");
 }
 
-function resolveTaskPidPath(env: Record<string, string | undefined>): string {
+function resolveLegacyPidPath(env: Record<string, string | undefined>): string {
   const home = resolveHomeDir(env);
   return path.join(home, ".summarize", "daemon.pid");
 }
@@ -32,27 +33,19 @@ function quoteCmdArg(value: string): string {
   return `"${value.replace(/"/g, '\\"')}"`;
 }
 
-function quoteVbsString(value: string): string {
-  return `"${value.replace(/"/g, '""')}"`;
-}
-
 function parseCommandLine(value: string): string[] {
   const args: string[] = [];
   let current = "";
   let inQuotes = false;
-  let escapeNext = false;
 
-  for (const char of value) {
-    if (escapeNext) {
-      current += char;
-      escapeNext = false;
-      continue;
-    }
-    if (char === "\\") {
-      escapeNext = true;
-      continue;
-    }
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
     if (char === '"') {
+      if (inQuotes && value[i + 1] === '"') {
+        current += '"';
+        i += 1;
+        continue;
+      }
       inQuotes = !inQuotes;
       continue;
     }
@@ -115,50 +108,6 @@ function buildTaskScript({
   return `${lines.join("\r\n")}\r\n`;
 }
 
-function buildTaskLauncherScript({
-  scriptPath,
-  pidPath,
-}: {
-  scriptPath: string;
-  pidPath: string;
-}): string {
-  const escapedScriptPath = quoteVbsString(scriptPath);
-  const escapedPidPath = quoteVbsString(pidPath);
-  return [
-    'Set fso = CreateObject("Scripting.FileSystemObject")',
-    'Set processStartup = GetObject("winmgmts:root\\cimv2:Win32_ProcessStartup").SpawnInstance_',
-    "processStartup.ShowWindow = 0",
-    `scriptPath = ${escapedScriptPath}`,
-    `pidPath = ${escapedPidPath}`,
-    'command = "cmd.exe /d /c " & Chr(34) & scriptPath & Chr(34)',
-    "processId = 0",
-    'result = GetObject("winmgmts:root\\cimv2:Win32_Process").Create(command, Null, processStartup, processId)',
-    "If result <> 0 Then",
-    "  WScript.Quit result",
-    "End If",
-    "Set pidFile = fso.OpenTextFile(pidPath, 2, True)",
-    "pidFile.Write CStr(processId)",
-    "pidFile.Close",
-    "Do While ProcessExists(processId)",
-    "  WScript.Sleep 1000",
-    "Loop",
-    "If fso.FileExists(pidPath) Then",
-    "  Set currentPidFile = fso.OpenTextFile(pidPath, 1, False)",
-    "  currentPid = Trim(currentPidFile.ReadAll)",
-    "  currentPidFile.Close",
-    "  If currentPid = CStr(processId) Then",
-    "    fso.DeleteFile pidPath, True",
-    "  End If",
-    "End If",
-    "",
-    "Function ProcessExists(pid)",
-    '  Set processes = GetObject("winmgmts:root\\cimv2").ExecQuery("SELECT ProcessId FROM Win32_Process WHERE ProcessId = " & pid)',
-    "  ProcessExists = (processes.Count > 0)",
-    "End Function",
-    "",
-  ].join("\r\n");
-}
-
 async function execWindowsCommand(
   file: string,
   args: string[],
@@ -192,6 +141,43 @@ async function execTaskkill(
   return execWindowsCommand("taskkill", args);
 }
 
+function isMissingProcessError(detail: string): boolean {
+  return /not found|not running|no running instance|does not exist/i.test(detail);
+}
+
+async function fetchDaemonPid(env: Record<string, string | undefined>): Promise<number | null> {
+  const cfg = await readDaemonConfig({ env });
+  if (!cfg) return null;
+  const url = `http://${DAEMON_HOST}:${cfg.port}/health`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1000);
+  try {
+    const res = await fetch(url, { method: "GET", signal: controller.signal });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { pid?: unknown };
+    const pid = typeof body.pid === "number" ? body.pid : null;
+    return pid && Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// schtasks /End only kills the task action process (cmd.exe). The daemon node
+// process detaches from cmd at startup, so /End orphans it and a subsequent
+// /Run hits "port already in use" and exits 1 — silent restart no-op. Ask the
+// daemon for its own pid via /health and taskkill the tree before /End.
+async function killRunningDaemon(env: Record<string, string | undefined>): Promise<void> {
+  const pid = await fetchDaemonPid(env);
+  if (pid === null) return;
+  const res = await execTaskkill(["/PID", `${pid}`, "/T", "/F"]);
+  const detail = (res.stderr || res.stdout).trim();
+  if (res.code !== 0 && !isMissingProcessError(detail)) {
+    throw new Error(`taskkill failed: ${detail || "unknown error"}`.trim());
+  }
+}
+
 async function assertSchtasksAvailable() {
   const res = await execSchtasks(["/Query"]);
   if (res.code === 0) return;
@@ -199,32 +185,11 @@ async function assertSchtasksAvailable() {
   throw new Error(`schtasks unavailable: ${detail || "unknown error"}`.trim());
 }
 
-function isMissingProcessError(detail: string): boolean {
-  return /not found|not running|no running instance|does not exist/i.test(detail);
-}
-
-async function stopTrackedTaskProcessTree(env: Record<string, string | undefined>): Promise<void> {
-  const pidPath = resolveTaskPidPath(env);
-  let pid = "";
-  try {
-    pid = (await fs.readFile(pidPath, "utf8")).trim();
-  } catch {
-    return;
-  }
-
-  const pidNumber = Number(pid);
-  if (!Number.isInteger(pidNumber) || pidNumber <= 0) {
-    await fs.unlink(pidPath).catch(() => {});
-    return;
-  }
-
-  const res = await execTaskkill(["/PID", `${pidNumber}`, "/T", "/F"]);
-  const detail = (res.stderr || res.stdout).trim();
-  if (res.code !== 0 && !isMissingProcessError(detail)) {
-    throw new Error(`taskkill failed: ${detail || "unknown error"}`.trim());
-  }
-
-  await fs.unlink(pidPath).catch(() => {});
+async function removeLegacyLauncherArtifacts(env: Record<string, string | undefined>): Promise<void> {
+  // Earlier versions wrote a VBS launcher and a tracked PID file. Both are
+  // gone, but clean up any leftovers from upgraded installs.
+  await fs.unlink(resolveLegacyLauncherPath(env)).catch(() => {});
+  await fs.unlink(resolveLegacyPidPath(env)).catch(() => {});
 }
 
 export async function installScheduledTask({
@@ -240,16 +205,16 @@ export async function installScheduledTask({
 }): Promise<{ scriptPath: string }> {
   await assertSchtasksAvailable();
   const scriptPath = resolveTaskScriptPath(env);
-  const launcherPath = resolveTaskLauncherPath(env);
-  const pidPath = resolveTaskPidPath(env);
   await fs.mkdir(path.dirname(scriptPath), { recursive: true });
   const script = buildTaskScript({ programArguments, workingDirectory });
   await fs.writeFile(scriptPath, script, "utf8");
-  await fs.unlink(pidPath).catch(() => {});
-  const launcher = buildTaskLauncherScript({ scriptPath, pidPath });
-  await fs.writeFile(launcherPath, launcher, "utf8");
+  await removeLegacyLauncherArtifacts(env);
 
-  const quotedLauncher = quoteCmdArg(launcherPath);
+  // schtasks /TR runs whatever string we give it via CreateProcess. CreateProcess
+  // can't launch a .cmd directly, so wrap it in cmd.exe /c. Earlier versions used
+  // a VBS launcher to spawn cmd.exe via WMI; that path was fragile under /RL LIMITED
+  // and added nothing — schtasks /End already terminates the task's process tree.
+  const taskCommand = `cmd.exe /c ${quoteCmdArg(scriptPath)}`;
   const create = await execSchtasks([
     "/Create",
     "/F",
@@ -260,7 +225,7 @@ export async function installScheduledTask({
     "/TN",
     DAEMON_WINDOWS_TASK_NAME,
     "/TR",
-    quotedLauncher,
+    taskCommand,
   ]);
   if (create.code !== 0) {
     const detail = (create.stderr || create.stdout).trim();
@@ -284,26 +249,18 @@ export async function uninstallScheduledTask({
   stdout: NodeJS.WritableStream;
 }): Promise<void> {
   await assertSchtasksAvailable();
-  await stopTrackedTaskProcessTree(env);
+  await killRunningDaemon(env);
   await execSchtasks(["/End", "/TN", DAEMON_WINDOWS_TASK_NAME]);
   await execSchtasks(["/Delete", "/F", "/TN", DAEMON_WINDOWS_TASK_NAME]);
 
   const scriptPath = resolveTaskScriptPath(env);
-  const launcherPath = resolveTaskLauncherPath(env);
-  const pidPath = resolveTaskPidPath(env);
   try {
     await fs.unlink(scriptPath);
     stdout.write(`Removed task script: ${scriptPath}\n`);
   } catch {
     stdout.write(`Task script not found at ${scriptPath}\n`);
   }
-  try {
-    await fs.unlink(launcherPath);
-    stdout.write(`Removed task launcher: ${launcherPath}\n`);
-  } catch {
-    stdout.write(`Task launcher not found at ${launcherPath}\n`);
-  }
-  await fs.unlink(pidPath).catch(() => {});
+  await removeLegacyLauncherArtifacts(env);
 }
 
 export async function restartScheduledTask({
@@ -314,7 +271,7 @@ export async function restartScheduledTask({
   stdout: NodeJS.WritableStream;
 }): Promise<void> {
   await assertSchtasksAvailable();
-  await stopTrackedTaskProcessTree(env);
+  await killRunningDaemon(env);
   await execSchtasks(["/End", "/TN", DAEMON_WINDOWS_TASK_NAME]);
   const res = await execSchtasks(["/Run", "/TN", DAEMON_WINDOWS_TASK_NAME]);
   if (res.code !== 0) {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -59,7 +59,7 @@ function buildScheduledTaskXml({
   // daemon look like it was failing to start. Register via /XML so we can flip
   // those flags off and own every other relevant setting too.
   return [
-    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<?xml version="1.0" encoding="UTF-8"?>',
     '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">',
     "  <RegistrationInfo>",
     "    <Author>summarize</Author>",
@@ -279,9 +279,8 @@ async function fetchDaemonPid(env: Record<string, string | undefined>): Promise<
   }
 }
 
-// schtasks /End only kills the task action process (cmd.exe). The daemon node
-// process detaches from cmd at startup, so /End orphans it and a subsequent
-// /Run hits "port already in use" and exits 1 — silent restart no-op. Ask the
+// schtasks /End only targets the task action process. Our wscript launcher
+// exits after detaching node, so /End cannot stop the daemon itself. Ask the
 // daemon for its own pid via /health and taskkill the tree before /End.
 async function killRunningDaemon(env: Record<string, string | undefined>): Promise<void> {
   const pid = await fetchDaemonPid(env);
@@ -350,7 +349,10 @@ export async function installScheduledTask({
     throw new Error(`schtasks create failed: ${detail}${hint}`);
   }
 
-  await execSchtasks(["/Run", "/TN", DAEMON_WINDOWS_TASK_NAME]);
+  const run = await execSchtasks(["/Run", "/TN", DAEMON_WINDOWS_TASK_NAME]);
+  if (run.code !== 0) {
+    throw new Error(`schtasks run failed: ${run.stderr || run.stdout}`.trim());
+  }
   stdout.write(`Installed Scheduled Task: ${DAEMON_WINDOWS_TASK_NAME}\n`);
   stdout.write(`Task script: ${scriptPath}\n`);
   return { scriptPath };

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -18,7 +18,97 @@ function resolveTaskScriptPath(env: Record<string, string | undefined>): string 
   return path.join(home, ".summarize", "daemon.cmd");
 }
 
+function resolveTaskLauncherPath(env: Record<string, string | undefined>): string {
+  const home = resolveHomeDir(env);
+  return path.join(home, ".summarize", "daemon-launch.vbs");
+}
+
+function resolveTaskDefinitionPath(env: Record<string, string | undefined>): string {
+  const home = resolveHomeDir(env);
+  return path.join(home, ".summarize", "daemon-task.xml");
+}
+
+function resolveCurrentUserPrincipal(env: Record<string, string | undefined>): string {
+  const username = env.USERNAME?.trim();
+  if (!username) throw new Error("Missing USERNAME");
+  const domain = env.USERDOMAIN?.trim() || env.COMPUTERNAME?.trim();
+  return domain ? `${domain}\\${username}` : username;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function buildScheduledTaskXml({
+  launcherPath,
+  userPrincipal,
+}: {
+  launcherPath: string;
+  userPrincipal: string;
+}): string {
+  const userId = escapeXml(userPrincipal);
+  const args = escapeXml(`//B //Nologo "${launcherPath}"`);
+  // schtasks /Create /SC ONLOGON defaults DisallowStartIfOnBatteries and
+  // StopIfGoingOnBatteries to true. On a laptop unplugged at install time the
+  // task silently no-ops every /Run with Last Result 0, which is what made the
+  // daemon look like it was failing to start. Register via /XML so we can flip
+  // those flags off and own every other relevant setting too.
+  return [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">',
+    "  <RegistrationInfo>",
+    "    <Author>summarize</Author>",
+    "  </RegistrationInfo>",
+    "  <Triggers>",
+    "    <LogonTrigger>",
+    "      <Enabled>true</Enabled>",
+    `      <UserId>${userId}</UserId>`,
+    "    </LogonTrigger>",
+    "  </Triggers>",
+    "  <Principals>",
+    '    <Principal id="Author">',
+    `      <UserId>${userId}</UserId>`,
+    "      <LogonType>InteractiveToken</LogonType>",
+    "      <RunLevel>LeastPrivilege</RunLevel>",
+    "    </Principal>",
+    "  </Principals>",
+    "  <Settings>",
+    "    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>",
+    "    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>",
+    "    <AllowHardTerminate>true</AllowHardTerminate>",
+    "    <StartWhenAvailable>true</StartWhenAvailable>",
+    "    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>",
+    "    <IdleSettings>",
+    "      <StopOnIdleEnd>false</StopOnIdleEnd>",
+    "      <RestartOnIdle>false</RestartOnIdle>",
+    "    </IdleSettings>",
+    "    <AllowStartOnDemand>true</AllowStartOnDemand>",
+    "    <Enabled>true</Enabled>",
+    "    <Hidden>true</Hidden>",
+    "    <RunOnlyIfIdle>false</RunOnlyIfIdle>",
+    "    <WakeToRun>false</WakeToRun>",
+    "    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>",
+    "    <Priority>7</Priority>",
+    "  </Settings>",
+    '  <Actions Context="Author">',
+    "    <Exec>",
+    "      <Command>wscript.exe</Command>",
+    `      <Arguments>${args}</Arguments>`,
+    "    </Exec>",
+    "  </Actions>",
+    "</Task>",
+    "",
+  ].join("\r\n");
+}
+
 function resolveLegacyLauncherPath(env: Record<string, string | undefined>): string {
+  // The pre-XML installer wrote a different VBS at this path. Removed in
+  // favor of daemon-launch.vbs; we still clean it up on upgrade.
   const home = resolveHomeDir(env);
   return path.join(home, ".summarize", "daemon-run.vbs");
 }
@@ -108,6 +198,31 @@ function buildTaskScript({
   return `${lines.join("\r\n")}\r\n`;
 }
 
+function quoteVbsString(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function buildLauncherVbs({
+  programArguments,
+  workingDirectory,
+}: {
+  programArguments: string[];
+  workingDirectory?: string;
+}): string {
+  // Run the daemon via wscript + WshShell.Run with windowStyle=0 so node is
+  // started with CREATE_NO_WINDOW. wscript itself is a Windows-subsystem app,
+  // so it never allocates a console. Net effect: zero windows, zero conhost,
+  // even on a logged-in interactive session.
+  const command = programArguments.map(quoteCmdArg).join(" ");
+  const lines = ['Set sh = CreateObject("WScript.Shell")'];
+  if (workingDirectory) {
+    lines.push(`sh.CurrentDirectory = ${quoteVbsString(workingDirectory)}`);
+  }
+  lines.push(`sh.Run ${quoteVbsString(command)}, 0, False`);
+  lines.push("");
+  return lines.join("\r\n");
+}
+
 async function execWindowsCommand(
   file: string,
   args: string[],
@@ -185,9 +300,10 @@ async function assertSchtasksAvailable() {
   throw new Error(`schtasks unavailable: ${detail || "unknown error"}`.trim());
 }
 
-async function removeLegacyLauncherArtifacts(env: Record<string, string | undefined>): Promise<void> {
-  // Earlier versions wrote a VBS launcher and a tracked PID file. Both are
-  // gone, but clean up any leftovers from upgraded installs.
+async function removeLegacyPidArtifact(env: Record<string, string | undefined>): Promise<void> {
+  // Earlier versions tracked a PID file alongside the launcher. The launcher
+  // path moved to daemon-launch.vbs and PID tracking is gone — clean up
+  // both leftovers from upgraded installs.
   await fs.unlink(resolveLegacyLauncherPath(env)).catch(() => {});
   await fs.unlink(resolveLegacyPidPath(env)).catch(() => {});
 }
@@ -205,32 +321,31 @@ export async function installScheduledTask({
 }): Promise<{ scriptPath: string }> {
   await assertSchtasksAvailable();
   const scriptPath = resolveTaskScriptPath(env);
+  const launcherPath = resolveTaskLauncherPath(env);
+  const xmlPath = resolveTaskDefinitionPath(env);
   await fs.mkdir(path.dirname(scriptPath), { recursive: true });
   const script = buildTaskScript({ programArguments, workingDirectory });
   await fs.writeFile(scriptPath, script, "utf8");
-  await removeLegacyLauncherArtifacts(env);
+  const launcher = buildLauncherVbs({ programArguments, workingDirectory });
+  await fs.writeFile(launcherPath, launcher, "utf8");
+  await removeLegacyPidArtifact(env);
 
-  // schtasks /TR runs whatever string we give it via CreateProcess. CreateProcess
-  // can't launch a .cmd directly, so wrap it in cmd.exe /c. Earlier versions used
-  // a VBS launcher to spawn cmd.exe via WMI; that path was fragile under /RL LIMITED
-  // and added nothing — schtasks /End already terminates the task's process tree.
-  const taskCommand = `cmd.exe /c ${quoteCmdArg(scriptPath)}`;
+  const userPrincipal = resolveCurrentUserPrincipal(env);
+  const xml = buildScheduledTaskXml({ launcherPath, userPrincipal });
+  await fs.writeFile(xmlPath, xml, "utf8");
+
   const create = await execSchtasks([
     "/Create",
     "/F",
-    "/SC",
-    "ONLOGON",
-    "/RL",
-    "LIMITED",
     "/TN",
     DAEMON_WINDOWS_TASK_NAME,
-    "/TR",
-    taskCommand,
+    "/XML",
+    xmlPath,
   ]);
   if (create.code !== 0) {
     const detail = (create.stderr || create.stdout).trim();
     const hint = /access is denied/i.test(detail)
-      ? " (run `summarize daemon install` from an elevated PowerShell/cmd — schtasks /SC ONLOGON requires Administrator)"
+      ? " (run `summarize daemon install` from an elevated PowerShell/cmd — schtasks /Create /XML requires Administrator)"
       : "";
     throw new Error(`schtasks create failed: ${detail}${hint}`);
   }
@@ -260,7 +375,9 @@ export async function uninstallScheduledTask({
   } catch {
     stdout.write(`Task script not found at ${scriptPath}\n`);
   }
-  await removeLegacyLauncherArtifacts(env);
+  await fs.unlink(resolveTaskLauncherPath(env)).catch(() => {});
+  await fs.unlink(resolveTaskDefinitionPath(env)).catch(() => {});
+  await removeLegacyPidArtifact(env);
 }
 
 export async function restartScheduledTask({

--- a/tests/daemon.schtasks.test.ts
+++ b/tests/daemon.schtasks.test.ts
@@ -2,13 +2,38 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Writable } from "node:stream";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   execFile: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({ execFile: mocks.execFile }));
+
+const originalFetch = globalThis.fetch;
+function setFetchPid(pid: number | null) {
+  globalThis.fetch = (async () => {
+    if (pid === null) throw new Error("daemon down");
+    return new Response(JSON.stringify({ ok: true, pid }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+function clearFetch() {
+  globalThis.fetch = originalFetch;
+}
+
+function writeDaemonConfig(home: string, port = 8787) {
+  const dir = path.join(home, ".summarize");
+  mkdirSync(dir, { recursive: true });
+  const token = "0123456789abcdef0123456789abcdef";
+  writeFileSync(
+    path.join(dir, "daemon.json"),
+    JSON.stringify({ version: 2, token, tokens: [token], port, env: {} }),
+    "utf8",
+  );
+}
 
 import { DAEMON_WINDOWS_TASK_NAME } from "../src/daemon/constants.js";
 import {
@@ -31,19 +56,11 @@ function collectStream(): { stream: Writable; getText: () => string } {
 function mockExecFileSuccess() {
   mocks.execFile.mockImplementation(
     (
-      file: string,
-      args: string[],
+      _file: string,
+      _args: string[],
       _options: { encoding: string; windowsHide: boolean },
       callback: (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void,
     ) => {
-      if (file === "taskkill") {
-        callback(null, "SUCCESS: The process was terminated.", "");
-        return {} as never;
-      }
-      if (file === "schtasks" && args[0] === "/Query") {
-        callback(null, "", "");
-        return {} as never;
-      }
       callback(null, "", "");
       return {} as never;
     },
@@ -55,7 +72,7 @@ describe("daemon/schtasks install", () => {
     mocks.execFile.mockReset();
   });
 
-  it("writes a hidden launcher that tracks the daemon pid", async () => {
+  it("registers the task with cmd.exe /c <daemon.cmd>", async () => {
     mockExecFileSuccess();
     const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
     const out = collectStream();
@@ -66,23 +83,76 @@ describe("daemon/schtasks install", () => {
       programArguments: ["node", "dist/cli.js", "daemon", "run"],
     });
 
-    const launcherPath = path.join(home, ".summarize", "daemon-run.vbs");
-    const pidPath = path.join(home, ".summarize", "daemon.pid");
-    const launcher = readFileSync(launcherPath, "utf8");
     const script = readFileSync(scriptPath, "utf8");
-
     expect(script).toContain("node dist/cli.js daemon run");
-    expect(launcher).toContain("processStartup.ShowWindow = 0");
-    expect(launcher).toContain('Win32_Process").Create');
-    expect(launcher).toContain(`pidPath = "${pidPath.replace(/\\/g, "\\\\")}"`);
-    expect(launcher).toContain("fso.DeleteFile pidPath, True");
     expect(out.getText()).toContain("Installed Scheduled Task");
 
     const createCall = mocks.execFile.mock.calls.find(
       (call) => call[0] === "schtasks" && (call[1] as string[])[0] === "/Create",
     );
     expect(createCall).toBeTruthy();
-    expect(createCall?.[1]).toContain(path.join(home, ".summarize", "daemon-run.vbs"));
+    const createArgs = createCall?.[1] as string[];
+    const trIndex = createArgs.indexOf("/TR");
+    expect(trIndex).toBeGreaterThanOrEqual(0);
+    expect(createArgs[trIndex + 1]).toBe(`cmd.exe /c ${scriptPath}`);
+    expect(createArgs).toContain("/SC");
+    expect(createArgs).toContain("ONLOGON");
+    expect(createArgs).toContain("/RL");
+    expect(createArgs).toContain("LIMITED");
+  });
+
+  it("cleans up legacy launcher and pid artifacts on install", async () => {
+    mockExecFileSuccess();
+    const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
+    const summarizeDir = path.join(home, ".summarize");
+    mkdirSync(summarizeDir, { recursive: true });
+    const legacyLauncher = path.join(summarizeDir, "daemon-run.vbs");
+    const legacyPid = path.join(summarizeDir, "daemon.pid");
+    writeFileSync(legacyLauncher, "old", "utf8");
+    writeFileSync(legacyPid, "1234", "utf8");
+    const out = collectStream();
+
+    await installScheduledTask({
+      env: { HOME: home },
+      stdout: out.stream,
+      programArguments: ["node", "dist/cli.js", "daemon", "run"],
+    });
+
+    expect(existsSync(legacyLauncher)).toBe(false);
+    expect(existsSync(legacyPid)).toBe(false);
+  });
+
+  it("hints at elevation when schtasks /Create returns access denied", async () => {
+    mocks.execFile.mockImplementation(
+      (
+        file: string,
+        args: string[],
+        _options: { encoding: string; windowsHide: boolean },
+        callback: (error: unknown, stdout: string, stderr: string) => void,
+      ) => {
+        if (file === "schtasks" && args[0] === "/Create") {
+          const error = Object.assign(new Error("schtasks failed"), {
+            code: 1,
+            stdout: "",
+            stderr: "ERROR: Access is denied.",
+          });
+          callback(error, "", "ERROR: Access is denied.");
+          return {} as never;
+        }
+        callback(null, "", "");
+        return {} as never;
+      },
+    );
+    const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
+    const out = collectStream();
+
+    await expect(
+      installScheduledTask({
+        env: { HOME: home },
+        stdout: out.stream,
+        programArguments: ["node", "dist/cli.js", "daemon", "run"],
+      }),
+    ).rejects.toThrow(/elevated/);
   });
 });
 
@@ -90,13 +160,15 @@ describe("daemon/schtasks lifecycle", () => {
   beforeEach(() => {
     mocks.execFile.mockReset();
   });
+  afterEach(() => {
+    clearFetch();
+  });
 
-  it("kills the tracked daemon pid before rerunning the task", async () => {
+  it("kills the live daemon pid before rerunning the task", async () => {
     mockExecFileSuccess();
+    setFetchPid(4242);
     const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
-    const pidPath = path.join(home, ".summarize", "daemon.pid");
-    mkdirSync(path.dirname(pidPath), { recursive: true });
-    writeFileSync(pidPath, "4242", "utf8");
+    writeDaemonConfig(home);
     const out = collectStream();
 
     await restartScheduledTask({
@@ -108,24 +180,47 @@ describe("daemon/schtasks lifecycle", () => {
       ([file, args]) => `${file} ${(args as string[]).join(" ")}`,
     );
     const taskkillCommand = "taskkill /PID 4242 /T /F";
+    const endCommand = `schtasks /End /TN ${DAEMON_WINDOWS_TASK_NAME}`;
     const runCommand = `schtasks /Run /TN ${DAEMON_WINDOWS_TASK_NAME}`;
     expect(commands).toContain(taskkillCommand);
+    expect(commands).toContain(endCommand);
     expect(commands).toContain(runCommand);
-    expect(commands.indexOf(taskkillCommand)).toBeLessThan(commands.indexOf(runCommand));
+    expect(commands.indexOf(taskkillCommand)).toBeLessThan(commands.indexOf(endCommand));
+    expect(commands.indexOf(endCommand)).toBeLessThan(commands.indexOf(runCommand));
     expect(out.getText()).toContain("Restarted Scheduled Task");
   });
 
-  it("removes the tracked pid and launcher on uninstall", async () => {
+  it("skips taskkill on restart when the daemon is already down", async () => {
     mockExecFileSuccess();
+    setFetchPid(null);
     const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
+    writeDaemonConfig(home);
+    const out = collectStream();
+
+    await restartScheduledTask({
+      env: { HOME: home },
+      stdout: out.stream,
+    });
+
+    const commands = mocks.execFile.mock.calls.map(
+      ([file, args]) => `${file} ${(args as string[]).join(" ")}`,
+    );
+    expect(commands.some((c) => c.startsWith("taskkill"))).toBe(false);
+    expect(commands).toContain(`schtasks /Run /TN ${DAEMON_WINDOWS_TASK_NAME}`);
+  });
+
+  it("removes the task script and any legacy artifacts on uninstall", async () => {
+    mockExecFileSuccess();
+    setFetchPid(5252);
+    const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
+    writeDaemonConfig(home);
     const summarizeDir = path.join(home, ".summarize");
-    mkdirSync(summarizeDir, { recursive: true });
-    const pidPath = path.join(summarizeDir, "daemon.pid");
-    const launcherPath = path.join(summarizeDir, "daemon-run.vbs");
     const scriptPath = path.join(summarizeDir, "daemon.cmd");
-    writeFileSync(pidPath, "5252", "utf8");
-    writeFileSync(launcherPath, "launcher", "utf8");
+    const legacyLauncher = path.join(summarizeDir, "daemon-run.vbs");
+    const legacyPid = path.join(summarizeDir, "daemon.pid");
     writeFileSync(scriptPath, "script", "utf8");
+    writeFileSync(legacyLauncher, "launcher", "utf8");
+    writeFileSync(legacyPid, "5252", "utf8");
     const out = collectStream();
 
     await uninstallScheduledTask({
@@ -137,10 +232,11 @@ describe("daemon/schtasks lifecycle", () => {
       ([file, args]) => `${file} ${(args as string[]).join(" ")}`,
     );
     expect(commands).toContain("taskkill /PID 5252 /T /F");
+    expect(commands).toContain(`schtasks /End /TN ${DAEMON_WINDOWS_TASK_NAME}`);
     expect(commands).toContain(`schtasks /Delete /F /TN ${DAEMON_WINDOWS_TASK_NAME}`);
-    expect(out.getText()).toContain("Removed task launcher");
-    expect(existsSync(pidPath)).toBe(false);
-    expect(existsSync(launcherPath)).toBe(false);
+    expect(out.getText()).toContain("Removed task script");
     expect(existsSync(scriptPath)).toBe(false);
+    expect(existsSync(legacyLauncher)).toBe(false);
+    expect(existsSync(legacyPid)).toBe(false);
   });
 });

--- a/tests/daemon.schtasks.test.ts
+++ b/tests/daemon.schtasks.test.ts
@@ -94,6 +94,7 @@ describe("daemon/schtasks install", () => {
 
     const xmlPath = path.join(home, ".summarize", "daemon-task.xml");
     const xml = readFileSync(xmlPath, "utf8");
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
     expect(xml).toContain("<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>");
     expect(xml).toContain("<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>");
     expect(xml).toContain("<Hidden>true</Hidden>");
@@ -182,6 +183,39 @@ describe("daemon/schtasks install", () => {
         programArguments: ["node", "dist/cli.js", "daemon", "run"],
       }),
     ).rejects.toThrow(/elevated/);
+  });
+
+  it("reports schtasks /Run failures after task creation", async () => {
+    mocks.execFile.mockImplementation(
+      (
+        file: string,
+        args: string[],
+        _options: { encoding: string; windowsHide: boolean },
+        callback: (error: unknown, stdout: string, stderr: string) => void,
+      ) => {
+        if (file === "schtasks" && args[0] === "/Run") {
+          const error = Object.assign(new Error("schtasks run failed"), {
+            code: 1,
+            stdout: "",
+            stderr: "ERROR: The task could not be started.",
+          });
+          callback(error, "", "ERROR: The task could not be started.");
+          return {} as never;
+        }
+        callback(null, "", "");
+        return {} as never;
+      },
+    );
+    const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
+    const out = collectStream();
+
+    await expect(
+      installScheduledTask({
+        env: { HOME: home, USERNAME: "testuser", USERDOMAIN: "TESTHOST" },
+        stdout: out.stream,
+        programArguments: ["node", "dist/cli.js", "daemon", "run"],
+      }),
+    ).rejects.toThrow(/task could not be started/);
   });
 });
 

--- a/tests/daemon.schtasks.test.ts
+++ b/tests/daemon.schtasks.test.ts
@@ -72,13 +72,13 @@ describe("daemon/schtasks install", () => {
     mocks.execFile.mockReset();
   });
 
-  it("registers the task with cmd.exe /c <daemon.cmd>", async () => {
+  it("registers a hidden /XML task that launches via wscript with battery flags off", async () => {
     mockExecFileSuccess();
     const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
     const out = collectStream();
 
     const { scriptPath } = await installScheduledTask({
-      env: { HOME: home },
+      env: { HOME: home, USERNAME: "testuser", USERDOMAIN: "TESTHOST" },
       stdout: out.stream,
       programArguments: ["node", "dist/cli.js", "daemon", "run"],
     });
@@ -87,18 +87,47 @@ describe("daemon/schtasks install", () => {
     expect(script).toContain("node dist/cli.js daemon run");
     expect(out.getText()).toContain("Installed Scheduled Task");
 
+    const launcherPath = path.join(home, ".summarize", "daemon-launch.vbs");
+    const launcher = readFileSync(launcherPath, "utf8");
+    expect(launcher).toContain('Set sh = CreateObject("WScript.Shell")');
+    expect(launcher).toContain('sh.Run "node dist/cli.js daemon run", 0, False');
+
+    const xmlPath = path.join(home, ".summarize", "daemon-task.xml");
+    const xml = readFileSync(xmlPath, "utf8");
+    expect(xml).toContain("<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>");
+    expect(xml).toContain("<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>");
+    expect(xml).toContain("<Hidden>true</Hidden>");
+    expect(xml).toContain("<LogonTrigger>");
+    expect(xml).toContain("<UserId>TESTHOST\\testuser</UserId>");
+    expect(xml).toContain("<LogonType>InteractiveToken</LogonType>");
+    expect(xml).toContain("<RunLevel>LeastPrivilege</RunLevel>");
+    expect(xml).toContain("<Command>wscript.exe</Command>");
+    expect(xml).toContain(`<Arguments>//B //Nologo &quot;${launcherPath}&quot;</Arguments>`);
+
     const createCall = mocks.execFile.mock.calls.find(
       (call) => call[0] === "schtasks" && (call[1] as string[])[0] === "/Create",
     );
     expect(createCall).toBeTruthy();
     const createArgs = createCall?.[1] as string[];
-    const trIndex = createArgs.indexOf("/TR");
-    expect(trIndex).toBeGreaterThanOrEqual(0);
-    expect(createArgs[trIndex + 1]).toBe(`cmd.exe /c ${scriptPath}`);
-    expect(createArgs).toContain("/SC");
-    expect(createArgs).toContain("ONLOGON");
-    expect(createArgs).toContain("/RL");
-    expect(createArgs).toContain("LIMITED");
+    const xmlIndex = createArgs.indexOf("/XML");
+    expect(xmlIndex).toBeGreaterThanOrEqual(0);
+    expect(createArgs[xmlIndex + 1]).toBe(xmlPath);
+    expect(createArgs).not.toContain("/TR");
+  });
+
+  it("falls back to COMPUTERNAME when USERDOMAIN is missing", async () => {
+    mockExecFileSuccess();
+    const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
+    const out = collectStream();
+
+    await installScheduledTask({
+      env: { HOME: home, USERNAME: "testuser", COMPUTERNAME: "FALLBACK" },
+      stdout: out.stream,
+      programArguments: ["node", "dist/cli.js", "daemon", "run"],
+    });
+
+    const xml = readFileSync(path.join(home, ".summarize", "daemon-task.xml"), "utf8");
+    expect(xml).toContain("<UserId>FALLBACK\\testuser</UserId>");
   });
 
   it("cleans up legacy launcher and pid artifacts on install", async () => {
@@ -113,7 +142,7 @@ describe("daemon/schtasks install", () => {
     const out = collectStream();
 
     await installScheduledTask({
-      env: { HOME: home },
+      env: { HOME: home, USERNAME: "testuser", USERDOMAIN: "TESTHOST" },
       stdout: out.stream,
       programArguments: ["node", "dist/cli.js", "daemon", "run"],
     });
@@ -148,7 +177,7 @@ describe("daemon/schtasks install", () => {
 
     await expect(
       installScheduledTask({
-        env: { HOME: home },
+        env: { HOME: home, USERNAME: "testuser", USERDOMAIN: "TESTHOST" },
         stdout: out.stream,
         programArguments: ["node", "dist/cli.js", "daemon", "run"],
       }),
@@ -209,17 +238,21 @@ describe("daemon/schtasks lifecycle", () => {
     expect(commands).toContain(`schtasks /Run /TN ${DAEMON_WINDOWS_TASK_NAME}`);
   });
 
-  it("removes the task script and any legacy artifacts on uninstall", async () => {
+  it("removes the task script, launcher, xml definition, and any legacy artifacts on uninstall", async () => {
     mockExecFileSuccess();
     setFetchPid(5252);
     const home = mkdtempSync(path.join(tmpdir(), "summarize-schtasks-"));
     writeDaemonConfig(home);
     const summarizeDir = path.join(home, ".summarize");
     const scriptPath = path.join(summarizeDir, "daemon.cmd");
+    const launcherPath = path.join(summarizeDir, "daemon-launch.vbs");
+    const xmlPath = path.join(summarizeDir, "daemon-task.xml");
     const legacyLauncher = path.join(summarizeDir, "daemon-run.vbs");
     const legacyPid = path.join(summarizeDir, "daemon.pid");
     writeFileSync(scriptPath, "script", "utf8");
-    writeFileSync(legacyLauncher, "launcher", "utf8");
+    writeFileSync(launcherPath, "launcher", "utf8");
+    writeFileSync(xmlPath, "xml", "utf8");
+    writeFileSync(legacyLauncher, "old", "utf8");
     writeFileSync(legacyPid, "5252", "utf8");
     const out = collectStream();
 
@@ -236,6 +269,8 @@ describe("daemon/schtasks lifecycle", () => {
     expect(commands).toContain(`schtasks /Delete /F /TN ${DAEMON_WINDOWS_TASK_NAME}`);
     expect(out.getText()).toContain("Removed task script");
     expect(existsSync(scriptPath)).toBe(false);
+    expect(existsSync(launcherPath)).toBe(false);
+    expect(existsSync(xmlPath)).toBe(false);
     expect(existsSync(legacyLauncher)).toBe(false);
     expect(existsSync(legacyPid)).toBe(false);
   });


### PR DESCRIPTION
## Summary

`summarize daemon install` was broken on Windows in five compounding ways. Each one masked the next, so the user-visible failure mode kept shifting after every patch. This PR fixes them all.

### 1. VBS launcher's WMI moniker was malformed

`src/daemon/schtasks.ts` emitted `winmgmts:root\cimv2` into `daemon-run.vbs`. VBS string literals don't escape backslashes, so WMI received a literal double-backslash and rejected `CreateObject` with `0x80041021` (invalid parameter) on line 2. The launcher exited before spawning `cmd.exe`, which is why install printed `Installed Scheduled Task` and then `Daemon not reachable`. The whole VBS-via-WMI launcher was an unnecessary detour and is gone now (see #4 below) — but the original reduction from `\\` to `\` would have been the minimum patch.

### 2. Bare `.vbs` path in `schtasks /Create /TR`

With the WMI moniker fixed, the task itself still didn't run anything. `schtasks /Create /TR <vbs-path>` calls `CreateProcess` on the file, and `CreateProcess` can't launch a `.vbs` directly, so the scheduled task action exited 0 without ever invoking `wscript`. The `/TR` value needs an explicit interpreter. Fixed as part of the larger refactor in #4.

### 3. `parseCommandLine` stripped backslashes from Windows paths

`readScheduledTaskCommand` parses `daemon.cmd` to display the program arguments in the `Daemon command:` line at the end of `install` and `restart`. The parser treated `\` as an escape character, so `C:\nvm4w\nodejs\node.exe` came out as `C:nvm4wnodejsnode.exe` and the `Daemon command:` output looked corrupt even on successful installs. Fixed by removing the unix-style escape handling — `parseCommandLine` now only handles `""` quote escaping inside quoted spans and leaves `\` alone.

### 4. `daemon restart` was a silent no-op

`schtasks /End` only kills the task action process. The intermediate VBS/cmd wrapper exits as soon as it spawns node, so by the time `restart` calls `/End` there's nothing to kill — the actual daemon has been orphaned. The next `/Run` then hits `EADDRINUSE`, exits 1, and leaves the original daemon untouched. `restart` and `uninstall` now ask the daemon for its own PID via `GET /health` and `taskkill /T /F` the tree before `/End` + `/Run`. This also let me delete the old VBS+PID-file scaffolding entirely; the launcher is just a 3-line `WScript.Shell.Run` (see #5).

### 5. Battery defaults silently no-op'd `schtasks /Run`, and `cmd.exe` left a console window

After all of the above, fresh installs on a laptop unplugged from AC still failed to bring the daemon up. `schtasks /Create /SC ONLOGON` defaults `DisallowStartIfOnBatteries` and `StopIfGoingOnBatteries` to `true`, and there is no `schtasks /Create` flag to override them. Every `/Run` returned `Last Result: 0` (the scheduler reporting "I'm not running this on battery"), so the install / restart loop looked successful but nothing ever spawned. Switched the installer to `schtasks /Create /XML <file>`, which lets us own every flag in the task definition: battery flags off, `Hidden=true`, principal/trigger/action all spelled out explicitly.

Separately, even after the task started running, wrapping the daemon in `cmd.exe /c daemon.cmd` allocated a console window (`cmd` + `conhost`) for the node process tree on every logon — a visible flash and a phantom window on the user's desktop. The fix is to launch through `wscript.exe` (a Windows-subsystem app, no console) using a tiny `daemon-launch.vbs`:

```vbs
Set sh = CreateObject("WScript.Shell")
sh.Run "<node command line>", 0, False
```

`WshShell.Run` with `windowStyle=0` calls `CreateProcess` with `CREATE_NO_WINDOW` for the node child, then `wscript` exits immediately, leaving node detached and console-less. End state: the *only* process related to the daemon is `node.exe` itself, with `MainWindowHandle=0`. No `cmd`, no `wscript`, no `conhost`.

### Other bits

- Install error appends an elevation hint when `schtasks` returns "Access is denied" — `schtasks /Create /XML` requires Administrator on `ONLOGON` triggers, just like the old `/SC ONLOGON` path did.
- `apps/chrome-extension/README.md` and the troubleshooting section in `docs/chrome-extension.md` say to run the install terminal as Administrator and how to inspect the task if `/health` is unreachable.
- The XML principal is built from `USERDOMAIN` / `USERNAME` (with `COMPUTERNAME` as fallback) at install time — no hardcoded user or machine names anywhere.

## Test plan

`tests/daemon.schtasks.test.ts` — 7 unit tests, all passing:

- registers a hidden `/XML` task that launches via `wscript` with battery flags off
- falls back to `COMPUTERNAME` when `USERDOMAIN` is missing
- cleans up legacy `daemon-run.vbs` / `daemon.pid` artifacts on install
- hints at elevation when `schtasks /Create` returns access denied
- kills the live daemon pid before rerunning the task on `restart`
- skips `taskkill` on `restart` when the daemon is already down
- removes the task script, launcher, xml definition, and any legacy artifacts on `uninstall`

End-to-end on Windows 11, unplugged from AC, against a fresh build:

- [x] `summarize daemon install --token <TOKEN>` from elevated PowerShell prints `OK: daemon is running and authenticated`; `/health` returns 200; `summarize daemon status` reports `registered / up / auth ok`.
- [x] `summarize daemon restart` actually swaps the daemon pid (verified via `/health` before and after).
- [x] `summarize daemon uninstall` kills the daemon process, releases port 8787, leaves no `node` processes behind, and removes `daemon.cmd` / `daemon-launch.vbs` / `daemon-task.xml` from `~/.summarize`.
- [x] After install and after restart, the only daemon-related process is `node.exe` with `MainWindowHandle=0` — no `cmd`, no `wscript`, no `conhost`, no visible window.
- [x] `Daemon command:` output preserves Windows backslashes (`C:\nvm4w\nodejs\node.exe …`).
- [x] `summarize daemon install` from a non-elevated shell shows the elevation hint.