### PR TITLE
fix: use stable CLI aliases for gemini ('flash') and agent ('auto') default models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - CLI build: mark the generated `dist/cli.js` wrapper executable so `npm link` and global installs can run the binary directly on Unix-like systems (#191, thanks @maciej).
+- CLI providers: use stable default aliases for Gemini (`flash`) and Cursor Agent (`auto`) so installed CLI versions resolve supported models reliably (#193, thanks @mvance).
 - Spotify podcasts: skip encrypted Spotify embed audio, fall back to publisher RSS enclosures, and surface podcast transcription failures instead of summarizing a bare URL.
 - CLI progress: show only the active transcription provider/model in status text instead of the full remote fallback chain.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ Summarize can use installed CLIs (Claude, Codex, Gemini, Cursor Agent, OpenClaw,
 
 - `cli/claude/<model>` (e.g. `cli/claude/sonnet`)
 - `cli/codex/<model>` (e.g. `cli/codex/gpt-5.2`)
-- `cli/gemini/<model>` (e.g. `cli/gemini/gemini-3-flash`)
+- `cli/gemini/<model>` (e.g. `cli/gemini/flash`)
 - `cli/agent/<model>` (e.g. `cli/agent/gpt-5.2`)
 - `cli/openclaw/<model>` (e.g. `cli/openclaw/main`)
 - `openclaw/<model>` (alias for the same OpenClaw CLI path)
@@ -102,7 +102,7 @@ path-based prompt and enables the required tool flags:
       "order": ["claude", "gemini", "codex", "agent", "openclaw", "opencode"]
     },
     "codex": { "model": "gpt-5.2" },
-    "gemini": { "model": "gemini-3-flash", "extraArgs": ["--verbose"] },
+    "gemini": { "model": "flash", "extraArgs": ["--verbose"] },
     "claude": {
       "model": "sonnet",
       "binary": "/usr/local/bin/claude",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,7 +13,7 @@ Summarize can use installed CLIs (Claude, Codex, Gemini, Cursor Agent, OpenClaw,
 - `cli/claude/<model>` (e.g. `cli/claude/sonnet`)
 - `cli/codex/<model>` (e.g. `cli/codex/gpt-5.2`)
 - `cli/gemini/<model>` (e.g. `cli/gemini/flash`)
-- `cli/agent/<model>` (e.g. `cli/agent/gpt-5.2`)
+- `cli/agent/<model>` (e.g. `cli/agent/auto`)
 - `cli/openclaw/<model>` (e.g. `cli/openclaw/main`)
 - `openclaw/<model>` (alias for the same OpenClaw CLI path)
 - `cli/opencode/<model>` (e.g. `cli/opencode/openai/gpt-5.4`)
@@ -109,7 +109,7 @@ path-based prompt and enables the required tool flags:
       "extraArgs": ["--verbose"]
     },
     "agent": {
-      "model": "gpt-5.2",
+      "model": "auto",
       "binary": "/usr/local/bin/agent"
     },
     "openclaw": {

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -43,7 +43,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
   - Examples:
     - `cli/codex/gpt-5.2`
     - `cli/claude/sonnet`
-    - `cli/gemini/gemini-3-flash`
+    - `cli/gemini/flash`
     - `cli/agent/gpt-5.2`
     - `cli/openclaw/main`
     - `cli/opencode/openai/gpt-5.4`

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -44,7 +44,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
     - `cli/codex/gpt-5.2`
     - `cli/claude/sonnet`
     - `cli/gemini/flash`
-    - `cli/agent/gpt-5.2`
+    - `cli/agent/auto`
     - `cli/openclaw/main`
     - `cli/opencode/openai/gpt-5.4`
     - `openai/gpt-5.4`

--- a/src/llm/provider-profile.ts
+++ b/src/llm/provider-profile.ts
@@ -89,7 +89,7 @@ export const DEFAULT_CLI_MODELS: Record<CliProvider, string | null> = {
   claude: "sonnet",
   codex: "gpt-5.2",
   gemini: "flash",
-  agent: "gpt-5.2",
+  agent: "auto",
   openclaw: "main",
   opencode: null,
 };

--- a/src/llm/provider-profile.ts
+++ b/src/llm/provider-profile.ts
@@ -88,7 +88,7 @@ const GATEWAY_PROVIDER_PROFILES: Record<GatewayProvider, GatewayProviderProfile>
 export const DEFAULT_CLI_MODELS: Record<CliProvider, string | null> = {
   claude: "sonnet",
   codex: "gpt-5.2",
-  gemini: "gemini-3-flash",
+  gemini: "flash",
   agent: "gpt-5.2",
   openclaw: "main",
   opencode: null,

--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -11,7 +11,7 @@ const DEFAULT_CLI_MODELS: Record<CliProvider, string | null> = {
   claude: "sonnet",
   codex: "gpt-5.2",
   gemini: "flash",
-  agent: "gpt-5.2",
+  agent: "auto",
   openclaw: "main",
   opencode: null,
 };

--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -2,19 +2,11 @@ import type { CliProvider } from "./config.js";
 import { normalizeGatewayStyleModelId, parseGatewayStyleModelId } from "./llm/model-id.js";
 import type { LlmProvider } from "./llm/model-id.js";
 import {
+  DEFAULT_CLI_MODELS,
   type RequiredModelEnv,
   requiredEnvForCliProvider,
   resolveRequiredEnvForModelId,
 } from "./llm/provider-capabilities.js";
-
-const DEFAULT_CLI_MODELS: Record<CliProvider, string | null> = {
-  claude: "sonnet",
-  codex: "gpt-5.2",
-  gemini: "flash",
-  agent: "auto",
-  openclaw: "main",
-  opencode: null,
-};
 
 export type FixedModelSpec =
   | {

--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -10,7 +10,7 @@ import {
 const DEFAULT_CLI_MODELS: Record<CliProvider, string | null> = {
   claude: "sonnet",
   codex: "gpt-5.2",
-  gemini: "gemini-3-flash",
+  gemini: "flash",
   agent: "gpt-5.2",
   openclaw: "main",
   opencode: null,

--- a/tests/llm.provider-capabilities.test.ts
+++ b/tests/llm.provider-capabilities.test.ts
@@ -23,7 +23,7 @@ describe("llm provider capabilities", () => {
       "openclaw",
       "opencode",
     ]);
-    expect(DEFAULT_CLI_MODELS.gemini).toBe("gemini-3-flash");
+    expect(DEFAULT_CLI_MODELS.gemini).toBe("flash");
     expect(DEFAULT_CLI_MODELS.openclaw).toBe("main");
     expect(DEFAULT_CLI_MODELS.opencode).toBeNull();
     expect(parseCliProviderName(" GeMiNi ")).toBe("gemini");

--- a/tests/model-auto.test.ts
+++ b/tests/model-auto.test.ts
@@ -501,7 +501,7 @@ describe("auto model selection", () => {
       lastSuccessfulCliProvider: "gemini",
     });
 
-    expect(attempts[0]?.userModelId).toBe("cli/gemini/gemini-3-flash");
+    expect(attempts[0]?.userModelId).toBe("cli/gemini/flash");
     expect(attempts[1]?.userModelId).toBe("cli/claude/sonnet");
   });
 

--- a/tests/model-auto.test.ts
+++ b/tests/model-auto.test.ts
@@ -593,4 +593,47 @@ describe("auto model selection", () => {
       }),
     ).toEqual(["cli/opencode", "openai/gpt-5-mini"]);
   });
+
+  it("skips CLI candidates when video understanding is required", () => {
+    const config: SummarizeConfig = {
+      cli: { enabled: ["claude"] },
+      model: { mode: "auto", rules: [{ candidates: ["google/gemini-3-flash"] }] },
+    };
+    const attempts = buildAutoModelAttempts({
+      kind: "video",
+      promptTokens: 100,
+      desiredOutputTokens: 50,
+      requiresVideoUnderstanding: true,
+      env: {},
+      config,
+      catalog: null,
+      openrouterProvidersFromEnv: null,
+      cliAvailability: { claude: true },
+    });
+
+    expect(attempts.every((a) => a.transport !== "cli")).toBe(true);
+    expect(attempts[0]?.userModelId).toBe("google/gemini-3-flash");
+  });
+
+  it("does not reorder CLI providers when preferred is already first", () => {
+    const config: SummarizeConfig = {
+      model: { mode: "auto", rules: [{ candidates: ["openai/gpt-5-mini"] }] },
+    };
+    const attempts = buildAutoModelAttempts({
+      kind: "text",
+      promptTokens: 100,
+      desiredOutputTokens: 50,
+      requiresVideoUnderstanding: false,
+      env: {},
+      config,
+      catalog: null,
+      openrouterProvidersFromEnv: null,
+      cliAvailability: { claude: true, gemini: true },
+      isImplicitAutoSelection: true,
+      lastSuccessfulCliProvider: "claude", // claude is already first in default order
+    });
+
+    expect(attempts[0]?.userModelId).toBe("cli/claude/sonnet");
+    expect(attempts[1]?.userModelId).toBe("cli/gemini/flash");
+  });
 });

--- a/tests/model-spec.test.ts
+++ b/tests/model-spec.test.ts
@@ -60,7 +60,7 @@ describe("model spec parsing", () => {
     expect(parsed.kind).toBe("fixed");
     expect(parsed.transport).toBe("cli");
     expect(parsed.cliProvider).toBe("gemini");
-    expect(parsed.cliModel).toBe("gemini-3-flash");
+    expect(parsed.cliModel).toBe("flash");
     expect(parsed.requiredEnv).toBe("CLI_GEMINI");
   });
 

--- a/tests/model-spec.test.ts
+++ b/tests/model-spec.test.ts
@@ -33,7 +33,7 @@ describe("model spec parsing", () => {
     expect(parsed.kind).toBe("fixed");
     expect(parsed.transport).toBe("cli");
     expect(parsed.cliProvider).toBe("agent");
-    expect(parsed.cliModel).toBe("gpt-5.2");
+    expect(parsed.cliModel).toBe("auto");
     expect(parsed.requiredEnv).toBe("CLI_AGENT");
   });
 

--- a/tests/model-spec.test.ts
+++ b/tests/model-spec.test.ts
@@ -133,4 +133,16 @@ describe("model spec parsing", () => {
     expect(parsed.llmModelId).toBe("github-copilot/openai/gpt-4.1");
     expect(parsed.forceChatCompletions).toBe(true);
   });
+
+  it("rejects empty zai model id", () => {
+    expect(() => parseRequestedModelId("zai/")).toThrow(/missing the model id/);
+  });
+
+  it("rejects empty nvidia model id", () => {
+    expect(() => parseRequestedModelId("nvidia/")).toThrow(/missing the model id/);
+  });
+
+  it("rejects empty github-copilot model id", () => {
+    expect(() => parseRequestedModelId("github-copilot/")).toThrow(/missing the model id/);
+  });
 });


### PR DESCRIPTION
## Summary

- Changes the default `--cli gemini` model from `gemini-3-flash` to the stable alias `flash`
- Changes the default `--cli agent` (Cursor Agent) model from `gpt-5.2` to the stable alias `auto`
- Eliminates a duplicate `DEFAULT_CLI_MODELS` definition in `src/model-spec.ts` by importing the canonical constant from `src/llm/provider-profile.ts`
- Adds branch coverage tests for CLI video-skip behavior, provider reorder no-op, and invalid model id error paths

## Motivation

**gemini**: The specific model name `gemini-3-flash` introduced in [04f0932](https://github.com/steipete/summarize/commit/04f0932ff831fecf7b9cef87622e2e7d79fe1cb6) is not available in all versions of the gemini CLI, causing a `Requested entity was not found` error. The `flash` alias is maintained by the gemini CLI itself and always resolves to a currently-supported flash-tier model regardless of CLI version:

```
% gemini --model flash -p "test"   # older CLIs: resolves to gemini-3-flash-preview
% gemini --model flash -p "test"   # newer CLIs: resolves to gemini-3-flash
```

**agent**: The versioned slug `gpt-5.2` will eventually be removed. The Cursor Agent CLI exposes an `auto` alias (confirmed via `agent --list-models`) that dynamically selects the best available model for the account. Verified working:

```
% agent --print --model auto --trust "Say exactly: ok"
{"type":"result","subtype":"success","is_error":false,...,"result":"\nok"}
```

**refactor**: `src/model-spec.ts` previously defined its own local copy of `DEFAULT_CLI_MODELS` alongside the canonical exported version in `src/llm/provider-profile.ts`. The two were kept in sync manually, but any future edit to one without the other would silently change parsing behavior. The local copy has been removed in favor of importing the shared constant directly.

## Changes

- `src/llm/provider-profile.ts` — `DEFAULT_CLI_MODELS.gemini`: `"gemini-3-flash"` → `"flash"`; `DEFAULT_CLI_MODELS.agent`: `"gpt-5.2"` → `"auto"`
- `src/model-spec.ts` — removed duplicate `DEFAULT_CLI_MODELS` definition; now imports from `./llm/provider-capabilities.js`
- `tests/model-auto.test.ts`, `tests/model-spec.test.ts` — added branch coverage tests (CLI video skip, provider reorder no-op, invalid `zai/`, `nvidia/`, `github-copilot/` model ids)
- `docs/cli.md`, `docs/llm.md` — updated examples

## Test plan

- [x] `pnpm exec vitest run tests/llm.provider-capabilities.test.ts tests/model-spec.test.ts tests/model-auto.test.ts` — all 47 tests pass
- [x] `agent --print --model auto --trust "Say exactly: ok"` — confirmed `auto` is a valid alias
- [ ] Manual: `summarize --cli gemini <url>` resolves without "Requested entity was not found"
- [ ] Manual: `summarize --cli agent <url>` resolves using the auto-selected model

🤖 Generated with [Claude Code](https://claude.com/claude-code)