### PR TITLE
feat: add --extract support for local PDF files

### DIFF
--- a/src/run/runner-execution.ts
+++ b/src/run/runner-execution.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "node:url";
-import type { InputTarget } from "../content/asset.js";
+import { loadLocalAsset, type InputTarget } from "../content/asset.js";
 import { isDirectVideoInput } from "../content/index.js";
 import type { RunMetricsReport } from "../costs.js";
 import type { ExecFileFn } from "../markitdown.js";
@@ -99,6 +99,27 @@ export async function executeRunnerInput(options: {
     } finally {
       await stdinTempFile.cleanup();
     }
+  }
+
+  // Handle --extract for local PDF files (markitdown path, no LLM needed)
+  if (
+    extractMode &&
+    inputTarget.kind === "file" &&
+    inputTarget.filePath.toLowerCase().endsWith(".pdf")
+  ) {
+    const loaded = await loadLocalAsset({ filePath: inputTarget.filePath });
+    const extracted = await extractAssetContent({
+      ctx: extractAssetContext,
+      attachment: loaded.attachment,
+    });
+    await outputExtractedAsset({
+      ...outputExtractedAssetContext,
+      url: inputTarget.filePath,
+      sourceLabel: loaded.sourceLabel,
+      attachment: loaded.attachment,
+      extracted,
+    });
+    return;
   }
 
   if (slidesDirectInputUrl && inputTarget.kind === "file") {

--- a/src/run/runner-plan.ts
+++ b/src/run/runner-plan.ts
@@ -284,10 +284,11 @@ export async function createRunnerPlan(options: {
   if (
     extractMode &&
     inputTarget.kind === "file" &&
-    !isTranscribableExtension(inputTarget.filePath)
+    !isTranscribableExtension(inputTarget.filePath) &&
+    !inputTarget.filePath.toLowerCase().endsWith(".pdf")
   ) {
     throw new Error(
-      "--extract for local files is only supported for media files (MP3, MP4, WAV, etc.)",
+      "--extract for local files is only supported for media files (MP3, MP4, WAV, etc.) and PDF files",
     );
   }
   if (extractMode && inputTarget.kind === "stdin") {

--- a/tests/cli.asset.local-pdf-extract.test.ts
+++ b/tests/cli.asset.local-pdf-extract.test.ts
@@ -1,0 +1,104 @@
+import type { ChildProcess } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import type { ExecFileFn } from "../src/markitdown.js";
+import { runCli } from "../src/run.js";
+
+function collectStream() {
+  let text = "";
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      text += chunk.toString();
+      callback();
+    },
+  });
+  return { stream, getText: () => text };
+}
+
+const mocks = vi.hoisted(() => ({
+  streamSimple: vi.fn(),
+  completeSimple: vi.fn(),
+  getModel: vi.fn(() => {
+    throw new Error("no model");
+  }),
+}));
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: mocks.streamSimple,
+  completeSimple: mocks.completeSimple,
+  getModel: mocks.getModel,
+}));
+
+const execFileMock: ExecFileFn = ((file, args, _options, callback) => {
+  void file;
+  void args;
+  callback(null, "# Extracted Heading\n\nExtracted PDF content.\n", "");
+  return { pid: 123 } as unknown as ChildProcess;
+}) as ExecFileFn;
+
+describe("cli --extract with local PDF files", () => {
+  it("extracts text from a local PDF using markitdown without LLM", async () => {
+    const root = mkdtempSync(join(tmpdir(), "summarize-extract-pdf-"));
+    const pdfPath = join(root, "test.pdf");
+    writeFileSync(pdfPath, Buffer.from("%PDF-1.7\n%âãÏÓ\n1 0 obj\n<<>>\nendobj\n", "utf8"));
+
+    const stdout = collectStream();
+    const stderr = collectStream();
+
+    await runCli(["--extract", "--plain", pdfPath], {
+      env: { HOME: root, UVX_PATH: "uvx" },
+      fetch: vi.fn(async () => {
+        throw new Error("unexpected fetch — extract mode should not hit network");
+      }) as unknown as typeof fetch,
+      execFile: execFileMock,
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+    });
+
+    expect(stdout.getText()).toContain("Extracted PDF content.");
+    expect(mocks.streamSimple).not.toHaveBeenCalled();
+  });
+
+  it("rejects --extract on a non-PDF local file with a helpful error", async () => {
+    const root = mkdtempSync(join(tmpdir(), "summarize-extract-txt-"));
+    const txtPath = join(root, "notes.txt");
+    writeFileSync(txtPath, "Hello world", "utf8");
+
+    await expect(
+      runCli(["--extract", "--plain", txtPath], {
+        env: { HOME: root },
+        fetch: vi.fn(async () => {
+          throw new Error("unexpected fetch");
+        }) as unknown as typeof fetch,
+        stdout: collectStream().stream,
+        stderr: collectStream().stream,
+      }),
+    ).rejects.toThrow(/--extract for local files is only supported for media files/i);
+  });
+
+  it("errors with a helpful message when uvx is not available", async () => {
+    const root = mkdtempSync(join(tmpdir(), "summarize-extract-pdf-no-uvx-"));
+    const pdfPath = join(root, "test.pdf");
+    writeFileSync(pdfPath, Buffer.from("%PDF-1.7\n%âãÏÓ\n1 0 obj\n<<>>\nendobj\n", "utf8"));
+
+    const failingExecFile: ExecFileFn = ((_file, _args, _options, callback) => {
+      callback(new Error("uvx not found"), "", "");
+      return { pid: 0 } as unknown as ChildProcess;
+    }) as ExecFileFn;
+
+    await expect(
+      runCli(["--extract", "--plain", pdfPath], {
+        env: { HOME: root },
+        fetch: vi.fn(async () => {
+          throw new Error("unexpected fetch");
+        }) as unknown as typeof fetch,
+        execFile: failingExecFile,
+        stdout: collectStream().stream,
+        stderr: collectStream().stream,
+      }),
+    ).rejects.toThrow(/uvx|markitdown/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `--extract` to accept local PDF files, routing them through the existing markitdown extraction path (same as remote PDF URLs)
- Updates the validation guard in `runner-plan.ts` to allow `.pdf` extensions alongside audio/video
- Adds a PDF extract path in `runner-execution.ts` before `handleFileInput` that loads the file, calls `extractAssetContent`, and outputs via `outputExtractedAsset`
- Adds 3 tests: happy path extraction, rejection of non-PDF local files, and missing uvx error

## Test plan

- [ ] `pnpm test tests/cli.asset.local-pdf-extract.test.ts` — all 3 new tests pass
- [ ] `pnpm test` — no regressions in existing tests
- [ ] Manual: `node dist/cli.js --extract /path/to/file.pdf` outputs markitdown-extracted markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)