### PR TITLE
feat: add --extract support for local PDF files

### DIFF
--- a/src/run/constants.ts
+++ b/src/run/constants.ts
@@ -8,6 +8,7 @@ export const UVX_TIP =
 export const SUPPORT_URL = "https://github.com/steipete/summarize";
 export const TWITTER_HOSTS = new Set(["x.com", "twitter.com", "mobile.twitter.com"]);
 export const MAX_TEXT_BYTES_DEFAULT = 10 * 1024 * 1024;
+export const MAX_PDF_EXTRACT_BYTES = 500 * 1024 * 1024; // 500 MB
 
 export const BUILTIN_MODELS: Record<string, ModelConfig> = {
   free: {

--- a/src/run/flows/asset/input.ts
+++ b/src/run/flows/asset/input.ts
@@ -70,6 +70,10 @@ export function isTranscribableExtension(filePath: string): boolean {
   return isDirectMediaExtension(ext);
 }
 
+export function isPdfExtension(filePath: string): boolean {
+  return path.extname(normalizePathForExtension(filePath)).toLowerCase() === ".pdf";
+}
+
 function formatTranscriptionMeta({
   filename,
   sizeLabel,

--- a/src/run/runner-execution.ts
+++ b/src/run/runner-execution.ts
@@ -6,11 +6,13 @@ import type { ExecFileFn } from "../markitdown.js";
 import type { AssetAttachment } from "./attachments.js";
 import { extractAssetContent } from "./flows/asset/extract.js";
 import type { AssetExtractContext } from "./flows/asset/extract.js";
-import { handleFileInput, withUrlAsset } from "./flows/asset/input.js";
+import { handleFileInput, isPdfExtension, withUrlAsset } from "./flows/asset/input.js";
 import { outputExtractedAsset } from "./flows/asset/output.js";
 import type { SummarizeAssetArgs } from "./flows/asset/summary.js";
+import { MAX_PDF_EXTRACT_BYTES } from "./constants.js";
 import { runUrlFlow } from "./flows/url/flow.js";
 import { createTempFileFromStdin } from "./stdin-temp-file.js";
+import { startSpinner } from "../tty/spinner.js";
 
 export async function executeRunnerInput(options: {
   inputTarget: InputTarget;
@@ -102,23 +104,35 @@ export async function executeRunnerInput(options: {
   }
 
   // Handle --extract for local PDF files (markitdown path, no LLM needed)
-  if (
-    extractMode &&
-    inputTarget.kind === "file" &&
-    inputTarget.filePath.toLowerCase().endsWith(".pdf")
-  ) {
-    const loaded = await loadLocalAsset({ filePath: inputTarget.filePath });
-    const extracted = await extractAssetContent({
-      ctx: extractAssetContext,
-      attachment: loaded.attachment,
+  if (extractMode && inputTarget.kind === "file" && isPdfExtension(inputTarget.filePath)) {
+    const spinner = startSpinner({
+      text: renderSpinnerStatus("Loading file"),
+      enabled: progressEnabled,
+      stream: outputExtractedAssetContext.io.stderr,
+      color: undefined,
     });
-    await outputExtractedAsset({
-      ...outputExtractedAssetContext,
-      url: inputTarget.filePath,
-      sourceLabel: loaded.sourceLabel,
-      attachment: loaded.attachment,
-      extracted,
-    });
+    try {
+      const loaded = await loadLocalAsset({
+        filePath: inputTarget.filePath,
+        maxBytes: MAX_PDF_EXTRACT_BYTES,
+      });
+      if (progressEnabled) spinner.setText(renderSpinnerStatus("Extracting text"));
+      const extracted = await extractAssetContent({
+        ctx: extractAssetContext,
+        attachment: loaded.attachment,
+      });
+      spinner.stopAndClear();
+      await outputExtractedAsset({
+        ...outputExtractedAssetContext,
+        url: inputTarget.filePath,
+        sourceLabel: loaded.sourceLabel,
+        attachment: loaded.attachment,
+        extracted,
+      });
+    } catch (err) {
+      spinner.stopAndClear();
+      throw err;
+    }
     return;
   }
 

--- a/src/run/runner-execution.ts
+++ b/src/run/runner-execution.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "node:url";
-import type { InputTarget } from "../content/asset.js";
+import { loadLocalAsset, type InputTarget } from "../content/asset.js";
 import { isDirectVideoInput } from "../content/index.js";
 import type { RunMetricsReport } from "../costs.js";
 import type { ExecFileFn } from "../markitdown.js";
@@ -99,6 +99,27 @@ export async function executeRunnerInput(options: {
     } finally {
       await stdinTempFile.cleanup();
     }
+  }
+
+  // Handle --extract for local PDF files (markitdown path, no LLM needed)
+  if (
+    extractMode &&
+    inputTarget.kind === "file" &&
+    inputTarget.filePath.toLowerCase().endsWith(".pdf")
+  ) {
+    const loaded = await loadLocalAsset({ filePath: inputTarget.filePath });
+    const extracted = await extractAssetContent({
+      ctx: extractAssetContext,
+      attachment: loaded.attachment,
+    });
+    await outputExtractedAsset({
+      ...outputExtractedAssetContext,
+      url: inputTarget.filePath,
+      sourceLabel: loaded.sourceLabel,
+      attachment: loaded.attachment,
+      extracted,
+    });
+    return;
   }
 
   if (slidesDirectInputUrl && inputTarget.kind === "file") {

--- a/src/run/runner-plan.ts
+++ b/src/run/runner-plan.ts
@@ -284,10 +284,11 @@ export async function createRunnerPlan(options: {
   if (
     extractMode &&
     inputTarget.kind === "file" &&
-    !isTranscribableExtension(inputTarget.filePath)
+    !isTranscribableExtension(inputTarget.filePath) &&
+    !inputTarget.filePath.toLowerCase().endsWith(".pdf")
   ) {
     throw new Error(
-      "--extract for local files is only supported for media files (MP3, MP4, WAV, etc.)",
+      "--extract for local files is only supported for media files (MP3, MP4, WAV, etc.) and PDF files",
     );
   }
   if (extractMode && inputTarget.kind === "stdin") {

--- a/src/run/runner-plan.ts
+++ b/src/run/runner-plan.ts
@@ -9,7 +9,7 @@ import {
 } from "../tty/theme.js";
 import { createCacheStateFromConfig } from "./cache-state.js";
 import { parseCliProviderArg } from "./env.js";
-import { isTranscribableExtension } from "./flows/asset/input.js";
+import { isPdfExtension, isTranscribableExtension } from "./flows/asset/input.js";
 import { summarizeMediaFile as summarizeMediaFileImpl } from "./flows/asset/media.js";
 import { createMediaCacheFromConfig } from "./media-cache-state.js";
 import { createProgressGate } from "./progress.js";
@@ -285,7 +285,7 @@ export async function createRunnerPlan(options: {
     extractMode &&
     inputTarget.kind === "file" &&
     !isTranscribableExtension(inputTarget.filePath) &&
-    !inputTarget.filePath.toLowerCase().endsWith(".pdf")
+    !isPdfExtension(inputTarget.filePath)
   ) {
     throw new Error(
       "--extract for local files is only supported for media files (MP3, MP4, WAV, etc.) and PDF files",

--- a/tests/cli.asset.local-pdf-extract.test.ts
+++ b/tests/cli.asset.local-pdf-extract.test.ts
@@ -1,0 +1,104 @@
+import type { ChildProcess } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import type { ExecFileFn } from "../src/markitdown.js";
+import { runCli } from "../src/run.js";
+
+function collectStream() {
+  let text = "";
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      text += chunk.toString();
+      callback();
+    },
+  });
+  return { stream, getText: () => text };
+}
+
+const mocks = vi.hoisted(() => ({
+  streamSimple: vi.fn(),
+  completeSimple: vi.fn(),
+  getModel: vi.fn(() => {
+    throw new Error("no model");
+  }),
+}));
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: mocks.streamSimple,
+  completeSimple: mocks.completeSimple,
+  getModel: mocks.getModel,
+}));
+
+const execFileMock: ExecFileFn = ((file, args, _options, callback) => {
+  void file;
+  void args;
+  callback(null, "# Extracted Heading\n\nExtracted PDF content.\n", "");
+  return { pid: 123 } as unknown as ChildProcess;
+}) as ExecFileFn;
+
+describe("cli --extract with local PDF files", () => {
+  it("extracts text from a local PDF using markitdown without LLM", async () => {
+    const root = mkdtempSync(join(tmpdir(), "summarize-extract-pdf-"));
+    const pdfPath = join(root, "test.pdf");
+    writeFileSync(pdfPath, Buffer.from("%PDF-1.7\n%âãÏÓ\n1 0 obj\n<<>>\nendobj\n", "utf8"));
+
+    const stdout = collectStream();
+    const stderr = collectStream();
+
+    await runCli(["--extract", "--plain", pdfPath], {
+      env: { HOME: root, UVX_PATH: "uvx" },
+      fetch: vi.fn(async () => {
+        throw new Error("unexpected fetch — extract mode should not hit network");
+      }) as unknown as typeof fetch,
+      execFile: execFileMock,
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+    });
+
+    expect(stdout.getText()).toContain("Extracted PDF content.");
+    expect(mocks.streamSimple).not.toHaveBeenCalled();
+  });
+
+  it("rejects --extract on a non-PDF local file with a helpful error", async () => {
+    const root = mkdtempSync(join(tmpdir(), "summarize-extract-txt-"));
+    const txtPath = join(root, "notes.txt");
+    writeFileSync(txtPath, "Hello world", "utf8");
+
+    await expect(
+      runCli(["--extract", "--plain", txtPath], {
+        env: { HOME: root },
+        fetch: vi.fn(async () => {
+          throw new Error("unexpected fetch");
+        }) as unknown as typeof fetch,
+        stdout: collectStream().stream,
+        stderr: collectStream().stream,
+      }),
+    ).rejects.toThrow(/--extract for local files is only supported for media files/i);
+  });
+
+  it("errors with a helpful message when uvx is not available", async () => {
+    const root = mkdtempSync(join(tmpdir(), "summarize-extract-pdf-no-uvx-"));
+    const pdfPath = join(root, "test.pdf");
+    writeFileSync(pdfPath, Buffer.from("%PDF-1.7\n%âãÏÓ\n1 0 obj\n<<>>\nendobj\n", "utf8"));
+
+    const failingExecFile: ExecFileFn = ((_file, _args, _options, callback) => {
+      callback(new Error("uvx not found"), "", "");
+      return { pid: 0 } as unknown as ChildProcess;
+    }) as ExecFileFn;
+
+    await expect(
+      runCli(["--extract", "--plain", pdfPath], {
+        env: { HOME: root },
+        fetch: vi.fn(async () => {
+          throw new Error("unexpected fetch");
+        }) as unknown as typeof fetch,
+        execFile: failingExecFile,
+        stdout: collectStream().stream,
+        stderr: collectStream().stream,
+      }),
+    ).rejects.toThrow(/uvx|markitdown/i);
+  });
+});

--- a/tests/cli.asset.local-pdf-extract.test.ts
+++ b/tests/cli.asset.local-pdf-extract.test.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Writable } from "node:stream";
@@ -32,73 +32,86 @@ vi.mock("@mariozechner/pi-ai", () => ({
   getModel: mocks.getModel,
 }));
 
-const execFileMock: ExecFileFn = ((file, args, _options, callback) => {
-  void file;
-  void args;
-  callback(null, "# Extracted Heading\n\nExtracted PDF content.\n", "");
-  return { pid: 123 } as unknown as ChildProcess;
-}) as ExecFileFn;
-
 describe("cli --extract with local PDF files", () => {
   it("extracts text from a local PDF using markitdown without LLM", async () => {
     const root = mkdtempSync(join(tmpdir(), "summarize-extract-pdf-"));
-    const pdfPath = join(root, "test.pdf");
-    writeFileSync(pdfPath, Buffer.from("%PDF-1.7\n%âãÏÓ\n1 0 obj\n<<>>\nendobj\n", "utf8"));
+    try {
+      const pdfPath = join(root, "test.pdf");
+      writeFileSync(pdfPath, Buffer.from("%PDF-1.7\n%âãÏÓ\n1 0 obj\n<<>>\nendobj\n", "utf8"));
 
-    const stdout = collectStream();
-    const stderr = collectStream();
+      const stdout = collectStream();
+      const stderr = collectStream();
 
-    await runCli(["--extract", "--plain", pdfPath], {
-      env: { HOME: root, UVX_PATH: "uvx" },
-      fetch: vi.fn(async () => {
-        throw new Error("unexpected fetch — extract mode should not hit network");
-      }) as unknown as typeof fetch,
-      execFile: execFileMock,
-      stdout: stdout.stream,
-      stderr: stderr.stream,
-    });
+      const execFileMock = vi.fn(((file, args, _options, callback) => {
+        void file;
+        void args;
+        callback(null, "# Extracted Heading\n\nExtracted PDF content.\n", "");
+        return { pid: 123 } as unknown as ChildProcess;
+      }) as ExecFileFn);
 
-    expect(stdout.getText()).toContain("Extracted PDF content.");
-    expect(mocks.streamSimple).not.toHaveBeenCalled();
+      await runCli(["--extract", "--plain", pdfPath], {
+        env: { HOME: root, UVX_PATH: "uvx" },
+        fetch: vi.fn(async () => {
+          throw new Error("unexpected fetch — extract mode should not hit network");
+        }) as unknown as typeof fetch,
+        execFile: execFileMock,
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+      });
+
+      expect(stdout.getText()).toContain("Extracted PDF content.");
+      expect(execFileMock).toHaveBeenCalled();
+      expect(mocks.streamSimple).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("rejects --extract on a non-PDF local file with a helpful error", async () => {
     const root = mkdtempSync(join(tmpdir(), "summarize-extract-txt-"));
-    const txtPath = join(root, "notes.txt");
-    writeFileSync(txtPath, "Hello world", "utf8");
+    try {
+      const txtPath = join(root, "notes.txt");
+      writeFileSync(txtPath, "Hello world", "utf8");
 
-    await expect(
-      runCli(["--extract", "--plain", txtPath], {
-        env: { HOME: root },
-        fetch: vi.fn(async () => {
-          throw new Error("unexpected fetch");
-        }) as unknown as typeof fetch,
-        stdout: collectStream().stream,
-        stderr: collectStream().stream,
-      }),
-    ).rejects.toThrow(/--extract for local files is only supported for media files/i);
+      await expect(
+        runCli(["--extract", "--plain", txtPath], {
+          env: { HOME: root },
+          fetch: vi.fn(async () => {
+            throw new Error("unexpected fetch");
+          }) as unknown as typeof fetch,
+          stdout: collectStream().stream,
+          stderr: collectStream().stream,
+        }),
+      ).rejects.toThrow(/--extract for local files is only supported for media files/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("errors with a helpful message when uvx is not available", async () => {
     const root = mkdtempSync(join(tmpdir(), "summarize-extract-pdf-no-uvx-"));
-    const pdfPath = join(root, "test.pdf");
-    writeFileSync(pdfPath, Buffer.from("%PDF-1.7\n%âãÏÓ\n1 0 obj\n<<>>\nendobj\n", "utf8"));
+    try {
+      const pdfPath = join(root, "test.pdf");
+      writeFileSync(pdfPath, Buffer.from("%PDF-1.7\n%âãÏÓ\n1 0 obj\n<<>>\nendobj\n", "utf8"));
 
-    const failingExecFile: ExecFileFn = ((_file, _args, _options, callback) => {
-      callback(new Error("uvx not found"), "", "");
-      return { pid: 0 } as unknown as ChildProcess;
-    }) as ExecFileFn;
+      const failingExecFile = vi.fn(((_file, _args, _options, callback) => {
+        callback(new Error("uvx not found"), "", "");
+        return { pid: 0 } as unknown as ChildProcess;
+      }) as ExecFileFn);
 
-    await expect(
-      runCli(["--extract", "--plain", pdfPath], {
-        env: { HOME: root },
-        fetch: vi.fn(async () => {
-          throw new Error("unexpected fetch");
-        }) as unknown as typeof fetch,
-        execFile: failingExecFile,
-        stdout: collectStream().stream,
-        stderr: collectStream().stream,
-      }),
-    ).rejects.toThrow(/uvx|markitdown/i);
+      await expect(
+        runCli(["--extract", "--plain", pdfPath], {
+          env: { HOME: root },
+          fetch: vi.fn(async () => {
+            throw new Error("unexpected fetch");
+          }) as unknown as typeof fetch,
+          execFile: failingExecFile,
+          stdout: collectStream().stream,
+          stderr: collectStream().stream,
+        }),
+      ).rejects.toThrow(/uvx|markitdown/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Extends `--extract` to accept local PDF files, routing them through the existing markitdown extraction path (same as remote PDF URLs)
- Updates the validation guard in `runner-plan.ts` to allow `.pdf` extensions alongside audio/video
- Adds `isPdfExtension()` helper to `src/run/flows/asset/input.ts` alongside `isTranscribableExtension`
- Adds `MAX_PDF_EXTRACT_BYTES` constant (500 MB) to raise the default 50 MB limit for PDF extraction
- Adds a progress spinner ("Loading file" → "Extracting text") around the load+extract sequence
- Adds tests covering happy path, non-PDF rejection, and missing uvx error

## Behaviour

```sh
# Before: rejected with an error
summarize --extract document.pdf

# After: extracts and prints markdown via markitdown, no LLM call
summarize --extract document.pdf
```

Note: image-based (scanned) PDFs with no embedded text layer will produce empty output from markitdown — this is a markitdown limitation, not a bug in this change. OCR plugin support would be a separate feature.

## Test plan

- [x] `pnpm test tests/cli.asset.local-pdf-extract.test.ts` — 3 new tests pass
- [x] `pnpm test` — no regressions in existing tests
- [x] Manual: tested against a real multi-hundred-page PDF, output confirmed correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)