### PR TITLE
fix: use config env for auto model selection

### DIFF
--- a/src/run/run-env.ts
+++ b/src/run/run-env.ts
@@ -156,7 +156,9 @@ export function resolveEnvState({
   const anthropicConfigured = typeof anthropicApiKey === "string" && anthropicApiKey.length > 0;
   const openrouterConfigured = typeof openrouterApiKey === "string" && openrouterApiKey.length > 0;
   const cliAvailability = resolveCliAvailability({ env, config: configForCli });
-  const envForAuto = openrouterApiKey ? { ...env, OPENROUTER_API_KEY: openrouterApiKey } : env;
+  const envForAuto = openrouterApiKey
+    ? { ...envForRun, OPENROUTER_API_KEY: openrouterApiKey }
+    : envForRun;
   const providerBaseUrls = {
     openai: openaiBaseUrl,
     nvidia: nvidiaBaseUrl,

--- a/tests/cli.config-env.test.ts
+++ b/tests/cli.config-env.test.ts
@@ -87,4 +87,42 @@ describe("cli config env", () => {
     expect(stdout.getText().trim()).toBe("OK");
     expect(mocks.completeSimple).toHaveBeenCalledTimes(1);
   });
+
+  it("uses API keys from config env for auto model selection", async () => {
+    mocks.completeSimple.mockClear();
+
+    const root = mkdtempSync(join(tmpdir(), "summarize-cli-config-env-auto-"));
+    mkdirSync(join(root, ".summarize"), { recursive: true });
+    writeFileSync(
+      join(root, ".summarize", "config.json"),
+      JSON.stringify({
+        model: {
+          mode: "auto",
+          rules: [{ candidates: ["openai/gpt-5-chat"] }],
+        },
+        env: { OPENAI_API_KEY: "test-config-key" },
+      }),
+      "utf8",
+    );
+
+    const html =
+      "<!doctype html><html><head><title>Hello</title></head>" +
+      `<body><article><p>${"Hello world. ".repeat(800)}</p></article></body></html>`;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url === "https://example.com") return htmlResponse(html);
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    const stdout = collectStdout();
+
+    await runCli(["--force-summary", "--timeout", "2s", "https://example.com"], {
+      env: { HOME: root },
+      fetch: fetchMock as unknown as typeof fetch,
+      stdout: stdout.stream,
+      stderr: noopStream(),
+    });
+
+    expect(stdout.getText().trim()).toBe("OK");
+    expect(mocks.completeSimple).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- Use the merged runtime environment when building auto model candidates so config-provided API keys are visible to auto selection.
- Add a regression test for URL summarization with `model: auto` and an API key supplied only through `~/.summarize/config.json`.

## Root cause
Fixed model runs used the merged environment, but auto candidate filtering used the raw process environment. When the API key came from config, auto mode filtered out otherwise usable candidates and fell back to extracted text with `no model`.

Fixes #205.

## Verification
- `pnpm -s test tests/cli.config-env.test.ts tests/cli.config-apikeys-legacy.test.ts tests/run.env-state.test.ts tests/model-auto.test.ts tests/cli.auto.no-model-url-json.test.ts tests/cli.auto.no-model-needed.test.ts`
- `pnpm exec oxfmt --check src/run/run-env.ts tests/cli.config-env.test.ts`
- `git diff --check`