### PR TITLE
feat: add extension extractor router

### DIFF
--- a/apps/chrome-extension/src/entrypoints/background.ts
+++ b/apps/chrome-extension/src/entrypoints/background.ts
@@ -3,6 +3,7 @@ import { defineBackground } from "wxt/utils/define-background";
 import { buildDaemonRequestBody, buildSummarizeRequestBody } from "../lib/daemon-payload";
 import { createDaemonRecovery, isDaemonUnreachableError } from "../lib/daemon-recovery";
 import { createDaemonStatusTracker } from "../lib/daemon-status";
+import { logExtensionEvent } from "../lib/extension-logs";
 import type { BgToPanel, PanelCachePayload, PanelToBg } from "../lib/panel-contracts";
 import { loadSettings, patchSettings } from "../lib/settings";
 import { canSummarizeUrl, extractFromTab, seekInTab } from "./background/content-script-bridge";
@@ -63,6 +64,16 @@ export default defineBackground(() => {
     if (normalized.includes("warn")) return "warn";
     return "verbose";
   }
+  const logExtract = (windowId: number) => (event: string, detail?: Record<string, unknown>) => {
+    const detailPayload = detail ? { windowId, ...detail } : { windowId };
+    logExtensionEvent({
+      event,
+      detail: detailPayload,
+      scope: "extractor",
+      level: resolveLogLevel(event),
+    });
+    console.debug("[summarize][extractor]", { event, ...detailPayload });
+  };
   const runtimeActionsHandler = createRuntimeActionsHandler({
     armedTabs: nativeInputArmedTabs,
   });
@@ -175,6 +186,7 @@ export default defineBackground(() => {
               sendStatus: (status) => sendStatus(session, status),
               extractFromTab,
               fetchImpl: fetch,
+              log: logExtract(session.windowId),
             });
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
@@ -252,6 +264,7 @@ export default defineBackground(() => {
               sendStatus: () => {},
               extractFromTab,
               fetchImpl: fetch,
+              log: logExtract(session.windowId),
             });
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);

--- a/apps/chrome-extension/src/entrypoints/background/extract-cache.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extract-cache.ts
@@ -1,5 +1,11 @@
 import { shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import type { ExtractResponse } from "./content-script-bridge";
+import {
+  routeExtract,
+  type ExtractLog,
+  type ExtractorContext,
+  type ExtractorResult,
+} from "./extractors/router";
 import type { SlidesPayload } from "./panel-utils";
 
 export type CachedExtract = {
@@ -39,6 +45,8 @@ type CachedExtractStore = {
 };
 
 type LoadSettingsResult = {
+  extendedLogging: boolean;
+  maxChars: number;
   slidesEnabled: boolean;
   token: string;
 };
@@ -52,6 +60,7 @@ function countWords(text: string): number {
 
 function fromPageExtract({
   extracted,
+  result,
   title,
 }: {
   extracted: {
@@ -62,13 +71,14 @@ function fromPageExtract({
     media?: { hasVideo: boolean; hasAudio: boolean; hasCaptions: boolean } | null;
     mediaDurationSeconds?: number | null;
   };
+  result?: Pick<ExtractorResult, "source" | "diagnostics"> | null;
   title: string | null;
 }): CachedExtract {
   return {
     url: extracted.url,
     title: extracted.title ?? title,
     text: extracted.text,
-    source: "page",
+    source: result?.source ?? "page",
     truncated: extracted.truncated,
     totalCharacters: extracted.text.length,
     wordCount: countWords(extracted.text),
@@ -81,7 +91,7 @@ function fromPageExtract({
     transcriptTimedText: null,
     mediaDurationSeconds: extracted.mediaDurationSeconds ?? null,
     slides: null,
-    diagnostics: null,
+    diagnostics: result?.diagnostics ?? null,
   };
 }
 
@@ -93,14 +103,16 @@ export async function ensureChatExtract({
   sendStatus,
   extractFromTab,
   fetchImpl,
+  log,
 }: {
   session: { windowId: number };
   tab: chrome.tabs.Tab;
   settings: LoadSettingsResult;
   panelSessionStore: CachedExtractStore;
   sendStatus: (status: string) => void;
-  extractFromTab: (tabId: number, maxCharacters: number) => Promise<ExtractResponse>;
+  extractFromTab: ExtractorContext["extractFromTab"];
   fetchImpl: typeof fetch;
+  log?: ExtractLog;
 }): Promise<CachedExtract> {
   if (!tab.id || !tab.url) {
     throw new Error("Cannot chat on this page");
@@ -109,30 +121,53 @@ export async function ensureChatExtract({
   const preferUrl = shouldPreferUrlMode(tab.url);
   const cached = panelSessionStore.getCachedExtract(tab.id, tab.url);
   if (cached && (!preferUrl || cached.source === "url")) return cached;
+  const routeLog = log ?? (() => {});
 
-  if (!preferUrl) {
-    const extractedAttempt = await extractFromTab(tab.id, CHAT_FULL_TRANSCRIPT_MAX_CHARS);
-    if (extractedAttempt.ok) {
-      const extracted = extractedAttempt.data;
-      const text = extracted.text.trim();
-      if (text.length >= MIN_CHAT_CHARS) {
-        const next = fromPageExtract({
-          extracted,
-          title: tab.title?.trim() ?? null,
-        });
-        panelSessionStore.setCachedExtract(tab.id, next);
-        return next;
-      }
-    } else if (
-      extractedAttempt.error.toLowerCase().includes("chrome blocked") ||
-      extractedAttempt.error.toLowerCase().includes("failed to inject")
-    ) {
-      throw new Error(extractedAttempt.error);
+  if (preferUrl) {
+    await routeExtract({
+      tabId: tab.id,
+      url: tab.url,
+      title: tab.title?.trim() ?? null,
+      maxChars: settings.maxChars,
+      minTextChars: 1,
+      token: settings.token,
+      includeDiagnostics: settings.extendedLogging,
+      fetchImpl,
+      extractFromTab,
+      log: routeLog,
+    });
+  } else {
+    const routed = await routeExtract({
+      tabId: tab.id,
+      url: tab.url,
+      title: tab.title?.trim() ?? null,
+      maxChars: CHAT_FULL_TRANSCRIPT_MAX_CHARS,
+      minTextChars: MIN_CHAT_CHARS,
+      token: settings.token,
+      includeDiagnostics: settings.extendedLogging,
+      fetchImpl,
+      extractFromTab,
+      log: routeLog,
+    });
+    if (routed) {
+      const next = fromPageExtract({
+        extracted: routed.extracted,
+        result: routed,
+        title: tab.title?.trim() ?? null,
+      });
+      panelSessionStore.setCachedExtract(tab.id, next);
+      return next;
     }
   }
 
   const wantsSlides = settings.slidesEnabled && shouldPreferUrlMode(tab.url);
-  sendStatus(wantsSlides ? "Extracting video + thumbnails…" : "Extracting video transcript…");
+  sendStatus(
+    wantsSlides
+      ? "Extracting video + thumbnails…"
+      : preferUrl
+        ? "Extracting video transcript…"
+        : "Extracting URL content…",
+  );
   const extractTimeoutMs = wantsSlides ? 6 * 60_000 : 3 * 60_000;
   const extractController = new AbortController();
   const extractTimeout = setTimeout(() => {

--- a/apps/chrome-extension/src/entrypoints/background/extractors/page-readability.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extractors/page-readability.ts
@@ -1,0 +1,21 @@
+import type { Extractor, ExtractorContext, ExtractorResult } from "./types";
+
+export const pageReadabilityExtractor: Extractor = {
+  name: "page-readability",
+  match: () => true,
+  async extract(ctx: ExtractorContext): Promise<ExtractorResult | null> {
+    const attempt = await ctx.extractFromTab(ctx.tabId, ctx.maxChars, {
+      timeoutMs: 8_000,
+      log: ctx.log,
+    });
+    if (!attempt.ok) return null;
+
+    const text = attempt.data.text.trim();
+    if (text.length < ctx.minTextChars) return null;
+
+    return {
+      source: "page",
+      extracted: attempt.data,
+    };
+  },
+};

--- a/apps/chrome-extension/src/entrypoints/background/extractors/reddit-thread.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extractors/reddit-thread.ts
@@ -1,0 +1,286 @@
+import type { Extractor, ExtractorContext, ExtractorResult } from "./types";
+
+type RedditThing<TKind extends string, TData> = {
+  kind: TKind;
+  data: TData;
+};
+
+type RedditListing = RedditThing<
+  "Listing",
+  {
+    children: RedditChild[];
+  }
+>;
+
+type RedditPost = RedditThing<
+  "t3",
+  {
+    author?: string;
+    created_utc?: number;
+    num_comments?: number;
+    score?: number;
+    selftext?: string;
+    subreddit?: string;
+    title?: string;
+  }
+>;
+
+type RedditComment = RedditThing<
+  "t1",
+  {
+    author?: string;
+    body?: string;
+    created_utc?: number;
+    replies?: RedditListing | "";
+    score?: number;
+  }
+>;
+
+type RedditChild = RedditPost | RedditComment | RedditThing<string, Record<string, unknown>>;
+
+type RedditThreadRoute = {
+  subreddit: string;
+  postId: string;
+  jsonUrl: string;
+};
+
+const MAX_COMMENT_CHARS = 2_000;
+const MAX_COMMENTS = 160;
+const MAX_DEPTH = 6;
+const TRUNCATED_MARKER = "\n\n[TRUNCATED]";
+
+function getRedditThreadRoute(url: string): RedditThreadRoute | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (host !== "reddit.com" && !host.endsWith(".reddit.com")) return null;
+
+  const parts = parsed.pathname.split("/").filter(Boolean);
+  const subredditIndex = parts.findIndex((part) => part.toLowerCase() === "r");
+  if (subredditIndex < 0) return null;
+  if (parts[subredditIndex + 2]?.toLowerCase() !== "comments") return null;
+
+  const subreddit = parts[subredditIndex + 1];
+  const postId = parts[subredditIndex + 3];
+  if (!subreddit || !postId) return null;
+
+  return {
+    subreddit,
+    postId,
+    jsonUrl: `https://www.reddit.com/r/${encodeURIComponent(
+      subreddit,
+    )}/comments/${encodeURIComponent(postId)}.json`,
+  };
+}
+
+function isListing(value: unknown): value is RedditListing {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    (value as { kind?: unknown }).kind === "Listing" &&
+    Array.isArray((value as { data?: { children?: unknown } }).data?.children)
+  );
+}
+
+function isPost(value: unknown): value is RedditPost {
+  return Boolean(value) && typeof value === "object" && (value as { kind?: unknown }).kind === "t3";
+}
+
+function isComment(value: unknown): value is RedditComment {
+  return Boolean(value) && typeof value === "object" && (value as { kind?: unknown }).kind === "t1";
+}
+
+function formatDate(seconds: unknown): string {
+  return typeof seconds === "number" && Number.isFinite(seconds)
+    ? new Date(seconds * 1000).toISOString()
+    : "unknown date";
+}
+
+function cleanText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function clampText(text: string, maxChars: number, state: { truncated: boolean }): string {
+  if (text.length <= maxChars) return text;
+  state.truncated = true;
+  return `${text.slice(0, Math.max(0, maxChars - TRUNCATED_MARKER.length))}${TRUNCATED_MARKER}`;
+}
+
+function appendLine(
+  lines: string[],
+  line: string,
+  state: { totalChars: number; truncated: boolean },
+  maxChars: number,
+) {
+  if (state.totalChars >= maxChars) {
+    state.truncated = true;
+    return false;
+  }
+
+  const next = `${line}\n`;
+  const remaining = maxChars - state.totalChars;
+  if (next.length > remaining) {
+    const marker = TRUNCATED_MARKER.trim();
+    lines.push(`${next.slice(0, Math.max(0, remaining - marker.length - 1)).trimEnd()}\n${marker}`);
+    state.totalChars = maxChars;
+    state.truncated = true;
+    return false;
+  }
+
+  lines.push(line);
+  state.totalChars += next.length;
+  return true;
+}
+
+function appendComment(
+  lines: string[],
+  comment: RedditComment,
+  depth: number,
+  state: { totalChars: number; truncated: boolean; comments: number },
+  maxChars: number,
+) {
+  if (depth > MAX_DEPTH || state.comments >= MAX_COMMENTS) {
+    state.truncated = true;
+    return;
+  }
+
+  const data = comment.data;
+  const body = cleanText(data.body);
+  if (!body || body === "[deleted]" || body === "[removed]") return;
+
+  state.comments += 1;
+  const indent = "  ".repeat(depth);
+  const score = typeof data.score === "number" && Number.isFinite(data.score) ? data.score : 0;
+  const author = cleanText(data.author) || "[unknown]";
+  const date = formatDate(data.created_utc);
+  const bodyState = { truncated: false };
+  const formattedBody = clampText(body.replace(/\n{3,}/g, "\n\n"), MAX_COMMENT_CHARS, bodyState);
+  if (bodyState.truncated) state.truncated = true;
+
+  if (
+    !appendLine(
+      lines,
+      `${indent}[${date}] ${author} (score:${score}): ${formattedBody}`,
+      state,
+      maxChars,
+    )
+  ) {
+    return;
+  }
+
+  const replies = data.replies;
+  if (!replies || typeof replies === "string" || !isListing(replies)) return;
+  for (const child of replies.data.children) {
+    if (!isComment(child)) continue;
+    appendComment(lines, child, depth + 1, state, maxChars);
+    if (state.totalChars >= maxChars || state.comments >= MAX_COMMENTS) return;
+  }
+}
+
+function parseThreadJson(value: unknown): { post: RedditPost; comments: RedditComment[] } | null {
+  if (!Array.isArray(value) || value.length < 2) return null;
+  const postListing = value[0];
+  const commentsListing = value[1];
+  if (!isListing(postListing) || !isListing(commentsListing)) return null;
+  const post = postListing.data.children.find(isPost);
+  if (!post) return null;
+  const comments = commentsListing.data.children.filter(isComment);
+  return { post, comments };
+}
+
+function formatThread(
+  thread: { post: RedditPost; comments: RedditComment[] },
+  fallback: { subreddit: string; title: string | null },
+  maxChars: number,
+) {
+  const postData = thread.post.data;
+  const state = { totalChars: 0, truncated: false, comments: 0 };
+  const lines: string[] = [];
+  const title = cleanText(postData.title) || fallback.title || "Reddit thread";
+  const subreddit = cleanText(postData.subreddit) || fallback.subreddit;
+  const author = cleanText(postData.author) || "[unknown]";
+  const score =
+    typeof postData.score === "number" && Number.isFinite(postData.score) ? postData.score : 0;
+  const commentCount =
+    typeof postData.num_comments === "number" && Number.isFinite(postData.num_comments)
+      ? postData.num_comments
+      : thread.comments.length;
+  const postBody = cleanText(postData.selftext);
+
+  appendLine(
+    lines,
+    `[${formatDate(postData.created_utc)}] ${author} posted in r/${subreddit} (score:${score})`,
+    state,
+    maxChars,
+  );
+  appendLine(lines, `Title: ${title}`, state, maxChars);
+  appendLine(lines, `Comments: ${commentCount}`, state, maxChars);
+  if (postBody) {
+    appendLine(lines, "", state, maxChars);
+    appendLine(lines, clampText(postBody, MAX_COMMENT_CHARS, state), state, maxChars);
+  }
+  appendLine(lines, "", state, maxChars);
+  appendLine(lines, "--- Comments ---", state, maxChars);
+
+  for (const comment of thread.comments) {
+    appendComment(lines, comment, 0, state, maxChars);
+    if (state.totalChars >= maxChars || state.comments >= MAX_COMMENTS) break;
+  }
+
+  return {
+    title,
+    text: lines.join("\n").trim(),
+    truncated: state.truncated,
+    comments: state.comments,
+  };
+}
+
+export const redditThreadExtractor: Extractor = {
+  name: "reddit-thread",
+  match: (ctx: ExtractorContext) => Boolean(getRedditThreadRoute(ctx.url)),
+  async extract(ctx: ExtractorContext): Promise<ExtractorResult | null> {
+    const route = getRedditThreadRoute(ctx.url);
+    if (!route) return null;
+
+    const res = await ctx.fetchImpl(route.jsonUrl, {
+      credentials: "include",
+      headers: {
+        accept: "application/json",
+      },
+      signal: ctx.signal,
+    });
+    if (!res.ok) return null;
+
+    const thread = parseThreadJson(await res.json());
+    if (!thread) return null;
+
+    const formatted = formatThread(
+      thread,
+      { subreddit: route.subreddit, title: ctx.title },
+      ctx.maxChars,
+    );
+    if (!formatted.text) return null;
+
+    ctx.log("extractor.redditThread.parsed", {
+      comments: formatted.comments,
+      truncated: formatted.truncated,
+    });
+
+    return {
+      source: "page",
+      extracted: {
+        ok: true,
+        url: ctx.url,
+        title: formatted.title,
+        text: formatted.text,
+        truncated: formatted.truncated,
+        media: null,
+      },
+    };
+  },
+};

--- a/apps/chrome-extension/src/entrypoints/background/extractors/router.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extractors/router.ts
@@ -1,0 +1,51 @@
+import { shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
+import { pageReadabilityExtractor } from "./page-readability";
+import { redditThreadExtractor } from "./reddit-thread";
+import type { Extractor, ExtractorContext, ExtractorResult } from "./types";
+import { urlDaemonExtractor } from "./url-daemon";
+
+const extractors: Extractor[] = [
+  redditThreadExtractor,
+  pageReadabilityExtractor,
+  urlDaemonExtractor,
+];
+
+export async function routeExtract(ctx: ExtractorContext): Promise<ExtractorResult | null> {
+  const preferUrl = shouldPreferUrlMode(ctx.url);
+  ctx.log("extractor.route.start", { tabId: ctx.tabId, preferUrl });
+  if (preferUrl) {
+    ctx.log("extractor.route.preferUrlHardSwitch", { tabId: ctx.tabId });
+    return null;
+  }
+
+  for (const extractor of extractors) {
+    const matched = extractor.match(ctx);
+    ctx.log("extractor.try", { extractor: extractor.name, matched });
+    if (!matched) continue;
+
+    try {
+      const result = await extractor.extract(ctx);
+      if (!result) {
+        ctx.log("extractor.fail", { extractor: extractor.name, reason: "no-result" });
+        continue;
+      }
+      ctx.log("extractor.success", {
+        extractor: extractor.name,
+        source: result.source,
+        characters: result.extracted.text.length,
+        truncated: result.extracted.truncated,
+      });
+      return result;
+    } catch (err) {
+      ctx.log("extractor.fail", {
+        extractor: extractor.name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  ctx.log("extractor.route.fail", { reason: "no-extractor-result" });
+  return null;
+}
+
+export type { ExtractLog, ExtractorContext, ExtractorResult } from "./types";

--- a/apps/chrome-extension/src/entrypoints/background/extractors/types.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extractors/types.ts
@@ -1,0 +1,46 @@
+import type { ExtractResponse } from "../content-script-bridge";
+
+export type ExtractLog = (event: string, detail?: Record<string, unknown>) => void;
+
+export type ExtractorContext = {
+  tabId: number;
+  url: string;
+  title: string | null;
+  maxChars: number;
+  minTextChars: number;
+  token: string;
+  noCache?: boolean;
+  includeDiagnostics?: boolean;
+  signal?: AbortSignal;
+  fetchImpl: typeof fetch;
+  extractFromTab: (
+    tabId: number,
+    maxCharacters: number,
+    opts?: {
+      timeoutMs?: number;
+      log?: ExtractLog;
+    },
+  ) => Promise<{ ok: true; data: ExtractResponse & { ok: true } } | { ok: false; error: string }>;
+  log: ExtractLog;
+};
+
+export type ExtractorResult = {
+  extracted: ExtractResponse & { ok: true };
+  source: "page" | "url";
+  diagnostics?: {
+    strategy: string;
+    markdown?: { used?: boolean; provider?: string | null } | null;
+    firecrawl?: { used?: boolean } | null;
+    transcript?: {
+      provider?: string | null;
+      cacheStatus?: string | null;
+      attemptedProviders?: string[] | null;
+    } | null;
+  } | null;
+};
+
+export type Extractor = {
+  name: string;
+  match: (ctx: ExtractorContext) => boolean;
+  extract: (ctx: ExtractorContext) => Promise<ExtractorResult | null>;
+};

--- a/apps/chrome-extension/src/entrypoints/background/extractors/url-daemon.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extractors/url-daemon.ts
@@ -1,0 +1,65 @@
+import type { Extractor, ExtractorContext, ExtractorResult } from "./types";
+
+type UrlDaemonExtractResponse = {
+  ok?: boolean;
+  extracted?: {
+    content?: string;
+    title?: string | null;
+    url?: string;
+    wordCount?: number;
+    totalCharacters?: number;
+    truncated?: boolean;
+    transcriptSource?: string | null;
+    transcriptCharacters?: number | null;
+    transcriptWordCount?: number | null;
+    transcriptLines?: number | null;
+    transcriptionProvider?: string | null;
+    transcriptTimedText?: string | null;
+    mediaDurationSeconds?: number | null;
+    diagnostics?: ExtractorResult["diagnostics"];
+  };
+  error?: string;
+};
+
+export const urlDaemonExtractor: Extractor = {
+  name: "url-daemon",
+  match: () => true,
+  async extract(ctx: ExtractorContext): Promise<ExtractorResult | null> {
+    const res = await ctx.fetchImpl("http://127.0.0.1:8787/v1/summarize", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${ctx.token.trim()}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        url: ctx.url,
+        title: ctx.title,
+        mode: "url",
+        extractOnly: true,
+        ...(ctx.noCache ? { noCache: true } : {}),
+        maxCharacters: ctx.maxChars,
+        diagnostics: ctx.includeDiagnostics ? { includeContent: true } : null,
+      }),
+      signal: ctx.signal,
+    });
+    const json = (await res.json()) as UrlDaemonExtractResponse;
+    if (!res.ok || !json.ok || !json.extracted) return null;
+
+    const text = json.extracted.content?.trim() ?? "";
+    if (text.length < ctx.minTextChars) return null;
+
+    return {
+      source: "url",
+      diagnostics: json.extracted.diagnostics ?? null,
+      extracted: {
+        ok: true,
+        url: json.extracted.url || ctx.url,
+        title: json.extracted.title ?? ctx.title,
+        text,
+        truncated: Boolean(json.extracted.truncated),
+        mediaDurationSeconds: json.extracted.mediaDurationSeconds ?? null,
+        media: null,
+      },
+    };
+  },
+};

--- a/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
@@ -4,6 +4,7 @@ import type { Settings } from "../../lib/settings";
 import { isYouTubeWatchUrl } from "../../lib/youtube-url";
 import type { ExtractResponse } from "./content-script-bridge";
 import type { CachedExtract } from "./extract-cache";
+import { routeExtract, type ExtractorContext, type ExtractorResult } from "./extractors/router";
 
 type DaemonRecoveryLike = {
   recordFailure: (url: string) => void;
@@ -90,14 +91,7 @@ export async function summarizeActiveTab({
   sendStatus: (status: string) => void;
   send: SendFn;
   fetchImpl: typeof fetch;
-  extractFromTab: (
-    tabId: number,
-    maxChars: number,
-    opts?: {
-      timeoutMs?: number;
-      log?: (event: string, detail?: Record<string, unknown>) => void;
-    },
-  ) => Promise<ExtractResponse>;
+  extractFromTab: ExtractorContext["extractFromTab"];
   urlsMatch: (left: string, right: string) => boolean;
   buildSummarizeRequestBody: (args: {
     extracted: ExtractResponse & { ok: true };
@@ -144,7 +138,10 @@ export async function summarizeActiveTab({
     Boolean(tab.url && isYouTubeWatchUrl(tab.url)) && opts?.inputMode !== "page" && prefersUrlMode;
 
   let extracted: ExtractResponse & { ok: true };
+  let routedResult: Pick<ExtractorResult, "source" | "diagnostics"> | null = null;
   if (wantsUrlFastPath) {
+    logPanel("extractor.route.start", { tabId: tab.id, preferUrl: prefersUrlMode });
+    logPanel("extractor.route.preferUrlHardSwitch", { tabId: tab.id });
     sendStatus(`Fetching transcript… (${reason})`);
     logPanel("extract:url-fastpath:start", { reason, tabId: tab.id });
     try {
@@ -245,22 +242,61 @@ export async function summarizeActiveTab({
         sendStatus(`Extracting: reading… (${reason})`);
       }
     };
-    const extractedAttempt = await extractFromTab(tab.id, settings.maxChars, {
-      timeoutMs: 8_000,
-      log: (event, detail) => {
-        statusFromExtractEvent(event);
-        logPanel(event, detail);
-      },
-    });
-    logPanel(extractedAttempt.ok ? "extract:done" : "extract:failed", {
-      ok: extractedAttempt.ok,
-      ...(extractedAttempt.ok
-        ? { url: extractedAttempt.data.url }
-        : { error: extractedAttempt.error }),
-    });
-    extracted = extractedAttempt.ok
-      ? extractedAttempt.data
-      : {
+    if (prefersUrlMode) {
+      logPanel("extractor.route.start", { tabId: tab.id, preferUrl: true });
+      logPanel("extractor.route.preferUrlHardSwitch", { tabId: tab.id });
+      const extractedAttempt = await extractFromTab(tab.id, settings.maxChars, {
+        timeoutMs: 8_000,
+        log: (event, detail) => {
+          statusFromExtractEvent(event);
+          logPanel(event, detail);
+        },
+      });
+      logPanel(extractedAttempt.ok ? "extract:done" : "extract:failed", {
+        ok: extractedAttempt.ok,
+        ...(extractedAttempt.ok
+          ? { url: extractedAttempt.data.url }
+          : { error: extractedAttempt.error }),
+      });
+      extracted = extractedAttempt.ok
+        ? extractedAttempt.data
+        : {
+            ok: true,
+            url: tab.url,
+            title: tab.title ?? null,
+            text: "",
+            truncated: false,
+            media: null,
+          };
+    } else {
+      const routed = await routeExtract({
+        tabId: tab.id,
+        url: tab.url,
+        title: tab.title?.trim() ?? null,
+        maxChars: settings.maxChars,
+        minTextChars: 1,
+        token: settings.token,
+        noCache: Boolean(opts?.refresh),
+        includeDiagnostics: settings.extendedLogging,
+        signal: controller.signal,
+        fetchImpl,
+        extractFromTab,
+        log: (event, detail) => {
+          statusFromExtractEvent(event);
+          logPanel(event, detail);
+        },
+      });
+      logPanel(routed ? "extract:done" : "extract:failed", {
+        ok: Boolean(routed),
+        ...(routed
+          ? { url: routed.extracted.url, source: routed.source }
+          : { error: "No extractor result" }),
+      });
+      if (routed) {
+        extracted = routed.extracted;
+        routedResult = routed;
+      } else {
+        extracted = {
           ok: true,
           url: tab.url,
           title: tab.title ?? null,
@@ -268,6 +304,8 @@ export async function summarizeActiveTab({
           truncated: false,
           media: null,
         };
+      }
+    }
   }
 
   if (tab.url && extracted.url && !urlsMatch(tab.url, extracted.url)) {
@@ -279,6 +317,7 @@ export async function summarizeActiveTab({
     });
     if (retry.ok) {
       extracted = retry.data;
+      routedResult = null;
     }
   }
 
@@ -341,7 +380,7 @@ export async function summarizeActiveTab({
     url: resolvedPayload.url,
     title: resolvedTitle,
     text: resolvedPayload.text,
-    source: "page",
+    source: routedResult?.source ?? "page",
     truncated: resolvedPayload.truncated,
     totalCharacters: resolvedPayload.text.length,
     wordCount,
@@ -354,7 +393,7 @@ export async function summarizeActiveTab({
     transcriptTimedText: null,
     mediaDurationSeconds: resolvedPayload.mediaDurationSeconds ?? null,
     slides: null,
-    diagnostics: null,
+    diagnostics: routedResult?.diagnostics ?? null,
   });
 
   sendStatus("Connecting…");

--- a/tests/chrome.extractor-router.test.ts
+++ b/tests/chrome.extractor-router.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  routeExtract,
+  type ExtractLog,
+} from "../apps/chrome-extension/src/entrypoints/background/extractors/router.js";
+
+function createContext(overrides: Partial<Parameters<typeof routeExtract>[0]> = {}) {
+  const logs: { event: string; detail?: Record<string, unknown> }[] = [];
+  const log: ExtractLog = (event, detail) => {
+    logs.push({ event, detail });
+  };
+  const extractFromTab = vi.fn(async () => ({
+    ok: true as const,
+    data: {
+      ok: true as const,
+      url: "https://example.com/article",
+      title: "Page Title",
+      text: "Readable page text",
+      truncated: false,
+      media: null,
+    },
+  }));
+  const fetchImpl = vi.fn(
+    async () => new Response("{}", { status: 500 }),
+  ) as unknown as typeof fetch;
+
+  return {
+    ctx: {
+      tabId: 7,
+      url: "https://example.com/article",
+      title: "Tab Title",
+      maxChars: 10_000,
+      minTextChars: 1,
+      token: "token",
+      fetchImpl,
+      extractFromTab,
+      log,
+      ...overrides,
+    },
+    extractFromTab,
+    fetchImpl,
+    logs,
+  };
+}
+
+describe("chrome/extractor-router", () => {
+  it("hard-switches preferUrl pages without trying extractors", async () => {
+    const { ctx, extractFromTab, fetchImpl, logs } = createContext({
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+
+    const result = await routeExtract(ctx);
+
+    expect(result).toBeNull();
+    expect(extractFromTab).not.toHaveBeenCalled();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(logs.map((entry) => entry.event)).toEqual([
+      "extractor.route.start",
+      "extractor.route.preferUrlHardSwitch",
+    ]);
+  });
+
+  it("extracts Reddit comments through the .json API before page readability", async () => {
+    const redditJson = [
+      {
+        kind: "Listing",
+        data: {
+          children: [
+            {
+              kind: "t3",
+              data: {
+                title: "Useful thread",
+                selftext: "Original post body",
+                author: "op",
+                created_utc: 1_700_000_000,
+                num_comments: 2,
+                subreddit: "summarize",
+                score: 42,
+              },
+            },
+          ],
+        },
+      },
+      {
+        kind: "Listing",
+        data: {
+          children: [
+            {
+              kind: "t1",
+              data: {
+                body: "Top level comment",
+                author: "alice",
+                created_utc: 1_700_000_100,
+                score: 5,
+                replies: {
+                  kind: "Listing",
+                  data: {
+                    children: [
+                      {
+                        kind: "t1",
+                        data: {
+                          body: "Nested reply",
+                          author: "bob",
+                          created_utc: 1_700_000_200,
+                          score: 3,
+                          replies: "",
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    ];
+    const fetchImpl = vi.fn(async () => Response.json(redditJson)) as unknown as typeof fetch;
+    const { ctx, extractFromTab, logs } = createContext({
+      url: "https://www.reddit.com/r/summarize/comments/abc123/useful_thread/",
+      title: "Fallback title",
+      fetchImpl,
+    });
+
+    const result = await routeExtract(ctx);
+
+    expect(result?.source).toBe("page");
+    expect(result?.extracted.title).toBe("Useful thread");
+    expect(result?.extracted.text).toContain("op posted in r/summarize");
+    expect(result?.extracted.text).toContain("Title: Useful thread");
+    expect(result?.extracted.text).toContain(
+      "[2023-11-14T22:15:00.000Z] alice (score:5): Top level comment",
+    );
+    expect(result?.extracted.text).toContain(
+      "  [2023-11-14T22:16:40.000Z] bob (score:3): Nested reply",
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://www.reddit.com/r/summarize/comments/abc123.json",
+      expect.objectContaining({ credentials: "include" }),
+    );
+    expect(extractFromTab).not.toHaveBeenCalled();
+    expect(
+      logs.some(
+        (entry) =>
+          entry.event === "extractor.success" && entry.detail?.extractor === "reddit-thread",
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to page readability when Reddit .json extraction fails", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("{}", { status: 429 }),
+    ) as unknown as typeof fetch;
+    const { ctx, extractFromTab, logs } = createContext({
+      url: "https://old.reddit.com/r/summarize/comments/abc123/useful_thread/",
+      fetchImpl,
+    });
+
+    const result = await routeExtract(ctx);
+
+    expect(result?.source).toBe("page");
+    expect(result?.extracted.text).toBe("Readable page text");
+    expect(extractFromTab).toHaveBeenCalledOnce();
+    expect(
+      logs.some(
+        (entry) => entry.event === "extractor.fail" && entry.detail?.extractor === "reddit-thread",
+      ),
+    ).toBe(true);
+    expect(
+      logs.some(
+        (entry) =>
+          entry.event === "extractor.success" && entry.detail?.extractor === "page-readability",
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to daemon URL extraction when page readability is too small", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        ok: true,
+        extracted: {
+          content:
+            "Daemon extracted article content with enough text to satisfy the chat threshold. This covers the fallback path after page extraction returns only a tiny stub.",
+          title: "Daemon Title",
+          url: "https://example.com/article",
+          truncated: false,
+        },
+      }),
+    );
+    const extractFromTab = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        ok: true as const,
+        url: "https://example.com/article",
+        title: "Page Title",
+        text: "short",
+        truncated: false,
+        media: null,
+      },
+    }));
+    const { ctx, logs } = createContext({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      extractFromTab,
+      minTextChars: 100,
+    });
+
+    const result = await routeExtract(ctx);
+
+    expect(result?.source).toBe("url");
+    expect(result?.extracted.title).toBe("Daemon Title");
+    expect(result?.extracted.text).toContain("Daemon extracted article content");
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      url: "https://example.com/article",
+      mode: "url",
+      extractOnly: true,
+    });
+    expect(
+      logs.some(
+        (entry) => entry.event === "extractor.success" && entry.detail?.extractor === "url-daemon",
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a background-side extractor router for extension summarize/chat flows
- add a Reddit thread extractor that fetches `/comments/<post>.json` asynchronously and formats post metadata plus nested comments
- preserve the `shouldPreferUrlMode` hard switch so media/preferUrl URLs skip new extractors and log `extractor.route.preferUrlHardSwitch`

Fixes #174

## Verification
- `pnpm -s test tests/chrome.extractor-router.test.ts tests/content.url.test.ts tests/chrome.panel-session-actions.test.ts tests/sidepanel.panel-cache.test.ts tests/chrome.chat-context.test.ts`
- `pnpm -s test tests/chrome.extractor-router.test.ts tests/chrome.extension-logs.test.ts tests/extension.firefox.manifest.test.ts`
- `pnpm -C apps/chrome-extension exec playwright test -c playwright.config.ts --project=chromium tests/sidepanel.core.spec.ts:26 --reporter=line`
- `pnpm -C apps/chrome-extension test:chrome` (50 passed, 3 skipped)
- `pnpm -C apps/chrome-extension build`
- `pnpm exec oxfmt --check apps/chrome-extension/src/entrypoints/background.ts apps/chrome-extension/src/entrypoints/background/extract-cache.ts apps/chrome-extension/src/entrypoints/background/panel-summarize.ts apps/chrome-extension/src/entrypoints/background/extractors/router.ts apps/chrome-extension/src/entrypoints/background/extractors/reddit-thread.ts apps/chrome-extension/src/entrypoints/background/extractors/page-readability.ts apps/chrome-extension/src/entrypoints/background/extractors/url-daemon.ts apps/chrome-extension/src/entrypoints/background/extractors/types.ts tests/chrome.extractor-router.test.ts`
- `git diff --check`

## Notes
- The first `test:chrome` attempt failed because the Playwright Chromium binary was missing locally. Installed it with `pnpm -C apps/chrome-extension exec playwright install chromium`, then reran the Chrome tests successfully.
