### PR TITLE
fix: exclude Meta sites from content scripts

### DIFF
--- a/apps/chrome-extension/src/entrypoints/automation.content.ts
+++ b/apps/chrome-extension/src/entrypoints/automation.content.ts
@@ -1,4 +1,5 @@
 import { defineContentScript } from "wxt/utils/define-content-script";
+import { META_SITE_EXCLUDE_MATCHES } from "../lib/content-script-matches";
 
 export type ElementInfo = {
   selector: string;
@@ -396,6 +397,7 @@ function handleArtifactsBridge() {
 
 export default defineContentScript({
   matches: ["<all_urls>"],
+  excludeMatches: META_SITE_EXCLUDE_MATCHES,
   runAt: "document_idle",
   main() {
     handleNativeInputBridge();

--- a/apps/chrome-extension/src/entrypoints/extract.content.ts
+++ b/apps/chrome-extension/src/entrypoints/extract.content.ts
@@ -1,5 +1,6 @@
 import { Readability } from "@mozilla/readability";
 import { defineContentScript } from "wxt/utils/define-content-script";
+import { META_SITE_EXCLUDE_MATCHES } from "../lib/content-script-matches";
 import { resolveMediaDurationSecondsFromData } from "../lib/media-duration";
 import { type SeekResponse, seekToSecondsInDocument } from "../lib/seek";
 
@@ -143,6 +144,7 @@ function seekToSeconds(seconds: number): SeekResponse {
 
 export default defineContentScript({
   matches: ["<all_urls>"],
+  excludeMatches: META_SITE_EXCLUDE_MATCHES,
   runAt: "document_idle",
   main() {
     const flag = "__summarize_extract_installed__";

--- a/apps/chrome-extension/src/entrypoints/hover.content.ts
+++ b/apps/chrome-extension/src/entrypoints/hover.content.ts
@@ -1,4 +1,5 @@
 import { defineContentScript } from "wxt/utils/define-content-script";
+import { META_SITE_EXCLUDE_MATCHES } from "../lib/content-script-matches";
 import { mergeStreamingChunk } from "../lib/runtime-contracts";
 import { loadSettings, type Settings } from "../lib/settings";
 
@@ -191,6 +192,7 @@ function getAnchorFromEvent(event: Event): HTMLAnchorElement | null {
 
 export default defineContentScript({
   matches: ["<all_urls>"],
+  excludeMatches: META_SITE_EXCLUDE_MATCHES,
   runAt: "document_idle",
   main() {
     const flag = "__summarize_hover_installed__";

--- a/apps/chrome-extension/src/lib/content-script-matches.ts
+++ b/apps/chrome-extension/src/lib/content-script-matches.ts
@@ -1,0 +1,8 @@
+export const META_SITE_EXCLUDE_MATCHES = [
+  "*://facebook.com/*",
+  "*://*.facebook.com/*",
+  "*://fbcdn.net/*",
+  "*://*.fbcdn.net/*",
+  "*://instagram.com/*",
+  "*://*.instagram.com/*",
+];

--- a/apps/chrome-extension/tests/extension.spec.ts
+++ b/apps/chrome-extension/tests/extension.spec.ts
@@ -2,8 +2,10 @@ import fs from "node:fs";
 import { createServer as createHttpServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect, test } from "@playwright/test";
 import { runDaemonServer } from "../../../src/daemon/server.js";
+import { META_SITE_EXCLUDE_MATCHES } from "../src/lib/content-script-matches";
 import {
   BLOCKED_ENV_KEYS,
   DAEMON_PORT,
@@ -54,10 +56,33 @@ import {
 import { allowFirefoxExtensionTests } from "./helpers/extension-test-config";
 import { getPanelModel, getPanelPhase } from "./helpers/panel-hooks";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 test.skip(
   ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
   "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
 );
+
+test("manifest excludes Meta sites from always-on content scripts", () => {
+  const manifestPath = path.resolve(__dirname, "..", ".output", "chrome-mv3", "manifest.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+    content_scripts?: Array<{ js?: string[]; exclude_matches?: string[] }>;
+  };
+  const contentScripts = manifest.content_scripts ?? [];
+  const alwaysOnScripts = new Set([
+    "content-scripts/automation.js",
+    "content-scripts/extract.js",
+    "content-scripts/hover.js",
+  ]);
+  const matchingEntries = contentScripts.filter((entry) =>
+    entry.js?.some((script) => alwaysOnScripts.has(script)),
+  );
+
+  expect(matchingEntries.length).toBeGreaterThan(0);
+  for (const entry of matchingEntries) {
+    expect(entry.exclude_matches ?? []).toEqual(expect.arrayContaining(META_SITE_EXCLUDE_MATCHES));
+  }
+});
 
 test("sidepanel shows a ready state instead of going blank when switching tabs manually", async ({
   browserName: _browserName,


### PR DESCRIPTION
## Summary
- exclude Facebook, fbcdn, and Instagram URLs from always-on extension content script injection
- share the exclusion list across extract, hover, and automation content scripts
- add a manifest regression test that verifies the generated content_scripts exclusions

Fixes #106.

## Verification
- pnpm -C apps/chrome-extension test:chrome (51 passed, 3 skipped)
- pnpm -C apps/chrome-extension build:firefox
- inspected Chrome and Firefox manifests: both include the Meta `exclude_matches` list
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test:coverage (1731 passed, 40 skipped)

## Note
- `pnpm -s check` currently stops at `format:check` because existing `.claude/memory-handoffs/*.md` files are not formatted by repo rules; I did not rewrite those handoff files for this PR.