### PR TITLE
fix: nest temperature and maxOutputTokens inside generationConfig for Google document API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Google document summaries: send `temperature` and `maxOutputTokens` inside Gemini `generationConfig` for document requests, and include API error details when Google rejects the payload (#209, thanks @vincent-peng).
+
 ## 0.14.1 - 2026-04-26
 
 ### Features

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -120,7 +120,10 @@ export async function completeGoogleDocument({
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  const payload = {
+  const generationConfig: Record<string, unknown> = {};
+  if (typeof maxOutputTokens === "number") generationConfig.maxOutputTokens = maxOutputTokens;
+  if (typeof temperature === "number") generationConfig.temperature = temperature;
+  const payload: Record<string, unknown> = {
     contents: [
       {
         parts: [
@@ -134,8 +137,7 @@ export async function completeGoogleDocument({
         ],
       },
     ],
-    ...(typeof maxOutputTokens === "number" ? { maxOutputTokens } : {}),
-    ...(typeof temperature === "number" ? { temperature } : {}),
+    ...(Object.keys(generationConfig).length > 0 ? { generationConfig } : {}),
   };
 
   try {
@@ -148,7 +150,9 @@ export async function completeGoogleDocument({
 
     const bodyText = await response.text();
     if (!response.ok) {
-      const error = new Error(`Google API error (${response.status}).`);
+      const detail = extractGoogleErrorMessage(bodyText);
+      const hint = detail ? `: ${detail}` : "";
+      const error = new Error(`Google API error (${response.status})${hint}.`);
       (error as { statusCode?: number }).statusCode = response.status;
       (error as { responseBody?: string }).responseBody = bodyText;
       throw error;

--- a/tests/llm.google-document.test.ts
+++ b/tests/llm.google-document.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+
+// We test the payload structure that completeGoogleDocument sends to the Gemini API.
+// The key requirement is that `temperature` and `maxOutputTokens` must be nested
+// inside a `generationConfig` object, not placed at the top level of the request body.
+// Placing them at the top level causes a 400 INVALID_ARGUMENT error from the Gemini API.
+
+describe("completeGoogleDocument payload", () => {
+  it("nests temperature and maxOutputTokens inside generationConfig", async () => {
+    // Intercept fetch to capture the request payload
+    const capturedBodies: string[] = [];
+    const mockFetch = vi.fn(async (url: string, init: RequestInit) => {
+      capturedBodies.push(init.body as string);
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            candidates: [
+              { content: { parts: [{ text: "Summary result" }] } },
+            ],
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+          }),
+      };
+    });
+
+    const { completeGoogleDocument } = await import("../src/llm/providers/google.js");
+
+    await completeGoogleDocument({
+      modelId: "gemini-2.5-flash",
+      apiKey: "test-key",
+      promptText: "Summarize this document",
+      document: {
+        kind: "document",
+        mediaType: "application/pdf",
+        bytes: new Uint8Array([1, 2, 3]),
+        filename: "test.pdf",
+      },
+      maxOutputTokens: 2048,
+      temperature: 0,
+      timeoutMs: 30000,
+      fetchImpl: mockFetch as typeof fetch,
+    });
+
+    expect(capturedBodies.length).toBe(1);
+    const payload = JSON.parse(capturedBodies[0]);
+
+    // temperature and maxOutputTokens MUST be inside generationConfig, not at the top level
+    expect(payload).not.toHaveProperty("temperature");
+    expect(payload).not.toHaveProperty("maxOutputTokens");
+    expect(payload).toHaveProperty("generationConfig");
+    expect(payload.generationConfig).toEqual({
+      temperature: 0,
+      maxOutputTokens: 2048,
+    });
+  });
+
+  it("omits generationConfig when neither temperature nor maxOutputTokens is set", async () => {
+    const capturedBodies: string[] = [];
+    const mockFetch = vi.fn(async (url: string, init: RequestInit) => {
+      capturedBodies.push(init.body as string);
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            candidates: [
+              { content: { parts: [{ text: "Summary result" }] } },
+            ],
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+          }),
+      };
+    });
+
+    const { completeGoogleDocument } = await import("../src/llm/providers/google.js");
+
+    await completeGoogleDocument({
+      modelId: "gemini-2.5-flash",
+      apiKey: "test-key",
+      promptText: "Summarize this document",
+      document: {
+        kind: "document",
+        mediaType: "application/pdf",
+        bytes: new Uint8Array([1, 2, 3]),
+        filename: "test.pdf",
+      },
+      timeoutMs: 30000,
+      fetchImpl: mockFetch as typeof fetch,
+    });
+
+    expect(capturedBodies.length).toBe(1);
+    const payload = JSON.parse(capturedBodies[0]);
+
+    // No generationConfig should be present when neither param is provided
+    expect(payload).not.toHaveProperty("generationConfig");
+    expect(payload).not.toHaveProperty("temperature");
+    expect(payload).not.toHaveProperty("maxOutputTokens");
+  });
+
+  it("nests only temperature inside generationConfig when maxOutputTokens is omitted", async () => {
+    const capturedBodies: string[] = [];
+    const mockFetch = vi.fn(async (url: string, init: RequestInit) => {
+      capturedBodies.push(init.body as string);
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            candidates: [
+              { content: { parts: [{ text: "Summary result" }] } },
+            ],
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+          }),
+      };
+    });
+
+    const { completeGoogleDocument } = await import("../src/llm/providers/google.js");
+
+    await completeGoogleDocument({
+      modelId: "gemini-2.5-flash",
+      apiKey: "test-key",
+      promptText: "Summarize this document",
+      document: {
+        kind: "document",
+        mediaType: "application/pdf",
+        bytes: new Uint8Array([1, 2, 3]),
+        filename: "test.pdf",
+      },
+      temperature: 0.7,
+      timeoutMs: 30000,
+      fetchImpl: mockFetch as typeof fetch,
+    });
+
+    const payload = JSON.parse(capturedBodies[0]);
+    expect(payload).not.toHaveProperty("temperature");
+    expect(payload.generationConfig).toEqual({ temperature: 0.7 });
+  });
+
+  it("includes response body detail in error messages", async () => {
+    const mockFetch = vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      text: async () =>
+        JSON.stringify({
+          error: {
+            message: "Invalid JSON payload received. Unknown name \"temperature\": Cannot find field.",
+            status: "INVALID_ARGUMENT",
+          },
+        }),
+    }));
+
+    const { completeGoogleDocument } = await import("../src/llm/providers/google.js");
+
+    await expect(
+      completeGoogleDocument({
+        modelId: "gemini-2.5-flash",
+        apiKey: "test-key",
+        promptText: "Summarize this document",
+        document: {
+          kind: "document",
+          mediaType: "application/pdf",
+          bytes: new Uint8Array([1, 2, 3]),
+          filename: "test.pdf",
+        },
+        temperature: 0,
+        timeoutMs: 30000,
+        fetchImpl: mockFetch as typeof fetch,
+      }),
+    ).rejects.toThrow(/temperature/);
+  });
+});

--- a/tests/llm.google-document.test.ts
+++ b/tests/llm.google-document.test.ts
@@ -16,9 +16,7 @@ describe("completeGoogleDocument payload", () => {
         status: 200,
         text: async () =>
           JSON.stringify({
-            candidates: [
-              { content: { parts: [{ text: "Summary result" }] } },
-            ],
+            candidates: [{ content: { parts: [{ text: "Summary result" }] } }],
             usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
           }),
       };
@@ -64,9 +62,7 @@ describe("completeGoogleDocument payload", () => {
         status: 200,
         text: async () =>
           JSON.stringify({
-            candidates: [
-              { content: { parts: [{ text: "Summary result" }] } },
-            ],
+            candidates: [{ content: { parts: [{ text: "Summary result" }] } }],
             usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
           }),
       };
@@ -106,9 +102,7 @@ describe("completeGoogleDocument payload", () => {
         status: 200,
         text: async () =>
           JSON.stringify({
-            candidates: [
-              { content: { parts: [{ text: "Summary result" }] } },
-            ],
+            candidates: [{ content: { parts: [{ text: "Summary result" }] } }],
             usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
           }),
       };
@@ -143,7 +137,8 @@ describe("completeGoogleDocument payload", () => {
       text: async () =>
         JSON.stringify({
           error: {
-            message: "Invalid JSON payload received. Unknown name \"temperature\": Cannot find field.",
+            message:
+              'Invalid JSON payload received. Unknown name "temperature": Cannot find field.',
             status: "INVALID_ARGUMENT",
           },
         }),


### PR DESCRIPTION
## Summary
This fixes the Google Gemini document endpoint payload shape and improves error reporting when the API rejects a request.

## What changed
- Move `temperature` and `maxOutputTokens` under `generationConfig` for `completeGoogleDocument` requests.
- Include the API response body detail in thrown error messages so Gemini 400 responses are diagnosable.
- Add `tests/llm.google-document.test.ts` with 4 tests covering payload nesting, omission when unset, partial config handling, and error-detail propagation.

## Why
The Gemini document API expects generation settings inside the `generationConfig` object. Sending `temperature` or `maxOutputTokens` at the top level causes HTTP 400 `INVALID_ARGUMENT` responses.

This also fixes the secondary debugging issue where the thrown error hid the response body detail from the Gemini API, making the root cause harder to identify.

## Validation
- New Google document test file with 4 tests
- All 369 test files passing