### PR TITLE
feat(cli): add `copilot` provider for GitHub Copilot CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- CLI providers: add GitHub Copilot CLI as `--cli copilot` / `--model cli/copilot`, including config, auto fallback, daemon model discovery, and Chrome extension settings (#211, thanks @izecell).
+
 ### Fixes
 
 - Google document summaries: send `temperature` and `maxOutputTokens` inside Gemini `generationConfig` for document requests, and include API error details when Google rejects the payload (#209, thanks @vincent-peng).

--- a/apps/chrome-extension/src/entrypoints/options/index.html
+++ b/apps/chrome-extension/src/entrypoints/options/index.html
@@ -335,13 +335,13 @@
                 <label>
                   <span>Auto CLI order</span>
                   <span class="subtitle"
-                    >Comma-separated providers (claude, gemini, codex, agent, openclaw,
-                    opencode).</span
+                    >Comma-separated providers (claude, gemini, codex, agent, openclaw, opencode,
+                    copilot).</span
                   >
                   <input
                     id="autoCliOrder"
                     type="text"
-                    placeholder="claude,gemini,codex,agent,openclaw,opencode"
+                    placeholder="claude,gemini,codex,agent,openclaw,opencode,copilot"
                   />
                 </label>
                 <div class="combo span-2">

--- a/apps/chrome-extension/src/entrypoints/options/model-presets.ts
+++ b/apps/chrome-extension/src/entrypoints/options/model-presets.ts
@@ -45,6 +45,7 @@ export function createModelPresetsController({
       if (p.cliAgent === true) hints.push("cli/agent");
       if (p.cliOpenclaw === true) hints.push("cli/openclaw");
       if (p.cliOpencode === true) hints.push("cli/opencode");
+      if (p.cliCopilot === true) hints.push("cli/copilot");
     }
     if (discovery.localModelsSource && typeof discovery.localModelsSource === "object") {
       hints.push("local: openai/<id>");

--- a/apps/chrome-extension/src/lib/settings.ts
+++ b/apps/chrome-extension/src/lib/settings.ts
@@ -119,7 +119,8 @@ function normalizeAutoCliOrder(value: unknown): string {
       item !== "codex" &&
       item !== "agent" &&
       item !== "openclaw" &&
-      item !== "opencode"
+      item !== "opencode" &&
+      item !== "copilot"
     ) {
       continue;
     }
@@ -239,7 +240,7 @@ export const defaultSettings: Settings = {
   summaryTimestamps: true,
   extendedLogging: false,
   autoCliFallback: true,
-  autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode",
+  autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot",
   hoverPrompt:
     "Plain text only (no Markdown). Summarize the linked page concisely in 1-2 sentences; aim for 100-200 characters.",
   transcriber: "",

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ summary: "Docs index for summarize behaviors and modes."
 
 - `docs/chrome-extension.md` — Chrome side panel extension + daemon setup/troubleshooting
 - `docs/cache.md` — cache design + config (SQLite)
-- `docs/cli.md` — CLI models (Claude/Codex/Gemini/Agent/OpenClaw/OpenCode)
+- `docs/cli.md` — CLI models (Claude/Codex/Gemini/Agent/OpenClaw/OpenCode/Copilot)
 - `docs/config.md` — config file location, precedence, and schema
 - `docs/extract-only.md` — extract mode (no summary LLM call)
 - `docs/firecrawl.md` — Firecrawl mode + API key

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,14 +1,14 @@
 ---
 title: "CLI providers"
 kicker: "models"
-summary: "CLI model providers and config for Claude, Codex, Gemini, Cursor Agent, OpenClaw, and OpenCode."
+summary: "CLI model providers and config for Claude, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode, and GitHub Copilot."
 read_when:
   - "When changing CLI model integration."
 ---
 
 # CLI models
 
-Summarize can use installed CLIs (Claude, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode) as local model backends.
+Summarize can use installed CLIs (Claude, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode, GitHub Copilot) as local model backends.
 
 ## Model ids
 
@@ -20,6 +20,8 @@ Summarize can use installed CLIs (Claude, Codex, Gemini, Cursor Agent, OpenClaw,
 - `openclaw/<model>` (alias for the same OpenClaw CLI path)
 - `cli/opencode/<model>` (e.g. `cli/opencode/openai/gpt-5.4`)
 - `cli/opencode` (use the OpenCode runtime default model)
+- `cli/copilot/<model>` (e.g. `cli/copilot/gpt-5.2`)
+- `cli/copilot` (use the Copilot CLI runtime default model)
 
 Use `--cli [provider]` (case-insensitive) for the provider default, or `--model cli/<provider>/<model>` to pin a model.
 If `--cli` is provided without a provider, auto selection is used with CLI enabled.
@@ -39,7 +41,7 @@ Auto mode can prepend CLI attempts in two ways:
 - Auto CLI fallback (`cli.autoFallback`, default enabled):
   - Applies only to **implicit** auto (when no model is set via flag/env/config).
   - Default behavior: only when no API key is configured.
-  - Default order: `claude, gemini, codex, agent, openclaw, opencode`.
+  - Default order: `claude, gemini, codex, agent, openclaw, opencode, copilot`.
   - Remembers + prioritizes the last successful CLI provider (`~/.summarize/cli-state.json`).
 
 Gemini CLI performance: summarize sets `GEMINI_CLI_NO_RELAUNCH=true` for Gemini CLI runs to avoid a costly self-relaunch (can be overridden by setting it yourself).
@@ -60,7 +62,7 @@ Configure auto CLI fallback:
     "autoFallback": {
       "enabled": true,
       "onlyWhenNoApiKeys": true,
-      "order": ["claude", "gemini", "codex", "agent", "openclaw", "opencode"]
+      "order": ["claude", "gemini", "codex", "agent", "openclaw", "opencode", "copilot"]
     }
   }
 }
@@ -84,6 +86,7 @@ Binary lookup:
 - `AGENT_PATH` (optional override)
 - `OPENCLAW_PATH` (optional override)
 - `OPENCODE_PATH` (optional override)
+- `COPILOT_PATH` (optional override)
 - Otherwise uses `PATH`
 
 ## Attachments (images/files)
@@ -96,17 +99,18 @@ path-based prompt and enables the required tool flags:
 - Codex: `codex exec --output-last-message ...` and `-i <image>` for images
 - Agent: uses built-in file tools in `agent --print` mode (no extra flags)
 - OpenCode: `opencode run --format json ... --file <path>` when a file/image path is required
+- Copilot: `copilot -p <prompt>`; passes `--model <model>` when one is configured
 
 ## Config
 
 ```json
 {
   "cli": {
-    "enabled": ["claude", "gemini", "codex", "agent", "openclaw", "opencode"],
+    "enabled": ["claude", "gemini", "codex", "agent", "openclaw", "opencode", "copilot"],
     "autoFallback": {
       "enabled": true,
       "onlyWhenNoApiKeys": true,
-      "order": ["claude", "gemini", "codex", "agent", "openclaw", "opencode"]
+      "order": ["claude", "gemini", "codex", "agent", "openclaw", "opencode", "copilot"]
     },
     "codex": { "model": "gpt-5.2" },
     "gemini": { "model": "flash", "extraArgs": ["--verbose"] },
@@ -125,6 +129,9 @@ path-based prompt and enables the required tool flags:
     },
     "opencode": {
       "binary": "/usr/local/bin/opencode"
+    },
+    "copilot": {
+      "binary": "/usr/local/bin/copilot"
     }
   }
 }
@@ -138,6 +145,7 @@ Notes:
 - Gemini CLI is invoked in headless mode with `--prompt` for compatibility with current Gemini CLI releases.
 - OpenClaw uses `openclaw agent --agent <model> --message <prompt> --json` because current OpenClaw requires `-m/--message`; very large extracted inputs are rejected before launch to avoid argv limits.
 - OpenCode uses `opencode run --format json`, streams prompt text over stdin, and uses the runtime default model when none is configured.
+- Copilot uses `copilot -p`, treats stdout as plain text, and uses the runtime default model when none is configured.
 
 ## Quick smoke test (all CLI providers)
 
@@ -152,6 +160,7 @@ summarize --cli gemini --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 summarize --cli agent --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 summarize --cli openclaw --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 summarize --cli opencode --plain --timeout 2m /tmp/summarize-cli-smoke.txt
+summarize --cli copilot --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 ```
 
 If Agent fails with auth, run `agent login` (interactive) or set `CURSOR_API_KEY`.

--- a/docs/commands/summarize.md
+++ b/docs/commands/summarize.md
@@ -111,7 +111,7 @@ If `[input]` is omitted, summarize prints concise help and exits.
 : Model id. `auto`, `<config-preset>`, `cli/<provider>/<model>`, `xai/...`, `openai/...`, `nvidia/...`, `google/...`, `anthropic/...`, `zai/...`, `github-copilot/...`, or `openrouter/<author>/<slug>`. Default `auto`. See [LLM overview](../llm.md).
 
 `--cli [provider]`
-: Use a logged-in CLI provider: `claude`, `gemini`, `codex`, `agent`, `openclaw`, `opencode`. Equivalent to `--model cli/<provider>`. Without a value: enable CLI providers in auto-selection.
+: Use a logged-in CLI provider: `claude`, `gemini`, `codex`, `agent`, `openclaw`, `opencode`, `copilot`. Equivalent to `--model cli/<provider>`. Without a value: enable CLI providers in auto-selection.
 
 `--thinking <effort>`
 : OpenAI reasoning effort. `none`, `low`, `medium`, `high`, `xhigh`. Aliases: `off`, `min`, `mid`. Only affects reasoning-capable OpenAI models.

--- a/docs/config.md
+++ b/docs/config.md
@@ -361,17 +361,18 @@ Examples:
 ```json
 {
   "cli": {
-    "enabled": ["gemini", "agent", "openclaw", "opencode"],
+    "enabled": ["gemini", "agent", "openclaw", "opencode", "copilot"],
     "autoFallback": {
       "enabled": true,
       "onlyWhenNoApiKeys": true,
-      "order": ["claude", "gemini", "codex", "agent", "openclaw", "opencode"]
+      "order": ["claude", "gemini", "codex", "agent", "openclaw", "opencode", "copilot"]
     },
     "codex": { "model": "gpt-5.2" },
     "claude": { "binary": "/usr/local/bin/claude", "extraArgs": ["--verbose"] },
     "agent": { "binary": "/usr/local/bin/agent", "model": "gpt-5.2" },
     "openclaw": { "binary": "/usr/local/bin/openclaw", "model": "main" },
-    "opencode": { "binary": "/usr/local/bin/opencode", "model": "openai/gpt-5.4" }
+    "opencode": { "binary": "/usr/local/bin/opencode", "model": "openai/gpt-5.4" },
+    "copilot": { "binary": "/usr/local/bin/copilot", "model": "gpt-5.2" }
   }
 }
 ```
@@ -380,7 +381,7 @@ Notes:
 
 - `cli.enabled` is an allowlist (and order) for auto + explicit CLI model ids.
 - `cli.autoFallback` controls implicit-auto CLI fallback when `cli.enabled` is not set.
-- Default auto fallback order: `claude, gemini, codex, agent, openclaw, opencode`.
+- Default auto fallback order: `claude, gemini, codex, agent, openclaw, opencode, copilot`.
 - Auto fallback stores the last successful provider in `~/.summarize/cli-state.json` and prioritizes it on the next run.
 - `cli.<provider>.binary` overrides CLI binary discovery.
 - `cli.<provider>.extraArgs` appends extra CLI args.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ summarize "https://example.com" --json --metrics detailed
 
 - **Real extraction.** Readability for articles, `markitdown` for files, Firecrawl as fallback when sites fight back.
 - **Media-aware.** YouTube and podcast pages prefer published transcripts, then yt-dlp + Whisper, then optional ONNX models (Parakeet/Canary).
-- **Provider-agnostic models.** xAI, OpenAI, Google, Anthropic, NVIDIA, Z.AI, OpenRouter, GitHub Copilot, plus local CLI providers (Claude Code, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode).
+- **Provider-agnostic models.** xAI, OpenAI, Google, Anthropic, NVIDIA, Z.AI, OpenRouter, GitHub Copilot, plus local CLI providers (Claude Code, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode, Copilot CLI).
 - **Shaped output.** Streamed ANSI Markdown for terminals, plain text for pipes, JSON envelope for scripts, ANSI-stripped for `--no-color`.
 - **Slides for video.** `--slides` extracts scene-change keyframes from videos and renders them inline (Kitty / iTerm) or saves them to disk.
 - **Stays local where it matters.** Optional daemon + Chrome Side Panel pair the CLI with the active tab; the daemon is localhost-only and token-protected.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -37,7 +37,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
 - `ANTHROPIC_API_KEY` (required for `anthropic/...` models)
 - `ANTHROPIC_BASE_URL` (optional; override Anthropic API endpoint)
 - `SUMMARIZE_MODEL` (optional; overrides default model selection)
-- `CLAUDE_PATH` / `CODEX_PATH` / `GEMINI_PATH` / `AGENT_PATH` / `OPENCLAW_PATH` / `OPENCODE_PATH` (optional; override CLI binary paths)
+- `CLAUDE_PATH` / `CODEX_PATH` / `GEMINI_PATH` / `AGENT_PATH` / `OPENCLAW_PATH` / `OPENCODE_PATH` / `COPILOT_PATH` (optional; override CLI binary paths)
 
 ## Flags
 
@@ -51,6 +51,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
     - `cli/agent/auto`
     - `cli/openclaw/main`
     - `cli/opencode/openai/gpt-5.4`
+    - `cli/copilot/gpt-5.2`
     - `openai/gpt-5.4`
     - `openai/gpt-5.4-mini`
     - `openai/gpt-5.4-nano`
@@ -65,7 +66,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
     - `anthropic/claude-sonnet-4-5`
     - `openrouter/meta-llama/llama-3.3-70b-instruct:free` (force OpenRouter)
 - `--cli [provider]`
-  - Examples: `--cli claude`, `--cli Gemini`, `--cli codex`, `--cli agent`, `--cli openclaw`, `--cli opencode` (equivalent to `--model cli/<provider>`); `--cli` alone uses auto selection with CLI enabled.
+  - Examples: `--cli claude`, `--cli Gemini`, `--cli codex`, `--cli agent`, `--cli openclaw`, `--cli opencode`, `--cli copilot` (equivalent to `--model cli/<provider>`); `--cli` alone uses auto selection with CLI enabled.
 - `--model auto`
   - See `docs/model-auto.md`
 - `--model <preset>`

--- a/src/config/parse-helpers.ts
+++ b/src/config/parse-helpers.ts
@@ -16,7 +16,8 @@ export function parseCliProvider(value: unknown, path: string): CliProvider {
     trimmed === "gemini" ||
     trimmed === "agent" ||
     trimmed === "openclaw" ||
-    trimmed === "opencode"
+    trimmed === "opencode" ||
+    trimmed === "copilot"
   ) {
     return trimmed as CliProvider;
   }

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -311,6 +311,9 @@ export function parseCliConfig(root: Record<string, unknown>, path: string): Cli
   const opencode = value.opencode
     ? parseCliProviderConfig(value.opencode, path, "opencode")
     : undefined;
+  const copilot = value.copilot
+    ? parseCliProviderConfig(value.copilot, path, "copilot")
+    : undefined;
   if (typeof value.autoFallback !== "undefined" && typeof value.magicAuto !== "undefined") {
     throw new Error(
       `Invalid config file ${path}: use only one of "cli.autoFallback" or legacy "cli.magicAuto".`,
@@ -344,6 +347,7 @@ export function parseCliConfig(root: Record<string, unknown>, path: string): Cli
     agent ||
     openclaw ||
     opencode ||
+    copilot ||
     autoFallback ||
     promptOverride ||
     typeof allowTools === "boolean" ||
@@ -357,6 +361,7 @@ export function parseCliConfig(root: Record<string, unknown>, path: string): Cli
         ...(agent ? { agent } : {}),
         ...(openclaw ? { openclaw } : {}),
         ...(opencode ? { opencode } : {}),
+        ...(copilot ? { copilot } : {}),
         ...(autoFallback ? { autoFallback } : {}),
         ...(promptOverride ? { promptOverride } : {}),
         ...(typeof allowTools === "boolean" ? { allowTools } : {}),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,6 +1,13 @@
 export type AutoRuleKind = "text" | "website" | "youtube" | "image" | "video" | "file";
 export type VideoMode = "auto" | "transcript" | "understand";
-export type CliProvider = "claude" | "codex" | "gemini" | "agent" | "openclaw" | "opencode";
+export type CliProvider =
+  | "claude"
+  | "codex"
+  | "gemini"
+  | "agent"
+  | "openclaw"
+  | "opencode"
+  | "copilot";
 export type OpenAiReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh";
 export type OpenAiTextVerbosity = "low" | "medium" | "high";
 export type ModelRequestOptions = {
@@ -27,6 +34,7 @@ export type CliConfig = {
   agent?: CliProviderConfig;
   openclaw?: CliProviderConfig;
   opencode?: CliProviderConfig;
+  copilot?: CliProviderConfig;
   autoFallback?: CliAutoFallbackConfig;
   magicAuto?: CliAutoFallbackConfig;
   promptOverride?: string;

--- a/src/daemon/agent-model.ts
+++ b/src/daemon/agent-model.ts
@@ -204,6 +204,7 @@ function buildNoAgentModelAvailableError({
           if (attempt.requiredEnv === "CLI_GEMINI") return "gemini";
           if (attempt.requiredEnv === "CLI_AGENT") return "agent";
           if (attempt.requiredEnv === "CLI_OPENCLAW") return "openclaw";
+          if (attempt.requiredEnv === "CLI_COPILOT") return "copilot";
           return "opencode";
         })
         .filter((provider) => !cliAvailability[provider as keyof typeof cliAvailability]),

--- a/src/daemon/env-snapshot.ts
+++ b/src/daemon/env-snapshot.ts
@@ -39,6 +39,7 @@ const ENV_KEYS = [
   "AGENT_PATH",
   "OPENCLAW_PATH",
   "OPENCODE_PATH",
+  "COPILOT_PATH",
   "UVX_PATH",
 ] as const;
 

--- a/src/daemon/models.ts
+++ b/src/daemon/models.ts
@@ -140,6 +140,7 @@ export async function buildModelPickerOptions({
     cliAgent: boolean;
     cliOpenclaw: boolean;
     cliOpencode: boolean;
+    cliCopilot: boolean;
   };
   openaiBaseUrl: string | null;
   localModelsSource: { kind: "openai-compatible"; baseUrlHost: string } | null;
@@ -160,6 +161,7 @@ export async function buildModelPickerOptions({
     cliAgent: false,
     cliOpenclaw: false,
     cliOpencode: false,
+    cliCopilot: false,
   };
   const cliAvailability = resolveCliAvailability({ env: envForRun, config: configForCli });
   providers.cliClaude = Boolean(cliAvailability.claude);
@@ -168,6 +170,7 @@ export async function buildModelPickerOptions({
   providers.cliAgent = Boolean(cliAvailability.agent);
   providers.cliOpenclaw = Boolean(cliAvailability.openclaw);
   providers.cliOpencode = Boolean(cliAvailability.opencode);
+  providers.cliCopilot = Boolean(cliAvailability.copilot);
 
   const options: ModelPickerOption[] = [
     { id: "auto", label: "Auto" },
@@ -192,6 +195,9 @@ export async function buildModelPickerOptions({
   }
   if (providers.cliOpencode) {
     options.push({ id: "cli/opencode", label: "CLI: OpenCode" });
+  }
+  if (providers.cliCopilot) {
+    options.push({ id: "cli/copilot", label: "CLI: GitHub Copilot" });
   }
 
   if (providers.openrouter) {

--- a/src/llm/cli-provider-output.ts
+++ b/src/llm/cli-provider-output.ts
@@ -1,12 +1,17 @@
 import type { CliProvider } from "../config.js";
 import type { LlmTokenUsage } from "./generate-text.js";
 
-export type JsonCliProvider = Exclude<CliProvider, "codex" | "openclaw" | "opencode">;
+export type JsonCliProvider = Exclude<CliProvider, "codex" | "openclaw" | "opencode" | "copilot">;
 
 const JSON_RESULT_FIELDS = ["result", "response", "output", "message", "text"] as const;
 
 export function isJsonCliProvider(provider: CliProvider): provider is JsonCliProvider {
-  return provider !== "codex" && provider !== "openclaw" && provider !== "opencode";
+  return (
+    provider !== "codex" &&
+    provider !== "openclaw" &&
+    provider !== "opencode" &&
+    provider !== "copilot"
+  );
 }
 
 const parseJsonFromOutput = (output: string): unknown | null => {

--- a/src/llm/cli.ts
+++ b/src/llm/cli.ts
@@ -22,6 +22,7 @@ const DEFAULT_BINARIES: Record<CliProvider, string> = {
   agent: "agent",
   openclaw: "openclaw",
   opencode: "opencode",
+  copilot: "copilot",
 };
 
 const OPENCLAW_MAX_MESSAGE_ARG_BYTES = 120 * 1024;
@@ -35,6 +36,7 @@ const PROVIDER_PATH_ENV: Record<CliProvider, string> = {
   agent: "AGENT_PATH",
   openclaw: "OPENCLAW_PATH",
   opencode: "OPENCODE_PATH",
+  copilot: "COPILOT_PATH",
 };
 
 type RunCliModelOptions = {
@@ -69,7 +71,8 @@ function getCliProviderConfig(
   if (provider === "gemini") return config.gemini;
   if (provider === "agent") return config.agent;
   if (provider === "openclaw") return config.openclaw;
-  return config.opencode;
+  if (provider === "opencode") return config.opencode;
+  return config.copilot;
 }
 
 export function isCliDisabled(
@@ -312,6 +315,28 @@ export async function runCliModel({
       return { text: stdoutText, usage, costUsd };
     }
     throw new Error("CLI returned empty output");
+  }
+
+  if (provider === "copilot") {
+    const copilotArgs: string[] = [...providerExtraArgs, "-p", prompt];
+    if (allowTools) {
+      copilotArgs.push("--allow-all-tools");
+    }
+    if (requestedModel) {
+      copilotArgs.push("--model", requestedModel);
+    }
+    const { stdout } = await execCliWithInput({
+      execFileImpl: execFileFn,
+      cmd: binary,
+      args: copilotArgs,
+      input: "",
+      timeoutMs,
+      env: effectiveEnv,
+      cwd,
+    });
+    const text = stdout.trim();
+    if (!text) throw new Error("CLI returned empty output");
+    return { text, usage: null, costUsd: null };
   }
 
   if (!isJsonCliProvider(provider)) {

--- a/src/llm/provider-profile.ts
+++ b/src/llm/provider-profile.ts
@@ -32,7 +32,8 @@ export type RequiredModelEnv =
   | "CLI_GEMINI"
   | "CLI_AGENT"
   | "CLI_OPENCLAW"
-  | "CLI_OPENCODE";
+  | "CLI_OPENCODE"
+  | "CLI_COPILOT";
 
 type GatewayProviderProfile = {
   requiredEnv: RequiredModelEnv;
@@ -93,6 +94,7 @@ export const DEFAULT_CLI_MODELS: Record<CliProvider, string | null> = {
   agent: "auto",
   openclaw: "main",
   opencode: null,
+  copilot: null,
 };
 
 export const DEFAULT_AUTO_CLI_ORDER: CliProvider[] = [
@@ -102,6 +104,7 @@ export const DEFAULT_AUTO_CLI_ORDER: CliProvider[] = [
   "agent",
   "openclaw",
   "opencode",
+  "copilot",
 ];
 
 export function parseCliProviderName(raw: string): CliProvider | null {
@@ -112,6 +115,7 @@ export function parseCliProviderName(raw: string): CliProvider | null {
   if (normalized === "agent") return "agent";
   if (normalized === "openclaw") return "openclaw";
   if (normalized === "opencode") return "opencode";
+  if (normalized === "copilot") return "copilot";
   return null;
 }
 
@@ -126,7 +130,9 @@ export function requiredEnvForCliProvider(provider: CliProvider): RequiredModelE
           ? "CLI_OPENCLAW"
           : provider === "opencode"
             ? "CLI_OPENCODE"
-            : "CLI_CLAUDE";
+            : provider === "copilot"
+              ? "CLI_COPILOT"
+              : "CLI_CLAUDE";
 }
 
 export function getGatewayProviderProfile(provider: GatewayProvider): GatewayProviderProfile {

--- a/src/model-auto-cli.ts
+++ b/src/model-auto-cli.ts
@@ -112,7 +112,9 @@ export function prependCliCandidates({
               ? cli?.openclaw?.model
               : provider === "opencode"
                 ? cli?.opencode?.model
-                : cli?.claude?.model;
+                : provider === "copilot"
+                  ? cli?.copilot?.model
+                  : cli?.claude?.model;
     add(provider, modelOverride);
   }
 

--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -51,7 +51,8 @@ export type FixedModelSpec =
         | "CLI_GEMINI"
         | "CLI_AGENT"
         | "CLI_OPENCLAW"
-        | "CLI_OPENCODE";
+        | "CLI_OPENCODE"
+        | "CLI_COPILOT";
       cliProvider: CliProvider;
       cliModel: string | null;
     };
@@ -167,7 +168,8 @@ export function parseRequestedModelId(raw: string): RequestedModel {
       providerRaw !== "gemini" &&
       providerRaw !== "agent" &&
       providerRaw !== "openclaw" &&
-      providerRaw !== "opencode"
+      providerRaw !== "opencode" &&
+      providerRaw !== "copilot"
     ) {
       throw new Error(`Invalid CLI model id "${trimmed}". Expected cli/<provider>/<model>.`);
     }
@@ -176,7 +178,7 @@ export function parseRequestedModelId(raw: string): RequestedModel {
     const cliModel = requestedModel.length > 0 ? requestedModel : DEFAULT_CLI_MODELS[cliProvider];
     const requiredEnv = requiredEnvForCliProvider(cliProvider) as Extract<
       RequiredModelEnv,
-      "CLI_CLAUDE" | "CLI_CODEX" | "CLI_GEMINI" | "CLI_AGENT" | "CLI_OPENCLAW" | "CLI_OPENCODE"
+      "CLI_CLAUDE" | "CLI_CODEX" | "CLI_GEMINI" | "CLI_AGENT" | "CLI_OPENCLAW" | "CLI_OPENCODE" | "CLI_COPILOT"
     >;
     const userModelId = cliModel ? `cli/${cliProvider}/${cliModel}` : `cli/${cliProvider}`;
     return {

--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -178,7 +178,13 @@ export function parseRequestedModelId(raw: string): RequestedModel {
     const cliModel = requestedModel.length > 0 ? requestedModel : DEFAULT_CLI_MODELS[cliProvider];
     const requiredEnv = requiredEnvForCliProvider(cliProvider) as Extract<
       RequiredModelEnv,
-      "CLI_CLAUDE" | "CLI_CODEX" | "CLI_GEMINI" | "CLI_AGENT" | "CLI_OPENCLAW" | "CLI_OPENCODE" | "CLI_COPILOT"
+      | "CLI_CLAUDE"
+      | "CLI_CODEX"
+      | "CLI_GEMINI"
+      | "CLI_AGENT"
+      | "CLI_OPENCLAW"
+      | "CLI_OPENCODE"
+      | "CLI_COPILOT"
     >;
     const userModelId = cliModel ? `cli/${cliProvider}/${cliModel}` : `cli/${cliProvider}`;
     return {

--- a/src/run/cli-fallback-state.ts
+++ b/src/run/cli-fallback-state.ts
@@ -17,7 +17,8 @@ function parseCliProvider(value: unknown): CliProvider | null {
     value === "gemini" ||
     value === "agent" ||
     value === "openclaw" ||
-    value === "opencode"
+    value === "opencode" ||
+    value === "copilot"
   ) {
     return value;
   }

--- a/src/run/env.ts
+++ b/src/run/env.ts
@@ -76,7 +76,15 @@ export function resolveCliAvailability({
   config: ConfigForCli;
 }): Partial<Record<CliProvider, boolean>> {
   const cliConfig = config?.cli ?? null;
-  const providers: CliProvider[] = ["claude", "codex", "gemini", "agent", "openclaw", "opencode", "copilot"];
+  const providers: CliProvider[] = [
+    "claude",
+    "codex",
+    "gemini",
+    "agent",
+    "openclaw",
+    "opencode",
+    "copilot",
+  ];
   const availability: Partial<Record<CliProvider, boolean>> = {};
   for (const provider of providers) {
     if (isCliDisabled(provider, cliConfig)) {

--- a/src/run/env.ts
+++ b/src/run/env.ts
@@ -76,7 +76,7 @@ export function resolveCliAvailability({
   config: ConfigForCli;
 }): Partial<Record<CliProvider, boolean>> {
   const cliConfig = config?.cli ?? null;
-  const providers: CliProvider[] = ["claude", "codex", "gemini", "agent", "openclaw", "opencode"];
+  const providers: CliProvider[] = ["claude", "codex", "gemini", "agent", "openclaw", "opencode", "copilot"];
   const availability: Partial<Record<CliProvider, boolean>> = {};
   for (const provider of providers) {
     if (isCliDisabled(provider, cliConfig)) {
@@ -104,7 +104,8 @@ export function parseCliUserModelId(modelId: string): {
     provider !== "gemini" &&
     provider !== "agent" &&
     provider !== "openclaw" &&
-    provider !== "opencode"
+    provider !== "opencode" &&
+    provider !== "copilot"
   ) {
     throw new Error(`Invalid CLI model id "${modelId}". Expected cli/<provider>/<model>.`);
   }
@@ -120,7 +121,8 @@ export function parseCliProviderArg(raw: string): CliProvider {
     normalized === "gemini" ||
     normalized === "agent" ||
     normalized === "openclaw" ||
-    normalized === "opencode"
+    normalized === "opencode" ||
+    normalized === "copilot"
   ) {
     return normalized as CliProvider;
   }

--- a/src/run/help.ts
+++ b/src/run/help.ts
@@ -141,7 +141,7 @@ export function buildProgram() {
     .addOption(
       new Option(
         "--cli [provider]",
-        "Use a CLI provider: claude, gemini, codex, agent, openclaw, opencode (equivalent to --model cli/<provider>). If omitted, use auto selection with CLI enabled.",
+        "Use a CLI provider: claude, gemini, codex, agent, openclaw, opencode, copilot (equivalent to --model cli/<provider>). If omitted, use auto selection with CLI enabled.",
       ),
     )
     .option("--extract", "Print extracted content and exit (no LLM summary)", false)

--- a/src/run/help.ts
+++ b/src/run/help.ts
@@ -294,6 +294,7 @@ ${heading("Env Vars")}
   AGENT_PATH            optional (path to Cursor Agent CLI binary)
   OPENCLAW_PATH         optional (path to OpenClaw CLI binary)
   OPENCODE_PATH         optional (path to OpenCode CLI binary)
+  COPILOT_PATH          optional (path to GitHub Copilot CLI binary)
   SUMMARIZE_MODEL       optional (overrides default model selection)
   SUMMARIZE_THEME       optional (${CLI_THEME_NAMES.join(", ")})
   SUMMARIZE_TRUECOLOR   optional (force 24-bit color)

--- a/src/run/run-config.ts
+++ b/src/run/run-config.ts
@@ -61,7 +61,7 @@ export function resolveConfigState({
   const cliEnabledOverride: CliProvider[] | null = (() => {
     if (!cliFlagPresent || cliProviderArg) return null;
     if (Array.isArray(config?.cli?.enabled)) return config.cli.enabled;
-    return ["claude", "gemini", "codex", "agent", "openclaw", "opencode"];
+    return ["claude", "gemini", "codex", "agent", "openclaw", "opencode", "copilot"];
   })();
   const cliConfigForRun = cliEnabledOverride
     ? { ...(config?.cli ?? {}), enabled: cliEnabledOverride }

--- a/src/run/run-models.ts
+++ b/src/run/run-models.ts
@@ -9,18 +9,15 @@ function resolveConfiguredCliModel(
   config: SummarizeConfig | null,
 ): string | null {
   const cli = config?.cli;
-  const raw =
-    provider === "claude"
-      ? cli?.claude?.model
-      : provider === "codex"
-        ? cli?.codex?.model
-        : provider === "gemini"
-          ? cli?.gemini?.model
-          : provider === "agent"
-            ? cli?.agent?.model
-            : provider === "openclaw"
-              ? cli?.openclaw?.model
-              : cli?.opencode?.model;
+  const raw = (() => {
+    if (provider === "claude") return cli?.claude?.model;
+    if (provider === "codex") return cli?.codex?.model;
+    if (provider === "gemini") return cli?.gemini?.model;
+    if (provider === "agent") return cli?.agent?.model;
+    if (provider === "openclaw") return cli?.openclaw?.model;
+    if (provider === "opencode") return cli?.opencode?.model;
+    return cli?.copilot?.model;
+  })();
   return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;
 }
 

--- a/src/run/run-settings-parse.ts
+++ b/src/run/run-settings-parse.ts
@@ -43,6 +43,7 @@ export const parseCliProvider = (raw: string): CliProvider | null => {
   if (normalized === "agent") return "agent";
   if (normalized === "openclaw") return "openclaw";
   if (normalized === "opencode") return "opencode";
+  if (normalized === "copilot") return "copilot";
   return null;
 };
 

--- a/src/run/summary-engine.ts
+++ b/src/run/summary-engine.ts
@@ -147,6 +147,9 @@ export function createSummaryEngine(deps: SummaryEngineDeps) {
     if (requiredEnv === "CLI_OPENCODE") {
       return Boolean(deps.cliAvailability.opencode);
     }
+    if (requiredEnv === "CLI_COPILOT") {
+      return Boolean(deps.cliAvailability.copilot);
+    }
     if (requiredEnv === "GEMINI_API_KEY") {
       return deps.keyFlags.googleConfigured;
     }
@@ -189,6 +192,9 @@ export function createSummaryEngine(deps: SummaryEngineDeps) {
     }
     if (attempt.requiredEnv === "CLI_OPENCODE") {
       return `OpenCode CLI not found for model ${attempt.userModelId}. Install OpenCode CLI or set OPENCODE_PATH.`;
+    }
+    if (attempt.requiredEnv === "CLI_COPILOT") {
+      return `GitHub Copilot CLI not found for model ${attempt.userModelId}. Install Copilot CLI or set COPILOT_PATH.`;
     }
     return `Missing ${attempt.requiredEnv} for model ${attempt.userModelId}. Set the env var or choose a different --model.`;
   };

--- a/src/run/types.ts
+++ b/src/run/types.ts
@@ -16,7 +16,8 @@ export type ModelAttemptRequiredEnv =
   | "CLI_GEMINI"
   | "CLI_AGENT"
   | "CLI_OPENCLAW"
-  | "CLI_OPENCODE";
+  | "CLI_OPENCODE"
+  | "CLI_COPILOT";
 
 export type ModelAttempt = {
   transport: "native" | "openrouter" | "cli";

--- a/tests/chrome.daemon-payload.test.ts
+++ b/tests/chrome.daemon-payload.test.ts
@@ -26,7 +26,7 @@ describe("chrome/daemon-payload", () => {
       length: "xl",
       language: "auto",
       autoCliFallback: true,
-      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode",
+      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot",
       maxCharacters: defaultSettings.maxChars,
     });
   });
@@ -70,7 +70,7 @@ describe("chrome/daemon-payload", () => {
       retries: 2,
       maxOutputTokens: "2k",
       autoCliFallback: true,
-      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode",
+      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot",
       maxCharacters: defaultSettings.maxChars,
     });
   });

--- a/tests/chrome.settings.test.ts
+++ b/tests/chrome.settings.test.ts
@@ -92,15 +92,15 @@ describe("chrome/settings", () => {
     await saveSettings({
       ...defaultSettings,
       autoCliFallback: false,
-      autoCliOrder: " GeMiNi,openclaw,opencode,unknown,CLAUDE,gemini ",
+      autoCliOrder: " GeMiNi,openclaw,opencode,copilot,unknown,CLAUDE,gemini,COPILOT ",
     });
 
     const raw = storage.settings as Record<string, unknown>;
     expect(raw.autoCliFallback).toBe(false);
-    expect(raw.autoCliOrder).toBe("gemini,openclaw,opencode,claude");
+    expect(raw.autoCliOrder).toBe("gemini,openclaw,opencode,copilot,claude");
 
     const loaded = await loadSettings();
     expect(loaded.autoCliFallback).toBe(false);
-    expect(loaded.autoCliOrder).toBe("gemini,openclaw,opencode,claude");
+    expect(loaded.autoCliOrder).toBe("gemini,openclaw,opencode,copilot,claude");
   });
 });

--- a/tests/daemon.config.test.ts
+++ b/tests/daemon.config.test.ts
@@ -146,6 +146,7 @@ describe("daemon config", () => {
         env: buildEnvSnapshotFromEnv({
           OPENAI_API_KEY: " k ",
           OPENAI_WHISPER_BASE_URL: " http://127.0.0.1:8080/v1 ",
+          COPILOT_PATH: " /opt/copilot ",
           PATH: "",
           SUMMARIZE_TRANSCRIBER: " parakeet ",
           SUMMARIZE_ONNX_PARAKEET_CMD: " run-parakeet {input} ",
@@ -166,6 +167,7 @@ describe("daemon config", () => {
     expect(parsed.env).toEqual({
       OPENAI_API_KEY: "k",
       OPENAI_WHISPER_BASE_URL: "http://127.0.0.1:8080/v1",
+      COPILOT_PATH: "/opt/copilot",
       SUMMARIZE_TRANSCRIBER: "parakeet",
       SUMMARIZE_ONNX_PARAKEET_CMD: "run-parakeet {input}",
       SUMMARIZE_ONNX_CANARY_CMD: "run-canary {input}",

--- a/tests/daemon.models.test.ts
+++ b/tests/daemon.models.test.ts
@@ -51,10 +51,13 @@ describe("daemon /v1/models", () => {
     const binDir = mkdtempSync(path.join(tmpdir(), "summarize-cli-bin-"));
     const claudePath = path.join(binDir, "claude");
     const opencodePath = path.join(binDir, "opencode");
+    const copilotPath = path.join(binDir, "copilot");
     writeFileSync(claudePath, "#!/bin/sh\nexit 0\n", "utf8");
     writeFileSync(opencodePath, "#!/bin/sh\nexit 0\n", "utf8");
+    writeFileSync(copilotPath, "#!/bin/sh\nexit 0\n", "utf8");
     chmodSync(claudePath, 0o755);
     chmodSync(opencodePath, 0o755);
+    chmodSync(copilotPath, 0o755);
 
     const result = await buildModelPickerOptions({
       env: {},
@@ -66,8 +69,10 @@ describe("daemon /v1/models", () => {
     expect(result.ok).toBe(true);
     expect(result.providers.cliClaude).toBe(true);
     expect(result.providers.cliOpencode).toBe(true);
+    expect(result.providers.cliCopilot).toBe(true);
     expect(result.options.some((o) => o.id === "cli/claude")).toBe(true);
     expect(result.options.some((o) => o.id === "cli/opencode")).toBe(true);
+    expect(result.options.some((o) => o.id === "cli/copilot")).toBe(true);
   });
 
   it("includes NVIDIA models when NVIDIA_API_KEY is set", async () => {

--- a/tests/llm.cli.copilot.test.ts
+++ b/tests/llm.cli.copilot.test.ts
@@ -92,9 +92,9 @@ describe("runCliModel - copilot provider", () => {
     expect(resolveCliBinary("copilot", null, { COPILOT_PATH: "/custom/copilot" })).toBe(
       "/custom/copilot",
     );
-    expect(
-      resolveCliBinary("copilot", { copilot: { binary: "/cfg/copilot" } }, {}),
-    ).toBe("/cfg/copilot");
+    expect(resolveCliBinary("copilot", { copilot: { binary: "/cfg/copilot" } }, {})).toBe(
+      "/cfg/copilot",
+    );
     expect(resolveCliBinary("copilot", null, {})).toBe("copilot");
 
     const seen: string[][] = [];

--- a/tests/llm.cli.copilot.test.ts
+++ b/tests/llm.cli.copilot.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { resolveCliBinary, runCliModel } from "../src/llm/cli.js";
+import type { ExecFileFn } from "../src/markitdown.js";
+
+const makeStub = (handler: (args: string[]) => { stdout?: string; stderr?: string }) => {
+  const execFileStub: ExecFileFn = ((_cmd, args, _options, cb) => {
+    const result = handler(args);
+    if (cb) cb(null, result.stdout ?? "", result.stderr ?? "");
+    return {
+      stdin: { write: () => {}, end: () => {} },
+    } as unknown as ReturnType<ExecFileFn>;
+  }) as ExecFileFn;
+  return execFileStub;
+};
+
+describe("runCliModel - copilot provider", () => {
+  it("invokes copilot with -p and --allow-all-tools, returns plain text", async () => {
+    const seen: string[][] = [];
+    let seenCmd = "";
+    const execFileImpl: ExecFileFn = ((cmd, args, _options, cb) => {
+      seenCmd = String(cmd);
+      seen.push(args);
+      cb?.(null, "  Hello from Copilot.  \n", "");
+      return {
+        stdin: { write: () => {}, end: () => {} },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    const result = await runCliModel({
+      provider: "copilot",
+      prompt: "Summarize this.",
+      model: null,
+      allowTools: true,
+      timeoutMs: 1000,
+      env: {},
+      execFileImpl,
+      config: null,
+    });
+
+    expect(result.text).toBe("Hello from Copilot.");
+    expect(result.usage).toBeNull();
+    expect(result.costUsd).toBeNull();
+    expect(seenCmd).toBe("copilot");
+    expect(seen[0]).toContain("-p");
+    expect(seen[0]).toContain("Summarize this.");
+    expect(seen[0]).toContain("--allow-all-tools");
+  });
+
+  it("omits --allow-all-tools when allowTools is false and passes --model", async () => {
+    const seen: string[][] = [];
+    const execFileImpl = makeStub((args) => {
+      seen.push(args);
+      return { stdout: "answer text" };
+    });
+
+    const result = await runCliModel({
+      provider: "copilot",
+      prompt: "Q?",
+      model: "gpt-5.2",
+      allowTools: false,
+      timeoutMs: 1000,
+      env: {},
+      execFileImpl,
+      config: null,
+    });
+
+    expect(result.text).toBe("answer text");
+    expect(seen[0]).toContain("-p");
+    expect(seen[0]).toContain("Q?");
+    expect(seen[0]).not.toContain("--allow-all-tools");
+    expect(seen[0]).toContain("--model");
+    expect(seen[0]).toContain("gpt-5.2");
+  });
+
+  it("throws when copilot returns empty output", async () => {
+    const execFileImpl = makeStub(() => ({ stdout: "  \n" }));
+    await expect(
+      runCliModel({
+        provider: "copilot",
+        prompt: "Q",
+        model: null,
+        allowTools: false,
+        timeoutMs: 1000,
+        env: {},
+        execFileImpl,
+        config: null,
+      }),
+    ).rejects.toThrow(/empty output/);
+  });
+
+  it("respects COPILOT_PATH and config-provided binary/extraArgs", async () => {
+    expect(resolveCliBinary("copilot", null, { COPILOT_PATH: "/custom/copilot" })).toBe(
+      "/custom/copilot",
+    );
+    expect(
+      resolveCliBinary("copilot", { copilot: { binary: "/cfg/copilot" } }, {}),
+    ).toBe("/cfg/copilot");
+    expect(resolveCliBinary("copilot", null, {})).toBe("copilot");
+
+    const seen: string[][] = [];
+    const execFileImpl = makeStub((args) => {
+      seen.push(args);
+      return { stdout: "ok" };
+    });
+    await runCliModel({
+      provider: "copilot",
+      prompt: "Q",
+      model: null,
+      allowTools: false,
+      timeoutMs: 1000,
+      env: {},
+      execFileImpl,
+      config: { copilot: { extraArgs: ["--no-color"] } },
+    });
+    expect(seen[0]?.[0]).toBe("--no-color");
+  });
+});

--- a/tests/llm.provider-capabilities.test.ts
+++ b/tests/llm.provider-capabilities.test.ts
@@ -22,18 +22,22 @@ describe("llm provider capabilities", () => {
       "agent",
       "openclaw",
       "opencode",
+      "copilot",
     ]);
     expect(DEFAULT_CLI_MODELS.gemini).toBe("flash");
     expect(DEFAULT_CLI_MODELS.openclaw).toBe("main");
     expect(DEFAULT_CLI_MODELS.opencode).toBeNull();
+    expect(DEFAULT_CLI_MODELS.copilot).toBeNull();
     expect(parseCliProviderName(" GeMiNi ")).toBe("gemini");
     expect(parseCliProviderName(" openclaw ")).toBe("openclaw");
     expect(parseCliProviderName(" opencode ")).toBe("opencode");
     expect(parseCliProviderName(" OpenCode ")).toBe("opencode");
+    expect(parseCliProviderName(" Copilot ")).toBe("copilot");
     expect(parseCliProviderName("nope")).toBeNull();
     expect(requiredEnvForCliProvider("agent")).toBe("CLI_AGENT");
     expect(requiredEnvForCliProvider("openclaw")).toBe("CLI_OPENCLAW");
     expect(requiredEnvForCliProvider("opencode")).toBe("CLI_OPENCODE");
+    expect(requiredEnvForCliProvider("copilot")).toBe("CLI_COPILOT");
   });
 
   it("tracks native provider capabilities centrally", () => {

--- a/tests/run.models.test.ts
+++ b/tests/run.models.test.ts
@@ -87,6 +87,35 @@ describe("run model selection", () => {
     }
   });
 
+  it("resolves provider-default Copilot CLI ids through summarize config", () => {
+    const config = {
+      cli: {
+        opencode: {
+          model: "openai/gpt-5.4",
+        },
+        copilot: {
+          model: "gpt-5.2",
+        },
+      },
+    };
+
+    const result = resolveModelSelection({
+      config,
+      configForCli: config,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: "cli/copilot",
+    });
+
+    expect(result.requestedModel.kind).toBe("fixed");
+    expect(result.requestedModel.userModelId).toBe("cli/copilot/gpt-5.2");
+    expect(result.requestedModelLabel).toBe("cli/copilot/gpt-5.2");
+    if (result.requestedModel.kind === "fixed" && result.requestedModel.transport === "cli") {
+      expect(result.requestedModel.cliProvider).toBe("copilot");
+      expect(result.requestedModel.cliModel).toBe("gpt-5.2");
+    }
+  });
+
   it("keeps bare OpenCode ids when no configured model is available", () => {
     const result = resolveModelSelection({
       config: { cli: { opencode: { model: "   " } } },


### PR DESCRIPTION
Closes #210.

Adds **GitHub Copilot CLI** as a 7th `--cli` provider, available via `--cli copilot` or `--model cli/copilot[/<model>]`.

## What changes

- New `CliProvider` value `"copilot"` wired through every existing enumeration:
  - `src/config/types.ts`, `src/config/parse-helpers.ts`, `src/config/sections.ts`
  - `src/llm/cli.ts` — `DEFAULT_BINARIES.copilot = "copilot"`, `PROVIDER_PATH_ENV.copilot = "COPILOT_PATH"`, `getCliProviderConfig`, plus a new plain-text branch in `runCliModel`
  - `src/llm/cli-provider-output.ts` — excluded from `JsonCliProvider`
  - `src/llm/provider-profile.ts` — `DEFAULT_CLI_MODELS.copilot = null`, `DEFAULT_AUTO_CLI_ORDER`, `parseCliProviderName`, new `CLI_COPILOT` `RequiredModelEnv`, `requiredEnvForCliProvider`
  - `src/model-spec.ts`, `src/model-auto-cli.ts`
  - `src/run/{env,run-config,run-settings-parse,cli-fallback-state,types,summary-engine,help}.ts`
  - `src/daemon/agent-model.ts`
- Invocation: `copilot -p "<prompt>" [--allow-all-tools] [--model <model>]`. stdout is treated as plain text (trim, error if empty), no usage/cost reporting — same model as `codex`'s plain-text fallback.
- Default binary `copilot`, overridable via `COPILOT_PATH` env or `cli.copilot.binary` in config; `cli.copilot.{model,extraArgs}` honored as for the other providers.
- `--help` for `--cli` now lists `copilot` in the choices; no other docs/website changes needed.

Note: `copilot --help` exposes `--banner` (off by default) but no `--no-banner` flag, so the original `--no-banner` mention from the proposal is intentionally omitted — the default already produces clean stdout.

## Tests

- New: `tests/llm.cli.copilot.test.ts` — 4 cases covering invocation args, `allowTools` toggle, `--model` passthrough, empty-output error, `COPILOT_PATH` / `cli.copilot.binary` resolution, and `extraArgs`.
- Updated: `tests/llm.provider-capabilities.test.ts` — adds `copilot` to `DEFAULT_AUTO_CLI_ORDER`, `DEFAULT_CLI_MODELS`, `parseCliProviderName`, and `requiredEnvForCliProvider` expectations.

### Results

- `pnpm test` → **1759 passed, 0 failed, 40 skipped**
- `pnpm typecheck` → clean
- `pnpm build` → produces `./dist/cli.js`
- Live: `./dist/cli.js "https://example.com" --cli copilot --length short` → 1-paragraph summary, ~1m10s, 15 words, label `cli/copilot`.
- Live: `./dist/cli.js <10 min YouTube post-quantum cryptography talk> --cli copilot` → ~24s, ~1.2k word summary, label `cli/copilot`.

## Conventional Commits

Single commit: `feat(cli): add copilot provider for GitHub Copilot CLI`.
