### PR TITLE
[security] fix(daemon): keep daemon config private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Daemon: write `~/.summarize/daemon.json` with owner-only permissions and tighten existing config paths before rewriting daemon tokens or captured provider env values (#214, thanks @Hinotoi-agent).
 - Google document summaries: send `temperature` and `maxOutputTokens` inside Gemini `generationConfig` for document requests, and include API error details when Google rejects the payload (#209, thanks @vincent-peng).
 
 ## 0.14.1 - 2026-04-26

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -158,7 +158,10 @@ export async function writeDaemonConfig({
 }): Promise<string> {
   const configPath = resolveDaemonConfigPath(env);
   const dir = path.dirname(configPath);
-  await fs.mkdir(dir, { recursive: true });
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+  await fs.chmod(dir, 0o700).catch(() => {
+    // Best effort: Windows and some filesystems do not support POSIX modes.
+  });
   const primaryToken = normalizeDaemonToken(config.token);
   const tokens = normalizeDaemonTokens(
     Array.isArray(config.tokens) ? [primaryToken, ...config.tokens] : [primaryToken],
@@ -171,6 +174,12 @@ export async function writeDaemonConfig({
     env: config.env ?? {},
     installedAt: config.installedAt ?? new Date().toISOString(),
   };
-  await fs.writeFile(configPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  await fs.writeFile(configPath, `${JSON.stringify(payload, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await fs.chmod(configPath, 0o600).catch(() => {
+    // Best effort: Windows and some filesystems do not support POSIX modes.
+  });
   return configPath;
 }

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -162,6 +162,9 @@ export async function writeDaemonConfig({
   await fs.chmod(dir, 0o700).catch(() => {
     // Best effort: Windows and some filesystems do not support POSIX modes.
   });
+  await fs.chmod(configPath, 0o600).catch(() => {
+    // Tighten existing files before rewriting secrets; ignore first install.
+  });
   const primaryToken = normalizeDaemonToken(config.token);
   const tokens = normalizeDaemonTokens(
     Array.isArray(config.tokens) ? [primaryToken, ...config.tokens] : [primaryToken],

--- a/tests/daemon.config.test.ts
+++ b/tests/daemon.config.test.ts
@@ -173,4 +173,33 @@ describe("daemon config", () => {
       SUMMARIZE_ONNX_CANARY_CMD: "run-canary {input}",
     });
   });
+
+  it("writes daemon config with private permissions", async () => {
+    if (process.platform === "win32") return;
+
+    const home = mkdtempSync(path.join(tmpdir(), "summarize-daemon-config-"));
+    const env = { HOME: home };
+    const configPath = resolveDaemonConfigPath(env);
+    const configDir = path.dirname(configPath);
+
+    await fs.mkdir(configDir, { recursive: true, mode: 0o755 });
+    await fs.writeFile(configPath, "{}", { encoding: "utf8", mode: 0o644 });
+    await fs.chmod(configDir, 0o755);
+    await fs.chmod(configPath, 0o644);
+
+    const writtenPath = await writeDaemonConfig({
+      env,
+      config: {
+        token: "1234567890abcdef",
+        tokens: ["1234567890abcdef"],
+        port: 8787,
+        env: { OPENAI_API_KEY: "private-key" },
+        installedAt: "2025-12-27T00:00:00.000Z",
+      },
+    });
+
+    expect(writtenPath).toBe(configPath);
+    expect((await fs.stat(configDir)).mode & 0o777).toBe(0o700);
+    expect((await fs.stat(writtenPath)).mode & 0o777).toBe(0o600);
+  });
 });

--- a/tests/daemon.config.test.ts
+++ b/tests/daemon.config.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync } from "node:fs";
 import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   daemonConfigPrimaryToken,
   daemonConfigTokens,
@@ -187,6 +187,13 @@ describe("daemon config", () => {
     await fs.chmod(configDir, 0o755);
     await fs.chmod(configPath, 0o644);
 
+    let modeDuringWrite: number | null = null;
+    const originalWriteFile = fs.writeFile;
+    const writeFileSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+      modeDuringWrite = (await fs.stat(configPath)).mode & 0o777;
+      return await originalWriteFile(...args);
+    });
+
     const writtenPath = await writeDaemonConfig({
       env,
       config: {
@@ -198,7 +205,10 @@ describe("daemon config", () => {
       },
     });
 
+    writeFileSpy.mockRestore();
+
     expect(writtenPath).toBe(configPath);
+    expect(modeDuringWrite).toBe(0o600);
     expect((await fs.stat(configDir)).mode & 0o777).toBe(0o700);
     expect((await fs.stat(writtenPath)).mode & 0o777).toBe(0o600);
   });


### PR DESCRIPTION
## Summary

This PR hardens daemon credential storage by ensuring the generated daemon config directory and config file are private on POSIX filesystems.

The daemon config can contain bearer tokens used by the local daemon and an environment snapshot with provider credentials such as API keys. This change makes the default write path secure-by-default and repairs previously loose permissions when the config is rewritten.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Daemon config file created with default filesystem permissions | Another local account on the same machine could read daemon bearer tokens and persisted provider/API environment values from `~/.summarize/daemon.json` | Medium |

## Before this PR

- `writeDaemonConfig(...)` created `~/.summarize` with default directory permissions.
- `daemon.json` was written with default file creation permissions.
- On common Unix-like defaults, this can create a world-readable file depending on the process umask.
- Existing loose directory/file permissions were not repaired when the config was rewritten.

## After this PR

- `~/.summarize` is created with `0700` permissions.
- `daemon.json` is written with `0600` permissions.
- Existing loose permissions are best-effort repaired with `chmod` after writing.
- POSIX permission behavior is covered by a regression test that verifies `0755` / `0644` paths are tightened to `0700` / `0600`.

## Why this matters

The daemon config is a local credential boundary. It can contain:

- daemon bearer token material used for `/v1/*` daemon authorization
- provider/API-related environment values captured for daemon execution

If this file is readable by another local account, that account can recover secrets that were intended to stay within the owner account. The daemon token may also allow local requests against the victim's daemon while it is running.

## Attack flow

```text
shared Unix-like machine
    -> daemon config created with default permissions
        -> another local user reads ~/.summarize/daemon.json
            -> daemon bearer token and captured API/provider env values are disclosed
```

## Affected code

| Issue | Files |
|-------|-------|
| Private daemon config storage | `src/daemon/config.ts`, `tests/daemon.config.test.ts` |

## Root cause

Daemon config file created with default filesystem permissions:

- The write path used `fs.mkdir(..., { recursive: true })` and `fs.writeFile(..., "utf8")` without explicit private modes.
- The daemon config contains credential material, but the filesystem boundary did not enforce owner-only access.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Local daemon config credential disclosure | 6.1 Medium | `CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N` |

Rationale:

- Exploitation requires local access as another account on the same system.
- No user interaction is required after the victim has written the daemon config.
- Confidentiality impact is high because daemon tokens and provider/API environment values may be exposed.
- Integrity impact is low because a stolen daemon token may allow local daemon requests while the daemon is active.

## Safe reproduction steps

1. On a Unix-like system, create a loose config directory and file:

   ```bash
   mkdir -p ~/.summarize
   chmod 0755 ~/.summarize
   printf '{}\n' > ~/.summarize/daemon.json
   chmod 0644 ~/.summarize/daemon.json
   ```

2. Trigger a daemon config write through the existing config-writing path.
3. On vulnerable code, observe that the config path can remain readable beyond the owning user depending on umask/existing permissions.
4. With this PR, run the regression test and observe that both permissions are tightened.

## Expected vulnerable behavior

- `~/.summarize/daemon.json` could be created or left with non-private permissions.
- Sensitive daemon token and environment snapshot values could be readable by another local user.

## Changes in this PR

- Creates the daemon config directory with `0o700`.
- Best-effort repairs the daemon config directory to `0o700`.
- Writes `daemon.json` with `0o600`.
- Best-effort repairs the daemon config file to `0o600` after writing.
- Adds a POSIX regression test for existing loose directory/file permissions.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Daemon config hardening | `src/daemon/config.ts` | Adds private directory/file modes and best-effort chmod repair after writes |
| Regression tests | `tests/daemon.config.test.ts` | Verifies loose POSIX config permissions are tightened by `writeDaemonConfig(...)` |

## Maintainer impact

- This is a narrow daemon config storage hardening change.
- The config format, token generation, daemon routes, and client behavior are unchanged.
- `chmod` failures are ignored intentionally so Windows and filesystems without POSIX mode support continue to work.
- Existing installations with loose permissions are repaired the next time the daemon config is written.

## Fix rationale

The daemon config stores secrets, so the durable boundary should be the filesystem owner account. Setting private creation modes and repairing existing loose permissions is a small, durable defense that matches how local credential files are typically handled.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm -s format:check src/daemon/config.ts tests/daemon.config.test.ts`
- [x] `pnpm -s lint src/daemon/config.ts tests/daemon.config.test.ts`
- [x] `pnpm exec vitest run tests/daemon.config.test.ts`
- [x] `pnpm -C packages/core -s build`
- [x] `pnpm -s typecheck`
- [x] `pnpm -s test`
- [x] `git diff --check`

Note: local validation ran under Node `v22.22.2`; the repository declares `node >=24`, so pnpm emitted engine warnings, but the commands above completed successfully.

## Disclosure notes

- This PR is intentionally bounded to local daemon config file permissions.
- It does not claim a remote daemon bypass.
- I did not find a `SECURITY.md` file in the checkout.
- No unrelated files are changed.
