### PR TITLE
[security] fix(refresh-free): keep config rewrites private

### DIFF
--- a/src/refresh-free.ts
+++ b/src/refresh-free.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import JSON5 from "json5";
@@ -747,11 +747,14 @@ export async function refreshFree({
     root.model = "free";
   }
 
-  await mkdir(dirname(configPath), { recursive: true });
+  const configDir = dirname(configPath);
+  await mkdir(configDir, { recursive: true, mode: 0o700 });
+  await chmod(configDir, 0o700).catch(() => {});
   const next = `${JSON.stringify(root, null, 2)}\n`;
   const tmp = `${configPath}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmp, next, "utf8");
+  await writeFile(tmp, next, { encoding: "utf8", mode: 0o600 });
   await rename(tmp, configPath);
+  await chmod(configPath, 0o600).catch(() => {});
 
   stdout.write(`Wrote ${configPath} (models.free)\n`);
 

--- a/tests/refresh-free.permissions.test.ts
+++ b/tests/refresh-free.permissions.test.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Writable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { refreshFree } from "../src/refresh-free.js";
+
+const mocks = vi.hoisted(() => ({
+  generateTextWithModelId: vi.fn(async () => ({
+    text: "OK",
+    model: "openrouter/test/free:free",
+    usage: null,
+    raw: null,
+  })),
+}));
+
+vi.mock("../src/llm/generate-text.js", () => ({
+  generateTextWithModelId: mocks.generateTextWithModelId,
+}));
+
+function sink() {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+}
+
+describe("refresh-free config file permissions proof", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("keeps refresh-free config rewrites owner-only", async () => {
+    const oldUmask = process.umask(0o022);
+    try {
+      const home = mkdtempSync(join(tmpdir(), "summarize-refresh-free-perms-"));
+      const configDir = join(home, ".summarize");
+      const configPath = join(configDir, "config.json");
+      mkdirSync(configDir, { recursive: true, mode: 0o700 });
+      writeFileSync(
+        configPath,
+        JSON.stringify({ env: { OPENAI_API_KEY: "sk-secret" }, models: {} }, null, 2),
+        { encoding: "utf8", mode: 0o600 },
+      );
+      expect(statSync(configPath).mode & 0o777).toBe(0o600);
+
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "https://openrouter.ai/api/v1/models") {
+          return new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: "test/free:free",
+                  name: "Test Free 70B",
+                  context_length: 128000,
+                  top_provider: { max_completion_tokens: 4096 },
+                  supported_parameters: ["temperature"],
+                  architecture: { modality: "text->text" },
+                  created: Math.floor(Date.now() / 1000),
+                },
+              ],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }) as unknown as typeof fetch;
+
+      await refreshFree({
+        env: { HOME: home, OPENROUTER_API_KEY: "or-secret" },
+        fetchImpl,
+        stdout: sink(),
+        stderr: sink(),
+        options: { runs: 0, smart: 0, maxCandidates: 1, timeoutMs: 1, minParamB: 0 },
+      });
+
+      expect(statSync(configPath).mode & 0o777).toBe(0o600);
+      expect(statSync(configDir).mode & 0o777).toBe(0o700);
+    } finally {
+      process.umask(oldUmask);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR keeps `summarize refresh-free` config rewrites private when updating `~/.summarize/config.json`.

- `refresh-free` already preserves the existing config object, which can include `env` / legacy `apiKeys` secrets.
- The rewrite path now creates/repairs `~/.summarize` as `0700`, writes the replacement file as `0600`, and repairs the final config file after rename.
- A regression test starts from an owner-only config containing an API key and verifies the refresh path keeps both directory and file permissions private under a typical `022` umask.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| `refresh-free` rewrote `~/.summarize/config.json` with default filesystem permissions | Local disclosure of API keys/provider environment values stored in the config file on shared Unix-like systems | Medium |

## Before this PR

- `refresh-free` read and preserved the existing config root, including sensitive sections such as `env` and legacy `apiKeys`.
- The update path created `~/.summarize` with default directory permissions.
- The temp replacement file was written with default file permissions before being renamed over `config.json`.
- Existing owner-only config permissions could therefore be widened by a routine `refresh-free` update depending on the process umask.

## After this PR

- `~/.summarize` is created with `0700` and best-effort repaired to `0700`.
- The replacement config file is written with `0600`.
- The final `config.json` is best-effort repaired to `0600` after rename.
- Regression coverage verifies an owner-only config remains owner-only after the refresh path runs.

## Why this matters

`~/.summarize/config.json` is a local credential boundary when users store provider/API values in `env` or `apiKeys`. A local account on the same machine should not be able to read those secrets just because a model-refresh command rewrote the config file.

## Attack flow

```text
shared Unix-like machine
    -> victim has API/provider secrets in ~/.summarize/config.json
        -> victim runs summarize refresh-free
            -> config rewrite uses default filesystem permissions
                -> another local account may read the widened config file
```

## Affected code

| Issue | Files |
|-------|-------|
| Config rewrite permissions | `src/refresh-free.ts`, `tests/refresh-free.permissions.test.ts` |

## Root cause

Config rewrite permissions:
- The refresh path used `mkdir(..., { recursive: true })` and `writeFile(tmp, next, "utf8")` without explicit private modes.
- Because the rewrite preserves the full config object, non-model secrets in that same file can be exposed if the replacement file is created with group/world-readable permissions.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Config rewrite permissions | 6.1 Medium | `CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N` |

Rationale:
- The attacker is another local account on the same machine.
- Confidentiality impact is high because the config can contain API keys and provider environment values.
- Integrity impact is low because exposed credentials can enable downstream misuse of those accounts/services depending on what the user stored.

## Safe reproduction steps

1. On a Unix-like system with a typical `022` umask, create a private config with a placeholder secret:

   ```bash
   mkdir -p ~/.summarize
   chmod 0700 ~/.summarize
   printf '{"env":{"OPENAI_API_KEY":"sk-example"},"models":{}}\n' > ~/.summarize/config.json
   chmod 0600 ~/.summarize/config.json
   ```

2. Run the vulnerable `summarize refresh-free` path so it rewrites `~/.summarize/config.json`.
3. Observe that the replacement file can be created with default permissions, widening the config file mode despite the original file being owner-only.
4. With this PR, run the regression test and observe that the directory remains `0700` and `config.json` remains `0600`.

## Expected vulnerable behavior

- A routine refresh command should not widen permissions on a credential-bearing config file.
- Pre-patch, the temp-file-and-rename rewrite path could replace a private config with a default-mode file.

## Changes in this PR

- Creates the config directory with `0o700` in the refresh path.
- Best-effort repairs the config directory to `0o700` before writing.
- Writes the replacement config temp file with `0o600`.
- Best-effort repairs the final `config.json` to `0o600` after rename.
- Adds a POSIX regression test for an existing owner-only config containing an API key.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Config hardening | `src/refresh-free.ts` | Adds private directory/file modes and best-effort chmod repair around the refresh-free config rewrite |
| Regression tests | `tests/refresh-free.permissions.test.ts` | Verifies refresh-free keeps an owner-only credential-bearing config private |

## Maintainer impact

- The patch is scoped to the `refresh-free` config write path.
- It does not change model selection, OpenRouter probing, or unrelated daemon behavior.
- Best-effort chmod calls are ignored on platforms/filesystems where POSIX modes are unsupported, matching the defensive behavior used for local credential files.

## Suggested fix rationale

The config file can carry secrets outside the `models.free` section that `refresh-free` updates. The durable boundary is the owner account, so every rewrite should preserve owner-only access rather than inheriting process defaults.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `pnpm -s format:check src/refresh-free.ts tests/refresh-free.permissions.test.ts`
- [x] `pnpm -s lint src/refresh-free.ts tests/refresh-free.permissions.test.ts`
- [x] `pnpm -s typecheck`
- [x] `pnpm exec vitest run tests/refresh-free.permissions.test.ts tests/cli.refresh-free.test.ts`
- [x] `git diff --check`

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: exact token telemetry unavailable in this local review session.

## Disclosure notes

- Bounded to local filesystem permissions for `~/.summarize/config.json` rewrites.
- No unrelated files were changed.
- I did not find a `SECURITY.md` file in this checkout.
