### PR TITLE
[security] fix(extension): harden hover summary trust boundary

### DIFF
--- a/apps/chrome-extension/src/entrypoints/background/hover-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/background/hover-controller.ts
@@ -47,6 +47,61 @@ async function resolveHoverTabId(sender: chrome.runtime.MessageSender): Promise<
   return active?.id ?? null;
 }
 
+function isPrivateIpv4(hostname: string): boolean {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) return false;
+  const octets = parts.map((part) => Number.parseInt(part, 10));
+  if (octets.some((octet, index) => !/^\d+$/.test(parts[index]) || octet < 0 || octet > 255)) {
+    return false;
+  }
+  const [first, second] = octets;
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 169 && second === 254) ||
+    first === 0
+  );
+}
+
+function isPrivateIpv6Hostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  if (!normalized.startsWith("[") || !normalized.endsWith("]")) return false;
+  const address = normalized.slice(1, -1);
+  return (
+    address === "::1" ||
+    address.startsWith("fe8") ||
+    address.startsWith("fe9") ||
+    address.startsWith("fea") ||
+    address.startsWith("feb") ||
+    address.startsWith("fc") ||
+    address.startsWith("fd") ||
+    address === "::"
+  );
+}
+
+export function isHoverSummarizeUrlAllowed(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    const hostname = url.hostname.toLowerCase();
+    if (!hostname) return false;
+    if (
+      hostname === "localhost" ||
+      hostname.endsWith(".localhost") ||
+      hostname.endsWith(".local")
+    ) {
+      return false;
+    }
+    if (isPrivateIpv4(hostname)) return false;
+    if (isPrivateIpv6Hostname(hostname)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function createHoverController({
   hoverControllersByTabId,
   buildDaemonRequestBody,
@@ -105,6 +160,18 @@ export function createHoverController({
         requestId: msg.requestId,
         url: msg.url,
         message: "Setup required (missing token)",
+      });
+      return;
+    }
+
+    if (!isHoverSummarizeUrlAllowed(msg.url)) {
+      const message = "Hover summaries can only summarize public HTTP(S) URLs";
+      notifyStart({ ok: false, error: message });
+      await sendHover(tabId, {
+        type: "hover:error",
+        requestId: msg.requestId,
+        url: msg.url,
+        message,
       });
       return;
     }

--- a/apps/chrome-extension/src/entrypoints/hover.content.ts
+++ b/apps/chrome-extension/src/entrypoints/hover.content.ts
@@ -114,6 +114,10 @@ type HoverFromBg =
   | { type: "hover:done"; requestId: string; url: string }
   | { type: "hover:error"; requestId: string; url: string; message: string };
 
+export function shouldHandleHoverTriggerEvent(event: Pick<Event, "isTrusted">): boolean {
+  return event.isTrusted === true;
+}
+
 function ensureTooltip(): Tooltip {
   ensureStyle();
   let el = document.getElementById(TOOLTIP_ID) as HTMLDivElement | null;
@@ -394,6 +398,7 @@ export default defineContentScript({
     };
 
     document.addEventListener("mouseover", (event) => {
+      if (!shouldHandleHoverTriggerEvent(event)) return;
       const anchor = getAnchorFromEvent(event);
       if (!anchor) return;
       if (activeAnchor === anchor) {

--- a/tests/hover.security.test.ts
+++ b/tests/hover.security.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isHoverSummarizeUrlAllowed } from "../apps/chrome-extension/src/entrypoints/background/hover-controller.js";
+import { shouldHandleHoverTriggerEvent } from "../apps/chrome-extension/src/entrypoints/hover.content.js";
+
+describe("hover summary security boundaries", () => {
+  it("ignores synthetic hover events from page script", () => {
+    expect(shouldHandleHoverTriggerEvent({ isTrusted: false })).toBe(false);
+  });
+
+  it("accepts browser-trusted hover events", () => {
+    expect(shouldHandleHoverTriggerEvent({ isTrusted: true })).toBe(true);
+  });
+
+  it("rejects hover summaries for localhost and private literal hosts", () => {
+    expect(isHoverSummarizeUrlAllowed("http://127.0.0.1:8080/admin")).toBe(false);
+    expect(isHoverSummarizeUrlAllowed("http://[::1]:8080/admin")).toBe(false);
+    expect(isHoverSummarizeUrlAllowed("http://10.0.0.5/metadata")).toBe(false);
+    expect(isHoverSummarizeUrlAllowed("http://172.16.0.10/internal")).toBe(false);
+    expect(isHoverSummarizeUrlAllowed("http://192.168.1.20/router")).toBe(false);
+    expect(isHoverSummarizeUrlAllowed("http://169.254.169.254/latest/meta-data/")).toBe(false);
+    expect(isHoverSummarizeUrlAllowed("http://localhost:8787/health")).toBe(false);
+  });
+
+  it("allows ordinary public http and https URLs", () => {
+    expect(isHoverSummarizeUrlAllowed("https://example.com/article")).toBe(true);
+    expect(isHoverSummarizeUrlAllowed("http://example.com/article")).toBe(true);
+  });
+
+  it("rejects non-http hover summary URLs", () => {
+    expect(isHoverSummarizeUrlAllowed("file:///etc/passwd")).toBe(false);
+    expect(isHoverSummarizeUrlAllowed("javascript:alert(1)")).toBe(false);
+    expect(isHoverSummarizeUrlAllowed("notaurl")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens the Chrome extension hover-summary trust boundary so page script cannot silently drive authenticated local-daemon summaries through the extension.

- Requires hover-summary triggers to come from browser-trusted mouse events, blocking synthetic `mouseover` events dispatched by page JavaScript.
- Blocks hover-summary requests for localhost, link-local, and private literal hosts before the background worker uses the stored daemon token.
- Adds focused regression coverage for the event-trust gate and URL allowlist.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Synthetic page-driven hover summaries | A malicious page could dispatch hover events over attacker-controlled links and cause the extension background worker to make authenticated daemon requests with the stored token when hover summaries were enabled. Real-world exploitation is difficult because it requires the extension to be installed, configured, hover summaries enabled, and a user interaction with attacker-controlled content. | Low |
| Hover summaries to local/private literal hosts | A malicious page could place local or private-network URLs behind hoverable links and route them through the authenticated daemon summary path. Practical exploitation is constrained by the same opt-in and user-interaction requirements. | Low |

## Before this PR

- The hover content script accepted any `mouseover` event, including synthetic events created by page JavaScript.
- The background hover controller accepted any URL supplied by the content script as long as the stored daemon token was configured.
- There was no focused regression test covering synthetic hover events or private/local hover-summary targets.

## After this PR

- Hover summaries only schedule from browser-trusted hover events (`event.isTrusted === true`).
- Hover-summary URLs are constrained to public HTTP(S) targets; localhost, `.local`, private IPv4, link-local IPv4, loopback IPv6, link-local IPv6, and unique-local IPv6 literal hosts are rejected.
- Focused tests cover both the trusted-event gate and URL allowlist behavior.

## Why this matters

The extension background worker is more privileged than the page: it can read the stored daemon token and call the local daemon API. Hover summaries are intentionally page-facing, but page script should not be able to synthesize the user gesture or choose local/private targets that are then summarized with the user's authenticated daemon context.

## Attack flow

```text
malicious page JavaScript or hoverable link
    -> content script hover-summary listener
        -> extension background worker loads stored daemon token
            -> local daemon summarizes attacker-selected URL
                -> summary text can be rendered back into the page tooltip
```

## Affected code

| Issue | Files |
|-------|-------|
| Synthetic hover event trigger | `apps/chrome-extension/src/entrypoints/hover.content.ts` |
| Local/private hover-summary target | `apps/chrome-extension/src/entrypoints/background/hover-controller.ts` |
| Regression coverage | `tests/hover.security.test.ts` |

## Root cause

Synthetic page-driven hover summaries:
- The page-facing hover listener did not distinguish browser-generated pointer activity from page-created events.
- The content script then forwarded the target URL to the privileged background worker.

Local/private hover-summary targets:
- The background worker treated hover-summary URLs as already safe once received from the content script.
- The extension trust boundary did not independently enforce a public-URL constraint before using the daemon token.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Synthetic page-driven hover summaries | 3.1 Low | `CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N` |
| Local/private hover-summary target | 3.1 Low | `CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N` |

Rationale:
- Exploitation requires the extension to be installed, configured with a daemon token, hover summaries enabled, and the user to interact with attacker-controlled page content.
- Real-world replication is difficult because hover summaries are experimental/default-off and the attacker does not get direct daemon-token disclosure or code execution.
- The primary bounded impact is limited confidentiality exposure through attacker-selected content summarized by the authenticated local daemon path.

## Safe reproduction steps

### 1. Synthetic hover trigger

1. Enable hover summaries and configure the daemon token in the extension.
2. Open a test page containing an attacker-controlled link.
3. From page JavaScript, dispatch a synthetic `mouseover` event on that link.
4. Before this PR, the content script schedules a hover summary for the synthetic event.
5. After this PR, `event.isTrusted === false` causes the event to be ignored.

### 2. Local/private hover target

1. Enable hover summaries and configure the daemon token in the extension.
2. Open a test page containing a hoverable link to `http://127.0.0.1:8787/health` or `http://169.254.169.254/latest/meta-data/`.
3. Before this PR, the background hover controller can accept the URL and attempt an authenticated local-daemon summary request.
4. After this PR, the background controller rejects the URL before starting the daemon summary request.

## Expected vulnerable behavior

- Page script should not be able to synthesize the hover gesture that causes the extension to use the stored daemon token.
- Hover summaries should not be a page-controlled path to local, link-local, or private literal hosts.

## Changes in this PR

- Adds `shouldHandleHoverTriggerEvent()` and requires trusted browser events before scheduling hover summaries.
- Adds `isHoverSummarizeUrlAllowed()` for background-side URL validation.
- Rejects non-HTTP(S), localhost, `.localhost`, `.local`, private IPv4, link-local IPv4, loopback IPv6, link-local IPv6, and unique-local IPv6 literal targets.
- Adds regression tests for synthetic-event rejection, trusted-event acceptance, public URL allowance, non-HTTP(S) rejection, and private/local literal host rejection.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Content-script trust gate | `apps/chrome-extension/src/entrypoints/hover.content.ts` | Ignores untrusted/synthetic hover events. |
| Background URL boundary | `apps/chrome-extension/src/entrypoints/background/hover-controller.ts` | Rejects local/private hover-summary targets before daemon calls. |
| Tests | `tests/hover.security.test.ts` | Adds focused regression coverage for both boundaries. |

## Maintainer impact

- The patch is limited to the experimental hover-summary path.
- Normal hover summaries for public HTTP(S) URLs continue to work.
- Sidepanel, daemon auth middleware, and non-hover summarize flows are unchanged.
- Users get a safer default boundary without needing to change configuration.

## Fix rationale

The content script should require a real browser event before treating page activity as a user hover. The background worker should also enforce its own URL boundary because it is the component that holds and applies the daemon token. Keeping both checks makes the fix resilient if future content-script code changes how hover messages are created.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused hover security regression tests passed.
- [x] Existing daemon auth/server regression tests passed.
- [x] Chrome extension production build passed.
- [x] Formatting and lint checks for touched files passed.

Executed with:

- `pnpm exec vitest run tests/hover.security.test.ts`
- `pnpm exec vitest run tests/hover.security.test.ts tests/daemon.auth.test.ts tests/daemon.server.test.ts tests/daemon.windows-container.test.ts`
- `pnpm -C apps/chrome-extension build`
- `pnpm exec oxfmt --check apps/chrome-extension/src/entrypoints/hover.content.ts apps/chrome-extension/src/entrypoints/background/hover-controller.ts tests/hover.security.test.ts`
- `pnpm exec oxlint --type-aware --tsconfig tsconfig.build.json --config .oxlintrc.json apps/chrome-extension/src/entrypoints/hover.content.ts apps/chrome-extension/src/entrypoints/background/hover-controller.ts tests/hover.security.test.ts`

Local note: this machine is running Node `v22.22.2`, while the package declares `node >=24`; the focused tests and extension build still completed successfully.

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: token telemetry was not available for the whole audit/patch session.

## Disclosure notes

- This PR is intentionally bounded to the Chrome extension hover-summary path.
- It does not claim direct daemon-token disclosure or code execution.
- The repository does not currently include a `SECURITY.md` file.
- No unrelated files were changed.
