### PR TITLE
[security] fix(extension): confirm automation tool calls

### DIFF
--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-agent-loop.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-agent-loop.ts
@@ -98,10 +98,6 @@ export async function runChatAgentLoop({
 
     for (const call of toolCalls) {
       if (chatSession.isAbortRequested()) return;
-      if (call.name === "navigate") {
-        const args = call.arguments as { url?: string };
-        markAgentNavigationIntent(args?.url);
-      }
       if (confirmToolCall) {
         const confirmed = await confirmToolCall(call);
         if (!confirmed) {
@@ -124,6 +120,10 @@ export async function runChatAgentLoop({
           scrollToBottom(true);
           continue;
         }
+      }
+      if (call.name === "navigate") {
+        const args = call.arguments as { url?: string };
+        markAgentNavigationIntent(args?.url);
       }
       const result = await executeToolCall(call);
       if (call.name === "navigate" && !result.isError) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-agent-loop.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-agent-loop.ts
@@ -8,6 +8,7 @@ export async function runChatAgentLoop({
   chatController,
   chatSession,
   createStreamingAssistantMessage,
+  confirmToolCall,
   executeToolCall,
   getAutomationToolNames,
   hasDebuggerPermission,
@@ -37,6 +38,7 @@ export async function runChatAgentLoop({
     ) => Promise<{ ok: boolean; assistant?: Message; error?: string }>;
   };
   createStreamingAssistantMessage: () => ChatMessage;
+  confirmToolCall?: (call: ToolCall) => boolean | Promise<boolean>;
   executeToolCall: (call: ToolCall) => Promise<ToolResultMessage>;
   getAutomationToolNames: () => string[];
   hasDebuggerPermission: () => Promise<boolean>;
@@ -99,6 +101,29 @@ export async function runChatAgentLoop({
       if (call.name === "navigate") {
         const args = call.arguments as { url?: string };
         markAgentNavigationIntent(args?.url);
+      }
+      if (confirmToolCall) {
+        const confirmed = await confirmToolCall(call);
+        if (!confirmed) {
+          const toolCallId =
+            (call as { toolCallId?: string; id?: string }).toolCallId ??
+            (call as { id?: string }).id ??
+            `${call.name}-${Date.now()}`;
+          chatController.addMessage(
+            wrapMessage({
+              role: "toolResult",
+              toolCallId,
+              toolName: call.name,
+              content: [
+                { type: "text", text: `Tool call ${call.name} was cancelled by the user.` },
+              ],
+              isError: true,
+              timestamp: Date.now(),
+            }),
+          );
+          scrollToBottom(true);
+          continue;
+        }
       }
       const result = await executeToolCall(call);
       if (call.name === "navigate" && !result.isError) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
@@ -1,4 +1,4 @@
-import type { Message, ToolCall } from "@mariozechner/pi-ai";
+import type { Message, ToolCall, ToolResultMessage } from "@mariozechner/pi-ai";
 import { extractYouTubeVideoId } from "@steipete/summarize-core/content/url";
 import MarkdownIt from "markdown-it";
 import { executeToolCall, getAutomationToolNames } from "../../automation/tools";
@@ -1530,11 +1530,28 @@ function seedPlannedSlidesForRun(run: RunStart) {
   return true;
 }
 
+function describeAutomationToolCall(call: ToolCall): string {
+  const args = call.arguments ? JSON.stringify(call.arguments, null, 2) : "{}";
+  return `${call.name}\n\n${args}`;
+}
+
+async function confirmAutomationToolCall(call: ToolCall): Promise<boolean> {
+  return window.confirm(
+    [
+      "Summarize agent wants to run an automation tool.",
+      "Only approve this if you expected the current task to control the browser or extension automation.",
+      "",
+      describeAutomationToolCall(call),
+    ].join("\n"),
+  );
+}
+
 async function runAgentLoop() {
   await runChatAgentLoop({
     automationEnabled: automationEnabledValue,
     chatController,
     chatSession,
+    confirmToolCall: confirmAutomationToolCall,
     createStreamingAssistantMessage: buildStreamingAssistantMessage,
     executeToolCall: async (call) => (await executeToolCall(call)) as ToolResultMessage,
     getAutomationToolNames,

--- a/tests/sidepanel.chat-agent-loop-security.test.ts
+++ b/tests/sidepanel.chat-agent-loop-security.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import { runChatAgentLoop } from "../apps/chrome-extension/src/entrypoints/sidepanel/chat-agent-loop.js";
+
+function buildHarness({
+  confirmToolCall,
+}: { confirmToolCall?: () => Promise<boolean> | boolean } = {}) {
+  const executeToolCall = vi.fn(async (call) => ({
+    role: "toolResult" as const,
+    toolCallId: call.id,
+    toolName: call.name,
+    content: [{ type: "text" as const, text: "executed" }],
+    isError: false,
+    timestamp: Date.now(),
+  }));
+
+  const chatController = {
+    addMessage: vi.fn(),
+    buildRequestMessages: vi.fn(() => [
+      {
+        role: "user",
+        content: "Summarize this page with attacker-controlled content.",
+        timestamp: Date.now(),
+      },
+    ]),
+    finishStreamingMessage: vi.fn(),
+    removeMessage: vi.fn(),
+    replaceMessage: vi.fn(),
+    updateStreamingMessage: vi.fn(),
+  };
+
+  let calls = 0;
+  const chatSession = {
+    isAbortRequested: () => false,
+    requestAgent: vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          ok: true,
+          assistant: {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call-1",
+                name: "debugger",
+                arguments: { action: "eval", expression: "document.body.innerText" },
+              },
+            ],
+            timestamp: Date.now(),
+          },
+        };
+      }
+      return {
+        ok: true,
+        assistant: { role: "assistant", content: "done", timestamp: Date.now() },
+      };
+    }),
+  };
+
+  return {
+    executeToolCall,
+    chatController,
+    chatSession,
+    args: {
+      automationEnabled: true,
+      summaryMarkdown: "Attacker-controlled page content can be included here.",
+      chatController,
+      chatSession,
+      createStreamingAssistantMessage: () => ({
+        id: "streaming",
+        role: "assistant" as const,
+        content: "",
+        timestamp: Date.now(),
+      }),
+      executeToolCall,
+      getAutomationToolNames: () => ["debugger"],
+      hasDebuggerPermission: async () => true,
+      markAgentNavigationIntent: vi.fn(),
+      markAgentNavigationResult: vi.fn(),
+      scrollToBottom: vi.fn(),
+      wrapMessage: (message: unknown) => ({ id: "wrapped", ...(message as object) }),
+      confirmToolCall,
+    },
+  };
+}
+
+describe("chat agent automation tool confirmation", () => {
+  it("does not execute a dangerous tool call when confirmation is denied", async () => {
+    const confirmToolCall = vi.fn(async () => false);
+    const harness = buildHarness({ confirmToolCall });
+
+    await runChatAgentLoop(harness.args as never);
+
+    expect(confirmToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "debugger",
+        arguments: { action: "eval", expression: "document.body.innerText" },
+      }),
+    );
+    expect(harness.executeToolCall).not.toHaveBeenCalled();
+    expect(harness.chatController.addMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "toolResult",
+        toolName: "debugger",
+        isError: true,
+      }),
+    );
+  });
+});

--- a/tests/sidepanel.chat-agent-loop-security.test.ts
+++ b/tests/sidepanel.chat-agent-loop-security.test.ts
@@ -3,7 +3,21 @@ import { runChatAgentLoop } from "../apps/chrome-extension/src/entrypoints/sidep
 
 function buildHarness({
   confirmToolCall,
-}: { confirmToolCall?: () => Promise<boolean> | boolean } = {}) {
+  toolCall = {
+    type: "toolCall",
+    id: "call-1",
+    name: "debugger",
+    arguments: { action: "eval", expression: "document.body.innerText" },
+  },
+}: {
+  confirmToolCall?: () => Promise<boolean> | boolean;
+  toolCall?: {
+    type: "toolCall";
+    id: string;
+    name: string;
+    arguments: Record<string, unknown>;
+  };
+} = {}) {
   const executeToolCall = vi.fn(async (call) => ({
     role: "toolResult" as const,
     toolCallId: call.id,
@@ -38,14 +52,7 @@ function buildHarness({
           ok: true,
           assistant: {
             role: "assistant",
-            content: [
-              {
-                type: "toolCall",
-                id: "call-1",
-                name: "debugger",
-                arguments: { action: "eval", expression: "document.body.innerText" },
-              },
-            ],
+            content: [toolCall],
             timestamp: Date.now(),
           },
         };
@@ -73,7 +80,7 @@ function buildHarness({
         timestamp: Date.now(),
       }),
       executeToolCall,
-      getAutomationToolNames: () => ["debugger"],
+      getAutomationToolNames: () => [toolCall.name],
       hasDebuggerPermission: async () => true,
       markAgentNavigationIntent: vi.fn(),
       markAgentNavigationResult: vi.fn(),
@@ -105,5 +112,24 @@ describe("chat agent automation tool confirmation", () => {
         isError: true,
       }),
     );
+  });
+
+  it("does not mark navigation intent before a denied navigate call", async () => {
+    const confirmToolCall = vi.fn(async () => false);
+    const harness = buildHarness({
+      confirmToolCall,
+      toolCall: {
+        type: "toolCall",
+        id: "call-1",
+        name: "navigate",
+        arguments: { url: "https://example.com/phishing" },
+      },
+    });
+
+    await runChatAgentLoop(harness.args as never);
+
+    expect(harness.args.markAgentNavigationIntent).not.toHaveBeenCalled();
+    expect(harness.args.markAgentNavigationResult).not.toHaveBeenCalled();
+    expect(harness.executeToolCall).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

This PR hardens the Chrome extension sidepanel agent boundary before model-requested automation tools are executed.

- Adds an explicit user confirmation step for every automation tool call emitted by the chat agent loop.
- Returns a tool-result cancellation message when the user denies a tool call, so the agent loop can continue without executing privileged browser automation.
- Adds regression coverage for the denied-confirmation path and verifies existing tool execution behavior still works when confirmation is not wired in.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Model-requested browser automation ran without per-call approval | Attacker-controlled page/summary content could influence the agent into invoking enabled extension automation tools such as navigation or debugger-backed actions without a final user approval step | High |

## Before this PR

- When automation was enabled, the chat agent loop passed available automation tool names into the model request.
- If the model returned a tool call, the sidepanel executed it directly via `executeToolCall(call)`.
- A malicious or prompt-injected page summary could therefore attempt to steer tool execution once the user had automation enabled.
- There was no regression test proving that a denied or unexpected tool call could be blocked before execution.

## After this PR

- `runChatAgentLoop` accepts an optional `confirmToolCall` hook.
- The sidepanel wires that hook to a browser confirmation prompt showing the tool name and arguments before execution.
- If the user denies the prompt, the tool call is not executed and an error tool-result message is appended instead.
- A new security regression test verifies that denied automation tool calls do not reach `executeToolCall`.

## Why this matters

The extension’s chat context can include attacker-controlled web content. Automation tools are more privileged than ordinary summarization because they can control browser/extension behavior. A secure boundary should require a fresh, user-visible approval before turning model output into browser automation, even when the user has enabled the broader automation feature.

## Attack flow

```text
Attacker-controlled page content or summary instructions
    -> sidepanel chat agent context
        -> model emits an automation tool call
            -> pre-patch sidepanel executes the tool call without per-call approval
```

## Affected code

| Issue | Files |
|-------|-------|
| Missing per-call approval for automation tool execution | `apps/chrome-extension/src/entrypoints/sidepanel/chat-agent-loop.ts`, `apps/chrome-extension/src/entrypoints/sidepanel/main.ts` |
| Regression coverage | `tests/sidepanel.chat-agent-loop-security.test.ts` |

## Root cause

Model-requested automation tool execution:
- Direct cause: `runChatAgentLoop` called `executeToolCall(call)` for model-provided tool calls without a confirmation gate.
- Trust-boundary failure: web/content-derived chat context and model output were allowed to cross into privileged extension automation without a final user decision at the point of action.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Unconfirmed model-requested browser automation | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N` |

Rationale:
- The attack requires user interaction with attacker-controlled content and automation-enabled chat, but the resulting tool execution can impact confidentiality and integrity through privileged browser/extension automation.
- Availability impact is not claimed here.

## Safe reproduction steps

1. On the vulnerable code, run the added regression test before the patch:
   ```bash
   pnpm exec vitest run tests/sidepanel.chat-agent-loop-security.test.ts --reporter=verbose
   ```
2. The test fails because `confirmToolCall` is never called and the loop has no denial path:
   ```text
   expected "vi.fn()" to be called with arguments ... Number of calls: 0
   ```
3. Apply this patch.
4. Re-run the same test and observe that the denied tool call is converted into an error tool-result message and `executeToolCall` is not called.

## Expected vulnerable behavior

- Pre-patch, a model-returned automation tool call was executed directly when automation was enabled.
- There was no user-visible per-call prompt and no cancellation path before `executeToolCall`.

## Changes in this PR

- Adds an optional `confirmToolCall` hook to `runChatAgentLoop`.
- Checks the hook before executing each automation tool call.
- Appends a cancellation/error tool result when the user denies the call.
- Wires the Chrome extension sidepanel to `window.confirm(...)` with the tool name and JSON arguments.
- Adds a focused security regression test for denied automation tool execution.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Security boundary | `apps/chrome-extension/src/entrypoints/sidepanel/chat-agent-loop.ts` | Adds optional confirmation before tool execution and a safe denied-call result path |
| Sidepanel UI integration | `apps/chrome-extension/src/entrypoints/sidepanel/main.ts` | Shows a user confirmation prompt with the requested tool and arguments |
| Tests | `tests/sidepanel.chat-agent-loop-security.test.ts` | Covers denial of a dangerous model-requested automation tool call |

## Maintainer impact

- The patch is scoped to sidepanel agent automation and does not change non-automation summarization behavior.
- The core loop hook is optional, preserving existing tests and call sites that do not provide a confirmation callback.
- Operators/users who intentionally use automation can still approve expected tool calls, but unexpected page-influenced calls now stop at a visible prompt.

## Fix rationale

The safest durable boundary is at the last point before a model-requested action becomes privileged browser automation. A broad automation-enabled setting is useful, but it should not be treated as approval for every future tool call influenced by page content. Per-call confirmation keeps the default path reviewable while preserving advanced automation workflows.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Reproduced the missing confirmation path with the new regression test before implementing the fix.
- [x] `pnpm exec vitest run tests/sidepanel.chat-agent-loop-security.test.ts --reporter=verbose`
- [x] `pnpm exec vitest run tests/sidepanel.chat-agent-loop-security.test.ts tests/sidepanel.chat-agent-loop.test.ts --reporter=verbose`
- [x] `pnpm exec oxfmt --check apps/chrome-extension/src/entrypoints/sidepanel/chat-agent-loop.ts apps/chrome-extension/src/entrypoints/sidepanel/main.ts tests/sidepanel.chat-agent-loop-security.test.ts`
- [x] `pnpm exec oxlint --type-aware --tsconfig tsconfig.build.json --config .oxlintrc.json apps/chrome-extension/src/entrypoints/sidepanel/chat-agent-loop.ts apps/chrome-extension/src/entrypoints/sidepanel/main.ts tests/sidepanel.chat-agent-loop-security.test.ts`
- [x] `pnpm -C apps/chrome-extension build`
- [x] `pnpm test -- --runInBand`
- [x] `pnpm typecheck`

Notes:
- Local validation was run on Node v22.22.2, so pnpm printed the repository’s Node engine warning (`>=24`). The commands above still completed successfully.

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: Exact telemetry was not available in this local patching session.

## Disclosure notes

- This PR is bounded to the Chrome extension sidepanel agent automation execution boundary.
- It does not claim a bypass of browser extension permissions or unauthenticated code execution.
- Open PR/issue checks did not find an existing duplicate for this per-call automation confirmation gap. Nearby security PRs exist for other extension trust boundaries, but this patch addresses a distinct execution gate.
- No unrelated files were changed.
