### PR TITLE
[security] fix(daemon): keep slide output under user directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Daemon slides: ignore request-provided slide output directories and keep extracted slide artifacts under `~/.summarize/slides` (#220, thanks @Hinotoi-agent).
 - CLI progress: keep Ctrl+C responsive while spinners are active and forward interrupts to active CLI model backends so child processes are not left running (#216).
 - Codex CLI: isolate normal summary runs with `--ephemeral`, `--ignore-user-config`, `--ignore-rules`, a temporary cwd, and a sanitized temporary `CODEX_HOME` so local Codex context cannot bleed into summaries with little or no extracted content (#215, thanks @anntnzrb).
 - Daemon: write `~/.summarize/daemon.json` with owner-only permissions and tighten existing config paths before rewriting daemon tokens or captured provider env values (#214, thanks @Hinotoi-agent).

--- a/src/daemon/server-summarize-request.ts
+++ b/src/daemon/server-summarize-request.ts
@@ -38,7 +38,11 @@ function resolveRequestSlidesSettings({
   return resolveSlideSettings({
     slides: slidesValue,
     slidesOcr: slidesOcrValue,
-    slidesDir: request.slidesDir ?? ".summarize/slides",
+    // Daemon/API callers may be browser-extension or localhost clients that
+    // only need to request extraction, not select host filesystem paths. Keep
+    // slide artifacts under the per-user Summarize directory so an authenticated
+    // request cannot write/delete slide files in arbitrary writable locations.
+    slidesDir: ".summarize/slides",
     slidesSceneThreshold: request.slidesSceneThreshold,
     slidesSceneThresholdExplicit: typeof request.slidesSceneThreshold !== "undefined",
     slidesMax: request.slidesMax,

--- a/tests/daemon.request-slides-settings.test.ts
+++ b/tests/daemon.request-slides-settings.test.ts
@@ -1,0 +1,68 @@
+import type http from "node:http";
+import { Readable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { parseSummarizeRequest } from "../src/daemon/server-summarize-request.js";
+
+function createJsonRequest(body: unknown): http.IncomingMessage {
+  const req = Readable.from([JSON.stringify(body)]) as http.IncomingMessage;
+  req.headers = {};
+  return req;
+}
+
+function createResponse(): http.ServerResponse {
+  return {
+    writeHead: vi.fn(),
+    end: vi.fn(),
+  } as unknown as http.ServerResponse;
+}
+
+const resolveToolPath = (binary: string) => (binary === "tesseract" ? "/usr/bin/tesseract" : null);
+
+describe("parseSummarizeRequest slides settings", () => {
+  it("keeps daemon-requested slide output under the user Summarize directory", async () => {
+    for (const slidesDir of ["/tmp/attacker-slides", "../../attacker-slides", "nested/slides"]) {
+      const parsed = await parseSummarizeRequest({
+        req: createJsonRequest({
+          url: "https://example.com/video.mp4",
+          mode: "url",
+          slides: true,
+          slidesDir,
+        }),
+        res: createResponse(),
+        cors: {},
+        env: { HOME: "/home/alice" },
+        resolveToolPath,
+      });
+
+      expect(parsed).not.toBeNull();
+      expect(parsed?.slidesSettings?.outputDir).toBe("/home/alice/.summarize/slides");
+    }
+  });
+
+  it("still honors non-path slide options from daemon requests", async () => {
+    const parsed = await parseSummarizeRequest({
+      req: createJsonRequest({
+        url: "https://example.com/video.mp4",
+        mode: "url",
+        slides: true,
+        slidesOcr: true,
+        slidesMax: 3,
+        slidesMinDuration: 4,
+        slidesSceneThreshold: 0.5,
+      }),
+      res: createResponse(),
+      cors: {},
+      env: { HOME: "/home/alice" },
+      resolveToolPath,
+    });
+
+    expect(parsed?.slidesSettings).toMatchObject({
+      enabled: true,
+      ocr: true,
+      outputDir: "/home/alice/.summarize/slides",
+      maxSlides: 3,
+      minDurationSeconds: 4,
+      sceneThreshold: 0.5,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens the daemon/API slide-extraction boundary so authenticated daemon requests cannot choose arbitrary host filesystem output paths for generated slide artifacts.

- Keeps daemon-requested slide output under the per-user `~/.summarize/slides` directory.
- Prevents request-supplied absolute paths or `..` traversal from redirecting slide writes/deletes outside the Summarize-owned area.
- Adds regression coverage for absolute, traversal, and nested request `slidesDir` values while preserving non-path slide options.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Daemon request `slidesDir` path control | Authenticated daemon/API caller could write generated `slide_*.png` and `slides.json` files under an attacker-selected writable directory, and cleanup could delete matching files there on repeat extraction. | High |

## Before this PR

- `/v1/summarize` accepted a request body `slidesDir` value.
- The daemon passed that value into `resolveSlideSettings()` with `cwd` set to the user home directory.
- `path.resolve(home, slidesDir)` preserved absolute paths and allowed `..` traversal.
- Slide extraction then created/wrote files below the resolved output directory and cleaned existing `slide_*.png` / `slides.json` files in the derived slide directory.
- There was no regression test locking daemon/API slide output to a Summarize-owned path.

## After this PR

- Daemon/API requests always use `.summarize/slides` as the slide artifact root.
- Request-supplied `slidesDir` is ignored at the daemon boundary.
- Other slide request options such as OCR, max slides, min duration, and scene threshold still work.
- New tests verify that absolute, traversal, and nested request `slidesDir` values all resolve to `~/.summarize/slides`.

## Why this matters

The daemon is token-protected, but it is still a local host bridge: browser-extension and localhost clients can ask the daemon to run extraction work with the user's filesystem privileges.

A path selector in that API should not decide where host-side generated files are written or where slide cleanup runs. Keeping daemon-created slide artifacts under the Summarize-owned directory avoids turning a summarize request into a host filesystem write/delete primitive.

## Attack flow

```text
Authenticated daemon request with slides=true and slidesDir=/tmp/target
    -> src/daemon/server-summarize-request.ts
        -> resolveSlideSettings({ cwd: HOME, slidesDir: request.slidesDir })
            -> slide extraction writes slide_*.png / slides.json under attacker-selected output root
                -> repeat extraction cleanup can delete matching files in that selected location
```

## Affected code

| Issue | Files |
|-------|-------|
| Request-controlled daemon slide output path | `src/daemon/server-summarize-request.ts`, `src/slides/settings.ts`, `src/slides/extract.ts`, `src/slides/store.ts`, `src/slides/frame-extraction.ts`, `src/slides/extract-finalize.ts` |

## Root cause

Daemon request `slidesDir` path control:
- `resolveRequestSlidesSettings()` treated request JSON as trusted enough to select `slidesDir`.
- `resolveSlideSettings()` intentionally supports CLI-style path resolution, including absolute paths, but the daemon/API boundary did not narrow that behavior for browser/localhost clients.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Daemon request `slidesDir` path control | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H` |

Rationale:
- The route requires a valid daemon bearer token, so this is not unauthenticated RCE.
- With that token, the issue is low-complexity and does not require user interaction at the daemon API layer.
- Impact is primarily integrity/availability: generated files can be written under attacker-selected writable paths and cleanup can remove matching slide artifact names there.

## Safe reproduction steps

1. Start a vulnerable daemon with a valid token.
2. Send an authenticated `/v1/summarize` request with slides enabled and an absolute or traversal `slidesDir` value, for example:

```bash
curl -sS http://127.0.0.1:8787/v1/summarize \
  -H "Authorization: Bearer $TOKEN" \
  -H "content-type: application/json" \
  --data '{
    "url": "https://example.com/video.mp4",
    "mode": "url",
    "slides": true,
    "slidesDir": "/tmp/attacker-selected-slides"
  }'
```

3. On vulnerable code, the daemon resolves the slide output root from the request value.
4. After this PR, daemon parsing keeps the output root under `~/.summarize/slides` regardless of the request `slidesDir` value.

## Expected vulnerable behavior

- A daemon/API request could select a host filesystem output root outside the per-user Summarize area.
- Slide extraction would write generated slide artifacts there.
- Repeat extraction cleanup could remove existing `slide_*.png` and `slides.json` files in the derived slide directory.

## Changes in this PR

- Stops passing request-supplied `slidesDir` into daemon slide settings.
- Documents why daemon/API clients should not select host filesystem paths.
- Adds focused tests for absolute, traversal, and nested request `slidesDir` values.
- Adds coverage that non-path slide settings still work through the daemon request parser.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Daemon hardening | `src/daemon/server-summarize-request.ts` | Uses `.summarize/slides` for daemon/API slide artifact output instead of request-controlled `slidesDir`. |
| Regression tests | `tests/daemon.request-slides-settings.test.ts` | Verifies daemon request path containment and preservation of non-path slide options. |

## Maintainer impact

- CLI behavior is unchanged; CLI/config path handling still goes through the existing slide settings resolver.
- Browser-extension and daemon/API calls no longer support selecting arbitrary slide output directories.
- Generated slide artifacts from daemon requests now consistently live under the user's Summarize directory.
- No unrelated routes or frontend UI paths are changed.

## Suggested fix rationale

The daemon/API boundary should accept work requests, not arbitrary filesystem destinations. Keeping host-generated artifacts under a tool-owned directory is a narrow default that preserves slide extraction while preventing a token-bearing client from redirecting writes or cleanup into unrelated user paths.

The regression tests exercise the parser boundary directly, which is where the API-to-filesystem trust decision is made.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused daemon/slides regression tests.
- [x] Touched-file lint.
- [x] Touched-file formatting check.
- [x] Typecheck.
- [x] Build.
- [x] Diff whitespace check.

Executed with:

```bash
corepack pnpm exec vitest run tests/daemon.request-slides-settings.test.ts tests/slides.settings.test.ts
corepack pnpm exec oxlint --type-aware --tsconfig tsconfig.build.json --config .oxlintrc.json src/daemon/server-summarize-request.ts tests/daemon.request-slides-settings.test.ts
corepack pnpm exec oxfmt --check src/daemon/server-summarize-request.ts tests/daemon.request-slides-settings.test.ts
corepack pnpm exec tsgo -p tsconfig.build.json --noEmit
corepack pnpm -s build
git diff --check
```

Local environment note:
- `pnpm install` and validation emitted the repository's Node engine warning because local Node is `v22.22.2` while the package requests `>=24`. The focused tests, lint, typecheck, and build completed successfully in that environment.

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: exact token totals are not available from the local audit/validation workflow.

## Disclosure notes

- This PR is bounded to daemon/API slide artifact path control.
- It does not claim unauthenticated access; the affected `/v1/summarize` path remains bearer-token protected.
- The repository currently does not publish a GitHub security policy URL.
- No unrelated files are changed.
