### PR TITLE
[security] fix(extension): guard automation artifacts bridge

### DIFF
--- a/apps/chrome-extension/src/automation/native-input-guard.ts
+++ b/apps/chrome-extension/src/automation/native-input-guard.ts
@@ -4,7 +4,13 @@ export type NativeInputArmMessage = {
   enabled: boolean;
 };
 
-export function updateNativeInputArmedTabs(args: {
+export type ArtifactsArmMessage = {
+  type: "automation:artifacts-arm";
+  tabId: number;
+  enabled: boolean;
+};
+
+export function updateArmedTabs(args: {
   armedTabs: Set<number>;
   senderHasTab: boolean;
   tabId?: number;
@@ -17,14 +23,55 @@ export function updateNativeInputArmedTabs(args: {
   return true;
 }
 
+export function updateNativeInputArmedTabs(args: {
+  armedTabs: Set<number>;
+  senderHasTab: boolean;
+  tabId?: number;
+  enabled?: boolean;
+}): boolean {
+  return updateArmedTabs(args);
+}
+
+export function getArmedTabGuardError(args: {
+  armedTabs: Set<number>;
+  senderTabId?: number;
+  feature: string;
+}): string | null {
+  const { armedTabs, senderTabId, feature } = args;
+  if (typeof senderTabId !== "number") return "Missing sender tab";
+  if (!armedTabs.has(senderTabId)) return `${feature} not armed for this tab`;
+  return null;
+}
+
 export function getNativeInputGuardError(args: {
   armedTabs: Set<number>;
   senderTabId?: number;
 }): string | null {
-  const { armedTabs, senderTabId } = args;
-  if (typeof senderTabId !== "number") return "Missing sender tab";
-  if (!armedTabs.has(senderTabId)) return "Native input not armed for this tab";
-  return null;
+  return getArmedTabGuardError({ ...args, feature: "Native input" });
+}
+
+export function getArtifactsGuardError(args: {
+  armedTabs: Set<number>;
+  senderTabId?: number;
+}): string | null {
+  return getArmedTabGuardError({ ...args, feature: "Artifacts bridge" });
+}
+
+export async function withArmedTab<T, TMessage extends { tabId: number; enabled: boolean }>(args: {
+  enabled: boolean;
+  tabId: number;
+  armMessage: (input: { tabId: number; enabled: boolean }) => TMessage;
+  sendMessage: (message: TMessage) => Promise<unknown>;
+  run: () => Promise<T>;
+}): Promise<T> {
+  const { enabled, tabId, armMessage, sendMessage, run } = args;
+  if (!enabled) return run();
+  await sendMessage(armMessage({ tabId, enabled: true }));
+  try {
+    return await run();
+  } finally {
+    await sendMessage(armMessage({ tabId, enabled: false }));
+  }
 }
 
 export async function withNativeInputArmedTab<T>(args: {
@@ -33,12 +80,28 @@ export async function withNativeInputArmedTab<T>(args: {
   sendMessage: (message: NativeInputArmMessage) => Promise<unknown>;
   run: () => Promise<T>;
 }): Promise<T> {
-  const { enabled, tabId, sendMessage, run } = args;
-  if (!enabled) return run();
-  await sendMessage({ type: "automation:native-input-arm", tabId, enabled: true });
-  try {
-    return await run();
-  } finally {
-    void sendMessage({ type: "automation:native-input-arm", tabId, enabled: false });
-  }
+  return withArmedTab({
+    ...args,
+    armMessage: ({ tabId, enabled }) => ({
+      type: "automation:native-input-arm" as const,
+      tabId,
+      enabled,
+    }),
+  });
+}
+
+export async function withArtifactsArmedTab<T>(args: {
+  enabled: boolean;
+  tabId: number;
+  sendMessage: (message: ArtifactsArmMessage) => Promise<unknown>;
+  run: () => Promise<T>;
+}): Promise<T> {
+  return withArmedTab({
+    ...args,
+    armMessage: ({ tabId, enabled }) => ({
+      type: "automation:artifacts-arm" as const,
+      tabId,
+      enabled,
+    }),
+  });
 }

--- a/apps/chrome-extension/src/automation/repl.ts
+++ b/apps/chrome-extension/src/automation/repl.ts
@@ -5,7 +5,7 @@ import {
   parseArtifact,
   upsertArtifact,
 } from "./artifacts-store";
-import { withNativeInputArmedTab } from "./native-input-guard";
+import { withArtifactsArmedTab, withNativeInputArmedTab } from "./native-input-guard";
 import { executeNavigateTool } from "./navigate";
 import { listSkills } from "./skills-store";
 import { buildUserScriptsGuidance, getUserScriptsStatus } from "./userscripts";
@@ -229,17 +229,17 @@ async function runBrowserJs(
 
         const sendArtifactRpc = (action, payload) => {
           return new Promise((resolve, reject) => {
-            const requestId = \`\${Date.now()}-\${Math.random().toString(36).slice(2)}\`
-            const handler = (event) => {
-              if (event.source !== window) return
-              const msg = event.data || {}
-              if (msg?.source !== 'summarize-artifacts' || msg.requestId !== requestId) return
-              window.removeEventListener('message', handler)
-              if (msg.ok) resolve(msg.result)
-              else reject(new Error(msg.error || 'Artifact operation failed'))
-            }
-            window.addEventListener('message', handler)
-            window.postMessage({ source: 'summarize-artifacts', requestId, action, payload }, '*')
+            chrome.runtime.sendMessage(
+              { source: 'summarize-artifacts', type: 'automation:artifacts', action, payload },
+              (response) => {
+                if (chrome.runtime.lastError) {
+                  reject(new Error(chrome.runtime.lastError.message || 'Artifact operation failed'))
+                  return
+                }
+                if (response?.ok) resolve(response.result)
+                else reject(new Error(response?.error || 'Artifact operation failed'))
+              }
+            )
           })
         }
 
@@ -305,7 +305,7 @@ async function runBrowserJs(
   try {
     await userScripts.configureWorld?.({
       worldId: "summarize-browserjs",
-      messaging: false,
+      messaging: true,
       csp: "script-src 'unsafe-eval' 'unsafe-inline'; connect-src 'none'; img-src 'none'; media-src 'none'; frame-src 'none'; font-src 'none'; object-src 'none'; default-src 'none';",
     });
   } catch {
@@ -313,27 +313,33 @@ async function runBrowserJs(
   }
 
   try {
-    return await withNativeInputArmedTab({
-      enabled: nativeInputEnabled,
+    return await withArtifactsArmedTab({
+      enabled: true,
       tabId: tab.id,
       sendMessage: (message) => chrome.runtime.sendMessage(message),
-      run: async () => {
-        const results = await userScripts.execute({
-          target: { tabId: tab.id },
-          world: "USER_SCRIPT",
-          worldId: "summarize-browserjs",
-          injectImmediately: true,
-          js: [{ code: wrapperCode }],
-          ...(executionId ? { executionId } : {}),
-        });
+      run: async () =>
+        withNativeInputArmedTab({
+          enabled: nativeInputEnabled,
+          tabId: tab.id,
+          sendMessage: (message) => chrome.runtime.sendMessage(message),
+          run: async () => {
+            const results = await userScripts.execute({
+              target: { tabId: tab.id },
+              world: "USER_SCRIPT",
+              worldId: "summarize-browserjs",
+              injectImmediately: true,
+              js: [{ code: wrapperCode }],
+              ...(executionId ? { executionId } : {}),
+            });
 
-        if (signal?.aborted) {
-          return { ok: false, error: "Execution aborted" };
-        }
+            if (signal?.aborted) {
+              return { ok: false, error: "Execution aborted" };
+            }
 
-        const result = results?.[0]?.result as BrowserJsResult | undefined;
-        return result ?? { ok: false, error: "No result from browserjs()" };
-      },
+            const result = results?.[0]?.result as BrowserJsResult | undefined;
+            return result ?? { ok: false, error: "No result from browserjs()" };
+          },
+        }),
     });
   } finally {
     if (abortHandler) signal?.removeEventListener("abort", abortHandler);

--- a/apps/chrome-extension/src/entrypoints/automation.content.ts
+++ b/apps/chrome-extension/src/entrypoints/automation.content.ts
@@ -361,47 +361,12 @@ function handleNativeInputBridge() {
   });
 }
 
-// Bridge artifact RPC calls from userScripts (page world) to the extension.
-function handleArtifactsBridge() {
-  window.addEventListener("message", (event) => {
-    if (event.source !== window) return;
-    const data = event.data as {
-      source?: string;
-      requestId?: string;
-      action?: string;
-      payload?: unknown;
-    };
-    if (data?.source !== "summarize-artifacts" || !data.requestId) return;
-    chrome.runtime.sendMessage(
-      {
-        type: "automation:artifacts",
-        requestId: data.requestId,
-        action: data.action,
-        payload: data.payload,
-      },
-      (response: { ok: boolean; result?: unknown; error?: string } | undefined) => {
-        window.postMessage(
-          {
-            source: "summarize-artifacts",
-            requestId: data.requestId,
-            ok: response?.ok ?? false,
-            result: response?.result,
-            error: response?.error,
-          },
-          "*",
-        );
-      },
-    );
-  });
-}
-
 export default defineContentScript({
   matches: ["<all_urls>"],
   excludeMatches: META_SITE_EXCLUDE_MATCHES,
   runAt: "document_idle",
   main() {
     handleNativeInputBridge();
-    handleArtifactsBridge();
 
     chrome.runtime.onMessage.addListener(
       (

--- a/apps/chrome-extension/src/entrypoints/background.ts
+++ b/apps/chrome-extension/src/entrypoints/background.ts
@@ -57,6 +57,7 @@ export default defineBackground(() => {
   // Prevents arbitrary pages from triggering trusted clicks via the
   // postMessage → content-script → runtime bridge.
   const nativeInputArmedTabs = new Set<number>();
+  const artifactsArmedTabs = new Set<number>();
 
   function resolveLogLevel(event: string) {
     const normalized = event.toLowerCase();
@@ -75,7 +76,8 @@ export default defineBackground(() => {
     console.debug("[summarize][extractor]", { event, ...detailPayload });
   };
   const runtimeActionsHandler = createRuntimeActionsHandler({
-    armedTabs: nativeInputArmedTabs,
+    nativeInputArmedTabs,
+    artifactsArmedTabs,
   });
   const hoverController = createHoverController({
     hoverControllersByTabId,
@@ -412,6 +414,7 @@ export default defineBackground(() => {
     onTabRemoved: (tabId) => {
       hoverController.abortHoverForTab(tabId);
       nativeInputArmedTabs.delete(tabId);
+      artifactsArmedTabs.delete(tabId);
     },
   });
 

--- a/apps/chrome-extension/src/entrypoints/background/listeners.ts
+++ b/apps/chrome-extension/src/entrypoints/background/listeners.ts
@@ -55,6 +55,11 @@ export function bindBackgroundListeners<Session extends SessionWithNavAt>(option
     );
   });
 
+  chrome.runtime.onUserScriptMessage?.addListener(
+    (raw, sender, sendResponse): boolean | undefined =>
+      runtimeActionsHandler(raw, sender, sendResponse),
+  );
+
   chrome.storage.onChanged.addListener((changes, areaName) => {
     if (areaName !== "local") return;
     if (!changes.settings) return;

--- a/apps/chrome-extension/src/entrypoints/background/runtime-actions.ts
+++ b/apps/chrome-extension/src/entrypoints/background/runtime-actions.ts
@@ -6,8 +6,9 @@ import {
   upsertArtifact,
 } from "../../automation/artifacts-store";
 import {
+  getArtifactsGuardError,
   getNativeInputGuardError,
-  updateNativeInputArmedTabs,
+  updateArmedTabs,
 } from "../../automation/native-input-guard";
 
 export type NativeInputRequest = {
@@ -33,7 +34,8 @@ export type ArtifactsRequest = {
 type RuntimeMessage =
   | NativeInputRequest
   | ArtifactsRequest
-  | { type: "automation:native-input-arm" };
+  | { type: "automation:native-input-arm"; tabId?: number; enabled?: boolean }
+  | { type: "automation:artifacts-arm"; tabId?: number; enabled?: boolean };
 
 function safeSendResponse(sendResponse: (response?: unknown) => void, value: unknown) {
   try {
@@ -154,7 +156,13 @@ async function dispatchNativeInput(
   }
 }
 
-export function createRuntimeActionsHandler({ armedTabs }: { armedTabs: Set<number> }) {
+export function createRuntimeActionsHandler({
+  nativeInputArmedTabs,
+  artifactsArmedTabs,
+}: {
+  nativeInputArmedTabs: Set<number>;
+  artifactsArmedTabs: Set<number>;
+}) {
   return (
     raw: unknown,
     sender: chrome.runtime.MessageSender,
@@ -165,10 +173,11 @@ export function createRuntimeActionsHandler({ armedTabs }: { armedTabs: Set<numb
     }
 
     const type = (raw as RuntimeMessage).type;
-    if (type === "automation:native-input-arm") {
+    if (type === "automation:native-input-arm" || type === "automation:artifacts-arm") {
       const msg = raw as { tabId?: number; enabled?: boolean };
-      updateNativeInputArmedTabs({
-        armedTabs,
+      updateArmedTabs({
+        armedTabs:
+          type === "automation:native-input-arm" ? nativeInputArmedTabs : artifactsArmedTabs,
         senderHasTab: Boolean(sender.tab),
         tabId: msg.tabId,
         enabled: msg.enabled,
@@ -181,7 +190,7 @@ export function createRuntimeActionsHandler({ armedTabs }: { armedTabs: Set<numb
       void (async () => {
         const tabId = sender.tab?.id;
         const guardError = getNativeInputGuardError({
-          armedTabs,
+          armedTabs: nativeInputArmedTabs,
           senderTabId: tabId,
         });
         if (guardError) {
@@ -202,8 +211,12 @@ export function createRuntimeActionsHandler({ armedTabs }: { armedTabs: Set<numb
     const msg = raw as ArtifactsRequest;
     void (async () => {
       const tabId = sender.tab?.id;
-      if (!tabId) {
-        safeSendResponse(sendResponse, { ok: false, error: "Missing sender tab" });
+      const guardError = getArtifactsGuardError({
+        armedTabs: artifactsArmedTabs,
+        senderTabId: tabId,
+      });
+      if (guardError) {
+        safeSendResponse(sendResponse, { ok: false, error: guardError });
         return;
       }
 

--- a/tests/background-listeners.userscript.test.ts
+++ b/tests/background-listeners.userscript.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { bindBackgroundListeners } from "../apps/chrome-extension/src/entrypoints/background/listeners";
+
+function installChromeListenerStubs() {
+  const onMessage = { addListener: vi.fn() };
+  const onUserScriptMessage = { addListener: vi.fn() };
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime: {
+      onConnect: { addListener: vi.fn() },
+      onMessage,
+      onUserScriptMessage,
+    },
+    storage: { onChanged: { addListener: vi.fn() } },
+    webNavigation: { onHistoryStateUpdated: { addListener: vi.fn() } },
+    tabs: {
+      onActivated: { addListener: vi.fn() },
+      onUpdated: { addListener: vi.fn() },
+      onRemoved: { addListener: vi.fn() },
+    },
+  };
+  return { onMessage, onUserScriptMessage };
+}
+
+describe("background userScripts runtime messages", () => {
+  it("routes userScripts messages through runtime actions", () => {
+    const { onUserScriptMessage } = installChromeListenerStubs();
+    const runtimeActionsHandler = vi.fn(() => true);
+    const hoverRuntimeHandler = vi.fn(() => false);
+
+    bindBackgroundListeners({
+      panelSessionStore: {
+        registerPanelSession: vi.fn(),
+        deletePanelSession: vi.fn(),
+        getPanelSession: vi.fn(() => null),
+        getPanelSessions: vi.fn(() => []),
+        clearCachedExtractsForWindow: vi.fn(async () => undefined),
+        clearTab: vi.fn(),
+      },
+      handlePanelMessage: vi.fn(),
+      onPanelDisconnect: vi.fn(),
+      runtimeActionsHandler,
+      hoverRuntimeHandler,
+      emitState: vi.fn(),
+      summarizeActiveTab: vi.fn(),
+      onTabRemoved: vi.fn(),
+    });
+
+    const listener = onUserScriptMessage.addListener.mock.calls[0]?.[0];
+    expect(listener).toBeTypeOf("function");
+    const sendResponse = vi.fn();
+    const result = listener?.(
+      { type: "automation:artifacts", action: "listArtifacts" },
+      { tab: { id: 123 } },
+      sendResponse,
+    );
+
+    expect(result).toBe(true);
+    expect(runtimeActionsHandler).toHaveBeenCalledWith(
+      { type: "automation:artifacts", action: "listArtifacts" },
+      { tab: { id: 123 } },
+      sendResponse,
+    );
+    expect(hoverRuntimeHandler).not.toHaveBeenCalled();
+  });
+});

--- a/tests/runtime-actions.artifacts-security.test.ts
+++ b/tests/runtime-actions.artifacts-security.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeActionsHandler } from "../apps/chrome-extension/src/entrypoints/background/runtime-actions";
+
+const storage = new Map<string, unknown>();
+const TAB_ID = 777;
+
+function installChromeStorage() {
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    storage: {
+      session: {
+        async get(key: string) {
+          return { [key]: storage.get(key) };
+        },
+        async set(value: Record<string, unknown>) {
+          for (const [key, val] of Object.entries(value)) storage.set(key, val);
+        },
+      },
+    },
+  };
+}
+
+function createHandler() {
+  return createRuntimeActionsHandler({
+    nativeInputArmedTabs: new Set<number>(),
+    artifactsArmedTabs: new Set<number>(),
+  });
+}
+
+function dispatchArtifact(
+  handler: ReturnType<typeof createHandler>,
+  raw: unknown,
+  tabId: number | undefined = TAB_ID,
+): Promise<unknown> {
+  return new Promise((resolve) => {
+    const sender = typeof tabId === "number" ? ({ tab: { id: tabId } } as any) : ({} as any);
+    const ret = handler(raw, sender, resolve);
+    expect(ret).toBe(true);
+  });
+}
+
+describe("runtime artifact bridge guard", () => {
+  beforeEach(() => {
+    storage.clear();
+    installChromeStorage();
+  });
+
+  it("blocks page-origin artifact reads unless the tab is armed by extension code", async () => {
+    storage.set(`automation.artifacts.${TAB_ID}`, {
+      "legit-secret.txt": {
+        fileName: "legit-secret.txt",
+        mimeType: "text/plain",
+        contentBase64: btoa("LEGIT_AUTOMATION_ARTIFACT_SECRET"),
+        size: 32,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    const handler = createHandler();
+
+    const blocked = await dispatchArtifact(handler, {
+      type: "automation:artifacts",
+      requestId: "attacker-read-existing",
+      action: "getArtifact",
+      payload: { fileName: "legit-secret.txt" },
+    });
+
+    expect(blocked).toEqual({ ok: false, error: "Artifacts bridge not armed for this tab" });
+  });
+
+  it("ignores page-origin attempts to arm the artifact bridge", async () => {
+    const handler = createHandler();
+    const armResponse = vi.fn();
+
+    handler(
+      { type: "automation:artifacts-arm", tabId: TAB_ID, enabled: true },
+      { tab: { id: TAB_ID } } as any,
+      armResponse,
+    );
+
+    const blocked = await dispatchArtifact(handler, {
+      type: "automation:artifacts",
+      requestId: "attacker-create",
+      action: "createOrUpdateArtifact",
+      payload: { fileName: "attacker-note.txt", content: "PAGE_CONTROLLED" },
+    });
+
+    expect(armResponse).not.toHaveBeenCalled();
+    expect(blocked).toEqual({ ok: false, error: "Artifacts bridge not armed for this tab" });
+  });
+
+  it("allows artifact operations only while extension code has armed the tab", async () => {
+    const handler = createHandler();
+
+    handler({ type: "automation:artifacts-arm", tabId: TAB_ID, enabled: true }, {} as any, vi.fn());
+    const created = await dispatchArtifact(handler, {
+      type: "automation:artifacts",
+      requestId: "trusted-create",
+      action: "createOrUpdateArtifact",
+      payload: {
+        fileName: "trusted-note.txt",
+        content: "TRUSTED_AUTOMATION_ARTIFACT",
+        mimeType: "text/plain",
+      },
+    });
+    expect(created).toMatchObject({ ok: true });
+
+    handler(
+      { type: "automation:artifacts-arm", tabId: TAB_ID, enabled: false },
+      {} as any,
+      vi.fn(),
+    );
+    const blockedAfterDisarm = await dispatchArtifact(handler, {
+      type: "automation:artifacts",
+      requestId: "late-read",
+      action: "getArtifact",
+      payload: { fileName: "trusted-note.txt" },
+    });
+
+    expect(blockedAfterDisarm).toEqual({
+      ok: false,
+      error: "Artifacts bridge not armed for this tab",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens the Chrome extension automation-artifact boundary so arbitrary page JavaScript can no longer reach artifact storage through the content-script bridge.

- Removes the page-visible `summarize-artifacts` `window.postMessage` bridge from the all-pages automation content script.
- Moves BrowserJS artifact helpers to the `chrome.runtime.onUserScriptMessage` path with `userScripts` messaging enabled, so artifact RPCs come from the extension's user-script channel instead of the page window.
- Requires an extension-origin arm/disarm message before the background worker accepts `automation:artifacts` messages for a tab.
- Adds focused regression tests for unarmed artifact denial, page-origin arm denial, trusted armed operations, and user-script message routing.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Page-visible artifact bridge | A malicious page could use the globally installed content script's `window.postMessage` bridge to list, read, create/overwrite, or delete automation artifacts scoped to its tab. | High |

## Before this PR

- `automation.content.ts` installed on `<all_urls>` and listened for page `message` events with `source: "summarize-artifacts"`.
- The content script forwarded attacker-controlled `action` and `payload` values to the background worker as `automation:artifacts`.
- The background worker accepted artifact operations based on `sender.tab.id` alone.
- Any page script in the tab could list/read/write/delete that tab's automation artifacts without an active trusted BrowserJS run, nonce, or user approval.
- There was no regression coverage proving page-origin artifact bridge traffic is blocked before artifact storage is reached.

## After this PR

- The page-visible artifact `postMessage` bridge is removed from the content script.
- BrowserJS artifact helpers call `chrome.runtime.sendMessage` directly from the configured user-script world.
- The background worker registers `chrome.runtime.onUserScriptMessage` and routes those messages through the runtime action handler.
- Artifact operations require the tab to be explicitly armed by an extension-origin message; arm attempts from senders with `sender.tab` are ignored.
- The shared armed-tab helper now awaits disarm in `finally`, so trusted BrowserJS runs do not return before cleanup is attempted.
- Regression tests cover blocked unarmed reads, ignored page-origin arming, allowed trusted armed operations, post-disarm denial, and user-script runtime routing.

## Why this matters

Automation artifacts are extension-managed state. They can contain data produced or consumed by trusted automation and can influence later agent/user decisions. Exposing those records through a page-visible `postMessage` bridge lets arbitrary web content cross from the page trust boundary into extension storage.

The safest boundary is to avoid putting artifact RPCs on `window` at all. The patch moves artifact access onto the extension/user-script messaging path and keeps it behind a short-lived extension-controlled arm state.

## How this differs from related public PRs

- #218 hardens hover-summary triggers and local/private hover-summary targets.
- #219 adds confirmation before model-requested automation tool calls execute.
- #220 keeps daemon slide output under the Summarize-owned directory.

This PR covers a distinct bridge: page-script access to automation artifacts through the all-pages automation content script. It does not duplicate hover summary, model tool-call approval, or daemon slide-output containment.

## Attack flow

```text
Attacker-controlled page JavaScript
    -> window.postMessage({ source: "summarize-artifacts", action, payload })
        -> all-pages automation content script forwards automation:artifacts
            -> background worker reads/writes/deletes extension artifact storage for the tab
```

## Affected code

| Issue | Files |
|-------|-------|
| Page-visible artifact bridge | `apps/chrome-extension/src/entrypoints/automation.content.ts`, `apps/chrome-extension/src/entrypoints/background/runtime-actions.ts`, `apps/chrome-extension/src/automation/repl.ts` |

## Root cause

Page-visible artifact bridge:
- Direct cause: the all-pages automation content script accepted page `message` events for artifact RPCs and forwarded them to the background worker.
- Boundary failure: artifact operations were treated as tab-scoped runtime messages, but not bound to an active trusted BrowserJS run or an extension-only messaging channel.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Page-visible artifact bridge | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N` |

Rationale:
- Exploitation requires the user to have the extension installed/configured and to interact with attacker-controlled page content.
- Once reached, attacker-controlled page script could read or alter extension-managed automation artifact state for the tab.
- Availability impact is not claimed here.

## Safe reproduction steps

1. On vulnerable code, seed an artifact for a tab in extension session storage.
2. Simulate a page/content-script-origin runtime message with `sender.tab.id` and `type: "automation:artifacts"` / `action: "getArtifact"`.
3. Observe that the vulnerable path returns the artifact contents.
4. Apply this patch.
5. Re-run the regression tests:
   ```bash
   pnpm exec vitest run tests/runtime-actions.artifacts-security.test.ts tests/background-listeners.userscript.test.ts --reporter=verbose
   ```
6. Observe that unarmed artifact reads are denied, page-origin arming is ignored, and trusted extension-armed operations still work during the armed window.

## Expected vulnerable behavior

Pre-patch behavior allowed a page-visible artifact bridge to perform actions such as:

- `listArtifacts`
- `getArtifact`
- `createOrUpdateArtifact`
- `deleteArtifact`

The only effective scope check was the sender tab id supplied by the content-script/runtime message path.

## Changes in this PR

- Removes `handleArtifactsBridge()` from `automation.content.ts`.
- Enables user-script messaging for the `summarize-browserjs` world and sends artifact RPCs through `chrome.runtime.sendMessage` instead of `window.postMessage`.
- Adds `chrome.runtime.onUserScriptMessage` routing to the background listener setup.
- Adds shared armed-tab helpers for native input and artifacts.
- Adds a separate `artifactsArmedTabs` set in the background worker.
- Requires `automation:artifacts` to pass an artifact armed-tab guard before storage operations run.
- Ignores arm/disarm requests that originate from senders with `sender.tab`, preventing page/content-script-origin arming.
- Adds focused security regression tests.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Content-script boundary | `apps/chrome-extension/src/entrypoints/automation.content.ts` | Removed the page-visible artifact `postMessage` bridge. |
| BrowserJS transport | `apps/chrome-extension/src/automation/repl.ts` | Uses user-script runtime messaging for artifact helpers and arms artifacts for trusted BrowserJS execution. |
| Background listener | `apps/chrome-extension/src/entrypoints/background/listeners.ts` | Routes `onUserScriptMessage` to runtime actions. |
| Runtime guard | `apps/chrome-extension/src/entrypoints/background/runtime-actions.ts`, `apps/chrome-extension/src/entrypoints/background.ts`, `apps/chrome-extension/src/automation/native-input-guard.ts` | Adds extension-controlled artifact arming and guard checks before artifact operations. |
| Tests | `tests/runtime-actions.artifacts-security.test.ts`, `tests/background-listeners.userscript.test.ts` | Covers blocked page-origin access, ignored page-origin arming, trusted armed access, disarm behavior, and user-script routing. |

## Maintainer impact

- The patch is scoped to extension automation artifacts and BrowserJS artifact helper transport.
- Ordinary page summarization, hover summaries, daemon summarization, and direct sidepanel artifact tool calls are not changed.
- Existing BrowserJS artifact helper names remain available: `listArtifacts`, `getArtifact`, `createOrUpdateArtifact`, and `deleteArtifact`.
- Artifact access is now limited to the trusted BrowserJS execution window instead of being exposed as a global page-window bridge.

## Fix rationale

Removing the page-visible bridge is safer than trying to distinguish trusted and untrusted callers on `window.postMessage`. Page script can observe and send page messages, so artifact RPCs should not use the page window as the transport.

The extension/user-script messaging path is a narrower boundary: trusted BrowserJS code can still use artifacts, but arbitrary page JavaScript no longer has a direct `postMessage` primitive into extension artifact storage. The armed-tab guard also keeps artifact operations tied to the trusted execution window.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `pnpm exec vitest run tests/runtime-actions.artifacts-security.test.ts tests/background-listeners.userscript.test.ts --reporter=verbose`
- [x] `pnpm exec tsgo -p tsconfig.build.json --pretty false`
- [x] `pnpm exec oxfmt --check apps/chrome-extension/src/entrypoints/background/listeners.ts apps/chrome-extension/src/automation/native-input-guard.ts apps/chrome-extension/src/automation/repl.ts apps/chrome-extension/src/entrypoints/automation.content.ts apps/chrome-extension/src/entrypoints/background/runtime-actions.ts apps/chrome-extension/src/entrypoints/background.ts tests/runtime-actions.artifacts-security.test.ts tests/background-listeners.userscript.test.ts`
- [x] `pnpm exec oxlint --type-aware --tsconfig tsconfig.build.json --config .oxlintrc.json apps/chrome-extension/src/automation/native-input-guard.ts apps/chrome-extension/src/automation/repl.ts apps/chrome-extension/src/entrypoints/automation.content.ts apps/chrome-extension/src/entrypoints/background/listeners.ts apps/chrome-extension/src/entrypoints/background/runtime-actions.ts apps/chrome-extension/src/entrypoints/background.ts tests/runtime-actions.artifacts-security.test.ts tests/background-listeners.userscript.test.ts`
- [x] `pnpm -C apps/chrome-extension build`
- [x] `pnpm typecheck`
- [x] `pnpm test`

Notes:
- Local validation was run on Node v22.22.2, so pnpm printed the repository's Node engine warning (`>=24`). The commands above completed successfully.

## Disclosure notes

- This PR is bounded to the Chrome extension automation-artifact bridge and runtime artifact operations.
- It does not claim a browser permission bypass, unauthenticated daemon access, or remote code execution.
- The patch removes page-window artifact RPC exposure rather than adding a page-visible nonce scheme.
- Open PR/issue checks did not find an existing duplicate for the `summarize-artifacts` bridge. Nearby security PRs address different trust boundaries.
- No unrelated files were changed.

