### PR TITLE
feat(run): add language-aware local routing (RFC — see #224)

### DIFF
--- a/packages/core/src/language.ts
+++ b/packages/core/src/language.ts
@@ -77,9 +77,11 @@ const LANGUAGE_ALIASES: Record<string, { tag: string; label: string }> = {
   zh: { tag: "zh", label: "Chinese" },
   "zh-cn": { tag: "zh-CN", label: "Chinese (Simplified)" },
   "zh-hans": { tag: "zh-Hans", label: "Chinese (Simplified)" },
-  "zh-tw": { tag: "zh-TW", label: "Chinese (Traditional)" },
-  "zh-hant": { tag: "zh-Hant", label: "Chinese (Traditional)" },
+  "zh-tw": { tag: "zh-TW", label: "Traditional Chinese" },
+  "zh-hant": { tag: "zh-Hant", label: "Traditional Chinese" },
   chinese: { tag: "zh", label: "Chinese" },
+  "traditional-chinese": { tag: "zh-TW", label: "Traditional Chinese" },
+  "chinese-traditional": { tag: "zh-TW", label: "Traditional Chinese" },
 
   ja: { tag: "ja", label: "Japanese" },
   japanese: { tag: "ja", label: "Japanese" },
@@ -154,9 +156,27 @@ export function resolveOutputLanguage(raw: string | null | undefined): OutputLan
   }
 }
 
+function isTraditionalChineseLanguage(language: OutputLanguage): boolean {
+  if (language.kind !== "fixed") return false;
+  const normalized = `${language.tag} ${language.label}`
+    .toLowerCase()
+    .replaceAll("_", "-")
+    .replaceAll(NORMALIZE_PATTERN, "-")
+    .replaceAll(/-+/g, "-");
+  return (
+    normalized.includes("zh-tw") ||
+    normalized.includes("zh-hant") ||
+    normalized.includes("traditional-chinese") ||
+    normalized.includes("chinese-traditional")
+  );
+}
+
 export function formatOutputLanguageInstruction(language: OutputLanguage): string {
   if (language.kind === "auto") {
     return "Match the dominant source language. If you can't confidently detect it, use English.";
+  }
+  if (isTraditionalChineseLanguage(language)) {
+    return "Write the answer in Traditional Chinese (zh-Hant) using Traditional Chinese characters. Do not answer in English except for unavoidable source quotes or proper nouns.";
   }
   return `Write the answer in ${language.label}.`;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import {
   parseCliConfig,
   parseEnvConfig,
   parseLoggingConfig,
+  parseLocalModelRoutingConfig,
   parseMediaConfig,
   parseOpenAiConfig,
   parseOutputConfig,
@@ -30,6 +31,7 @@ export type {
   LoggingConfig,
   LoggingFormat,
   LoggingLevel,
+  LocalModelRoutingConfig,
   MediaCacheConfig,
   MediaCacheVerifyMode,
   ModelConfig,
@@ -88,6 +90,7 @@ export function loadSummarizeConfig({ env }: { env: Record<string, string | unde
   const output = parseOutputConfig(parsed, path);
   const ui = parseUiConfig(parsed, path);
   const logging = parseLoggingConfig(parsed, path);
+  const localRouting = parseLocalModelRoutingConfig(parsed, path);
   const openai = parseOpenAiConfig(parsed, path);
 
   const nvidia = parseProviderBaseUrlConfig(
@@ -121,6 +124,7 @@ export function loadSummarizeConfig({ env }: { env: Record<string, string | unde
       ...(google ? { google } : {}),
       ...(xai ? { xai } : {}),
       ...(zai ? { zai } : {}),
+      ...(localRouting ? { localRouting } : {}),
       ...(logging ? { logging } : {}),
       ...(configEnv ? { env: configEnv } : {}),
       ...(apiKeys ? { apiKeys } : {}),

--- a/src/config/local-model-routing-defaults.json
+++ b/src/config/local-model-routing-defaults.json
@@ -1,0 +1,21 @@
+{
+  "buckets": {
+    "english": {
+      "configKey": "englishModel",
+      "defaultModel": "openai/gemma4-31b"
+    },
+    "traditionalChinese": {
+      "configKey": "traditionalChineseModel",
+      "defaultModel": "openai/qwen3.6-27b"
+    },
+    "bilingual": {
+      "configKey": "bilingualModel",
+      "defaultModel": "openai/qwen3.6-27b"
+    },
+    "fallback": {
+      "configKey": "fallbackModel",
+      "defaultModel": "openai/gemma4-31b"
+    }
+  },
+  "retiredModelInputPatterns": ["^openai/qwen3\\.6-[0-9]+b-a3b$"]
+}

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -16,12 +16,28 @@ import type {
   CliProvider,
   CliProviderConfig,
   EnvConfig,
+  LocalModelRoutingConfig,
   LoggingConfig,
   MediaCacheConfig,
   MediaCacheVerifyMode,
   OpenAiConfig,
   VideoMode,
 } from "./types.js";
+
+function parseLocalRoutingModel(raw: unknown, path: string, label: string): string | undefined {
+  if (typeof raw === "undefined") return undefined;
+  if (typeof raw !== "string") {
+    throw new Error(`Invalid config file ${path}: "localRouting.${label}" must be a string.`);
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error(`Invalid config file ${path}: "localRouting.${label}" must not be empty.`);
+  }
+  if (trimmed.toLowerCase() === "auto") {
+    throw new Error(`Invalid config file ${path}: "localRouting.${label}" must not be "auto".`);
+  }
+  return trimmed;
+}
 
 export function parseProviderBaseUrlConfig(
   raw: unknown,
@@ -487,6 +503,50 @@ export function parseLoggingConfig(
         ...(file ? { file } : {}),
         ...(typeof maxMb === "number" ? { maxMb } : {}),
         ...(typeof maxFiles === "number" ? { maxFiles } : {}),
+      }
+    : undefined;
+}
+
+export function parseLocalModelRoutingConfig(
+  root: Record<string, unknown>,
+  path: string,
+): LocalModelRoutingConfig | undefined {
+  const value = root.localRouting;
+  if (typeof value === "undefined") return undefined;
+  if (!isRecord(value)) {
+    throw new Error(`Invalid config file ${path}: "localRouting" must be an object.`);
+  }
+
+  const enabled =
+    typeof value.enabled === "boolean"
+      ? value.enabled
+      : typeof value.enabled === "undefined"
+        ? undefined
+        : (() => {
+            throw new Error(
+              `Invalid config file ${path}: "localRouting.enabled" must be a boolean.`,
+            );
+          })();
+  const englishModel = parseLocalRoutingModel(value.englishModel, path, "englishModel");
+  const traditionalChineseModel = parseLocalRoutingModel(
+    value.traditionalChineseModel,
+    path,
+    "traditionalChineseModel",
+  );
+  const bilingualModel = parseLocalRoutingModel(value.bilingualModel, path, "bilingualModel");
+  const fallbackModel = parseLocalRoutingModel(value.fallbackModel, path, "fallbackModel");
+
+  return typeof enabled === "boolean" ||
+    englishModel ||
+    traditionalChineseModel ||
+    bilingualModel ||
+    fallbackModel
+    ? {
+        ...(typeof enabled === "boolean" ? { enabled } : {}),
+        ...(englishModel ? { englishModel } : {}),
+        ...(traditionalChineseModel ? { traditionalChineseModel } : {}),
+        ...(bilingualModel ? { bilingualModel } : {}),
+        ...(fallbackModel ? { fallbackModel } : {}),
       }
     : undefined;
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -151,6 +151,29 @@ export type ZaiConfig = {
   baseUrl?: string;
 };
 
+export type LocalModelRoutingConfig = {
+  /**
+   * Enable language-aware local model routing when the requested model is auto.
+   */
+  enabled?: boolean;
+  /**
+   * Preferred local model for English output.
+   */
+  englishModel?: string;
+  /**
+   * Preferred local model for Traditional Chinese output.
+   */
+  traditionalChineseModel?: string;
+  /**
+   * Preferred local model for bilingual output.
+   */
+  bilingualModel?: string;
+  /**
+   * Local model used when the language bucket is auto, unknown, or missing.
+   */
+  fallbackModel?: string;
+};
+
 export type AutoRule = {
   /**
    * Input kinds this rule applies to.
@@ -259,6 +282,7 @@ export type SummarizeConfig = {
   google?: GoogleConfig;
   xai?: XaiConfig;
   zai?: ZaiConfig;
+  localRouting?: LocalModelRoutingConfig;
   logging?: LoggingConfig;
   /**
    * Generic environment variable defaults.

--- a/src/run/local-model-routing.ts
+++ b/src/run/local-model-routing.ts
@@ -1,0 +1,202 @@
+import type { LocalModelRoutingConfig, ModelConfig, SummarizeConfig } from "../config.js";
+import localModelRoutingDefaults from "../config/local-model-routing-defaults.json" with { type: "json" };
+import type { OutputLanguage } from "../language.js";
+
+export type LocalModelRoutingBucket = "english" | "traditionalChinese" | "bilingual" | "fallback";
+
+type LocalModelRoutingConfigKey = keyof Required<Omit<LocalModelRoutingConfig, "enabled">>;
+type LocalModelRoutingBucketConfig = Record<
+  LocalModelRoutingBucket,
+  {
+    configKey: LocalModelRoutingConfigKey;
+    defaultModel: string;
+  }
+>;
+type RawLocalModelRoutingBucketConfig = Record<
+  LocalModelRoutingBucket,
+  {
+    configKey: string;
+    defaultModel: string;
+  }
+>;
+type RawLocalModelRoutingDefaults = {
+  buckets: RawLocalModelRoutingBucketConfig;
+  retiredModelInputPatterns?: string[];
+};
+
+const LOCAL_MODEL_ROUTING_BUCKETS = [
+  "english",
+  "traditionalChinese",
+  "bilingual",
+  "fallback",
+] as const satisfies readonly LocalModelRoutingBucket[];
+const LOCAL_MODEL_ROUTING_CONFIG_KEYS = [
+  "englishModel",
+  "traditionalChineseModel",
+  "bilingualModel",
+  "fallbackModel",
+] as const satisfies readonly LocalModelRoutingConfigKey[];
+
+function isLocalModelRoutingConfigKey(value: string): value is LocalModelRoutingConfigKey {
+  return (LOCAL_MODEL_ROUTING_CONFIG_KEYS as readonly string[]).includes(value);
+}
+
+function parseLocalModelRoutingBucketConfig(
+  raw: RawLocalModelRoutingBucketConfig,
+): LocalModelRoutingBucketConfig {
+  const parsed = {} as LocalModelRoutingBucketConfig;
+
+  for (const bucket of LOCAL_MODEL_ROUTING_BUCKETS) {
+    const value = raw[bucket];
+    if (!isLocalModelRoutingConfigKey(value.configKey)) {
+      throw new Error(`Invalid local model routing defaults: ${bucket}.configKey`);
+    }
+    const defaultModel = value.defaultModel.trim();
+    if (!defaultModel) {
+      throw new Error(`Invalid local model routing defaults: ${bucket}.defaultModel`);
+    }
+    parsed[bucket] = {
+      configKey: value.configKey,
+      defaultModel,
+    };
+  }
+
+  return parsed;
+}
+
+const rawLocalModelRoutingDefaults =
+  localModelRoutingDefaults satisfies RawLocalModelRoutingDefaults;
+const LOCAL_MODEL_ROUTING_BUCKET_CONFIG = parseLocalModelRoutingBucketConfig(
+  rawLocalModelRoutingDefaults.buckets,
+);
+const RETIRED_LOCAL_MODEL_ROUTING_INPUT_PATTERNS = (
+  rawLocalModelRoutingDefaults.retiredModelInputPatterns ?? []
+).map((pattern) => new RegExp(pattern, "i"));
+
+export const DEFAULT_LOCAL_MODEL_ROUTING_MODELS = Object.fromEntries(
+  Object.values(LOCAL_MODEL_ROUTING_BUCKET_CONFIG).map(({ configKey, defaultModel }) => [
+    configKey,
+    defaultModel,
+  ]),
+) as Required<Omit<LocalModelRoutingConfig, "enabled">>;
+
+export function getDefaultLocalModelRoutingModel(bucket: LocalModelRoutingBucket): string {
+  return LOCAL_MODEL_ROUTING_BUCKET_CONFIG[bucket].defaultModel;
+}
+
+function normalizeForMatch(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll("_", "-")
+    .replaceAll(/[^a-z0-9\u4e00-\u9fff+-]+/g, "-")
+    .replaceAll(/-+/g, "-")
+    .replaceAll(/^-|-$/g, "");
+}
+
+function isBilingualLanguage(language: OutputLanguage): boolean {
+  if (language.kind !== "fixed") return false;
+  const values = [language.tag, language.label].map(normalizeForMatch);
+  return values.some((value) => {
+    if (value.includes("bilingual")) return true;
+    if (value.includes("\u4e2d\u82f1") || value.includes("\u82f1\u4e2d")) return true;
+    const mentionsEnglish = value.includes("english") || /\ben\b/.test(value);
+    const mentionsChinese =
+      value.includes("chinese") ||
+      value.includes("zh") ||
+      value.includes("\u4e2d\u6587") ||
+      value.includes("\u6f22") ||
+      value.includes("\u7e41\u9ad4");
+    return mentionsEnglish && mentionsChinese;
+  });
+}
+
+function isTraditionalChineseLanguage(language: OutputLanguage): boolean {
+  if (language.kind !== "fixed") return false;
+  const values = [language.tag, language.label].map(normalizeForMatch);
+  return values.some(
+    (value) =>
+      value === "zh-tw" ||
+      value === "zh-hant" ||
+      value.includes("traditional-chinese") ||
+      value.includes("chinese-traditional") ||
+      value.includes("\u7e41\u4e2d") ||
+      value.includes("\u7e41\u9ad4") ||
+      value.includes("\u7e41\u4f53") ||
+      value.includes("\u6b63\u9ad4"),
+  );
+}
+
+function isEnglishLanguage(language: OutputLanguage): boolean {
+  if (language.kind !== "fixed") return false;
+  const tag = normalizeForMatch(language.tag);
+  const label = normalizeForMatch(language.label);
+  return tag === "en" || tag.startsWith("en-") || label === "english";
+}
+
+export function classifyLocalModelRoutingLanguage(
+  language: OutputLanguage,
+): LocalModelRoutingBucket {
+  if (isBilingualLanguage(language)) return "bilingual";
+  if (isTraditionalChineseLanguage(language)) return "traditionalChinese";
+  if (isEnglishLanguage(language)) return "english";
+  return "fallback";
+}
+
+function findNamedModel(config: SummarizeConfig | null, rawModel: string): ModelConfig | null {
+  const requested = rawModel.trim().toLowerCase();
+  if (!requested || requested === "auto") return null;
+  for (const [name, model] of Object.entries(config?.models ?? {})) {
+    if (name.trim().toLowerCase() === requested) return model;
+  }
+  return null;
+}
+
+function normalizeRoutedModelInput(config: SummarizeConfig | null, rawModel: string): string {
+  const trimmed = rawModel.trim();
+  if (findNamedModel(config, trimmed)) return trimmed;
+  return trimmed.includes("/") ? trimmed : `openai/${trimmed}`;
+}
+
+function resolveActiveRoutedModelInput(
+  config: SummarizeConfig | null,
+  rawModel: string | null | undefined,
+): string | null {
+  if (!rawModel) return null;
+  const modelInput = normalizeRoutedModelInput(config, rawModel);
+  return RETIRED_LOCAL_MODEL_ROUTING_INPUT_PATTERNS.some((pattern) => pattern.test(modelInput))
+    ? null
+    : modelInput;
+}
+
+export function resolveLanguageAwareLocalModelInput({
+  config,
+  outputLanguage,
+}: {
+  config: SummarizeConfig | null;
+  outputLanguage: OutputLanguage | null | undefined;
+}): { modelInput: string; bucket: LocalModelRoutingBucket } | null {
+  const routing = config?.localRouting;
+  if (routing?.enabled !== true) return null;
+
+  const bucket = outputLanguage
+    ? classifyLocalModelRoutingLanguage(outputLanguage)
+    : ("fallback" as const);
+  const bucketConfig = LOCAL_MODEL_ROUTING_BUCKET_CONFIG[bucket];
+  const configured = routing[bucketConfig.configKey];
+  const defaultModel = bucketConfig.defaultModel;
+  const defaultModelInput = normalizeRoutedModelInput(config, defaultModel);
+  const configuredModelInput = resolveActiveRoutedModelInput(config, configured);
+  if (configured) {
+    return {
+      modelInput: configuredModelInput ?? defaultModelInput,
+      bucket,
+    };
+  }
+
+  const fallbackModelInput = resolveActiveRoutedModelInput(config, routing.fallbackModel);
+  return {
+    modelInput: fallbackModelInput ?? defaultModelInput,
+    bucket,
+  };
+}

--- a/src/run/run-models.ts
+++ b/src/run/run-models.ts
@@ -1,8 +1,10 @@
 import type { CliProvider, ModelConfig, SummarizeConfig } from "../config.js";
+import type { OutputLanguage } from "../language.js";
 import { mergeModelRequestOptions } from "../llm/model-options.js";
 import type { RequestedModel } from "../model-spec.js";
 import { parseRequestedModelId } from "../model-spec.js";
 import { BUILTIN_MODELS } from "./constants.js";
+import { resolveLanguageAwareLocalModelInput } from "./local-model-routing.js";
 
 function resolveConfiguredCliModel(
   provider: CliProvider,
@@ -58,6 +60,7 @@ export type ModelSelection = {
   requestedModel: RequestedModel;
   requestedModelInput: string;
   requestedModelLabel: string;
+  selectionSource: ModelSelectionSource;
   isNamedModelSelection: boolean;
   isImplicitAutoSelection: boolean;
   wantsFreeNamedModel: boolean;
@@ -65,18 +68,30 @@ export type ModelSelection = {
   isFallbackModel: boolean;
 };
 
+export type ModelSelectionSource =
+  | "explicit"
+  | "env"
+  | "config"
+  | "local-routing"
+  | "auto"
+  | "fallback";
+
 export function resolveModelSelection({
   config,
   configForCli,
   configPath,
   envForRun,
   explicitModelArg,
+  outputLanguage,
+  allowLanguageAwareLocalRouting = true,
 }: {
   config: SummarizeConfig | null;
   configForCli: SummarizeConfig | null;
   configPath: string | null;
   envForRun: Record<string, string | undefined>;
   explicitModelArg: string | null;
+  outputLanguage?: OutputLanguage | null;
+  allowLanguageAwareLocalRouting?: boolean;
 }): ModelSelection {
   const modelMap = (() => {
     const out = new Map<string, { name: string; model: ModelConfig }>();
@@ -118,9 +133,19 @@ export function resolveModelSelection({
   })();
 
   const explicitModelInput = explicitModelArg?.trim() ?? "";
-  const requestedModelInput = (explicitModelInput || defaultModelResolution.value).trim();
-  const requestedModelSource =
-    explicitModelInput.length > 0 ? ("explicit" as const) : defaultModelResolution.source;
+  const baseRequestedModelInput = (explicitModelInput || defaultModelResolution.value).trim();
+  const localRoute =
+    allowLanguageAwareLocalRouting && baseRequestedModelInput.toLowerCase() === "auto"
+      ? resolveLanguageAwareLocalModelInput({ config, outputLanguage })
+      : null;
+  const requestedModelInput = (localRoute?.modelInput ?? baseRequestedModelInput).trim();
+  const requestedModelSource: ModelSelectionSource = localRoute
+    ? "local-routing"
+    : explicitModelInput.length > 0
+      ? "explicit"
+      : defaultModelResolution.source === "default"
+        ? "auto"
+        : defaultModelResolution.source;
   const requestedModelInputLower = requestedModelInput.toLowerCase();
   const wantsFreeNamedModel = requestedModelInputLower === "free";
 
@@ -176,12 +201,13 @@ export function resolveModelSelection({
 
   const isFallbackModel = requestedModelResolved.kind === "auto";
   const isImplicitAutoSelection =
-    requestedModelResolved.kind === "auto" && requestedModelSource === "default";
+    requestedModelResolved.kind === "auto" && requestedModelSource === "auto";
 
   return {
     requestedModel: requestedModelResolved,
     requestedModelInput,
     requestedModelLabel,
+    selectionSource: requestedModelSource,
     isNamedModelSelection,
     isImplicitAutoSelection,
     wantsFreeNamedModel,

--- a/src/run/runner-plan.ts
+++ b/src/run/runner-plan.ts
@@ -269,6 +269,8 @@ export async function createRunnerPlan(options: {
     configPath,
     envForRun,
     explicitModelArg,
+    outputLanguage,
+    allowLanguageAwareLocalRouting: !cliFlagPresent,
   });
 
   const verboseColor = supportsColor(stderr, envForRun);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -71,6 +71,29 @@ describe("config loading", () => {
     });
   });
 
+  it("loads local model routing config", () => {
+    const { root } = writeJsonConfig({
+      localRouting: {
+        enabled: true,
+        englishModel: " gemma4-31b ",
+        traditionalChineseModel: "openai/qwen3.6-27b",
+        bilingualModel: "qwen3.6-27b",
+        fallbackModel: "gemma4-31b",
+      },
+    });
+
+    const result = loadSummarizeConfig({ env: { HOME: root } });
+    expect(result.config).toEqual({
+      localRouting: {
+        enabled: true,
+        englishModel: "gemma4-31b",
+        traditionalChineseModel: "openai/qwen3.6-27b",
+        bilingualModel: "qwen3.6-27b",
+        fallbackModel: "gemma4-31b",
+      },
+    });
+  });
+
   it("supports ui.theme", () => {
     const { root } = writeJsonConfig({
       model: { id: "openai/gpt-5-mini" },
@@ -492,6 +515,28 @@ describe("config loading", () => {
 
     const { root: badMin } = writeJsonConfig({ slides: { minDuration: -1 } });
     expect(() => loadSummarizeConfig({ env: { HOME: badMin } })).toThrow(/slides\.minDuration/);
+  });
+
+  it("rejects invalid local model routing config", () => {
+    const { root: badRoot } = writeJsonConfig({ localRouting: "nope" });
+    expect(() => loadSummarizeConfig({ env: { HOME: badRoot } })).toThrow(
+      /"localRouting" must be an object/,
+    );
+
+    const { root: badEnabled } = writeJsonConfig({ localRouting: { enabled: "yes" } });
+    expect(() => loadSummarizeConfig({ env: { HOME: badEnabled } })).toThrow(
+      /localRouting\.enabled/,
+    );
+
+    const { root: badModel } = writeJsonConfig({ localRouting: { englishModel: "  " } });
+    expect(() => loadSummarizeConfig({ env: { HOME: badModel } })).toThrow(
+      /localRouting\.englishModel.*must not be empty/,
+    );
+
+    const { root: badAuto } = writeJsonConfig({ localRouting: { fallbackModel: "auto" } });
+    expect(() => loadSummarizeConfig({ env: { HOME: badAuto } })).toThrow(
+      /localRouting\.fallbackModel.*must not be "auto"/,
+    );
   });
 
   it("rejects invalid cli enabled providers", () => {

--- a/tests/language.test.ts
+++ b/tests/language.test.ts
@@ -16,6 +16,16 @@ describe("output language", () => {
     expect(parseOutputLanguage("English")).toEqual({ kind: "fixed", tag: "en", label: "English" });
     expect(parseOutputLanguage("de")).toEqual({ kind: "fixed", tag: "de", label: "German" });
     expect(parseOutputLanguage("Deutsch")).toEqual({ kind: "fixed", tag: "de", label: "German" });
+    expect(parseOutputLanguage("zh-tw")).toEqual({
+      kind: "fixed",
+      tag: "zh-TW",
+      label: "Traditional Chinese",
+    });
+    expect(parseOutputLanguage("Traditional Chinese")).toEqual({
+      kind: "fixed",
+      tag: "zh-TW",
+      label: "Traditional Chinese",
+    });
     expect(parseOutputLanguage("pt-BR")).toEqual({
       kind: "fixed",
       tag: "pt-BR",
@@ -65,6 +75,15 @@ describe("output language", () => {
     expect(formatOutputLanguageInstruction({ kind: "auto" })).toMatch(/dominant source language/i);
     expect(formatOutputLanguageInstruction({ kind: "fixed", tag: "en", label: "English" })).toBe(
       "Write the answer in English.",
+    );
+    expect(
+      formatOutputLanguageInstruction({
+        kind: "fixed",
+        tag: "zh-TW",
+        label: "Traditional Chinese",
+      }),
+    ).toBe(
+      "Write the answer in Traditional Chinese (zh-Hant) using Traditional Chinese characters. Do not answer in English except for unavoidable source quotes or proper nouns.",
     );
   });
 

--- a/tests/run.models.test.ts
+++ b/tests/run.models.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { parseOutputLanguage } from "../src/language.js";
 import { resolveModelSelection } from "../src/run/run-models.js";
 
 describe("run model selection", () => {
@@ -236,6 +237,300 @@ describe("run model selection", () => {
     if (result.requestedModel.kind === "fixed" && result.requestedModel.transport === "cli") {
       expect(result.requestedModel.userModelId).toBe("cli/opencode/openai/gpt-5.4");
     }
+  });
+
+  it("routes English output to the configured local model when auto is selected", () => {
+    const result = resolveModelSelection({
+      config: {
+        localRouting: {
+          enabled: true,
+          englishModel: "gemma-local",
+          fallbackModel: "llama-local",
+        },
+      },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("en"),
+    });
+
+    expect(result.requestedModelInput).toBe("openai/gemma-local");
+    expect(result.requestedModelLabel).toBe("openai/gemma-local");
+    expect(result.isFallbackModel).toBe(false);
+    expect(result.requestedModel.kind).toBe("fixed");
+    if (result.requestedModel.kind === "fixed") {
+      expect(result.requestedModel.userModelId).toBe("openai/gemma-local");
+    }
+  });
+
+  it("routes Traditional Chinese output to the configured local model", () => {
+    const result = resolveModelSelection({
+      config: {
+        localRouting: {
+          enabled: true,
+          traditionalChineseModel: "openai/qwen3-local",
+          fallbackModel: "llama-local",
+        },
+      },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: "auto",
+      outputLanguage: parseOutputLanguage("Traditional Chinese"),
+    });
+
+    expect(result.requestedModelInput).toBe("openai/qwen3-local");
+    expect(result.requestedModelLabel).toBe("openai/qwen3-local");
+    expect(result.requestedModel.kind).toBe("fixed");
+    if (result.requestedModel.kind === "fixed") {
+      expect(result.requestedModel.userModelId).toBe("openai/qwen3-local");
+    }
+  });
+
+  it("routes bilingual output to the configured local model", () => {
+    const result = resolveModelSelection({
+      config: {
+        localRouting: {
+          enabled: true,
+          bilingualModel: "qwen3-bilingual-local",
+          fallbackModel: "llama-local",
+        },
+      },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("en+zh-TW bilingual"),
+    });
+
+    expect(result.requestedModelInput).toBe("openai/qwen3-bilingual-local");
+    expect(result.requestedModel.kind).toBe("fixed");
+    if (result.requestedModel.kind === "fixed") {
+      expect(result.requestedModel.userModelId).toBe("openai/qwen3-bilingual-local");
+    }
+  });
+
+  it("uses the fallback local model for auto or unknown output language", () => {
+    const result = resolveModelSelection({
+      config: {
+        localRouting: {
+          enabled: true,
+          fallbackModel: "llama-local",
+        },
+      },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("auto"),
+    });
+
+    expect(result.requestedModelInput).toBe("openai/llama-local");
+    expect(result.requestedModel.kind).toBe("fixed");
+    if (result.requestedModel.kind === "fixed") {
+      expect(result.requestedModel.userModelId).toBe("openai/llama-local");
+    }
+  });
+
+  it("keeps auto selection unchanged when local routing is disabled or missing", () => {
+    const disabled = resolveModelSelection({
+      config: { localRouting: { enabled: false, englishModel: "gemma-local" } },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("en"),
+    });
+    const missing = resolveModelSelection({
+      config: null,
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("en"),
+    });
+
+    expect(disabled.requestedModel.kind).toBe("auto");
+    expect(disabled.requestedModelInput).toBe("auto");
+    expect(missing.requestedModel.kind).toBe("auto");
+    expect(missing.requestedModelInput).toBe("auto");
+  });
+
+  it("uses default local routing models when a bucket model is not configured", () => {
+    const english = resolveModelSelection({
+      config: { localRouting: { enabled: true } },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("English"),
+    });
+    const traditionalChinese = resolveModelSelection({
+      config: { localRouting: { enabled: true } },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("zh-Hant"),
+    });
+    const bilingual = resolveModelSelection({
+      config: { localRouting: { enabled: true } },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("en+zh-TW bilingual"),
+    });
+    const fallback = resolveModelSelection({
+      config: { localRouting: { enabled: true } },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("auto"),
+    });
+
+    expect(english.requestedModelInput).toBe("openai/gemma4-31b");
+    expect(traditionalChinese.requestedModelInput).toBe("openai/qwen3.6-27b");
+    expect(bilingual.requestedModelInput).toBe("openai/qwen3.6-27b");
+    expect(fallback.requestedModelInput).toBe("openai/gemma4-31b");
+  });
+
+  it("routes common Traditional Chinese aliases to the Qwen local default", () => {
+    for (const language of [
+      "Traditional Chinese",
+      "Chinese (Traditional)",
+      "\u7e41\u4e2d",
+      "\u7e41\u9ad4\u4e2d\u6587",
+      "\u6b63\u9ad4\u4e2d\u6587",
+    ]) {
+      const resolved = resolveModelSelection({
+        config: { localRouting: { enabled: true } },
+        configForCli: null,
+        configPath: null,
+        envForRun: {},
+        explicitModelArg: null,
+        outputLanguage: parseOutputLanguage(language),
+      });
+
+      expect(resolved.requestedModelInput, language).toBe("openai/qwen3.6-27b");
+    }
+  });
+
+  it("falls back to bucket defaults for retired local routing model inputs", () => {
+    const retiredQwen = ["qwen3.6", "35b", "a3b"].join("-");
+    const traditionalChinese = resolveModelSelection({
+      config: {
+        localRouting: {
+          enabled: true,
+          traditionalChineseModel: retiredQwen,
+          fallbackModel: "gemma-local",
+        },
+      },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("zh-Hant"),
+    });
+    const bilingual = resolveModelSelection({
+      config: {
+        localRouting: {
+          enabled: true,
+          bilingualModel: `openai/${retiredQwen}`,
+          fallbackModel: "gemma-local",
+        },
+      },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("en+zh-TW bilingual"),
+    });
+
+    expect(traditionalChinese.requestedModelInput).toBe("openai/qwen3.6-27b");
+    expect(bilingual.requestedModelInput).toBe("openai/qwen3.6-27b");
+  });
+
+  it("does not override explicit fixed models with local routing", () => {
+    const explicit = resolveModelSelection({
+      config: {
+        localRouting: {
+          enabled: true,
+          englishModel: "gemma-local",
+        },
+      },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: "openai/gpt-5.2",
+      outputLanguage: parseOutputLanguage("en"),
+    });
+
+    expect(explicit.requestedModelInput).toBe("openai/gpt-5.2");
+    expect(explicit.requestedModel.kind).toBe("fixed");
+    if (explicit.requestedModel.kind === "fixed") {
+      expect(explicit.requestedModel.userModelId).toBe("openai/gpt-5.2");
+    }
+  });
+
+  it("keeps Gemini 3.1 Pro explicit when local routing defaults apply", () => {
+    const explicit = resolveModelSelection({
+      config: { localRouting: { enabled: true } },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: "google/gemini-3.1-pro",
+      outputLanguage: parseOutputLanguage("Traditional Chinese"),
+    });
+
+    expect(explicit.requestedModelInput).toBe("google/gemini-3.1-pro");
+    expect(explicit.selectionSource).toBe("explicit");
+    expect(explicit.requestedModel.kind).toBe("fixed");
+    if (explicit.requestedModel.kind === "fixed") {
+      expect(explicit.requestedModel.userModelId).toBe("google/gemini-3.1-pro");
+    }
+  });
+
+  it("does not override env or config fixed model defaults with local routing", () => {
+    const envDefault = resolveModelSelection({
+      config: { localRouting: { enabled: true, englishModel: "gemma-local" } },
+      configForCli: null,
+      configPath: null,
+      envForRun: { SUMMARIZE_MODEL: "openai/gpt-env" },
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("en"),
+    });
+    const configDefault = resolveModelSelection({
+      config: {
+        model: { id: "openai/gpt-config" },
+        localRouting: { enabled: true, englishModel: "gemma-local" },
+      },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: null,
+      outputLanguage: parseOutputLanguage("en"),
+    });
+
+    expect(envDefault.requestedModelInput).toBe("openai/gpt-env");
+    expect(configDefault.requestedModelInput).toBe("openai/gpt-config");
+  });
+
+  it("keeps bare --cli auto behavior out of local routing", () => {
+    const result = resolveModelSelection({
+      config: { localRouting: { enabled: true, englishModel: "gemma-local" } },
+      configForCli: null,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: "auto",
+      outputLanguage: parseOutputLanguage("en"),
+      allowLanguageAwareLocalRouting: false,
+    });
+
+    expect(result.requestedModel.kind).toBe("auto");
+    expect(result.requestedModelInput).toBe("auto");
   });
 
   it("rejects unknown bare model ids with a config hint", () => {


### PR DESCRIPTION
> [!NOTE]
> **Draft / RFC.** Opened as a reference for the discussion in #224.
> Please review direction before code — happy to redesign or split based on the issue thread.

## TL;DR

When `model: "auto"` runs against a local LLM setup, pick a different local model based on the document's output language (`en`, `zh-Hant`, bilingual). No change unless `localRouting.enabled` is set.

```jsonc
{
  "model": "auto",
  "localRouting": {
    "enabled": true,
    "englishModel": "gemma4-31b",
    "traditionalChineseModel": "qwen3.6-27b",
    "bilingualModel": "qwen3.6-27b",
    "fallbackModel": "gemma4-31b"
  }
}
```

## Why

Local open-weight models have lopsided language strengths: a small Llama/Gemma checkpoint is good for English but weak on Traditional Chinese, while a Qwen/DeepSeek checkpoint inverts those scores. Today `model: "auto"` picks one fixed default regardless of the source document's language, so users running locally get sub-par summaries on the side they didn't optimize for.

## What this changes

- `packages/core/src/language.ts`: shared `OutputLanguage` helpers — `resolveLanguageBucket(language)` collapses a language code into a routing bucket (`english`, `traditionalChinese`, `bilingual`, `fallback`).
- `src/config/types.ts` + `src/config/sections.ts` + `src/config.ts`: schema for `localRouting` and config loader.
- `src/config/local-model-routing-defaults.json`: ship defaults (Qwen for zh-Hant, Gemma for English, no default for `auto`).
- `src/run/local-model-routing.ts`: pure `resolveLanguageAwareLocalModelInput({ language, config })` resolver.
- `src/run/run-models.ts` + `src/run/runner-plan.ts`: when `model:auto`, consult the resolver before falling back to the configured default.

## Routing decision

```
summarize --model auto
  └─ output language known?
       ├─ en              → localRouting.englishModel
       ├─ zh-Hant         → localRouting.traditionalChineseModel
       ├─ en+zh bilingual → localRouting.bilingualModel
       └─ unknown / auto  → localRouting.fallbackModel
```

If `localRouting.enabled` is `false` or `localRouting` is omitted, behavior is identical to today.

## Design notes

- Bucket keys are coarse on purpose. Adding a new bucket is a config-only change; the resolver does not hard-code language tags beyond what it reads from `language.ts`.
- Defaults file is shipped JSON (not TS) so users can copy-paste it as a starting point.
- The resolver is pure and side-effect free; daemon and CLI consume the same code path.

## Test plan

- `pnpm test tests/run.models.test.ts` — 295-line suite covering bucket selection, default fallthrough, override precedence, and interaction with explicit `--model` flags.
- `pnpm test tests/language.test.ts` — `resolveLanguageBucket` boundary cases.
- `pnpm test tests/config.test.ts` — schema parsing for `localRouting`.
- `pnpm typecheck`.

## Follow-ups (separate PRs)

If this direction lands, I have:
- Graceful fallback to `fallbackModel` when the bucket-specific local model errors / returns empty
- Model-aware summary cache lookup so changing the routed model invalidates correctly