### PR TITLE
fix(core): extract video id from YouTube /live/ URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Chrome extension: abort stale side-panel summary streams on tab changes so delayed output from a closed or replaced tab cannot render under the new page title.
+- Core: extract video IDs from YouTube `/live/` URLs so live and premiere links no longer abort summarization (#232, thanks @devYRPauli).
 
 ## 0.16.3 - 2026-05-22
 

--- a/packages/core/src/content/url.ts
+++ b/packages/core/src/content/url.ts
@@ -63,6 +63,8 @@ export function extractYouTubeVideoId(rawUrl: string): string | null {
         candidate = url.searchParams.get("v");
       } else if (url.pathname.startsWith("/shorts/")) {
         candidate = url.pathname.split("/")[2] ?? null;
+      } else if (url.pathname.startsWith("/live/")) {
+        candidate = url.pathname.split("/")[2] ?? null;
       } else if (url.pathname.startsWith("/embed/")) {
         candidate = url.pathname.split("/")[2] ?? null;
       } else if (url.pathname.startsWith("/v/")) {

--- a/tests/content.url.test.ts
+++ b/tests/content.url.test.ts
@@ -23,6 +23,7 @@ describe("content/url", () => {
     expect(isYouTubeVideoUrl("https://youtu.be/dQw4w9WgXcQ")).toBe(true);
     expect(isYouTubeVideoUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")).toBe(true);
     expect(isYouTubeVideoUrl("https://www.youtube.com/shorts/dQw4w9WgXcQ")).toBe(true);
+    expect(isYouTubeVideoUrl("https://www.youtube.com/live/dQw4w9WgXcQ")).toBe(true);
     expect(isYouTubeVideoUrl("https://youtu.be/")).toBe(false);
     expect(isYouTubeVideoUrl("https://www.youtube.com/watch?v=abc")).toBe(true);
   });
@@ -32,6 +33,10 @@ describe("content/url", () => {
       "dQw4w9WgXcQ",
     );
     expect(extractYouTubeVideoId("https://youtu.be/dQw4w9WgXcQ?t=1")).toBe("dQw4w9WgXcQ");
+    expect(extractYouTubeVideoId("https://www.youtube.com/live/dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+    expect(extractYouTubeVideoId("https://www.youtube.com/live/dQw4w9WgXcQ?feature=share")).toBe(
+      "dQw4w9WgXcQ",
+    );
     expect(extractYouTubeVideoId("https://youtu.be/")).toBeNull();
   });
 


### PR DESCRIPTION
Extract the video id from YouTube `/live/` URLs so summarizing a stream or premiere link no longer aborts the run.

## Problem
Summarizing a YouTube live or premiere link like `https://www.youtube.com/live/dQw4w9WgXcQ` fails the whole run with `Invalid YouTube video id in URL`. YouTube hands these URLs out for streams and premieres, so the feature is unusable for them.

## Root cause
Two functions in `packages/core/src/content/url.ts` disagree about `/live/`:
- `isYouTubeVideoUrl()` accepts `/live/<id>` as a video URL.
- `extractYouTubeVideoId()` only had branches for `/watch`, `/shorts/`, `/embed/`, and `/v/`, so it returned `null` for `/live/`.

The guard in `packages/core/src/content/link-preview/content/html.ts` is:

    if (isYouTubeVideoUrl(url) && !extractYouTubeVideoId(url)) {
      throw new Error("Invalid YouTube video id in URL");
    }

For a `/live/` URL the first call is `true` and the second is `null`, so the guard throws and the summarization run is aborted.

## Fix
Add the missing `/live/` branch to `extractYouTubeVideoId`, parsing the id from the path exactly like `/embed/` and `/v/`:

    } else if (url.pathname.startsWith("/live/")) {
      candidate = url.pathname.split("/")[2] ?? null;
    }

## Tests
Added focused cases to `tests/content.url.test.ts`:
- `isYouTubeVideoUrl("https://www.youtube.com/live/dQw4w9WgXcQ")` is `true`
- `extractYouTubeVideoId("https://www.youtube.com/live/dQw4w9WgXcQ")` is `"dQw4w9WgXcQ"`
- `extractYouTubeVideoId("https://www.youtube.com/live/dQw4w9WgXcQ?feature=share")` is `"dQw4w9WgXcQ"`

Before the fix the `extractYouTubeVideoId` case fails with `expected null to be 'dQw4w9WgXcQ'`; after the fix all 11 cases in the file pass.

## Verification
Real-behavior check running the exact guard from `html.ts` against the real functions, on main vs this branch.

Before (main):

    URL: https://www.youtube.com/live/dQw4w9WgXcQ    -> THREW: Invalid YouTube video id in URL
    URL: https://www.youtube.com/watch?v=dQw4w9WgXcQ -> ok -> id=dQw4w9WgXcQ

After (this branch):

    URL: https://www.youtube.com/live/dQw4w9WgXcQ    -> ok -> id=dQw4w9WgXcQ
    URL: https://www.youtube.com/watch?v=dQw4w9WgXcQ -> ok -> id=dQw4w9WgXcQ

Full suite (`pnpm check`) is green:

    All matched files use the correct format.   (oxfmt)
    (oxlint: no errors)
    (tsgo typecheck: no errors)
    Test Files  402 passed | 27 skipped (429)
    Tests  1992 passed | 41 skipped (2033)

Found and fixed with the help of the Claude CLI.
