### PR TITLE
fix(anthropic): forward --thinking to extended thinking API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - OpenAI-compatible gateways: honor `OPENAI_USE_CHAT_COMPLETIONS=false` and `openai.useChatCompletions=false` so custom base URLs can use the Responses API (#235, #236, thanks @mzbgf).
 - RSS transcripts: block feed-controlled transcript URLs that target loopback, private, link-local, reserved, or redirected local-network addresses (#239, thanks @Hinotoi-agent).
 - Podcast transcripts: cap remote media downloads at 512 MB by default, with a finite opt-in override for larger files (#237, thanks @Hinotoi-agent).
+- Anthropic: forward explicit CLI `--thinking` to Anthropic text and streaming requests without leaking persisted OpenAI thinking defaults into non-OpenAI providers (#233, thanks @wangwllu).
 - Chrome extension: abort stale side-panel summary streams on tab changes so delayed output from a closed or replaced tab cannot render under the new page title.
 - Core: extract video IDs from YouTube `/live/` URLs so live and premiere links no longer abort summarization (#232, thanks @devYRPauli).
 - Chrome extension: keep YouTube slide cards on the shared slide-summary path so local browser thumbnails receive the same summary text shape as CLI `--slides`.

--- a/src/daemon/chat.ts
+++ b/src/daemon/chat.ts
@@ -4,7 +4,8 @@ import { runCliModel } from "../llm/cli.js";
 import type { LlmApiKeys } from "../llm/generate-text.js";
 import { streamTextWithContext } from "../llm/generate-text.js";
 import { resolveGitHubModelsApiKey } from "../llm/github-models.js";
-import { mergeModelRequestOptions } from "../llm/model-options.js";
+import { parseGatewayStyleModelId } from "../llm/model-id.js";
+import { mergeModelRequestOptions, mergeRequestOptionsForProvider } from "../llm/model-options.js";
 import { buildAutoModelAttempts, envHasKey } from "../model-auto.js";
 import { parseBooleanEnv, parseCliUserModelId } from "../run/env.js";
 import { resolveEnvState } from "../run/run-env.js";
@@ -257,7 +258,12 @@ export async function streamChatResponse({
       forceOpenRouter: resolved.forceOpenRouter,
       openaiBaseUrlOverride: resolved.openaiBaseUrlOverride,
       forceChatCompletions: resolved.forceChatCompletions,
-      requestOptions: mergeModelRequestOptions(openaiRequestOptions, resolved.requestOptions),
+      requestOptions: mergeRequestOptionsForProvider({
+        provider: parseGatewayStyleModelId(resolved.modelId!).provider,
+        openaiGlobalDefault: openaiRequestOptions,
+        attemptOptions: resolved.requestOptions,
+        openaiOverride: undefined,
+      }),
     });
     for await (const chunk of result.textStream) {
       pushToSession({ event: "content", data: chunk });
@@ -332,7 +338,12 @@ export async function streamChatResponse({
         : attempt.requiredEnv === "OPENAI_API_KEY"
           ? openaiUseChatCompletions
           : undefined,
-    requestOptions: mergeModelRequestOptions(openaiRequestOptions, attempt.requestOptions),
+    requestOptions: mergeRequestOptionsForProvider({
+      provider: parseGatewayStyleModelId(attempt.llmModelId!).provider,
+      openaiGlobalDefault: openaiRequestOptions,
+      attemptOptions: attempt.requestOptions,
+      openaiOverride: undefined,
+    }),
   });
   for await (const chunk of result.textStream) {
     pushToSession({ event: "content", data: chunk });

--- a/src/llm/generate-text-stream.ts
+++ b/src/llm/generate-text-stream.ts
@@ -10,7 +10,10 @@ import {
   resolveOpenAiCompatibleClientConfigForProvider,
   supportsStreaming,
 } from "./provider-capabilities.js";
-import { normalizeAnthropicModelAccessError } from "./providers/anthropic.js";
+import {
+  normalizeAnthropicModelAccessError,
+  prepareAnthropicReasoning,
+} from "./providers/anthropic.js";
 import {
   resolveAnthropicModel,
   resolveGoogleModel,
@@ -296,14 +299,20 @@ export async function streamTextWithContext({
     if (parsed.provider === "anthropic") {
       const apiKey = apiKeys.anthropicApiKey;
       if (!apiKey) throw new Error("Missing ANTHROPIC_API_KEY for anthropic/... model");
-      const model = resolveAnthropicModel({
+      const baseModel = resolveAnthropicModel({
         modelId: parsed.model,
         context,
         anthropicBaseUrlOverride,
       });
+      const { model, reasoning } = prepareAnthropicReasoning({
+        modelId: parsed.model,
+        baseModel,
+        reasoningEffort: requestOptions?.reasoningEffort,
+      });
       const stream = streamSimple(model, context, {
         ...(typeof effectiveTemperature === "number" ? { temperature: effectiveTemperature } : {}),
         ...(typeof maxOutputTokens === "number" ? { maxTokens: maxOutputTokens } : {}),
+        ...(reasoning ? { reasoning } : {}),
         apiKey,
         signal: controller.signal,
       });

--- a/src/llm/generate-text.ts
+++ b/src/llm/generate-text.ts
@@ -250,6 +250,7 @@ export async function generateTextWithModelId({
           context,
           temperature: effectiveTemperature,
           maxOutputTokens,
+          reasoningEffort: requestOptions?.reasoningEffort,
           signal: controller.signal,
           anthropicBaseUrlOverride,
         });

--- a/src/llm/model-options.ts
+++ b/src/llm/model-options.ts
@@ -79,6 +79,32 @@ export function mergeModelRequestOptions(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
+/**
+ * Merge request options for a specific provider. The OpenAI-scoped global
+ * default (`openaiRequestOptions`) and CLI override (`openaiRequestOptionsOverride`)
+ * are sourced from `openai.*` config and `--thinking`/`--fast`/`--service-tier`
+ * flags that documentation/CLI help describe as OpenAI-only. Those entries are
+ * only applied for the `openai` provider; for every other provider only the
+ * per-attempt options (set via the model config or a provider-prefixed CLI
+ * model id) flow through.
+ */
+export function mergeRequestOptionsForProvider({
+  provider,
+  openaiGlobalDefault,
+  attemptOptions,
+  openaiOverride,
+}: {
+  provider: string;
+  openaiGlobalDefault: ModelRequestOptionsInput | null | undefined;
+  attemptOptions: ModelRequestOptionsInput | null | undefined;
+  openaiOverride: ModelRequestOptionsInput | null | undefined;
+}): ModelRequestOptions | undefined {
+  if (provider === "openai") {
+    return mergeModelRequestOptions(openaiGlobalDefault, attemptOptions, openaiOverride);
+  }
+  return mergeModelRequestOptions(attemptOptions);
+}
+
 export function toOpenAiServiceTierParam(serviceTier: string | undefined): string | undefined {
   const normalized = serviceTier?.trim();
   if (!normalized) return undefined;

--- a/src/llm/model-options.ts
+++ b/src/llm/model-options.ts
@@ -80,29 +80,43 @@ export function mergeModelRequestOptions(
 }
 
 /**
- * Merge request options for a specific provider. The OpenAI-scoped global
- * default (`openaiRequestOptions`) and CLI override (`openaiRequestOptionsOverride`)
- * are sourced from `openai.*` config and `--thinking`/`--fast`/`--service-tier`
- * flags that documentation/CLI help describe as OpenAI-only. Those entries are
- * only applied for the `openai` provider; for every other provider only the
- * per-attempt options (set via the model config or a provider-prefixed CLI
- * model id) flow through.
+ * Merge request options for a specific provider.
+ *
+ * - `openaiGlobalDefault` comes from the persisted `openai.*` config block — a
+ *   provider-scoped default that must NOT bleed into non-openai requests.
+ * - `openaiOverride` comes from `--fast` / `--service-tier`, which are
+ *   documented as OpenAI-only knobs. Also only for the openai provider.
+ * - `cliReasoningEffortOverride` comes from the explicit `--thinking` CLI flag,
+ *   which is cross-provider (the user opted in for this run). It is forwarded
+ *   to whichever provider is dispatched.
+ * - `attemptOptions` is the per-attempt options bag (from the model config or
+ *   provider-prefixed CLI id) and applies to every provider.
  */
 export function mergeRequestOptionsForProvider({
   provider,
   openaiGlobalDefault,
   attemptOptions,
   openaiOverride,
+  cliReasoningEffortOverride,
 }: {
   provider: string;
   openaiGlobalDefault: ModelRequestOptionsInput | null | undefined;
   attemptOptions: ModelRequestOptionsInput | null | undefined;
   openaiOverride: ModelRequestOptionsInput | null | undefined;
+  cliReasoningEffortOverride?: OpenAiReasoningEffort | undefined;
 }): ModelRequestOptions | undefined {
+  const cliReasoningEntry: ModelRequestOptionsInput | undefined = cliReasoningEffortOverride
+    ? { reasoningEffort: cliReasoningEffortOverride }
+    : undefined;
   if (provider === "openai") {
-    return mergeModelRequestOptions(openaiGlobalDefault, attemptOptions, openaiOverride);
+    return mergeModelRequestOptions(
+      openaiGlobalDefault,
+      attemptOptions,
+      openaiOverride,
+      cliReasoningEntry,
+    );
   }
-  return mergeModelRequestOptions(attemptOptions);
+  return mergeModelRequestOptions(attemptOptions, cliReasoningEntry);
 }
 
 export function toOpenAiServiceTierParam(serviceTier: string | undefined): string | undefined {

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1,17 +1,48 @@
-import type { Context, ThinkingLevel } from "@earendil-works/pi-ai";
+import type { Context, Model, ThinkingLevel } from "@earendil-works/pi-ai";
+import type { Api } from "@earendil-works/pi-ai";
 import { completeSimple } from "@earendil-works/pi-ai";
 import type { Attachment } from "../attachments.js";
 import type { OpenAiReasoningEffort } from "../model-options.js";
 import type { LlmTokenUsage } from "../types.js";
 import { normalizeAnthropicUsage, normalizeTokenUsage } from "../usage.js";
 import { resolveAnthropicModel } from "./models.js";
-import { bytesToBase64, extractText, resolveBaseUrlOverride } from "./shared.js";
+import { bytesToBase64, extractText, resolveBaseUrlOverride, tryGetModel } from "./shared.js";
 
 function effortToThinkingLevel(
   effort: OpenAiReasoningEffort | undefined,
 ): ThinkingLevel | undefined {
   if (!effort || effort === "none") return undefined;
   return effort;
+}
+
+/**
+ * Decide the model and `reasoning` option to pass into the pi-ai Anthropic
+ * adapter. Shared by non-streaming and streaming text dispatch.
+ *
+ * pi-ai gates extended thinking on `model.reasoning`. For models present in
+ * the pi-ai registry, we trust that flag — flipping it for known unsupported
+ * Claude 3/3.5 models would turn previously successful no-thinking requests
+ * into API rejections. For synthetic models (`tryGetModel` miss — typically
+ * custom `ANTHROPIC_BASE_URL` proxies in front of newer Claude versions),
+ * `createSyntheticModel` hard-codes `reasoning: false`, so we opt them into
+ * thinking when the caller asked for an effort level.
+ */
+export function prepareAnthropicReasoning({
+  modelId,
+  baseModel,
+  reasoningEffort,
+}: {
+  modelId: string;
+  baseModel: Model<Api>;
+  reasoningEffort?: OpenAiReasoningEffort;
+}): { model: Model<Api>; reasoning?: ThinkingLevel } {
+  const reasoning = effortToThinkingLevel(reasoningEffort);
+  if (!reasoning) return { model: baseModel };
+  const isSynthetic = !tryGetModel("anthropic", modelId);
+  if (isSynthetic && !baseModel.reasoning) {
+    return { model: { ...baseModel, reasoning: true }, reasoning };
+  }
+  return { model: baseModel, reasoning };
 }
 
 function parseAnthropicErrorPayload(
@@ -83,12 +114,7 @@ export async function completeAnthropicText({
     context,
     anthropicBaseUrlOverride,
   });
-  const reasoning = effortToThinkingLevel(reasoningEffort);
-  // Synthetic (unknown) models default to `reasoning: false`, which makes the
-  // pi-ai Anthropic adapter silently drop the thinking block. When the caller
-  // requested a reasoning level, opt the model into thinking so the parameter
-  // round-trips to the API.
-  const model = reasoning && !baseModel.reasoning ? { ...baseModel, reasoning: true } : baseModel;
+  const { model, reasoning } = prepareAnthropicReasoning({ modelId, baseModel, reasoningEffort });
   const result = await completeSimple(model, context, {
     ...(typeof temperature === "number" ? { temperature } : {}),
     ...(typeof maxOutputTokens === "number" ? { maxTokens: maxOutputTokens } : {}),

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -19,13 +19,17 @@ function effortToThinkingLevel(
  * Decide the model and `reasoning` option to pass into the pi-ai Anthropic
  * adapter. Shared by non-streaming and streaming text dispatch.
  *
- * pi-ai gates extended thinking on `model.reasoning`. For models present in
- * the pi-ai registry, we trust that flag — flipping it for known unsupported
- * Claude 3/3.5 models would turn previously successful no-thinking requests
- * into API rejections. For synthetic models (`tryGetModel` miss — typically
- * custom `ANTHROPIC_BASE_URL` proxies in front of newer Claude versions),
- * `createSyntheticModel` hard-codes `reasoning: false`, so we opt them into
- * thinking when the caller asked for an effort level.
+ * pi-ai 0.75.5 enables extended thinking whenever the caller passes a
+ * `reasoning` option, regardless of `model.reasoning`. So:
+ *
+ * - Registered models with `reasoning: true` (Claude 4+): forward `reasoning`.
+ * - Registered models with `reasoning: false` (Claude 3 / 3.5): drop
+ *   `reasoning` entirely; forwarding it would have pi-ai send a `thinking`
+ *   block to an API that rejects it.
+ * - Synthetic models (`tryGetModel` miss — typically custom
+ *   `ANTHROPIC_BASE_URL` proxies in front of newer Claude versions):
+ *   `createSyntheticModel` hard-codes `reasoning: false`, so we flip a copy
+ *   to `reasoning: true` and forward the effort level.
  */
 export function prepareAnthropicReasoning({
   modelId,
@@ -39,8 +43,13 @@ export function prepareAnthropicReasoning({
   const reasoning = effortToThinkingLevel(reasoningEffort);
   if (!reasoning) return { model: baseModel };
   const isSynthetic = !tryGetModel("anthropic", modelId);
-  if (isSynthetic && !baseModel.reasoning) {
-    return { model: { ...baseModel, reasoning: true }, reasoning };
+  if (!baseModel.reasoning) {
+    if (isSynthetic) {
+      return { model: { ...baseModel, reasoning: true }, reasoning };
+    }
+    // Registered but flagged unsupported (e.g. Claude 3/3.5): drop reasoning
+    // so pi-ai does not enable thinking on a model the API rejects it for.
+    return { model: baseModel };
   }
   return { model: baseModel, reasoning };
 }

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1,10 +1,18 @@
-import type { Context } from "@earendil-works/pi-ai";
+import type { Context, ThinkingLevel } from "@earendil-works/pi-ai";
 import { completeSimple } from "@earendil-works/pi-ai";
 import type { Attachment } from "../attachments.js";
+import type { OpenAiReasoningEffort } from "../model-options.js";
 import type { LlmTokenUsage } from "../types.js";
 import { normalizeAnthropicUsage, normalizeTokenUsage } from "../usage.js";
 import { resolveAnthropicModel } from "./models.js";
 import { bytesToBase64, extractText, resolveBaseUrlOverride } from "./shared.js";
+
+function effortToThinkingLevel(
+  effort: OpenAiReasoningEffort | undefined,
+): ThinkingLevel | undefined {
+  if (!effort || effort === "none") return undefined;
+  return effort;
+}
 
 function parseAnthropicErrorPayload(
   responseBody: string,
@@ -57,6 +65,7 @@ export async function completeAnthropicText({
   context,
   temperature,
   maxOutputTokens,
+  reasoningEffort,
   signal,
   anthropicBaseUrlOverride,
 }: {
@@ -65,17 +74,25 @@ export async function completeAnthropicText({
   context: Context;
   temperature?: number;
   maxOutputTokens?: number;
+  reasoningEffort?: OpenAiReasoningEffort;
   signal: AbortSignal;
   anthropicBaseUrlOverride?: string | null;
 }): Promise<{ text: string; usage: LlmTokenUsage | null }> {
-  const model = resolveAnthropicModel({
+  const baseModel = resolveAnthropicModel({
     modelId,
     context,
     anthropicBaseUrlOverride,
   });
+  const reasoning = effortToThinkingLevel(reasoningEffort);
+  // Synthetic (unknown) models default to `reasoning: false`, which makes the
+  // pi-ai Anthropic adapter silently drop the thinking block. When the caller
+  // requested a reasoning level, opt the model into thinking so the parameter
+  // round-trips to the API.
+  const model = reasoning && !baseModel.reasoning ? { ...baseModel, reasoning: true } : baseModel;
   const result = await completeSimple(model, context, {
     ...(typeof temperature === "number" ? { temperature } : {}),
     ...(typeof maxOutputTokens === "number" ? { maxTokens: maxOutputTokens } : {}),
+    ...(reasoning ? { reasoning } : {}),
     apiKey,
     signal,
   });

--- a/src/run/flows/url/markdown.ts
+++ b/src/run/flows/url/markdown.ts
@@ -1,7 +1,7 @@
 import { resolveGitHubModelsApiKey } from "../../../llm/github-models.js";
 import { createHtmlToMarkdownConverter } from "../../../llm/html-to-markdown.js";
 import { parseGatewayStyleModelId } from "../../../llm/model-id.js";
-import { mergeModelRequestOptions } from "../../../llm/model-options.js";
+import { mergeRequestOptionsForProvider } from "../../../llm/model-options.js";
 import {
   type ConvertTranscriptToMarkdown,
   createTranscriptToMarkdownConverter,
@@ -257,11 +257,13 @@ export function createMarkdownConverters(
           forceChatCompletions:
             markdownModel.forceChatCompletions ??
             (ctx.model.openaiUseChatCompletions && markdownProvider === "openai"),
-          requestOptions: mergeModelRequestOptions(
-            ctx.model.openaiRequestOptions,
-            markdownModel.requestOptions,
-            ctx.model.openaiRequestOptionsOverride,
-          ),
+          requestOptions: mergeRequestOptionsForProvider({
+            provider: markdownProvider,
+            openaiGlobalDefault: ctx.model.openaiRequestOptions,
+            attemptOptions: markdownModel.requestOptions,
+            openaiOverride: ctx.model.openaiRequestOptionsOverride,
+            cliReasoningEffortOverride: ctx.model.cliReasoningEffortOverride,
+          }),
           fetchImpl: ctx.io.fetch,
           retries: ctx.flags.retries,
           onRetry: createRetryLogger({
@@ -363,11 +365,13 @@ export function createMarkdownConverters(
           forceChatCompletions:
             markdownModel.forceChatCompletions ??
             (ctx.model.openaiUseChatCompletions && markdownProvider === "openai"),
-          requestOptions: mergeModelRequestOptions(
-            ctx.model.openaiRequestOptions,
-            markdownModel.requestOptions,
-            ctx.model.openaiRequestOptionsOverride,
-          ),
+          requestOptions: mergeRequestOptionsForProvider({
+            provider: markdownProvider,
+            openaiGlobalDefault: ctx.model.openaiRequestOptions,
+            attemptOptions: markdownModel.requestOptions,
+            openaiOverride: ctx.model.openaiRequestOptionsOverride,
+            cliReasoningEffortOverride: ctx.model.cliReasoningEffortOverride,
+          }),
           fetchImpl: ctx.io.fetch,
           retries: ctx.flags.retries,
           onRetry: createRetryLogger({

--- a/src/run/flows/url/types.ts
+++ b/src/run/flows/url/types.ts
@@ -8,7 +8,7 @@ import type {
 import type { LlmCall, RunMetricsReport } from "../../../costs.js";
 import type { StreamMode } from "../../../flags.js";
 import type { OutputLanguage } from "../../../language.js";
-import type { ModelRequestOptions } from "../../../llm/model-options.js";
+import type { ModelRequestOptions, OpenAiReasoningEffort } from "../../../llm/model-options.js";
 import type { ExecFileFn } from "../../../markitdown.js";
 import type { FixedModelSpec, RequestedModel } from "../../../model-spec.js";
 import type { SummaryLength } from "../../../shared/contracts.js";
@@ -89,6 +89,7 @@ export type UrlFlowModel = {
   openaiUseChatCompletions: boolean | undefined;
   openaiRequestOptions?: ModelRequestOptions;
   openaiRequestOptionsOverride?: ModelRequestOptions;
+  cliReasoningEffortOverride?: OpenAiReasoningEffort;
   openaiWhisperUsdPerMinute: number;
   apiStatus: {
     xaiApiKey: string | null;

--- a/src/run/run-config.ts
+++ b/src/run/run-config.ts
@@ -3,7 +3,7 @@ import { loadSummarizeConfig } from "../config.js";
 import { parseVideoMode } from "../flags.js";
 import { type OutputLanguage, parseOutputLanguage } from "../language.js";
 import { parseOpenAiReasoningEffort, parseOpenAiServiceTier } from "../llm/model-options.js";
-import type { ModelRequestOptions } from "../llm/model-options.js";
+import type { ModelRequestOptions, OpenAiReasoningEffort } from "../llm/model-options.js";
 import { parseBooleanEnv } from "./env.js";
 
 export type ConfigState = {
@@ -17,6 +17,7 @@ export type ConfigState = {
   openaiUseChatCompletions: boolean | undefined;
   openaiRequestOptions: ModelRequestOptions | undefined;
   openaiRequestOptionsOverride: ModelRequestOptions | undefined;
+  cliReasoningEffortOverride: OpenAiReasoningEffort | undefined;
   configModelLabel: string | null;
 };
 
@@ -110,11 +111,13 @@ export function resolveConfigState({
       }
       options.serviceTier = serviceTier;
     }
-    const rawThinking = typeof programOpts.thinking === "string" ? programOpts.thinking : null;
-    if (rawThinking) {
-      options.reasoningEffort = parseOpenAiReasoningEffort(rawThinking, "--thinking");
-    }
     return Object.keys(options).length > 0 ? options : undefined;
+  })();
+
+  const cliReasoningEffortOverride: OpenAiReasoningEffort | undefined = (() => {
+    const rawThinking = typeof programOpts.thinking === "string" ? programOpts.thinking : null;
+    if (!rawThinking) return undefined;
+    return parseOpenAiReasoningEffort(rawThinking, "--thinking");
   })();
 
   const configModelLabel = (() => {
@@ -137,6 +140,7 @@ export function resolveConfigState({
     openaiUseChatCompletions,
     openaiRequestOptions,
     openaiRequestOptionsOverride,
+    cliReasoningEffortOverride,
     configModelLabel,
   };
 }

--- a/src/run/runner-plan.ts
+++ b/src/run/runner-plan.ts
@@ -145,6 +145,7 @@ export async function createRunnerPlan(options: {
     openaiUseChatCompletions,
     openaiRequestOptions,
     openaiRequestOptionsOverride,
+    cliReasoningEffortOverride,
     configModelLabel,
     apiKey,
     openrouterApiKey,
@@ -340,6 +341,7 @@ export async function createRunnerPlan(options: {
     openaiUseChatCompletions,
     openaiRequestOptions,
     openaiRequestOptionsOverride,
+    cliReasoningEffortOverride,
     cliConfigForRun: cliConfigForRun ?? null,
     cliAvailability,
     trackedFetch,
@@ -452,6 +454,7 @@ export async function createRunnerPlan(options: {
       openaiUseChatCompletions,
       openaiRequestOptions,
       openaiRequestOptionsOverride,
+      cliReasoningEffortOverride,
       openaiWhisperUsdPerMinute,
       apiStatus: {
         xaiApiKey,

--- a/src/run/summary-engine.ts
+++ b/src/run/summary-engine.ts
@@ -6,7 +6,7 @@ import { streamTextWithModelId } from "../llm/generate-text.js";
 import { resolveGitHubModelsApiKey } from "../llm/github-models.js";
 import { parseGatewayStyleModelId } from "../llm/model-id.js";
 import { mergeRequestOptionsForProvider } from "../llm/model-options.js";
-import type { ModelRequestOptions } from "../llm/model-options.js";
+import type { ModelRequestOptions, OpenAiReasoningEffort } from "../llm/model-options.js";
 import type { Prompt } from "../llm/prompt.js";
 import { formatCompactCount } from "../tty/format.js";
 import { createRetryLogger, writeVerbose } from "./logging.js";
@@ -39,6 +39,7 @@ export type SummaryEngineDeps = {
   openaiUseChatCompletions: boolean | undefined;
   openaiRequestOptions?: ModelRequestOptions;
   openaiRequestOptionsOverride?: ModelRequestOptions;
+  cliReasoningEffortOverride?: OpenAiReasoningEffort;
   cliConfigForRun: Parameters<typeof runCliModel>[0]["config"];
   cliAvailability: Partial<Record<CliProvider, boolean>>;
   trackedFetch: typeof fetch;
@@ -327,6 +328,7 @@ export function createSummaryEngine(deps: SummaryEngineDeps) {
       openaiGlobalDefault: deps.openaiRequestOptions,
       attemptOptions: attempt.requestOptions,
       openaiOverride: deps.openaiRequestOptionsOverride,
+      cliReasoningEffortOverride: deps.cliReasoningEffortOverride,
     });
     const streamingEnabledForCall =
       allowStreaming &&

--- a/src/run/summary-engine.ts
+++ b/src/run/summary-engine.ts
@@ -5,7 +5,7 @@ import { isCliDisabled, runCliModel } from "../llm/cli.js";
 import { streamTextWithModelId } from "../llm/generate-text.js";
 import { resolveGitHubModelsApiKey } from "../llm/github-models.js";
 import { parseGatewayStyleModelId } from "../llm/model-id.js";
-import { mergeModelRequestOptions } from "../llm/model-options.js";
+import { mergeRequestOptionsForProvider } from "../llm/model-options.js";
 import type { ModelRequestOptions } from "../llm/model-options.js";
 import type { Prompt } from "../llm/prompt.js";
 import { formatCompactCount } from "../tty/format.js";
@@ -322,11 +322,12 @@ export function createSummaryEngine(deps: SummaryEngineDeps) {
       );
     }
     const parsedModelEffective = parseGatewayStyleModelId(modelResolution.modelId);
-    const requestOptions = mergeModelRequestOptions(
-      deps.openaiRequestOptions,
-      attempt.requestOptions,
-      deps.openaiRequestOptionsOverride,
-    );
+    const requestOptions = mergeRequestOptionsForProvider({
+      provider: parsedModelEffective.provider,
+      openaiGlobalDefault: deps.openaiRequestOptions,
+      attemptOptions: attempt.requestOptions,
+      openaiOverride: deps.openaiRequestOptionsOverride,
+    });
     const streamingEnabledForCall =
       allowStreaming &&
       deps.streamingEnabled &&

--- a/tests/llm.anthropic-reasoning.test.ts
+++ b/tests/llm.anthropic-reasoning.test.ts
@@ -54,21 +54,20 @@ describe("prepareAnthropicReasoning", () => {
     expect(result.model.reasoning).toBe(true);
   });
 
-  it("does NOT flip reasoning:false on registered unsupported models (Claude 3/3.5)", () => {
-    // pi-ai's registry marks Claude 3.5 Sonnet as reasoning: false because
-    // extended thinking is unsupported. We must preserve that flag so the SDK
-    // can keep dropping the thinking block instead of getting a 4xx from API.
+  it("drops reasoning on registered unsupported models (Claude 3/3.5) so pi-ai does not enable thinking", () => {
+    // pi-ai 0.75.5 enables extended thinking whenever `options.reasoning` is
+    // present, regardless of `model.reasoning`. For Claude 3/3.5 the API
+    // rejects thinking blocks, so we must drop the reasoning option entirely
+    // when the user has a global `thinking` setting active.
     const baseModel = makeBase("claude-3-5-sonnet-20241022", false);
     const result = prepareAnthropicReasoning({
       modelId: "claude-3-5-sonnet-20241022",
       baseModel,
       reasoningEffort: "high",
     });
-    // We still forward `reasoning` to pi-ai — pi-ai's adapter is responsible
-    // for deciding what to do with it given the model's metadata. The key
-    // invariant is that we did not mutate the model's reasoning flag.
     expect(result.model).toBe(baseModel);
     expect(result.model.reasoning).toBe(false);
+    expect(result.reasoning).toBeUndefined();
   });
 
   it("opts synthetic models into thinking so the request body carries thinking", () => {
@@ -76,7 +75,11 @@ describe("prepareAnthropicReasoning", () => {
     // routed through a jdcloud-style proxy) is built via createSyntheticModel
     // with reasoning: false. Without opting in, the pi-ai Anthropic adapter
     // would silently drop the thinking block.
-    const baseModel = makeBase("Definitely-Not-A-Real-Claude-Model-Id-42", false, "https://proxy.example/anthropic");
+    const baseModel = makeBase(
+      "Definitely-Not-A-Real-Claude-Model-Id-42",
+      false,
+      "https://proxy.example/anthropic",
+    );
     const result = prepareAnthropicReasoning({
       modelId: "Definitely-Not-A-Real-Claude-Model-Id-42",
       baseModel,

--- a/tests/llm.anthropic-reasoning.test.ts
+++ b/tests/llm.anthropic-reasoning.test.ts
@@ -1,0 +1,92 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { prepareAnthropicReasoning } from "../src/llm/providers/anthropic.js";
+
+function makeBase(
+  modelId: string,
+  reasoning: boolean,
+  baseUrl = "https://api.anthropic.com",
+): Model<Api> {
+  return {
+    id: modelId,
+    name: `anthropic/${modelId}`,
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl,
+    reasoning,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 32_000,
+  };
+}
+
+describe("prepareAnthropicReasoning", () => {
+  it("returns the base model untouched when no effort is requested", () => {
+    const baseModel = makeBase("claude-opus-4-5", true);
+    const result = prepareAnthropicReasoning({ modelId: "claude-opus-4-5", baseModel });
+    expect(result.model).toBe(baseModel);
+    expect(result.reasoning).toBeUndefined();
+  });
+
+  it("treats 'none' as off and does not forward reasoning", () => {
+    const baseModel = makeBase("claude-opus-4-5", true);
+    const result = prepareAnthropicReasoning({
+      modelId: "claude-opus-4-5",
+      baseModel,
+      reasoningEffort: "none",
+    });
+    expect(result.reasoning).toBeUndefined();
+    expect(result.model).toBe(baseModel);
+  });
+
+  it("forwards reasoning for a supported registered model without mutating metadata", () => {
+    // Registered Anthropic model with reasoning support; resolveAnthropicModel
+    // returns it intact so we should not flip any flags.
+    const baseModel = makeBase("claude-opus-4-5", true);
+    const result = prepareAnthropicReasoning({
+      modelId: "claude-opus-4-5",
+      baseModel,
+      reasoningEffort: "xhigh",
+    });
+    expect(result.reasoning).toBe("xhigh");
+    expect(result.model).toBe(baseModel);
+    expect(result.model.reasoning).toBe(true);
+  });
+
+  it("does NOT flip reasoning:false on registered unsupported models (Claude 3/3.5)", () => {
+    // pi-ai's registry marks Claude 3.5 Sonnet as reasoning: false because
+    // extended thinking is unsupported. We must preserve that flag so the SDK
+    // can keep dropping the thinking block instead of getting a 4xx from API.
+    const baseModel = makeBase("claude-3-5-sonnet-20241022", false);
+    const result = prepareAnthropicReasoning({
+      modelId: "claude-3-5-sonnet-20241022",
+      baseModel,
+      reasoningEffort: "high",
+    });
+    // We still forward `reasoning` to pi-ai — pi-ai's adapter is responsible
+    // for deciding what to do with it given the model's metadata. The key
+    // invariant is that we did not mutate the model's reasoning flag.
+    expect(result.model).toBe(baseModel);
+    expect(result.model.reasoning).toBe(false);
+  });
+
+  it("opts synthetic models into thinking so the request body carries thinking", () => {
+    // A custom modelId not in the pi-ai registry (e.g. `Claude-Opus-4.7`
+    // routed through a jdcloud-style proxy) is built via createSyntheticModel
+    // with reasoning: false. Without opting in, the pi-ai Anthropic adapter
+    // would silently drop the thinking block.
+    const baseModel = makeBase("Definitely-Not-A-Real-Claude-Model-Id-42", false, "https://proxy.example/anthropic");
+    const result = prepareAnthropicReasoning({
+      modelId: "Definitely-Not-A-Real-Claude-Model-Id-42",
+      baseModel,
+      reasoningEffort: "xhigh",
+    });
+    expect(result.reasoning).toBe("xhigh");
+    expect(result.model).not.toBe(baseModel);
+    expect(result.model.reasoning).toBe(true);
+    // Other model fields should be preserved.
+    expect(result.model.id).toBe(baseModel.id);
+    expect(result.model.baseUrl).toBe(baseModel.baseUrl);
+  });
+});

--- a/tests/model-options.test.ts
+++ b/tests/model-options.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   mergeModelRequestOptions,
+  mergeRequestOptionsForProvider,
   parseOpenAiReasoningEffort,
   toOpenAiServiceTierParam,
 } from "../src/llm/model-options.js";
@@ -24,5 +25,52 @@ describe("model request options", () => {
     expect(parseOpenAiReasoningEffort("mid")).toBe("medium");
     expect(parseOpenAiReasoningEffort("x-high")).toBe("xhigh");
     expect(() => parseOpenAiReasoningEffort("minimal")).toThrow(/expected none, low/);
+  });
+});
+
+describe("mergeRequestOptionsForProvider", () => {
+  const openaiGlobalDefault = { reasoningEffort: "high" as const };
+  const openaiOverride = { serviceTier: "fast" };
+
+  it("applies the OpenAI-scoped global default and override only for the openai provider", () => {
+    const merged = mergeRequestOptionsForProvider({
+      provider: "openai",
+      openaiGlobalDefault,
+      attemptOptions: undefined,
+      openaiOverride,
+    });
+    expect(merged).toEqual({ reasoningEffort: "high", serviceTier: "fast" });
+  });
+
+  it("does not bleed the OpenAI-scoped global default into the anthropic provider", () => {
+    const merged = mergeRequestOptionsForProvider({
+      provider: "anthropic",
+      openaiGlobalDefault,
+      attemptOptions: undefined,
+      openaiOverride,
+    });
+    expect(merged).toBeUndefined();
+  });
+
+  it("forwards the per-attempt reasoning effort to anthropic when the user opted in for that attempt", () => {
+    const merged = mergeRequestOptionsForProvider({
+      provider: "anthropic",
+      openaiGlobalDefault,
+      attemptOptions: { reasoningEffort: "xhigh" },
+      openaiOverride,
+    });
+    expect(merged).toEqual({ reasoningEffort: "xhigh" });
+  });
+
+  it("isolates other non-openai providers (zai, google, xai) from openai-scoped defaults", () => {
+    for (const provider of ["zai", "google", "xai", "nvidia", "ollama", "github-copilot"]) {
+      const merged = mergeRequestOptionsForProvider({
+        provider,
+        openaiGlobalDefault,
+        attemptOptions: undefined,
+        openaiOverride,
+      });
+      expect(merged, `provider ${provider}`).toBeUndefined();
+    }
   });
 });

--- a/tests/model-options.test.ts
+++ b/tests/model-options.test.ts
@@ -73,4 +73,61 @@ describe("mergeRequestOptionsForProvider", () => {
       expect(merged, `provider ${provider}`).toBeUndefined();
     }
   });
+
+  it("forwards an explicit CLI --thinking override to the anthropic provider", () => {
+    const merged = mergeRequestOptionsForProvider({
+      provider: "anthropic",
+      openaiGlobalDefault,
+      attemptOptions: undefined,
+      openaiOverride,
+      cliReasoningEffortOverride: "xhigh",
+    });
+    expect(merged).toEqual({ reasoningEffort: "xhigh" });
+  });
+
+  it("does not leak a persisted openai.thinking config default into anthropic without a CLI override", () => {
+    const merged = mergeRequestOptionsForProvider({
+      provider: "anthropic",
+      openaiGlobalDefault: { reasoningEffort: "high" },
+      attemptOptions: undefined,
+      openaiOverride: undefined,
+      cliReasoningEffortOverride: undefined,
+    });
+    expect(merged).toBeUndefined();
+  });
+
+  it("respects persisted openai.thinking for openai when no CLI override is set", () => {
+    const merged = mergeRequestOptionsForProvider({
+      provider: "openai",
+      openaiGlobalDefault: { reasoningEffort: "high" },
+      attemptOptions: undefined,
+      openaiOverride: undefined,
+      cliReasoningEffortOverride: undefined,
+    });
+    expect(merged).toEqual({ reasoningEffort: "high" });
+  });
+
+  it("lets a CLI --thinking override beat persisted openai.thinking for the openai provider", () => {
+    const merged = mergeRequestOptionsForProvider({
+      provider: "openai",
+      openaiGlobalDefault: { reasoningEffort: "high" },
+      attemptOptions: undefined,
+      openaiOverride: undefined,
+      cliReasoningEffortOverride: "xhigh",
+    });
+    expect(merged).toEqual({ reasoningEffort: "xhigh" });
+  });
+
+  it("forwards CLI --thinking to other non-openai providers (zai, google, xai, ...)", () => {
+    for (const provider of ["zai", "google", "xai", "nvidia", "ollama", "github-copilot"]) {
+      const merged = mergeRequestOptionsForProvider({
+        provider,
+        openaiGlobalDefault,
+        attemptOptions: undefined,
+        openaiOverride,
+        cliReasoningEffortOverride: "xhigh",
+      });
+      expect(merged, `provider ${provider}`).toEqual({ reasoningEffort: "xhigh" });
+    }
+  });
 });

--- a/tests/run.config.test.ts
+++ b/tests/run.config.test.ts
@@ -33,13 +33,12 @@ function resolveTestConfigStateWithEnv(
 }
 
 describe("run config", () => {
-  it("maps --fast and --thinking to OpenAI request overrides", () => {
-    expect(
-      resolveTestConfigState({ fast: true, thinking: "mid" }).openaiRequestOptionsOverride,
-    ).toEqual({
+  it("maps --fast to OpenAI request overrides and --thinking to the cross-provider CLI override", () => {
+    const state = resolveTestConfigState({ fast: true, thinking: "mid" });
+    expect(state.openaiRequestOptionsOverride).toEqual({
       serviceTier: "fast",
-      reasoningEffort: "medium",
     });
+    expect(state.cliReasoningEffortOverride).toBe("medium");
   });
 
   it("maps --service-tier to OpenAI request overrides", () => {
@@ -71,5 +70,11 @@ describe("run config", () => {
 
   it("leaves openaiUseChatCompletions unset when there is no env or config override", () => {
     expect(resolveTestConfigState({}).openaiUseChatCompletions).toBeUndefined();
+  });
+
+  it("lifts --thinking out of the openai-scoped override entirely", () => {
+    const state = resolveTestConfigState({ thinking: "xhigh" });
+    expect(state.openaiRequestOptionsOverride).toBeUndefined();
+    expect(state.cliReasoningEffortOverride).toBe("xhigh");
   });
 });

--- a/tests/run.url-markdown-anthropic.test.ts
+++ b/tests/run.url-markdown-anthropic.test.ts
@@ -1,0 +1,117 @@
+import { Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { parseRequestedModelId } from "../src/model-spec.js";
+
+const mocks = vi.hoisted(() => ({
+  createHtmlToMarkdownConverter: vi.fn(() => async () => "# Converted"),
+}));
+
+vi.mock("../src/llm/html-to-markdown.js", () => ({
+  createHtmlToMarkdownConverter: mocks.createHtmlToMarkdownConverter,
+}));
+
+import { createMarkdownConverters } from "../src/run/flows/url/markdown.js";
+import type { UrlFlowContext } from "../src/run/flows/url/types.js";
+
+function sink() {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+}
+
+function buildCtx(opts: {
+  openaiRequestOptions?: { reasoningEffort?: "high" };
+  openaiRequestOptionsOverride?: { serviceTier?: "fast" };
+  cliReasoningEffortOverride?: "xhigh";
+}): UrlFlowContext {
+  const fixedModel = parseRequestedModelId("anthropic/claude-sonnet-4-5");
+  if (fixedModel.kind !== "fixed" || fixedModel.transport !== "native") {
+    throw new Error("expected fixed native anthropic model");
+  }
+  return {
+    io: {
+      env: {},
+      envForRun: {},
+      stdout: sink(),
+      stderr: sink(),
+      fetch: globalThis.fetch.bind(globalThis),
+      execFileImpl: vi.fn(),
+    },
+    flags: {
+      format: "markdown",
+      markdownMode: "llm",
+      transcriptTimestamps: false,
+      preprocessMode: "off",
+      retries: 0,
+      verbose: false,
+      verboseColor: false,
+    },
+    model: {
+      requestedModel: fixedModel,
+      fixedModelSpec: fixedModel,
+      apiStatus: {
+        xaiApiKey: null,
+        googleApiKey: null,
+        apiKey: null,
+        anthropicApiKey: "sk-test",
+        openrouterApiKey: null,
+        openrouterConfigured: false,
+        googleConfigured: false,
+        anthropicConfigured: true,
+        zaiApiKey: null,
+        zaiBaseUrl: "",
+        nvidiaApiKey: null,
+        nvidiaBaseUrl: "",
+        ollamaBaseUrl: "",
+        providerBaseUrls: {
+          openai: null,
+          anthropic: null,
+          google: null,
+          xai: null,
+        },
+      },
+      openaiUseChatCompletions: false,
+      openaiRequestOptions: opts.openaiRequestOptions,
+      openaiRequestOptionsOverride: opts.openaiRequestOptionsOverride,
+      cliReasoningEffortOverride: opts.cliReasoningEffortOverride,
+      llmCalls: [],
+    },
+  } as unknown as UrlFlowContext;
+}
+
+describe("URL markdown anthropic routing", () => {
+  it("scopes openai-only request options away from anthropic markdown calls", () => {
+    mocks.createHtmlToMarkdownConverter.mockClear();
+    const ctx = buildCtx({
+      openaiRequestOptions: { reasoningEffort: "high" },
+      openaiRequestOptionsOverride: { serviceTier: "fast" },
+    });
+
+    createMarkdownConverters(ctx, { isYoutubeUrl: false });
+
+    expect(mocks.createHtmlToMarkdownConverter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: expect.stringContaining("anthropic"),
+        requestOptions: undefined,
+      }),
+    );
+  });
+
+  it("forwards an explicit CLI --thinking override to anthropic markdown calls", () => {
+    mocks.createHtmlToMarkdownConverter.mockClear();
+    const ctx = buildCtx({
+      openaiRequestOptions: { reasoningEffort: "high" },
+      cliReasoningEffortOverride: "xhigh",
+    });
+
+    createMarkdownConverters(ctx, { isYoutubeUrl: false });
+
+    expect(mocks.createHtmlToMarkdownConverter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestOptions: { reasoningEffort: "xhigh" },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Proof

**Latest head 3d7cc968 proof**: see comment [#4638051618](https://github.com/steipete/summarize/pull/233#issuecomment-4638051618) — outbound request captures for both (a) CLI `--thinking xhigh` correctly forwarding the `thinking` block to Anthropic and (b) persisted `openai.thinking` *not* leaking into Anthropic requests.

## Problem

The Anthropic provider accepts `--thinking <effort>` (and the matching `thinking` config field) without error, but never forwards the value to the API. Requests go out with no `thinking` block, so users who set a reasoning level on `anthropic/...` models get no extended thinking and don't know it.

Reproduces on `main` against any Claude model:

```bash
summarize "https://example.com" --model anthropic/claude-opus-4-5 --thinking xhigh --verbose
```

Verbose log shows `model=anthropic/claude-opus-4-5` but the outbound request has no `thinking` field.

## Root cause

Two layers:

1. `generateTextWithModelId` in `src/llm/generate-text.ts` reads `requestOptions.reasoningEffort` for the OpenAI path but never threads it into `completeAnthropicText`.
2. `completeAnthropicText` in `src/llm/providers/anthropic.ts` calls pi-ai's `completeSimple` without a `reasoning` option. Even when threaded through, models built via `createSyntheticModel` default to `reasoning: false`, which makes the pi-ai Anthropic adapter silently drop the block (see `streamSimpleAnthropic` — it gates on `model.reasoning`).

## Fix

1. Pass `requestOptions?.reasoningEffort` from `generateTextWithModelId` into `completeAnthropicText`, mirroring how the OpenAI path uses it.
2. In `completeAnthropicText`, map the OpenAI effort enum (`low`/`medium`/`high`/`xhigh`; `none` is treated as off) to a pi-ai `ThinkingLevel` and forward it as `reasoning`. When the model came from `createSyntheticModel` (`reasoning: false`), opt the model into thinking so the pi-ai adapter does not silently drop the block.

## Verification

Tested end-to-end against a custom `ANTHROPIC_BASE_URL` (Claude Opus 4.7 via a proxy that exposes the synthetic-model code path). The outbound request body (captured with a `fetch` monkey-patch wrapper) before vs after this PR:

| `--thinking` | Before | After |
|---|---|---|
| _(unset)_ | `has_thinking: false` | `has_thinking: false` (unchanged) |
| `low` | `has_thinking: false` | `thinking: {enabled, budget_tokens: 2048}` |
| `medium` | `has_thinking: false` | `thinking: {enabled, budget_tokens: 8192}` |
| `high` | `has_thinking: false` | `thinking: {enabled, budget_tokens: 15360}` |
| `xhigh` | `has_thinking: false` | `thinking: {enabled, budget_tokens: 15360}` |

(With `max_tokens=16384` the pi-ai SDK caps thinking budget at `max_tokens − 1024`, hence `high` and `xhigh` both land at 15360 — that's SDK behavior, not this patch.)

Summaries still return correctly in all cases.

## Notes / scope

- Only `completeAnthropicText` is patched. `completeAnthropicDocument` builds its request body by hand (no pi-ai dispatch) — extending thinking support there would be a separate, larger change touching the manual payload assembly.
- `--thinking`'s CLI help text still reads "OpenAI reasoning effort"; happy to update it in this PR if you'd like the wording to acknowledge the Anthropic path now works.
