### PR TITLE
[security] fix(core): guard RSS transcript fetches

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,8 @@
     "cheerio": "^1.2.0",
     "es-toolkit": "^1.46.1",
     "jsdom": "29.1.1",
-    "sanitize-html": "^2.17.4"
+    "sanitize-html": "^2.17.4",
+    "undici": "8.3.0"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.3",

--- a/packages/core/src/content/transcript/providers/podcast/rss-transcript.ts
+++ b/packages/core/src/content/transcript/providers/podcast/rss-transcript.ts
@@ -1,3 +1,6 @@
+import { lookup as dnsLookup } from "node:dns/promises";
+import { createRequire } from "node:module";
+import { isIP } from "node:net";
 import type { TranscriptSegment } from "../../../link-preview/types.js";
 import {
   jsonTranscriptToPlainText,
@@ -14,8 +17,24 @@ import {
 } from "./rss-feed.js";
 
 type TranscriptCandidate = { url: string; type: string | null };
+type LookupAddress = { address: string; family?: number };
+type LookupFn = (hostname: string) => Promise<LookupAddress[]>;
+type LookupCallback = (
+  error: Error | null,
+  address: string | LookupAddress[],
+  family?: number,
+) => void;
+type UndiciAgentConstructor = new (options: {
+  autoSelectFamily?: boolean;
+  autoSelectFamilyAttemptTimeout?: number;
+  connect: {
+    lookup: (hostname: string, options: unknown, callback: LookupCallback) => void;
+  };
+}) => unknown;
+type UndiciModule = { Agent: UndiciAgentConstructor; fetch: typeof fetch };
 
 const MAX_TRANSCRIPT_REDIRECTS = 10;
+const require = createRequire(import.meta.url);
 
 function parseIpv4(address: string): number[] | null {
   const parts = address.split(".");
@@ -28,9 +47,9 @@ function parseIpv4(address: string): number[] | null {
   return octets.every((value) => value != null) ? (octets as number[]) : null;
 }
 
-function isBlockedIpv4Literal(hostname: string): boolean {
-  const octets = parseIpv4(hostname);
-  if (!octets) return false;
+function isBlockedIpv4(address: string): boolean {
+  const octets = parseIpv4(address);
+  if (!octets) return true;
   const [a, b] = octets;
   return (
     a === 0 ||
@@ -72,9 +91,9 @@ function expandIpv6(address: string): number[] | null {
   return parts.length === 8 && parts.every((part) => part >= 0 && part <= 0xffff) ? parts : null;
 }
 
-function isBlockedIpv6Literal(hostname: string): boolean {
-  const parts = expandIpv6(hostname);
-  if (!parts) return false;
+function isBlockedIpv6(address: string): boolean {
+  const parts = expandIpv6(address);
+  if (!parts) return true;
   const [first, second, , , , fifth, sixth, eighth] = parts;
   const allZero = parts.every((part) => part === 0);
   const loopback = parts.slice(0, 7).every((part) => part === 0) && eighth === 1;
@@ -82,7 +101,7 @@ function isBlockedIpv6Literal(hostname: string): boolean {
   const compatibleIpv4 = parts.slice(0, 6).every((part) => part === 0) && !allZero && !loopback;
   if (mappedIpv4 || compatibleIpv4) {
     const ipv4 = `${((sixth ?? 0) >> 8) & 0xff}.${(sixth ?? 0) & 0xff}.${((eighth ?? 0) >> 8) & 0xff}.${(eighth ?? 0) & 0xff}`;
-    return isBlockedIpv4Literal(ipv4);
+    return isBlockedIpv4(ipv4);
   }
   return (
     allZero ||
@@ -102,7 +121,22 @@ function normalizeHostname(hostname: string): string {
     .replace(/\.$/, "");
 }
 
-function assertSafeTranscriptUrl(rawUrl: string): URL {
+export function isBlockedNetworkAddress(address: string): boolean {
+  const normalized = address.trim().replace(/^\[|\]$/g, "");
+  const family = isIP(normalized);
+  if (family === 4) return isBlockedIpv4(normalized);
+  if (family === 6) return isBlockedIpv6(normalized);
+  return true;
+}
+
+async function defaultLookup(hostname: string): Promise<LookupAddress[]> {
+  return await dnsLookup(hostname, { all: true, verbatim: true });
+}
+
+async function resolveSafeTranscriptUrl(
+  rawUrl: string,
+  { lookup = defaultLookup }: { lookup?: LookupFn } = {},
+): Promise<{ url: URL; addresses: LookupAddress[] }> {
   let url: URL;
   try {
     url = new URL(rawUrl);
@@ -113,41 +147,82 @@ function assertSafeTranscriptUrl(rawUrl: string): URL {
     throw new Error("RSS transcript URL must use http or https");
   }
   const hostname = normalizeHostname(url.hostname);
-  if (
-    hostname === "localhost" ||
-    hostname.endsWith(".localhost") ||
-    isBlockedIpv4Literal(hostname) ||
-    isBlockedIpv6Literal(hostname)
-  ) {
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) {
     throw new Error("RSS transcript URL targets a blocked local network host");
   }
-  return url;
+  if (isIP(hostname)) {
+    if (isBlockedNetworkAddress(hostname)) {
+      throw new Error("RSS transcript URL resolves to a blocked local network address");
+    }
+    return { url, addresses: [] };
+  }
+  const addresses = await lookup(hostname);
+  if (addresses.length === 0 || addresses.some((entry) => isBlockedNetworkAddress(entry.address))) {
+    throw new Error("RSS transcript URL resolves to a blocked local network address");
+  }
+  return { url, addresses };
 }
 
 function isRedirectStatus(status: number): boolean {
   return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }
 
+function isNativeFetchImpl(fetchImpl: typeof fetch): boolean {
+  return fetchImpl === globalThis.fetch || fetchImpl.name === "bound fetch";
+}
+
+function loadUndici(): UndiciModule {
+  return require("undici") as UndiciModule;
+}
+
+function createPinnedDispatcher(addresses: LookupAddress[]): unknown {
+  const { Agent } = loadUndici();
+  const pinnedAddresses = addresses.map((address) => ({
+    address: address.address,
+    family: address.family ?? (isIP(address.address) || 4),
+  }));
+  return new Agent({
+    autoSelectFamily: true,
+    autoSelectFamilyAttemptTimeout: 250,
+    connect: {
+      lookup: (_hostname, options, callback) => {
+        if ((options as { all?: boolean } | undefined)?.all) {
+          callback(null, pinnedAddresses);
+          return;
+        }
+        const first = pinnedAddresses[0];
+        callback(null, first?.address ?? "0.0.0.0", first?.family ?? 4);
+      },
+    },
+  });
+}
+
 async function fetchSafeTranscriptUrl(
   fetchImpl: typeof fetch,
   transcriptUrl: string,
+  { lookup = defaultLookup }: { lookup?: LookupFn } = {},
   redirectCount = 0,
 ): Promise<Response> {
-  const url = assertSafeTranscriptUrl(transcriptUrl);
-  const res = await fetchImpl(url.href, {
-    redirect: "manual",
+  const target = await resolveSafeTranscriptUrl(transcriptUrl, { lookup });
+  const pinnedInit = {
+    redirect: "manual" as const,
     signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
     headers: { accept: "text/vtt,text/plain,application/json;q=0.9,*/*;q=0.8" },
-  });
+    ...(target.addresses.length > 0
+      ? { dispatcher: createPinnedDispatcher(target.addresses) }
+      : {}),
+  } as RequestInit & { dispatcher?: unknown };
+  const pinnedFetchImpl =
+    target.addresses.length > 0 && isNativeFetchImpl(fetchImpl) ? loadUndici().fetch : fetchImpl;
+  const res = await pinnedFetchImpl(target.url.href, pinnedInit);
   if (!isRedirectStatus(res.status)) return res;
   const location = res.headers.get("location");
   if (!location) return res;
   if (redirectCount >= MAX_TRANSCRIPT_REDIRECTS) {
     throw new Error("RSS transcript URL redirected too many times");
   }
-  const nextUrl = new URL(location, res.url || url.href).href;
-  assertSafeTranscriptUrl(nextUrl);
-  return await fetchSafeTranscriptUrl(fetchImpl, nextUrl, redirectCount + 1);
+  const nextUrl = new URL(location, res.url || target.url.href).href;
+  return await fetchSafeTranscriptUrl(fetchImpl, nextUrl, { lookup }, redirectCount + 1);
 }
 
 export async function tryFetchTranscriptFromFeedXml({
@@ -155,11 +230,13 @@ export async function tryFetchTranscriptFromFeedXml({
   feedXml,
   episodeTitle,
   notes,
+  lookup,
 }: {
   fetchImpl: typeof fetch;
   feedXml: string;
   episodeTitle: string | null;
   notes: string[];
+  lookup?: LookupFn;
 }): Promise<{
   text: string;
   transcriptUrl: string;
@@ -185,7 +262,7 @@ export async function tryFetchTranscriptFromFeedXml({
 
     const transcriptUrl = decodeXmlEntities(preferred.url);
     try {
-      const res = await fetchSafeTranscriptUrl(fetchImpl, transcriptUrl);
+      const res = await fetchSafeTranscriptUrl(fetchImpl, transcriptUrl, { lookup });
       if (!res.ok) throw new Error(`transcript fetch failed (${res.status})`);
 
       const contentType =

--- a/packages/core/src/content/transcript/providers/podcast/rss-transcript.ts
+++ b/packages/core/src/content/transcript/providers/podcast/rss-transcript.ts
@@ -15,6 +15,141 @@ import {
 
 type TranscriptCandidate = { url: string; type: string | null };
 
+const MAX_TRANSCRIPT_REDIRECTS = 10;
+
+function parseIpv4(address: string): number[] | null {
+  const parts = address.split(".");
+  if (parts.length !== 4) return null;
+  const octets = parts.map((part) => {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const value = Number(part);
+    return Number.isInteger(value) && value >= 0 && value <= 255 ? value : null;
+  });
+  return octets.every((value) => value != null) ? (octets as number[]) : null;
+}
+
+function isBlockedIpv4Literal(hostname: string): boolean {
+  const octets = parseIpv4(hostname);
+  if (!octets) return false;
+  const [a, b] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 192 && b === 0) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224
+  );
+}
+
+function expandIpv6(address: string): number[] | null {
+  const normalized = address.split("%", 1)[0]?.toLowerCase() ?? "";
+  if (!normalized) return null;
+  const mapped = normalized.match(/^(.*:)(\d{1,3}(?:\.\d{1,3}){3})$/);
+  const ipv4 = mapped ? parseIpv4(mapped[2] ?? "") : null;
+  const head = mapped ? (mapped[1] ?? "") : normalized;
+  const partsAroundGap = head.split("::");
+  if (partsAroundGap.length > 2) return null;
+  const [leftRaw, rightRaw] = partsAroundGap;
+  const left = leftRaw ? leftRaw.split(":").filter(Boolean) : [];
+  const right = typeof rightRaw === "string" && rightRaw ? rightRaw.split(":").filter(Boolean) : [];
+  const ipv4Parts = ipv4
+    ? [((ipv4[0] ?? 0) << 8) | (ipv4[1] ?? 0), ((ipv4[2] ?? 0) << 8) | (ipv4[3] ?? 0)]
+    : [];
+  const missing = 8 - left.length - right.length - ipv4Parts.length;
+  if (missing < 0 || (partsAroundGap.length === 1 && missing !== 0)) return null;
+  const parsePart = (part: string) => (/^[0-9a-f]{1,4}$/.test(part) ? parseInt(part, 16) : -1);
+  const parts = [
+    ...left.map(parsePart),
+    ...Array.from({ length: missing }, () => 0),
+    ...right.map(parsePart),
+    ...ipv4Parts,
+  ];
+  return parts.length === 8 && parts.every((part) => part >= 0 && part <= 0xffff) ? parts : null;
+}
+
+function isBlockedIpv6Literal(hostname: string): boolean {
+  const parts = expandIpv6(hostname);
+  if (!parts) return false;
+  const [first, second, , , , fifth, sixth, eighth] = parts;
+  const allZero = parts.every((part) => part === 0);
+  const loopback = parts.slice(0, 7).every((part) => part === 0) && eighth === 1;
+  const mappedIpv4 = parts.slice(0, 5).every((part) => part === 0) && fifth === 0xffff;
+  const compatibleIpv4 = parts.slice(0, 6).every((part) => part === 0) && !allZero && !loopback;
+  if (mappedIpv4 || compatibleIpv4) {
+    const ipv4 = `${((sixth ?? 0) >> 8) & 0xff}.${(sixth ?? 0) & 0xff}.${((eighth ?? 0) >> 8) & 0xff}.${(eighth ?? 0) & 0xff}`;
+    return isBlockedIpv4Literal(ipv4);
+  }
+  return (
+    allZero ||
+    loopback ||
+    ((first ?? 0) & 0xfe00) === 0xfc00 ||
+    ((first ?? 0) & 0xffc0) === 0xfe80 ||
+    ((first ?? 0) & 0xff00) === 0xff00 ||
+    (first === 0x2001 && second === 0xdb8)
+  );
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname
+    .trim()
+    .replace(/^\[|\]$/g, "")
+    .toLowerCase()
+    .replace(/\.$/, "");
+}
+
+function assertSafeTranscriptUrl(rawUrl: string): URL {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error("RSS transcript URL is invalid");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("RSS transcript URL must use http or https");
+  }
+  const hostname = normalizeHostname(url.hostname);
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    isBlockedIpv4Literal(hostname) ||
+    isBlockedIpv6Literal(hostname)
+  ) {
+    throw new Error("RSS transcript URL targets a blocked local network host");
+  }
+  return url;
+}
+
+function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+async function fetchSafeTranscriptUrl(
+  fetchImpl: typeof fetch,
+  transcriptUrl: string,
+  redirectCount = 0,
+): Promise<Response> {
+  const url = assertSafeTranscriptUrl(transcriptUrl);
+  const res = await fetchImpl(url.href, {
+    redirect: "manual",
+    signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
+    headers: { accept: "text/vtt,text/plain,application/json;q=0.9,*/*;q=0.8" },
+  });
+  if (!isRedirectStatus(res.status)) return res;
+  const location = res.headers.get("location");
+  if (!location) return res;
+  if (redirectCount >= MAX_TRANSCRIPT_REDIRECTS) {
+    throw new Error("RSS transcript URL redirected too many times");
+  }
+  const nextUrl = new URL(location, res.url || url.href).href;
+  assertSafeTranscriptUrl(nextUrl);
+  return await fetchSafeTranscriptUrl(fetchImpl, nextUrl, redirectCount + 1);
+}
+
 export async function tryFetchTranscriptFromFeedXml({
   fetchImpl,
   feedXml,
@@ -50,11 +185,7 @@ export async function tryFetchTranscriptFromFeedXml({
 
     const transcriptUrl = decodeXmlEntities(preferred.url);
     try {
-      const res = await fetchImpl(transcriptUrl, {
-        redirect: "follow",
-        signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
-        headers: { accept: "text/vtt,text/plain,application/json;q=0.9,*/*;q=0.8" },
-      });
+      const res = await fetchSafeTranscriptUrl(fetchImpl, transcriptUrl);
       if (!res.ok) throw new Error(`transcript fetch failed (${res.status})`);
 
       const contentType =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       sanitize-html:
         specifier: ^2.17.4
         version: 2.17.4
+      undici:
+        specifier: 8.3.0
+        version: 8.3.0
     devDependencies:
       '@types/jsdom':
         specifier: ^28.0.3

--- a/tests/security.rss-transcript-ssrf.test.ts
+++ b/tests/security.rss-transcript-ssrf.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { tryFetchTranscriptFromFeedXml } from "../packages/core/src/content/transcript/providers/podcast/rss-transcript.js";
+
+describe("RSS podcast transcript URL handling", () => {
+  it("rejects loopback transcript URLs from feed XML before fetching them", async () => {
+    const internalTranscriptUrl = "http://127.0.0.1:65535/admin/metadata?token=[REDACTED]";
+    const feedXml = `<?xml version="1.0"?>
+      <rss xmlns:podcast="https://podcastindex.org/namespace/1.0">
+        <channel>
+          <item>
+            <title>Episode 1</title>
+            <guid>episode-1</guid>
+            <enclosure url="https://cdn.example/episode.mp3" type="audio/mpeg" />
+            <podcast:transcript url="${internalTranscriptUrl}" type="text/vtt" />
+          </item>
+        </channel>
+      </rss>`;
+
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("internal transcript URL should not be fetched");
+    });
+
+    const notes: string[] = [];
+    const result = await tryFetchTranscriptFromFeedXml({
+      feedXml,
+      episodeTitle: "Episode 1",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      notes,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+    expect(notes.join(" ")).toMatch(/blocked/i);
+  });
+
+  it("rejects redirects from public transcript URLs to loopback targets", async () => {
+    const publicTranscriptUrl = "https://transcripts.example/episode.vtt";
+    const internalRedirectUrl = "http://127.0.0.1:65535/admin/metadata?token=[REDACTED]";
+    const feedXml = `<?xml version="1.0"?>
+      <rss xmlns:podcast="https://podcastindex.org/namespace/1.0">
+        <channel>
+          <item>
+            <title>Episode 1</title>
+            <guid>episode-1</guid>
+            <podcast:transcript url="${publicTranscriptUrl}" type="text/vtt" />
+          </item>
+        </channel>
+      </rss>`;
+
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === publicTranscriptUrl) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: internalRedirectUrl },
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const notes: string[] = [];
+    const result = await tryFetchTranscriptFromFeedXml({
+      feedXml,
+      episodeTitle: "Episode 1",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      notes,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      publicTranscriptUrl,
+      expect.objectContaining({ redirect: "manual" }),
+    );
+    expect(result).toBeNull();
+    expect(notes.join(" ")).toMatch(/blocked/i);
+  });
+});

--- a/tests/security.rss-transcript-ssrf.test.ts
+++ b/tests/security.rss-transcript-ssrf.test.ts
@@ -59,11 +59,13 @@ describe("RSS podcast transcript URL handling", () => {
     });
 
     const notes: string[] = [];
+    const lookup = vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]);
     const result = await tryFetchTranscriptFromFeedXml({
       feedXml,
       episodeTitle: "Episode 1",
       fetchImpl: fetchImpl as unknown as typeof fetch,
       notes,
+      lookup,
     });
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
@@ -73,5 +75,113 @@ describe("RSS podcast transcript URL handling", () => {
     );
     expect(result).toBeNull();
     expect(notes.join(" ")).toMatch(/blocked/i);
+  });
+
+  it("rejects transcript hostnames that resolve to private addresses before fetching", async () => {
+    const transcriptUrl = "https://attacker-controlled.example/episode.vtt";
+    const feedXml = `<?xml version="1.0"?>
+      <rss xmlns:podcast="https://podcastindex.org/namespace/1.0">
+        <channel>
+          <item>
+            <title>Episode 1</title>
+            <podcast:transcript url="${transcriptUrl}" type="text/vtt" />
+          </item>
+        </channel>
+      </rss>`;
+    const lookup = vi.fn(async () => [{ address: "10.0.0.7", family: 4 }]);
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("hostname resolving to a private address should not be fetched");
+    });
+
+    const notes: string[] = [];
+    const result = await tryFetchTranscriptFromFeedXml({
+      feedXml,
+      episodeTitle: "Episode 1",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      notes,
+      lookup,
+    });
+
+    expect(lookup).toHaveBeenCalledWith("attacker-controlled.example");
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+    expect(notes.join(" ")).toMatch(/blocked local network address/i);
+  });
+
+  it("revalidates redirect hostnames with DNS before following to private addresses", async () => {
+    const publicTranscriptUrl = "https://transcripts.example/episode.vtt";
+    const reboundRedirectUrl = "https://rebind.example/internal.vtt";
+    const feedXml = `<?xml version="1.0"?>
+      <rss xmlns:podcast="https://podcastindex.org/namespace/1.0">
+        <channel>
+          <item>
+            <title>Episode 1</title>
+            <podcast:transcript url="${publicTranscriptUrl}" type="text/vtt" />
+          </item>
+        </channel>
+      </rss>`;
+    const lookup = vi.fn(async (hostname: string) => {
+      if (hostname === "transcripts.example") return [{ address: "93.184.216.34", family: 4 }];
+      if (hostname === "rebind.example") return [{ address: "127.0.0.1", family: 4 }];
+      return [];
+    });
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      if (input.toString() !== publicTranscriptUrl) throw new Error(`unexpected fetch: ${input}`);
+      return new Response(null, { status: 302, headers: { location: reboundRedirectUrl } });
+    });
+
+    const notes: string[] = [];
+    const result = await tryFetchTranscriptFromFeedXml({
+      feedXml,
+      episodeTitle: "Episode 1",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      notes,
+      lookup,
+    });
+
+    expect(lookup).toHaveBeenCalledWith("transcripts.example");
+    expect(lookup).toHaveBeenCalledWith("rebind.example");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+    expect(notes.join(" ")).toMatch(/blocked local network address/i);
+  });
+
+  it("pins transcript fetches to the DNS addresses that were validated", async () => {
+    const transcriptUrl = "https://transcripts.example/episode.vtt";
+    const feedXml = `<?xml version="1.0"?>
+      <rss xmlns:podcast="https://podcastindex.org/namespace/1.0">
+        <channel>
+          <item>
+            <title>Episode 1</title>
+            <podcast:transcript url="${transcriptUrl}" type="text/vtt" />
+          </item>
+        </channel>
+      </rss>`;
+    const lookup = vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]);
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("WEBVTT\n\n00:00.000 --> 00:01.000\nPinned", {
+          status: 200,
+          headers: { "content-type": "text/vtt" },
+        }),
+    );
+
+    const notes: string[] = [];
+    const result = await tryFetchTranscriptFromFeedXml({
+      feedXml,
+      episodeTitle: "Episode 1",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      notes,
+      lookup,
+    });
+
+    expect(result?.text).toBe("Pinned");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      transcriptUrl,
+      expect.objectContaining({
+        redirect: "manual",
+        dispatcher: expect.any(Object),
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

This PR hardens the RSS podcast transcript trust boundary so feed-controlled `<podcast:transcript>` URLs cannot drive host-side transcript fetching into local or private network services.

- Fixes a server-side request forgery risk in the RSS transcript provider path.
- Validates transcript URLs before any fetch, including rejected schemes and local/private address ranges.
- Resolves DNS for transcript hostnames before fetching, rejects any private/link-local/loopback result, and pins the fetch dispatcher to the already validated address set.
- Revalidates and pins every redirect target instead of relying on automatic redirect following.
- Adds regression coverage for direct loopback URLs, redirect-to-loopback URLs, hostnames resolving to private addresses, redirect hostnames resolving to private addresses, and pinned-fetch behavior.
- Adds redacted after-fix runtime proof showing a feed-controlled loopback transcript URL is blocked before the local service is contacted.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| RSS podcast transcript URLs can trigger SSRF to local/private network services | A malicious or compromised feed can cause the host-side transcript extraction path to request loopback, link-local, RFC1918/private, or otherwise internal URL literals/hostnames and treat the response as transcript content. | High under deployments that summarize attacker-controlled podcast/RSS URLs; Medium hardening if all feed inputs are trusted/operator-controlled. |

## Before this PR

- `tryFetchTranscriptFromFeedXml()` decoded the feed-controlled transcript `url` attribute and passed it directly to the transcript fetch implementation.
- Transcript fetches used automatic redirects, so a public transcript URL could redirect into a local/private/internal host after the initial request.
- Hostname URLs were not DNS-resolved by the transcript guard, so a hostname resolving or rebinding to loopback/private/link-local space could still reach runtime DNS.
- The RSS transcript tests did not lock in SSRF protection for direct loopback transcript URLs, DNS-resolved private hostnames, redirect-based bypasses, or DNS-pinned fetch behavior.

## After this PR

- RSS transcript URLs are parsed and validated before fetching.
- Non-HTTP(S) schemes and local/private/internal hostname literals are rejected before the fetch implementation is called.
- Transcript hostnames are resolved with `dns.lookup(..., { all: true, verbatim: true })`; empty results or any blocked address reject the transcript URL before fetch.
- For allowed DNS hostnames, transcript fetches use an Undici dispatcher whose lookup returns only the already validated address set, preventing a second runtime DNS lookup from rebinding the request to a private address.
- Transcript fetches use manual redirect handling, and every `Location` target repeats the same URL, DNS, private-address, and pinned-dispatcher handling before the next request.
- Regression tests cover direct loopback transcript URLs, public-to-loopback redirects, hostnames resolving to private addresses, redirect hostnames resolving to private addresses, and pinned dispatcher behavior.

## Why this matters

Podcast/RSS feed XML is content controlled by the feed publisher, and feed URLs may be user-supplied in deployments that summarize external podcasts. Without a URL and DNS boundary at the nested transcript-fetch layer, feed content can move the host process from normal remote content retrieval into requests against services that were only intended to be reachable from the local machine or private network.

## Attack flow

```text
attacker controls or influences a podcast/RSS feed
    -> feed includes <podcast:transcript url="http://127.0.0.1:...">
       or <podcast:transcript url="https://attacker-hostname.example/...">
    -> RSS transcript provider decodes the nested URL
    -> host-side fetch requests the local/private target or follows a redirect/rebinding hostname
    -> response is accepted as transcript text
```

## Affected code

| Issue | Files |
|-------|-------|
| RSS transcript SSRF via feed-controlled transcript URLs, DNS-resolved hostnames, and redirects | `packages/core/src/content/transcript/providers/podcast/rss-transcript.ts`, `tests/security.rss-transcript-ssrf.test.ts`, `packages/core/package.json`, `pnpm-lock.yaml` |

## Root cause

Issue: RSS podcast transcript URLs can trigger SSRF to local/private network services

- The nested transcript URL was trusted after XML extraction, even though it came from feed-controlled RSS content.
- Automatic redirect following let the final fetch target differ from the initially selected URL without another safety check.
- Hostnames were not resolved and pinned by the transcript guard before runtime fetch, leaving DNS rebinding/private-resolution bypasses.
- The provider lacked regression tests for local/private transcript URL denial, DNS resolution denial, and pinned-fetch behavior.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| RSS podcast transcript SSRF | 8.2 High | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:L` |

Rationale:

- The High assessment assumes a deployment where unauthenticated or low-friction users can submit attacker-controlled podcast/RSS URLs for summarization, and where the daemon or extension runs with host/network access to private services.
- Confidentiality is the primary concern because internal service responses can be fetched and treated as transcript text; availability impact is bounded to possible request pressure or redirect behavior.
- If maintainers consider all feed URLs trusted/operator-controlled, this is still useful Medium hardening for a brittle network trust boundary.

## Safe reproduction / after-fix proof

### Direct loopback transcript URL

1. Use RSS XML containing a `<podcast:transcript>` element whose `url` points at a loopback literal such as `http://127.0.0.1:8080/transcript.txt`.
2. Run the RSS transcript extraction path.
3. After this PR, the transcript URL is rejected before the fetch implementation contacts the local service.

Redacted terminal output from an after-fix runtime scenario with a real local HTTP listener:

```text
$ pnpm -s tsx /tmp/summarize-rss-transcript-ssrf-proof.ts
RSS transcript SSRF after-fix runtime proof
scenario: feed-controlled transcript URL -> http://127.0.0.1:58843/admin/metadata?token=[REDACTED]
result: blocked/no transcript returned
local_service_hits: 0
notes: RSS <podcast:transcript> fetch failed: RSS transcript URL resolves to a blocked local network address
```

### Public URL redirecting or rebinding to private space

1. Use RSS XML containing a `<podcast:transcript>` URL that initially points at a public-looking HTTPS URL.
2. Have the first response redirect to a loopback/private target, or have a redirect hostname resolve to loopback/private space.
3. After this PR, the redirect target is manually revalidated; private address results are rejected before the redirected request is fetched.
4. For allowed public DNS results, the fetch dispatcher is pinned to the validated address set to avoid DNS rebinding between validation and connect.

The regression tests added in this PR use mocked fetches/DNS where appropriate and do not contact production services or real private-network endpoints.

## Expected vulnerable behavior

- A feed-controlled transcript URL pointing at `localhost`, loopback/private address literals, or hostnames resolving to private space can be sent to the host-side fetch implementation.
- A public transcript URL can redirect to a local/private target without redirect-target validation.
- Runtime DNS can differ from pre-check assumptions when a hostname rebinds between validation and connect.
- The returned response can be accepted as transcript content by the summarization path.

## Changes in this PR

- Adds transcript URL validation before fetch.
- Rejects non-HTTP(S) transcript URL schemes.
- Blocks localhost and local/private/internal IPv4 literal ranges, including loopback, link-local, RFC1918/private, shared address space, benchmarking, multicast, and reserved ranges.
- Blocks local/private/internal IPv6 literal ranges, including unspecified, loopback, unique-local, link-local, multicast, documentation, and IPv4-mapped/compatible addresses that resolve to blocked IPv4 ranges.
- Resolves transcript hostnames before fetch and rejects empty DNS results or any blocked address.
- Pins allowed hostname fetches to the validated address set using an Undici dispatcher.
- Switches transcript fetches to `redirect: "manual"`.
- Revalidates each redirect `Location` before following it and applies the same DNS/private-address/pinned-dispatcher behavior to redirect targets.
- Caps transcript redirect handling to avoid unbounded redirect loops.
- Adds regression tests for direct loopback transcript URLs, public-to-loopback redirects, private DNS resolution, redirect-private DNS resolution, and pinned dispatcher behavior.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| RSS transcript provider hardening | `packages/core/src/content/transcript/providers/podcast/rss-transcript.ts` | Adds URL parsing, blocked host detection, DNS resolution, private-address rejection, pinned dispatcher fetches, manual redirect handling, redirect revalidation, and redirect-depth limiting. |
| Core dependency metadata | `packages/core/package.json`, `pnpm-lock.yaml` | Declares the existing Undici runtime dependency for the core transcript fetch guard's pinned dispatcher. |
| Security regression tests | `tests/security.rss-transcript-ssrf.test.ts` | Covers direct loopback rejection, redirect-to-loopback rejection, hostname-to-private DNS rejection, redirect hostname-to-private DNS rejection, and pinned fetch behavior. |

## Maintainer impact

- The patch is scoped to RSS podcast transcript fetching.
- Normal HTTP(S) transcript URLs on public hosts remain supported.
- Redirects still work when every redirect target remains within the allowed public HTTP(S) URL and public DNS boundary.
- The main behavior change is that transcript URLs resolving to local/private/internal literal hosts, unsupported schemes, private DNS answers, or unsafe redirect targets are skipped instead of fetched.

## Fix rationale

- The trust boundary belongs at the nested transcript URL fetch because the URL is declared by RSS feed content, not by local application code.
- DNS validation is required because URL literal checks do not cover hostnames resolving or rebinding to private space.
- Address pinning is required because checking DNS before fetch is not sufficient if the runtime fetch performs a second lookup that can rebind.
- Manual redirect handling is required because validating only the initial URL leaves a public-to-private redirect bypass.
- The tests exercise the security boundary with mocked fetches/DNS, so the regression signal is deterministic and does not depend on real internal services.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `pnpm -s test tests/security.rss-transcript-ssrf.test.ts` — `5` tests passed.
- [x] `git diff --check && pnpm -s typecheck` — passed.
- [x] `pnpm -s format:check` — passed; all matched files used the correct format.
- [x] `pnpm -s lint` — passed with `0` warnings and `0` errors.
- [x] `pnpm -s tsx /tmp/summarize-rss-transcript-ssrf-proof.ts` — runtime proof passed; local listener received `0` requests.

Executed with:

- `pnpm -s test tests/security.rss-transcript-ssrf.test.ts`
- `git diff --check && pnpm -s typecheck`
- `pnpm -s format:check`
- `pnpm -s lint`
- `pnpm -s tsx /tmp/summarize-rss-transcript-ssrf-proof.ts`

Note: local validation ran under Node `v22.22.2` even though the repo declares `node >=24`; the same targeted tests, typecheck, format check, and lint completed successfully in this workspace.

## Disclosure notes

- This PR is bounded to RSS podcast transcript URL fetching and redirect handling.
- The reproduction coverage is safe; no production services or real private-network endpoints were contacted.
- Runtime proof used a local loopback listener and redacted sensitive-looking query/body values.
- No unrelated files are changed.
