### PR TITLE
Fix local transcript cache mtime writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- CLI cache: include local media `fileMtime` when writing transcript cache entries so repeated unchanged audio/video extraction can hit cache (#240, #241, thanks @alfozan).
 - CLI: pass Codex image attachments to `codex exec` so local image summaries no longer fail before starting (#242, #243, thanks @alfozan).
 - Chrome extension: abort stale side-panel summary streams on tab changes so delayed output from a closed or replaced tab cannot render under the new page title.
 - Core: extract video IDs from YouTube `/live/` URLs so live and premiere links no longer abort summarization (#232, thanks @devYRPauli).

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -362,20 +362,17 @@ export async function createCacheStore({
     typeof transcriptNamespace === "string" && transcriptNamespace.trim().length > 0
       ? transcriptNamespace.trim()
       : null;
-  const getTranscriptKey = (url: string): string =>
+  const getTranscriptKey = (url: string, fileMtime?: number | null): string =>
     buildTranscriptCacheKey({
       url,
       namespace: normalizedTranscriptNamespace,
+      fileMtime,
     });
 
   const transcriptCache: TranscriptCache = {
     get: async ({ url, fileMtime }) => {
       const now = Date.now();
-      const key = buildTranscriptCacheKey({
-        url,
-        namespace: normalizedTranscriptNamespace,
-        fileMtime,
-      });
+      const key = getTranscriptKey(url, fileMtime);
       const row = readEntry("transcript", key, now);
       if (!row) return null;
       const expired = typeof row.expires_at === "number" && row.expires_at <= now;
@@ -400,8 +397,8 @@ export async function createCacheStore({
         metadata: (payload?.metadata as Record<string, unknown> | null | undefined) ?? null,
       };
     },
-    set: async ({ url, content, source, ttlMs, metadata, service, resourceKey }) => {
-      const key = getTranscriptKey(url);
+    set: async ({ url, content, source, ttlMs, metadata, service, resourceKey, fileMtime }) => {
+      const key = getTranscriptKey(url, fileMtime);
       setJson(
         "transcript",
         key,

--- a/tests/cache.store.test.ts
+++ b/tests/cache.store.test.ts
@@ -182,6 +182,34 @@ describe("cache store", () => {
     otherStore.close();
   });
 
+  it("keys local transcript cache writes by file mtime", async () => {
+    const root = mkdtempSync(join(tmpdir(), "summarize-cache-"));
+    const path = join(root, "cache.sqlite");
+    const store = await createCacheStore({ path, maxBytes: 1024 * 1024 });
+    const url = "file:///tmp/audio.opus";
+
+    await store.transcriptCache.set({
+      url,
+      service: "generic",
+      resourceKey: null,
+      ttlMs: 1000,
+      content: "cached transcript",
+      source: "yt-dlp",
+      metadata: null,
+      fileMtime: 1234,
+    });
+
+    const hit = await store.transcriptCache.get({ url, fileMtime: 1234 });
+    const staleFile = await store.transcriptCache.get({ url, fileMtime: 5678 });
+    const noMtime = await store.transcriptCache.get({ url });
+
+    expect(hit?.content).toBe("cached transcript");
+    expect(staleFile).toBeNull();
+    expect(noMtime).toBeNull();
+
+    store.close();
+  });
+
   it("transcript cache normalizes unknown sources and handles bad payloads", async () => {
     const root = mkdtempSync(join(tmpdir(), "summarize-cache-"));
     const path = join(root, "cache.sqlite");


### PR DESCRIPTION
Fixes #240

## Summary
- include `fileMtime` when writing transcript cache entries
- add real cache-store regression coverage for local file transcripts

## Tests
- `pnpm test tests/cache.store.test.ts tests/transcript.cache.filemtime.test.ts tests/cli.asset.audio-file-transcript-cache.test.ts`
- `pnpm exec oxfmt --check src/cache.ts tests/cache.store.test.ts`
- `pnpm typecheck`

## Maintainer proof

- Current `main` repro using a real `createCacheStore`: write transcript with `fileMtime: 1234`, read the same URL with `fileMtime: 1234` → `MISS`.
- Fixed branch repro using the same store script: write transcript with `fileMtime: 1234`, read the same URL with `fileMtime: 1234` → `cached transcript`.
- Focused tests: `pnpm test tests/cache.store.test.ts tests/transcript.cache.filemtime.test.ts tests/cli.asset.audio-file-transcript-cache.test.ts` → 3 files passed, 26 tests passed.
- Format/whitespace: `pnpm exec oxfmt --check src/cache.ts tests/cache.store.test.ts CHANGELOG.md`; `git diff --check`.
- Full gate: `pnpm -s check` → 409 files passed, 27 skipped; 2060 tests passed, 41 skipped; coverage completed.
- Review: `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local` → clean, no accepted/actionable findings.
- Review: `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main` → clean, no accepted/actionable findings.
