### PR TITLE
Fix Codex image arg order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- CLI: pass Codex image attachments to `codex exec` so local image summaries no longer fail before starting (#242, #243, thanks @alfozan).
 - Chrome extension: abort stale side-panel summary streams on tab changes so delayed output from a closed or replaced tab cannot render under the new page title.
 - Core: extract video IDs from YouTube `/live/` URLs so live and premiere links no longer abort summarization (#232, thanks @devYRPauli).
 - Chrome extension: keep YouTube slide cards on the shared slide-summary path so local browser thumbnails receive the same summary text shape as CLI `--slides`.

--- a/src/llm/cli.ts
+++ b/src/llm/cli.ts
@@ -304,8 +304,7 @@ export async function runCliModel({
       if (isolatedCodexHome) {
         await copyCodexAuthFiles(effectiveEnv.CODEX_HOME, isolatedCodexHome);
       }
-      args.push("exec");
-      args.push(...codexExtraArgs);
+      args.push("exec", ...codexExtraArgs);
       if (shouldIsolateCodex) {
         args.push("--ephemeral", "--ignore-user-config", "--ignore-rules");
         if (isolatedCwd) args.push("-C", isolatedCwd);

--- a/src/llm/cli.ts
+++ b/src/llm/cli.ts
@@ -304,8 +304,8 @@ export async function runCliModel({
       if (isolatedCodexHome) {
         await copyCodexAuthFiles(effectiveEnv.CODEX_HOME, isolatedCodexHome);
       }
-      args.push(...codexExtraArgs);
       args.push("exec");
+      args.push(...codexExtraArgs);
       if (shouldIsolateCodex) {
         args.push("--ephemeral", "--ignore-user-config", "--ignore-rules");
         if (isolatedCwd) args.push("-C", isolatedCwd);

--- a/tests/llm.cli.regressions.test.ts
+++ b/tests/llm.cli.regressions.test.ts
@@ -101,16 +101,67 @@ describe("runCliModel regressions", () => {
 
   it("passes Codex image args after exec so -i does not consume the subcommand", async () => {
     let seenArgs: string[] = [];
+    let stdinText = "";
+    const prompt = "summarize this image";
 
     const result = await runCliModel({
       provider: "codex",
-      prompt: "summarize this image",
+      prompt,
       model: "gpt-5.2",
       allowTools: true,
       timeoutMs: 1000,
       env: {},
       config: null,
-      extraArgs: ["-i", "/tmp/image.jpg"],
+      extraArgs: ["-i", "/tmp/image-1.jpg", "/tmp/image-2.jpg"],
+      execFileImpl: (_cmd, args, _opts, cb) => {
+        seenArgs = [...args];
+        const outputIndex = args.indexOf("--output-last-message");
+        const outputPath = outputIndex >= 0 ? args[outputIndex + 1] : null;
+        if (!outputPath) throw new Error("missing output path");
+        writeFileSync(outputPath, "ok", "utf8");
+        cb(null, "", "");
+        return {
+          stdin: {
+            write(value: string) {
+              stdinText += value;
+            },
+            end() {},
+          },
+        } as unknown as ChildProcess;
+      },
+    });
+
+    const execIndex = seenArgs.indexOf("exec");
+    const imageFlagIndex = seenArgs.indexOf("-i");
+    const firstImageIndex = seenArgs.indexOf("/tmp/image-1.jpg");
+    const secondImageIndex = seenArgs.indexOf("/tmp/image-2.jpg");
+    const outputIndex = seenArgs.indexOf("--output-last-message");
+    const modelIndex = seenArgs.indexOf("-m");
+    const verbosityIndex = seenArgs.indexOf("-c");
+
+    expect(result.text).toBe("ok");
+    expect(execIndex).toBe(0);
+    expect(imageFlagIndex).toBeGreaterThan(execIndex);
+    expect(firstImageIndex).toBe(imageFlagIndex + 1);
+    expect(secondImageIndex).toBe(firstImageIndex + 1);
+    expect(outputIndex).toBeGreaterThan(secondImageIndex);
+    expect(modelIndex).toBeGreaterThan(execIndex);
+    expect(verbosityIndex).toBeGreaterThan(execIndex);
+    expect(seenArgs).not.toContain(prompt);
+    expect(stdinText).toBe(prompt);
+  });
+
+  it("keeps generated Codex flags under exec for non-image summaries", async () => {
+    let seenArgs: string[] = [];
+
+    const result = await runCliModel({
+      provider: "codex",
+      prompt: "summarize text",
+      model: "gpt-fast",
+      allowTools: false,
+      timeoutMs: 1000,
+      env: {},
+      config: { codex: { extraArgs: ["--sandbox", "read-only"] } },
       execFileImpl: (_cmd, args, _opts, cb) => {
         seenArgs = [...args];
         const outputIndex = args.indexOf("--output-last-message");
@@ -122,8 +173,27 @@ describe("runCliModel regressions", () => {
       },
     });
 
+    const execIndex = seenArgs.indexOf("exec");
+
     expect(result.text).toBe("ok");
-    expect(seenArgs.indexOf("exec")).toBeLessThan(seenArgs.indexOf("-i"));
+    expect(execIndex).toBe(0);
+    expect(seenArgs).not.toContain("-i");
+    for (const flag of [
+      "--sandbox",
+      "--ephemeral",
+      "--ignore-user-config",
+      "--ignore-rules",
+      "-C",
+      "--output-last-message",
+      "--skip-git-repo-check",
+      "--json",
+      "-m",
+      "-c",
+    ]) {
+      expect(seenArgs.indexOf(flag)).toBeGreaterThan(execIndex);
+    }
+    expect(seenArgs).toContain("gpt-5.5");
+    expect(seenArgs).toContain('service_tier="fast"');
   });
 
   it("codex does not leak lifecycle JSONL when no assistant text was produced", async () => {

--- a/tests/llm.cli.regressions.test.ts
+++ b/tests/llm.cli.regressions.test.ts
@@ -99,6 +99,33 @@ describe("runCliModel regressions", () => {
     expect(result.text).toBe("Hello world");
   });
 
+  it("passes Codex image args after exec so -i does not consume the subcommand", async () => {
+    let seenArgs: string[] = [];
+
+    const result = await runCliModel({
+      provider: "codex",
+      prompt: "summarize this image",
+      model: "gpt-5.2",
+      allowTools: true,
+      timeoutMs: 1000,
+      env: {},
+      config: null,
+      extraArgs: ["-i", "/tmp/image.jpg"],
+      execFileImpl: (_cmd, args, _opts, cb) => {
+        seenArgs = [...args];
+        const outputIndex = args.indexOf("--output-last-message");
+        const outputPath = outputIndex >= 0 ? args[outputIndex + 1] : null;
+        if (!outputPath) throw new Error("missing output path");
+        writeFileSync(outputPath, "ok", "utf8");
+        cb(null, "", "");
+        return { stdin: { write() {}, end() {} } } as unknown as ChildProcess;
+      },
+    });
+
+    expect(result.text).toBe("ok");
+    expect(seenArgs.indexOf("exec")).toBeLessThan(seenArgs.indexOf("-i"));
+  });
+
   it("codex does not leak lifecycle JSONL when no assistant text was produced", async () => {
     await expect(
       runCliModel({


### PR DESCRIPTION
## Summary

- put the Codex `exec` subcommand before provider-specific extra args
- keep image args like `-i <image>` attached to `codex exec` instead of the top-level Codex command
- add regression coverage for the `-i` ordering case

Fixes #242.

## Why

Local image summaries can currently build this argv when the Codex backend is selected:

```bash
codex -i <image.jpg> exec --output-last-message ...
```

Codex's `-i/--image <FILE>...` option is variadic, so `exec` can be consumed as another image argument. The remaining `--output-last-message` flag is then parsed at the wrong command level and Codex exits before the summary starts.

This is adjacent to the Codex argument construction discussed in #215, but that issue fixed isolation/context loading and left the `codexExtraArgs`/`exec` order unchanged.

## Repo example

This came up from a repo workspace with a local WhatsApp media image. Any local JPEG should reproduce the same command shape when the Codex backend is selected:

```bash
summarize /path/to/WhatsApp-Assistant/profiles/global-equities-testing/media/3AFF789EBAE19B8737AB/0-example.jpg --length short --plain
```

Before this PR, `summarize` can invoke:

```bash
codex -i /path/to/image.jpg exec --output-last-message /tmp/.../last-message.txt --skip-git-repo-check --json -m gpt-5.5
```

and Codex reports:

```text
error: unexpected argument '--output-last-message' found
```

After this PR, the command is assembled as:

```bash
codex exec -i /path/to/image.jpg --output-last-message /tmp/.../last-message.txt --skip-git-repo-check --json -m gpt-5.5
```

## Validation

- `pnpm test tests/llm.cli.regressions.test.ts tests/llm.cli.test.ts`
- `pnpm exec oxfmt --check src/llm/cli.ts tests/llm.cli.regressions.test.ts`
- `git diff --check`

## Maintainer proof

- Current `main` repro with a generated local PNG:

```text
$ pnpm -s summarize /tmp/<generated-image>.png --cli codex --plain --length short --timeout 2m
Command failed: codex -i /tmp/<generated-image>.png exec --output-last-message /tmp/.../last-message.txt --skip-git-repo-check --json -m gpt-5.2 -c text.verbosity="medium"
error: unexpected argument '--output-last-message' found
```

- Fixed branch live Codex image run:

```text
$ pnpm -s summarize /tmp/<generated-image>.png --model cli/codex/kindle-alpha --plain --length short --timeout 2m
The image is a single opaque white pixel (1x1). It contains no visible text, objects, or other meaningful content to summarize.
via model cli/codex/kindle-alpha

16s · cli/codex/kindle-alpha · ↑78k ↓673 Δ79k
```

  Note: this local ChatGPT-backed Codex auth rejects the repo default `gpt-5.2`, so the live proof pins the locally supported Codex model from `codex doctor`. The fixed `summarize` command reaches `codex exec -i ...`; current `main` fails before model execution because `-i` consumes `exec`.

- Focused tests: `pnpm test tests/llm.cli.regressions.test.ts tests/llm.cli.test.ts` → 2 files passed, 32 tests passed.
- Format/whitespace: `pnpm exec oxfmt --check src/llm/cli.ts tests/llm.cli.regressions.test.ts CHANGELOG.md`; `git diff --check`.
- Full gate: `pnpm -s check` → 409 files passed, 27 skipped; 2059 tests passed, 41 skipped; coverage completed.
- Review: `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local` → clean, no accepted/actionable findings.
- Review: `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main` → clean, no accepted/actionable findings.
