### PR TITLE
feat: add daemonless browser runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### Features
 
 - Add Antigravity CLI (`agy`) as a supported CLI provider. (#231, thanks @yetmike)
+- Chrome extension: add Browser slide runtime so YouTube slide summaries can run without the daemon, while keeping Daemon as an optional faster runtime.
 
 ### Fixes
 
 - Chrome extension: abort stale side-panel summary streams on tab changes so delayed output from a closed or replaced tab cannot render under the new page title.
 - Core: extract video IDs from YouTube `/live/` URLs so live and premiere links no longer abort summarization (#232, thanks @devYRPauli).
+- Chrome extension: keep YouTube slide cards on the shared slide-summary path so local browser thumbnails receive the same summary text shape as CLI `--slides`.
 
 ## 0.16.3 - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add Antigravity CLI (`agy`) as a supported CLI provider. (#231, thanks @yetmike)
 - Chrome extension: add Browser slide runtime so YouTube slide summaries can run without the daemon, while keeping Daemon as an optional faster runtime.
+- Chrome extension: persist Browser-mode summaries, slide text, transcripts, and thumbnails in Chrome storage for 30 days, with Runtime settings showing cache status and a clear button.
 
 ### Fixes
 

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/summarize-chrome-extension",
-  "version": "0.8.0",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/chrome-extension/src/entrypoints/background.ts
+++ b/apps/chrome-extension/src/entrypoints/background.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
+import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import { defineBackground } from "wxt/utils/define-background";
 import { buildDaemonRequestBody, buildSummarizeRequestBody } from "../lib/daemon-payload";
 import { createDaemonRecovery, isDaemonUnreachableError } from "../lib/daemon-recovery";
@@ -6,7 +7,16 @@ import { createDaemonStatusTracker } from "../lib/daemon-status";
 import { logExtensionEvent } from "../lib/extension-logs";
 import type { BgToPanel, PanelCachePayload, PanelToBg } from "../lib/panel-contracts";
 import { loadSettings, patchSettings } from "../lib/settings";
-import { canSummarizeUrl, extractFromTab, seekInTab } from "./background/content-script-bridge";
+import { runBrowserSlidesForTab, takeBrowserSlidesPayload } from "./background/browser-slides";
+import {
+  beginSlideFrameCaptureInTab,
+  canSummarizeUrl,
+  extractFromTab,
+  prepareCurrentSlideFrameInTab,
+  prepareSlideFrameInTab,
+  restoreSlideFrameInTab,
+  seekInTab,
+} from "./background/content-script-bridge";
 import { daemonHealth, daemonPing, friendlyFetchError } from "./background/daemon-client";
 import { ensureChatExtract, primeMediaHint, type CachedExtract } from "./background/extract-cache";
 import { createHoverController, type HoverToBg } from "./background/hover-controller";
@@ -34,6 +44,7 @@ import {
   type ArtifactsRequest,
   type NativeInputRequest,
 } from "./background/runtime-actions";
+import { extractYouTubeTranscriptInTab } from "./background/youtube-transcript";
 
 type BackgroundPanelSession = PanelSession<
   ReturnType<typeof createDaemonRecovery>,
@@ -58,6 +69,14 @@ export default defineBackground(() => {
   // postMessage → content-script → runtime bridge.
   const nativeInputArmedTabs = new Map<number, string>();
   const artifactsArmedTabs = new Set<number>();
+  const browserSlidesInFlightByWindowId = new Map<
+    number,
+    { key: string; userInitiated: boolean }
+  >();
+  const browserSlidesRetryByWindowId = new Map<
+    number,
+    { inputMode?: "page" | "video"; reason?: string }
+  >();
 
   function resolveLogLevel(event: string) {
     const normalized = event.toLowerCase();
@@ -103,6 +122,142 @@ export default defineBackground(() => {
       resolveLogLevel,
     });
 
+  async function maybeStartBrowserSlides(
+    session: BackgroundPanelSession,
+    opts: { inputMode?: "page" | "video"; reason?: string },
+  ) {
+    const setBrowserSlidesDebug = (value: unknown) => {
+      (
+        globalThis as typeof globalThis & {
+          __summarizeBrowserSlidesLastResult?: unknown;
+        }
+      ).__summarizeBrowserSlidesLastResult = value;
+    };
+    const tab = await getActiveTab(session.windowId);
+    const tabUrl = tab?.url ?? "";
+    const inputMode =
+      opts.inputMode ?? (shouldPreferUrlMode(tabUrl) || isYouTubeVideoUrl(tabUrl) ? "video" : null);
+    const canAttemptBrowserCapture =
+      isYouTubeVideoUrl(tabUrl) || opts.inputMode === "video" || opts.reason === "slides-capture";
+    if (inputMode !== "video") {
+      return;
+    }
+    if (!canAttemptBrowserCapture) {
+      setBrowserSlidesDebug({ ok: false, error: "skipped: browser capture requires video" });
+      return;
+    }
+    const settings = await loadSettings();
+    const isUserInitiatedCapture =
+      opts.reason === "manual" ||
+      opts.reason === "refresh" ||
+      opts.reason === "length-change" ||
+      opts.reason === "slides-capture";
+    if (!isUserInitiatedCapture && opts.reason !== "cache-restore" && !settings.autoSummarize) {
+      setBrowserSlidesDebug({ ok: false, error: "skipped: auto summarize disabled" });
+      return;
+    }
+    if (!settings.slidesEnabled) {
+      setBrowserSlidesDebug({ ok: false, error: "skipped: slides disabled" });
+      return;
+    }
+    if (settings.slideRuntime !== "browser") {
+      setBrowserSlidesDebug({ ok: false, error: "skipped: daemon runtime selected" });
+      return;
+    }
+    if (!tab?.id || !canSummarizeUrl(tab.url)) {
+      setBrowserSlidesDebug({ ok: false, error: "skipped: no capturable active tab" });
+      return;
+    }
+    const cachedPanel = panelSessionStore.getPanelCache(tab.id, tab.url ?? null);
+    if (!isUserInitiatedCapture && cachedPanel?.slides?.slides?.length) {
+      setBrowserSlidesDebug({ ok: false, error: "skipped: slides already cached" });
+      return;
+    }
+    const captureKey = tab.url ?? String(tab.id);
+    const activeCaptureKey = browserSlidesInFlightByWindowId.get(session.windowId);
+    if (activeCaptureKey) {
+      if (
+        activeCaptureKey.key !== captureKey ||
+        (isUserInitiatedCapture && !activeCaptureKey.userInitiated)
+      ) {
+        browserSlidesRetryByWindowId.set(session.windowId, {
+          inputMode: opts.inputMode,
+          reason: opts.reason,
+        });
+      }
+      return;
+    }
+    browserSlidesInFlightByWindowId.set(session.windowId, {
+      key: captureKey,
+      userInitiated: isUserInitiatedCapture,
+    });
+    sendStatus(session, "Capturing slides in browser...");
+    const result = await (async () => {
+      try {
+        const transcript =
+          isYouTubeVideoUrl(tabUrl) && tab.id
+            ? await extractYouTubeTranscriptInTab(tab.id, settings.maxChars)
+            : null;
+        return await runBrowserSlidesForTab({
+          tab,
+          windowId: session.windowId,
+          beginFrameCapture: beginSlideFrameCaptureInTab,
+          prepareFrame: prepareSlideFrameInTab,
+          prepareCurrentFrame: prepareCurrentSlideFrameInTab,
+          restoreFrame: restoreSlideFrameInTab,
+          transcriptTimedText: transcript?.ok ? transcript.transcriptTimedText : null,
+          captureMode: isUserInitiatedCapture ? "seek" : "current",
+        });
+      } catch (err) {
+        return {
+          ok: false as const,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      } finally {
+        if (browserSlidesInFlightByWindowId.get(session.windowId)?.key === captureKey) {
+          browserSlidesInFlightByWindowId.delete(session.windowId);
+        }
+      }
+    })();
+    const retry = browserSlidesRetryByWindowId.get(session.windowId) ?? null;
+    if (retry) {
+      browserSlidesRetryByWindowId.delete(session.windowId);
+    }
+    setBrowserSlidesDebug(result);
+    if (!result.ok) {
+      if (retry) {
+        void maybeStartBrowserSlides(session, retry);
+        return;
+      }
+      void send(session, { type: "slides:run", ok: false, error: result.error });
+      sendStatus(session, `Slides failed: ${result.error}`);
+      return;
+    }
+    void send(session, {
+      type: "slides:run",
+      ok: true,
+      runId: result.runId,
+      url: result.slides.sourceUrl,
+      local: true,
+    });
+    sendStatus(session, "");
+    if (retry) {
+      void maybeStartBrowserSlides(session, retry);
+    }
+  }
+
+  function summarizeActiveTabWithBrowserSlides(
+    session: BackgroundPanelSession,
+    reason: string,
+    opts?: { refresh?: boolean; inputMode?: "page" | "video" },
+  ) {
+    void summarizeActiveTab(session, reason, opts);
+    void maybeStartBrowserSlides(session, {
+      inputMode: opts?.inputMode,
+      reason,
+    });
+  }
+
   const handlePanelMessage = (session: BackgroundPanelSession, raw: PanelToBg) => {
     if (!raw || typeof raw !== "object" || typeof (raw as { type?: unknown }).type !== "string") {
       return;
@@ -120,7 +275,7 @@ export default defineBackground(() => {
             void emitState(session, "");
           },
           summarizeActiveTab: (reason) => {
-            void summarizeActiveTab(session, reason);
+            summarizeActiveTabWithBrowserSlides(session, reason);
           },
         });
         break;
@@ -130,16 +285,14 @@ export default defineBackground(() => {
             panelSessionStore.clearCachedExtractsForWindow(windowId),
         });
         break;
-      case "panel:summarize":
-        void summarizeActiveTab(
-          session,
-          (raw as { refresh?: boolean }).refresh ? "refresh" : "manual",
-          {
-            refresh: Boolean((raw as { refresh?: boolean }).refresh),
-            inputMode: (raw as { inputMode?: "page" | "video" }).inputMode,
-          },
-        );
+      case "panel:summarize": {
+        const refresh = Boolean((raw as { refresh?: boolean }).refresh);
+        summarizeActiveTabWithBrowserSlides(session, refresh ? "refresh" : "manual", {
+          refresh,
+          inputMode: (raw as { inputMode?: "page" | "video" }).inputMode,
+        });
         break;
+      }
       case "panel:cache": {
         const payload = (raw as { cache?: PanelCachePayload }).cache;
         if (!payload || typeof payload.tabId !== "number" || !payload.url) return;
@@ -158,6 +311,14 @@ export default defineBackground(() => {
           ok: Boolean(cached),
           cache: cached ?? undefined,
         });
+        if (
+          cached?.summaryMarkdown &&
+          !cached.slides?.slides.length &&
+          cached.url &&
+          isYouTubeVideoUrl(cached.url)
+        ) {
+          void maybeStartBrowserSlides(session, { inputMode: "video", reason: "cache-restore" });
+        }
         break;
       }
       case "panel:agent":
@@ -178,18 +339,57 @@ export default defineBackground(() => {
             return;
           }
 
+          const latestPanelCache = panelSessionStore.getPanelCache(tab.id, tab.url);
+          const panelTranscript =
+            latestPanelCache?.transcriptTimedText ??
+            latestPanelCache?.slides?.transcriptTimedText ??
+            null;
+          const panelCacheText =
+            panelTranscript ??
+            latestPanelCache?.summaryMarkdown ??
+            tab.title ??
+            latestPanelCache?.url ??
+            tab.url;
           let cachedExtract: CachedExtract;
           try {
-            cachedExtract = await ensureChatExtract({
-              session,
-              tab,
-              settings,
-              panelSessionStore,
-              sendStatus: (status) => sendStatus(session, status),
-              extractFromTab,
-              fetchImpl: fetch,
-              log: logExtract(session.windowId),
-            });
+            cachedExtract =
+              settings.slideRuntime === "browser" &&
+              latestPanelCache &&
+              (panelTranscript || latestPanelCache.slides)
+                ? {
+                    url: latestPanelCache.url,
+                    title: latestPanelCache.title,
+                    text: panelCacheText,
+                    source: "url",
+                    truncated: false,
+                    totalCharacters: panelCacheText.length,
+                    wordCount: panelCacheText.split(/\s+/).filter(Boolean).length,
+                    media: {
+                      hasVideo: true,
+                      hasAudio: true,
+                      hasCaptions: Boolean(panelTranscript),
+                    },
+                    transcriptSource: panelTranscript ? "browser" : null,
+                    transcriptionProvider: null,
+                    transcriptCharacters: panelTranscript?.length ?? null,
+                    transcriptWordCount:
+                      panelTranscript?.split(/\s+/).filter(Boolean).length ?? null,
+                    transcriptLines: panelTranscript?.split(/\r?\n/).filter(Boolean).length ?? null,
+                    transcriptTimedText: panelTranscript,
+                    mediaDurationSeconds: null,
+                    slides: latestPanelCache.slides,
+                    diagnostics: null,
+                  }
+                : await ensureChatExtract({
+                    session,
+                    tab,
+                    settings,
+                    panelSessionStore,
+                    sendStatus: (status) => sendStatus(session, status),
+                    extractFromTab,
+                    fetchImpl: fetch,
+                    log: logExtract(session.windowId),
+                  });
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             void send(session, { type: "run:error", message });
@@ -203,7 +403,22 @@ export default defineBackground(() => {
             tools: string[];
             summary?: string | null;
           };
-          const slidesContext = buildSlidesText(cachedExtract.slides, settings.slidesOcrEnabled);
+          const cachedExtractWithPanelSlides =
+            latestPanelCache?.slides || latestPanelCache?.transcriptTimedText
+              ? {
+                  ...cachedExtract,
+                  slides: latestPanelCache.slides ?? cachedExtract.slides,
+                  transcriptTimedText:
+                    cachedExtract.transcriptTimedText ??
+                    latestPanelCache.transcriptTimedText ??
+                    null,
+                }
+              : cachedExtract;
+          const slidesContext = buildSlidesText(
+            cachedExtractWithPanelSlides.slides,
+            settings.slidesOcrEnabled,
+            settings.length,
+          );
           await handlePanelAgentRequest({
             session,
             requestId: agentPayload.requestId,
@@ -211,7 +426,7 @@ export default defineBackground(() => {
             tools: agentPayload.tools,
             summary: agentPayload.summary,
             settings,
-            cachedExtract,
+            cachedExtract: cachedExtractWithPanelSlides,
             slidesText: slidesContext,
             send: (msg) => {
               void send(session, msg as BgToPanel);
@@ -308,7 +523,7 @@ export default defineBackground(() => {
               void emitState(session, "");
             },
             summarizeActiveTab: (reason) => {
-              void summarizeActiveTab(session, reason);
+              summarizeActiveTabWithBrowserSlides(session, reason);
             },
           });
         })();
@@ -323,7 +538,7 @@ export default defineBackground(() => {
               void emitState(session, "");
             },
             summarizeActiveTab: (reason) => {
-              void summarizeActiveTab(session, reason);
+              summarizeActiveTabWithBrowserSlides(session, reason);
             },
           });
         })();
@@ -352,6 +567,25 @@ export default defineBackground(() => {
             resolveLogLevel,
           });
         })();
+        break;
+      case "panel:slides-local": {
+        const payload = raw as { requestId?: string; runId?: string };
+        if (!payload.requestId || !payload.runId) return;
+        const slides = takeBrowserSlidesPayload(payload.runId);
+        void send(session, {
+          type: "slides:local",
+          requestId: payload.requestId,
+          ok: Boolean(slides),
+          slides: slides ?? undefined,
+          error: slides ? undefined : "Local slides payload not found",
+        });
+        break;
+      }
+      case "panel:slides-capture":
+        void maybeStartBrowserSlides(session, {
+          inputMode: "video",
+          reason: raw.manual ? "slides-capture" : "cache-restore",
+        });
         break;
       case "panel:openOptions":
         void openOptionsWindow();
@@ -411,7 +645,7 @@ export default defineBackground(() => {
       void emitState(session, status);
     },
     summarizeActiveTab: (session, reason) => {
-      void summarizeActiveTab(session, reason);
+      summarizeActiveTabWithBrowserSlides(session, reason);
     },
     onTabRemoved: (tabId) => {
       hoverController.abortHoverForTab(tabId);

--- a/apps/chrome-extension/src/entrypoints/background.ts
+++ b/apps/chrome-extension/src/entrypoints/background.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
 import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import { defineBackground } from "wxt/utils/define-background";
+import { createBrowserPanelCacheStore } from "../lib/browser-panel-cache";
 import { buildDaemonRequestBody, buildSummarizeRequestBody } from "../lib/daemon-payload";
 import { createDaemonRecovery, isDaemonUnreachableError } from "../lib/daemon-recovery";
 import { createDaemonStatusTracker } from "../lib/daemon-status";
@@ -59,6 +60,13 @@ export default defineBackground(() => {
   >({
     createDaemonRecovery,
     createDaemonStatus: createDaemonStatusTracker,
+    persistentPanelCache: createBrowserPanelCacheStore(),
+    shouldUsePersistentPanelCache: async (payload) => {
+      const settings = await loadSettings();
+      if (settings.slideRuntime !== "browser") return false;
+      const tab = await chrome.tabs.get(payload.tabId).catch(() => null);
+      return tab?.incognito === false;
+    },
   });
   const hoverControllersByTabId = new Map<
     number,
@@ -304,21 +312,35 @@ export default defineBackground(() => {
         if (!payload.requestId || !payload.tabId || !payload.url) {
           return;
         }
-        const cached = panelSessionStore.getPanelCache(payload.tabId, payload.url);
-        void send(session, {
-          type: "ui:cache",
-          requestId: payload.requestId,
-          ok: Boolean(cached),
-          cache: cached ?? undefined,
-        });
-        if (
-          cached?.summaryMarkdown &&
-          !cached.slides?.slides.length &&
-          cached.url &&
-          isYouTubeVideoUrl(cached.url)
-        ) {
-          void maybeStartBrowserSlides(session, { inputMode: "video", reason: "cache-restore" });
-        }
+        const requestGeneration = `${session.activeSummaryRun?.run.id ?? ""}:${session.inflightUrl ?? ""}`;
+        void (async () => {
+          const cached = await panelSessionStore.getPanelCacheAsync(payload.tabId, payload.url);
+          const currentGeneration = `${session.activeSummaryRun?.run.id ?? ""}:${session.inflightUrl ?? ""}`;
+          if (currentGeneration !== requestGeneration) return;
+          const activeTab = await getActiveTab(session.windowId);
+          if (activeTab?.id !== payload.tabId || activeTab.url !== payload.url) return;
+          const activeRun = session.activeSummaryRun?.run ?? null;
+          const activeRunMatchesRequest =
+            activeRun &&
+            (activeRun.url.includes("#") || payload.url.includes("#")
+              ? activeRun.url === payload.url
+              : urlsMatch(activeRun.url, payload.url));
+          if (activeRunMatchesRequest && cached?.runId !== activeRun.id) return;
+          void send(session, {
+            type: "ui:cache",
+            requestId: payload.requestId,
+            ok: Boolean(cached),
+            cache: cached ?? undefined,
+          });
+          if (
+            cached?.summaryMarkdown &&
+            !cached.slides?.slides.length &&
+            cached.url &&
+            isYouTubeVideoUrl(cached.url)
+          ) {
+            void maybeStartBrowserSlides(session, { inputMode: "video", reason: "cache-restore" });
+          }
+        })();
         break;
       }
       case "panel:agent":
@@ -339,7 +361,7 @@ export default defineBackground(() => {
             return;
           }
 
-          const latestPanelCache = panelSessionStore.getPanelCache(tab.id, tab.url);
+          const latestPanelCache = await panelSessionStore.getPanelCacheAsync(tab.id, tab.url);
           const panelTranscript =
             latestPanelCache?.transcriptTimedText ??
             latestPanelCache?.slides?.transcriptTimedText ??
@@ -637,8 +659,38 @@ export default defineBackground(() => {
       panelSessionStore.deletePanelSession(windowId);
       void panelSessionStore.clearCachedExtractsForWindow(windowId);
     },
-    runtimeActionsHandler: (raw, sender, sendResponse) =>
-      runtimeActionsHandler(raw as NativeInputRequest | ArtifactsRequest, sender, sendResponse),
+    runtimeActionsHandler: (raw, sender, sendResponse) => {
+      if (
+        raw &&
+        typeof raw === "object" &&
+        (raw as { type?: unknown }).type === "browser-cache:stats"
+      ) {
+        void panelSessionStore.getPersistentPanelCacheStats().then((stats) => {
+          sendResponse({ ok: Boolean(stats), stats });
+        });
+        return true;
+      }
+      if (
+        raw &&
+        typeof raw === "object" &&
+        (raw as { type?: unknown }).type === "browser-cache:clear"
+      ) {
+        void panelSessionStore.clearPersistentPanelCache().then((stats) => {
+          if (stats) {
+            for (const panelSession of panelSessionStore.getPanelSessions()) {
+              void send(panelSession, { type: "ui:cache-cleared" });
+            }
+          }
+          sendResponse({ ok: Boolean(stats), stats });
+        });
+        return true;
+      }
+      return runtimeActionsHandler(
+        raw as NativeInputRequest | ArtifactsRequest,
+        sender,
+        sendResponse,
+      );
+    },
     hoverRuntimeHandler: (raw, sender, sendResponse) =>
       hoverController.handleRuntimeMessage(raw as HoverToBg, sender, sendResponse),
     emitState: (session, status) => {

--- a/apps/chrome-extension/src/entrypoints/background/browser-slides.ts
+++ b/apps/chrome-extension/src/entrypoints/background/browser-slides.ts
@@ -1,0 +1,218 @@
+import type { SseSlidesData } from "../../lib/runtime-contracts";
+import type { SlideFrameRestoreSnapshot, SlideFrameResponse } from "./content-script-bridge";
+
+type PreparedFrame = SlideFrameResponse & { ok: true };
+
+const MAX_LOCAL_SLIDES = 6;
+const MAX_BROWSER_SLIDE_PAYLOADS = 8;
+const BROWSER_SLIDE_PAYLOAD_TTL_MS = 5 * 60 * 1000;
+const VISIBLE_TAB_CAPTURE_INTERVAL_MS = 700;
+const MAX_THUMBNAIL_WIDTH = 960;
+const MAX_THUMBNAIL_HEIGHT = 540;
+const THUMBNAIL_JPEG_QUALITY = 0.72;
+const browserSlidesByRunId = new Map<
+  string,
+  { slides: SseSlidesData; expiresAt: number; createdAt: number }
+>();
+
+function makeRunId() {
+  const random =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `browser-${random}`;
+}
+
+function chooseTimestamps(durationSeconds: number | null, maxSlides = MAX_LOCAL_SLIDES): number[] {
+  if (!durationSeconds || durationSeconds <= 0 || !Number.isFinite(durationSeconds)) return [0];
+  const count = Math.min(maxSlides, Math.max(1, Math.ceil(durationSeconds / 2)));
+  const step = durationSeconds / count;
+  return Array.from({ length: count }, (_value, index) =>
+    Math.max(0, Math.min(durationSeconds - 0.1, index * step + Math.min(0.4, step / 3))),
+  );
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function blobToDataUrl(blob: Blob): Promise<string> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.slice(offset, offset + chunkSize));
+  }
+  return `data:${blob.type || "image/png"};base64,${btoa(binary)}`;
+}
+
+async function cropVisibleTabCapture(dataUrl: string, frame: PreparedFrame): Promise<string> {
+  const res = await fetch(dataUrl);
+  const blob = await res.blob();
+  const image = await createImageBitmap(blob);
+  const ratio = frame.devicePixelRatio || 1;
+  const sx = clamp(Math.round(frame.rect.x * ratio), 0, Math.max(0, image.width - 1));
+  const sy = clamp(Math.round(frame.rect.y * ratio), 0, Math.max(0, image.height - 1));
+  const sw = clamp(Math.round(frame.rect.width * ratio), 1, image.width - sx);
+  const sh = clamp(Math.round(frame.rect.height * ratio), 1, image.height - sy);
+  const scale = Math.min(1, MAX_THUMBNAIL_WIDTH / sw, MAX_THUMBNAIL_HEIGHT / sh);
+  const dw = Math.max(1, Math.round(sw * scale));
+  const dh = Math.max(1, Math.round(sh * scale));
+  const canvas = new OffscreenCanvas(dw, dh);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Could not prepare slide canvas");
+  ctx.drawImage(image, sx, sy, sw, sh, 0, 0, dw, dh);
+  const cropped = await canvas.convertToBlob({
+    type: "image/jpeg",
+    quality: THUMBNAIL_JPEG_QUALITY,
+  });
+  return await blobToDataUrl(cropped);
+}
+
+export function getBrowserSlidesPayload(runId: string): SseSlidesData | null {
+  return browserSlidesByRunId.get(runId)?.slides ?? null;
+}
+
+export function takeBrowserSlidesPayload(runId: string): SseSlidesData | null {
+  const stored = browserSlidesByRunId.get(runId);
+  if (!stored || stored.expiresAt <= Date.now()) return null;
+  return stored.slides;
+}
+
+function pruneBrowserSlidesPayloads(now = Date.now()) {
+  for (const [runId, stored] of browserSlidesByRunId) {
+    if (stored.expiresAt <= now) browserSlidesByRunId.delete(runId);
+  }
+  while (browserSlidesByRunId.size > MAX_BROWSER_SLIDE_PAYLOADS) {
+    const oldest = Array.from(browserSlidesByRunId.entries()).sort(
+      ([_leftId, left], [_rightId, right]) => left.createdAt - right.createdAt,
+    )[0]?.[0];
+    if (!oldest) return;
+    browserSlidesByRunId.delete(oldest);
+  }
+}
+
+export async function runBrowserSlidesForTab(args: {
+  tab: chrome.tabs.Tab;
+  windowId: number;
+  prepareFrame: (
+    tabId: number,
+    seconds: number,
+  ) => Promise<{ ok: true; data: PreparedFrame } | { ok: false; error: string }>;
+  prepareCurrentFrame?: (
+    tabId: number,
+  ) => Promise<{ ok: true; data: PreparedFrame } | { ok: false; error: string }>;
+  beginFrameCapture?: (
+    tabId: number,
+  ) => Promise<
+    { ok: true; state: SlideFrameRestoreSnapshot | null } | { ok: false; error: string }
+  >;
+  restoreFrame?: (
+    tabId: number,
+    state?: SlideFrameRestoreSnapshot | null,
+  ) => Promise<{ ok: true } | { ok: false; error: string }>;
+  transcriptTimedText?: string | null;
+  maxSlides?: number;
+  captureMode?: "seek" | "current";
+}): Promise<{ ok: true; runId: string; slides: SseSlidesData } | { ok: false; error: string }> {
+  const tabId = args.tab.id;
+  if (typeof tabId !== "number") return { ok: false, error: "No active tab to capture." };
+  if (typeof chrome.tabs.captureVisibleTab !== "function") {
+    return { ok: false, error: "Visible tab capture is not available in this browser." };
+  }
+
+  let expectedUrl = args.tab.url ?? null;
+  const ensureOriginalTabIsActive = async () => {
+    const [activeTab] = await chrome.tabs.query({ active: true, windowId: args.windowId });
+    return activeTab?.id === tabId && (!expectedUrl || activeTab.url === expectedUrl);
+  };
+
+  const captureMode = args.captureMode ?? "seek";
+  let restoreState: SlideFrameRestoreSnapshot | null = null;
+  try {
+    if (!(await ensureOriginalTabIsActive())) {
+      return { ok: false, error: "Slide capture cancelled because the active tab changed." };
+    }
+    if (captureMode === "seek") {
+      const begin = await args.beginFrameCapture?.(tabId);
+      if (begin && !begin.ok) return begin;
+      restoreState = begin?.state ?? null;
+    }
+    const first =
+      captureMode === "current"
+        ? await args.prepareCurrentFrame?.(tabId)
+        : await args.prepareFrame(tabId, 0.4);
+    if (!first) return { ok: false, error: "Current frame capture is not available." };
+    if (!first.ok) return first;
+    expectedUrl = first.data.url || expectedUrl;
+    const timestamps =
+      captureMode === "current"
+        ? [
+            typeof first.data.currentTimeSeconds === "number" &&
+            Number.isFinite(first.data.currentTimeSeconds)
+              ? first.data.currentTimeSeconds
+              : 0,
+          ]
+        : chooseTimestamps(first.data.durationSeconds, args.maxSlides);
+    const slides: SseSlidesData["slides"] = [];
+    let lastCaptureAt = 0;
+
+    for (const [index, timestamp] of timestamps.entries()) {
+      const prepared = index === 0 ? first : await args.prepareFrame(tabId, timestamp);
+      if (!prepared.ok) {
+        if (slides.length === 0) return prepared;
+        continue;
+      }
+      const elapsed = Date.now() - lastCaptureAt;
+      if (elapsed < VISIBLE_TAB_CAPTURE_INTERVAL_MS) {
+        await delay(VISIBLE_TAB_CAPTURE_INTERVAL_MS - elapsed);
+      }
+      if (!(await ensureOriginalTabIsActive())) {
+        return { ok: false, error: "Slide capture cancelled because the active tab changed." };
+      }
+      const capture = await chrome.tabs.captureVisibleTab(args.windowId, { format: "png" });
+      lastCaptureAt = Date.now();
+      if (!(await ensureOriginalTabIsActive())) {
+        return { ok: false, error: "Slide capture cancelled because the active tab changed." };
+      }
+      const imageUrl = await cropVisibleTabCapture(capture, prepared.data);
+      slides.push({
+        index: index + 1,
+        timestamp,
+        imageUrl,
+        ocrText: null,
+        ocrConfidence: null,
+      });
+    }
+
+    if (slides.length === 0) return { ok: false, error: "No slide frames captured." };
+
+    const runId = makeRunId();
+    const slidesPayload: SseSlidesData = {
+      sourceUrl: first.data.url || args.tab.url || "",
+      sourceId: runId,
+      sourceKind: "browser-capture",
+      slideRuntime: "browser",
+      ocrAvailable: false,
+      transcriptTimedText: args.transcriptTimedText?.trim() || null,
+      slides,
+    };
+    const now = Date.now();
+    pruneBrowserSlidesPayloads(now);
+    browserSlidesByRunId.set(runId, {
+      slides: slidesPayload,
+      createdAt: now,
+      expiresAt: now + BROWSER_SLIDE_PAYLOAD_TTL_MS,
+    });
+    pruneBrowserSlidesPayloads(now);
+    return { ok: true, runId, slides: slidesPayload };
+  } finally {
+    if (captureMode === "seek") {
+      await args.restoreFrame?.(tabId, restoreState).catch(() => null);
+    }
+  }
+}

--- a/apps/chrome-extension/src/entrypoints/background/browser-summary.ts
+++ b/apps/chrome-extension/src/entrypoints/background/browser-summary.ts
@@ -1,0 +1,73 @@
+import { parseTranscriptTimedText } from "../../lib/slides-text";
+
+type BrowserSummaryInput = {
+  title: string | null;
+  text: string;
+  transcriptTimedText?: string | null;
+};
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function splitSentences(value: string): string[] {
+  return collapseWhitespace(value)
+    .split(/(?<=[.!?])\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function formatTimestamp(seconds: number): string {
+  const clamped = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(clamped / 60);
+  const secs = clamped % 60;
+  return `${minutes}:${String(secs).padStart(2, "0")}`;
+}
+
+function escapeMarkdownText(value: string): string {
+  return value.replace(/[\\`*_[\]{}()#+\-.!|>]/g, "\\$&");
+}
+
+function pickEvenly<T>(items: T[], limit: number): T[] {
+  if (items.length <= limit) return items;
+  return Array.from({ length: limit }, (_value, index) => {
+    const itemIndex = Math.round((index * (items.length - 1)) / Math.max(1, limit - 1));
+    return items[itemIndex] as T;
+  });
+}
+
+export function buildBrowserSummaryMarkdown({
+  title,
+  text,
+  transcriptTimedText,
+}: BrowserSummaryInput): string {
+  const segments = parseTranscriptTimedText(transcriptTimedText);
+  const sourceText = segments.length > 0 ? segments.map((segment) => segment.text).join(" ") : text;
+  const sentences = splitSentences(sourceText);
+  const introSentences = sentences.slice(0, Math.min(4, Math.max(2, sentences.length)));
+  const intro =
+    introSentences.join(" ") ||
+    collapseWhitespace(sourceText)
+      .slice(0, 800)
+      .replace(/\s+\S*$/, "")
+      .trim();
+  const heading = title?.trim() ? `## ${escapeMarkdownText(title.trim())}` : "## Summary";
+  const parts = [
+    heading,
+    intro ? escapeMarkdownText(intro) : "No transcript text was available from the browser\\.",
+  ];
+
+  if (segments.length > 0) {
+    const keyMoments = pickEvenly(segments, Math.min(6, segments.length)).map(
+      (segment) =>
+        `- ${formatTimestamp(segment.startSeconds)} ${escapeMarkdownText(
+          collapseWhitespace(segment.text),
+        )}`,
+    );
+    if (keyMoments.length > 0) {
+      parts.push("## Key moments", keyMoments.join("\n"));
+    }
+  }
+
+  return parts.join("\n\n");
+}

--- a/apps/chrome-extension/src/entrypoints/background/content-script-bridge.ts
+++ b/apps/chrome-extension/src/entrypoints/background/content-script-bridge.ts
@@ -1,5 +1,21 @@
-export type ExtractRequest = { type: "extract"; maxChars: number };
+export type ExtractRequest = { type: "extract"; maxChars: number; inputMode?: "page" | "video" };
 export type SeekRequest = { type: "seek"; seconds: number };
+export type SlideFrameRestoreSnapshot = {
+  currentTime: number;
+  paused: boolean;
+  scrollX: number;
+  scrollY: number;
+  pageUrl?: string;
+  mediaSrc?: string;
+};
+export type BeginSlideFrameCaptureRequest = {
+  type: "begin-slide-frame-capture";
+  state: SlideFrameRestoreSnapshot | null;
+};
+export type PrepareSlideFrameRequest = { type: "prepare-slide-frame"; seconds: number };
+export type PrepareCurrentSlideFrameRequest = { type: "prepare-current-slide-frame" };
+export type RestoreSlideFrameRequest = { type: "restore-slide-frame" };
+type RestoreSlideFrameResponse = { ok: true; restored?: boolean } | { ok: false; error: string };
 
 export type ExtractResponse =
   | {
@@ -14,6 +30,17 @@ export type ExtractResponse =
   | { ok: false; error: string };
 
 export type SeekResponse = { ok: true } | { ok: false; error: string };
+export type SlideFrameResponse =
+  | {
+      ok: true;
+      url: string;
+      title: string | null;
+      durationSeconds: number | null;
+      currentTimeSeconds?: number | null;
+      rect: { x: number; y: number; width: number; height: number };
+      devicePixelRatio: number;
+    }
+  | { ok: false; error: string };
 
 function contentAccessError(message: string) {
   return (
@@ -60,10 +87,15 @@ export async function extractFromTab(
   maxChars: number,
   opts?: {
     timeoutMs?: number;
+    inputMode?: "page" | "video" | null;
     log?: (event: string, detail?: Record<string, unknown>) => void;
   },
 ): Promise<{ ok: true; data: ExtractResponse & { ok: true } } | { ok: false; error: string }> {
-  const req = { type: "extract", maxChars } satisfies ExtractRequest;
+  const req = {
+    type: "extract",
+    maxChars,
+    inputMode: opts?.inputMode ?? undefined,
+  } satisfies ExtractRequest;
   const timeoutMs = opts?.timeoutMs ?? 6_000;
 
   const sendMessageWithTimeout = async (): Promise<ExtractResponse> => {
@@ -169,4 +201,207 @@ export async function seekInTab(
   }
 
   return { ok: false, error: "Content script not ready" };
+}
+
+export async function prepareSlideFrameInTab(
+  tabId: number,
+  seconds: number,
+): Promise<{ ok: true; data: SlideFrameResponse & { ok: true } } | { ok: false; error: string }> {
+  const req = { type: "prepare-slide-frame", seconds } satisfies PrepareSlideFrameRequest;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const res = (await chrome.tabs.sendMessage(tabId, req)) as SlideFrameResponse;
+      if (!res.ok) return { ok: false, error: res.error };
+      return { ok: true, data: res };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const noReceiver =
+        message.includes("Receiving end does not exist") ||
+        message.includes("Could not establish connection");
+      if (noReceiver) {
+        const injected = await injectExtractScript(tabId);
+        if (!injected.ok) return injected;
+        await new Promise((resolve) => setTimeout(resolve, 120));
+        continue;
+      }
+
+      if (attempt === 2) {
+        return {
+          ok: false,
+          error: noReceiver
+            ? "Content script not ready. Check extension “Site access” → “On all sites”, then reload the tab."
+            : message,
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    }
+  }
+
+  return { ok: false, error: "Content script not ready" };
+}
+
+export async function prepareCurrentSlideFrameInTab(
+  tabId: number,
+): Promise<{ ok: true; data: SlideFrameResponse & { ok: true } } | { ok: false; error: string }> {
+  const req = { type: "prepare-current-slide-frame" } satisfies PrepareCurrentSlideFrameRequest;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const res = (await chrome.tabs.sendMessage(tabId, req)) as SlideFrameResponse;
+      if (!res.ok) return { ok: false, error: res.error };
+      return { ok: true, data: res };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const noReceiver =
+        message.includes("Receiving end does not exist") ||
+        message.includes("Could not establish connection");
+      if (noReceiver) {
+        const injected = await injectExtractScript(tabId);
+        if (!injected.ok) return injected;
+        await new Promise((resolve) => setTimeout(resolve, 120));
+        continue;
+      }
+
+      if (attempt === 2) {
+        return {
+          ok: false,
+          error: noReceiver
+            ? "Content script not ready. Check extension “Site access” → “On all sites”, then reload the tab."
+            : message,
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    }
+  }
+
+  return { ok: false, error: "Content script not ready" };
+}
+
+export async function beginSlideFrameCaptureInTab(
+  tabId: number,
+): Promise<{ ok: true; state: SlideFrameRestoreSnapshot | null } | { ok: false; error: string }> {
+  let stateResult: chrome.scripting.InjectionResult<SlideFrameRestoreSnapshot | null> | undefined;
+  try {
+    [stateResult] = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: "MAIN",
+      func: (): SlideFrameRestoreSnapshot | null => {
+        const best = Array.from(document.querySelectorAll("video")).reduce<{
+          video: HTMLVideoElement;
+          area: number;
+        } | null>((current, video) => {
+          const rect = video.getBoundingClientRect();
+          const area = Math.max(0, rect.width) * Math.max(0, rect.height);
+          if (area <= 0) return current;
+          if (!current || area > current.area) return { video, area };
+          return current;
+        }, null);
+        if (!best) return null;
+        return {
+          currentTime: best.video.currentTime,
+          paused: best.video.paused,
+          scrollX: window.scrollX,
+          scrollY: window.scrollY,
+          pageUrl: location.href,
+          mediaSrc: best.video.currentSrc || best.video.src || "",
+        };
+      },
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  const req = {
+    type: "begin-slide-frame-capture",
+    state: stateResult?.result ?? null,
+  } satisfies BeginSlideFrameCaptureRequest;
+
+  try {
+    const res = (await chrome.tabs.sendMessage(tabId, req)) as SeekResponse;
+    if (!res.ok) return { ok: false, error: res.error };
+    return { ok: true, state: req.state };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const noReceiver =
+      message.includes("Receiving end does not exist") ||
+      message.includes("Could not establish connection");
+    if (!noReceiver) return { ok: false, error: message };
+    const injected = await injectExtractScript(tabId);
+    if (!injected.ok) return injected;
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    const res = (await chrome.tabs.sendMessage(tabId, req)) as SeekResponse;
+    if (!res.ok) return { ok: false, error: res.error };
+    return { ok: true, state: req.state };
+  }
+}
+
+export async function restoreSlideFrameInTab(
+  tabId: number,
+  state?: SlideFrameRestoreSnapshot | null,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const req = { type: "restore-slide-frame" } satisfies RestoreSlideFrameRequest;
+
+  try {
+    const res = (await chrome.tabs.sendMessage(tabId, req)) as RestoreSlideFrameResponse;
+    if (!res.ok) return { ok: false, error: res.error };
+    if (state && res.restored !== true) {
+      await chrome.scripting.executeScript({
+        target: { tabId },
+        world: "MAIN",
+        args: [state],
+        func: async (snapshot: SlideFrameRestoreSnapshot) => {
+          const best = Array.from(document.querySelectorAll("video")).reduce<{
+            video: HTMLVideoElement;
+            area: number;
+          } | null>((current, video) => {
+            const rect = video.getBoundingClientRect();
+            const area = Math.max(0, rect.width) * Math.max(0, rect.height);
+            if (area <= 0) return current;
+            if (!current || area > current.area) return { video, area };
+            return current;
+          }, null);
+          if (!best) return;
+          const video = best.video;
+          const currentMediaSrc = video.currentSrc || video.src || "";
+          if (
+            (snapshot.pageUrl && location.href !== snapshot.pageUrl) ||
+            (snapshot.mediaSrc && currentMediaSrc !== snapshot.mediaSrc)
+          ) {
+            return;
+          }
+          video.pause();
+          if (
+            Number.isFinite(snapshot.currentTime) &&
+            Math.abs(video.currentTime - snapshot.currentTime) > 0.05
+          ) {
+            await new Promise<void>((resolve) => {
+              const timer = window.setTimeout(resolve, 1800);
+              video.addEventListener(
+                "seeked",
+                () => {
+                  window.clearTimeout(timer);
+                  resolve();
+                },
+                { once: true },
+              );
+              video.currentTime = Math.max(0, snapshot.currentTime);
+            });
+          }
+          if (snapshot.paused) {
+            video.pause();
+          } else {
+            await video.play().catch(() => undefined);
+          }
+          window.scrollTo(snapshot.scrollX, snapshot.scrollY);
+        },
+      });
+    }
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
 }

--- a/apps/chrome-extension/src/entrypoints/background/extract-cache.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extract-cache.ts
@@ -47,6 +47,7 @@ type CachedExtractStore = {
 type LoadSettingsResult = {
   extendedLogging: boolean;
   maxChars: number;
+  slideRuntime: "browser" | "daemon";
   slidesEnabled: boolean;
   token: string;
 };
@@ -160,7 +161,8 @@ export async function ensureChatExtract({
     }
   }
 
-  const wantsSlides = settings.slidesEnabled && shouldPreferUrlMode(tab.url);
+  const wantsSlides =
+    settings.slidesEnabled && settings.slideRuntime === "daemon" && shouldPreferUrlMode(tab.url);
   sendStatus(
     wantsSlides
       ? "Extracting video + thumbnails…"

--- a/apps/chrome-extension/src/entrypoints/background/extractors/types.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extractors/types.ts
@@ -18,6 +18,7 @@ export type ExtractorContext = {
     maxCharacters: number,
     opts?: {
       timeoutMs?: number;
+      inputMode?: "page" | "video" | null;
       log?: ExtractLog;
     },
   ) => Promise<{ ok: true; data: ExtractResponse & { ok: true } } | { ok: false; error: string }>;

--- a/apps/chrome-extension/src/entrypoints/background/panel-session-store.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-session-store.ts
@@ -30,6 +30,13 @@ export type PanelSession<Recovery, Status> = {
   daemonStatus: Status;
 };
 
+type PersistentPanelCache<PanelCachePayload> = {
+  getPanel: (url: string) => Promise<PanelCachePayload | null>;
+  setPanel: (payload: PanelCachePayload) => Promise<void>;
+  clear: () => Promise<unknown>;
+  stats: () => Promise<unknown>;
+};
+
 export function createPanelSessionStore<
   CachedExtract extends { url: string },
   PanelCachePayload extends { tabId: number; url: string },
@@ -38,14 +45,32 @@ export function createPanelSessionStore<
 >({
   createDaemonRecovery,
   createDaemonStatus,
+  persistentPanelCache,
+  shouldUsePersistentPanelCache,
 }: {
   createDaemonRecovery: () => Recovery;
   createDaemonStatus: () => Status;
+  persistentPanelCache?: PersistentPanelCache<PanelCachePayload> | null;
+  shouldUsePersistentPanelCache?:
+    | ((payload: Pick<PanelCachePayload, "tabId" | "url">) => Promise<boolean>)
+    | ((payload: Pick<PanelCachePayload, "tabId" | "url">) => boolean);
 }) {
   const panelSessions = new Map<number, PanelSession<Recovery, Status>>();
   const lastMediaProbeByTab = new Map<number, string>();
   const cachedExtracts = new Map<number, CachedExtract>();
   const panelCacheByTabId = new Map<number, PanelCachePayload>();
+  const panelCacheWriteGenerationByUrl = new Map<string, number>();
+  const panelCacheGenerationByTabId = new Map<number, number>();
+  let panelCacheWriteGeneration = 0;
+  let panelCacheGeneration = 0;
+  let persistentCacheEpoch = 0;
+
+  const getPanelCache = (tabId: number, url?: string | null) => {
+    const cached = panelCacheByTabId.get(tabId) ?? null;
+    if (!cached) return null;
+    if (url && cached.url !== url) return null;
+    return cached;
+  };
 
   const getPanelPortMap = () => {
     const global = globalThis as typeof globalThis & {
@@ -119,12 +144,49 @@ export function createPanelSessionStore<
     },
     storePanelCache(payload: PanelCachePayload) {
       panelCacheByTabId.set(payload.tabId, payload);
+      panelCacheGeneration += 1;
+      panelCacheGenerationByTabId.set(payload.tabId, panelCacheGeneration);
+      const cacheKey = payload.url;
+      panelCacheWriteGeneration += 1;
+      const writeGeneration = panelCacheWriteGeneration;
+      panelCacheWriteGenerationByUrl.set(cacheKey, writeGeneration);
+      void (async () => {
+        const epoch = persistentCacheEpoch;
+        if (shouldUsePersistentPanelCache && !(await shouldUsePersistentPanelCache(payload)))
+          return;
+        if (epoch !== persistentCacheEpoch) return;
+        if (panelCacheWriteGenerationByUrl.get(cacheKey) !== writeGeneration) return;
+        await persistentPanelCache?.setPanel(payload);
+      })().catch(() => null);
     },
     getPanelCache(tabId: number, url?: string | null) {
-      const cached = panelCacheByTabId.get(tabId) ?? null;
-      if (!cached) return null;
-      if (url && cached.url !== url) return null;
-      return cached;
+      return getPanelCache(tabId, url);
+    },
+    async getPanelCacheAsync(tabId: number, url?: string | null) {
+      const cached = getPanelCache(tabId, url);
+      if (cached || !url) return cached;
+      const epoch = persistentCacheEpoch;
+      const tabGeneration = panelCacheGenerationByTabId.get(tabId) ?? 0;
+      if (shouldUsePersistentPanelCache && !(await shouldUsePersistentPanelCache({ tabId, url })))
+        return null;
+      const persistent = (await persistentPanelCache?.getPanel(url).catch(() => null)) ?? null;
+      if (epoch !== persistentCacheEpoch) return null;
+      if (!persistent) return null;
+      const freshCached = getPanelCache(tabId, url);
+      if (freshCached) return freshCached;
+      if ((panelCacheGenerationByTabId.get(tabId) ?? 0) !== tabGeneration) return null;
+      panelCacheByTabId.set(tabId, { ...persistent, tabId });
+      return panelCacheByTabId.get(tabId) ?? null;
+    },
+    async getPersistentPanelCacheStats() {
+      return (await persistentPanelCache?.stats().catch(() => null)) ?? null;
+    },
+    async clearPersistentPanelCache() {
+      persistentCacheEpoch += 1;
+      panelCacheByTabId.clear();
+      panelCacheWriteGenerationByUrl.clear();
+      panelCacheGenerationByTabId.clear();
+      return (await persistentPanelCache?.clear().catch(() => null)) ?? null;
     },
     async clearCachedExtractsForWindow(windowId: number) {
       try {
@@ -142,6 +204,8 @@ export function createPanelSessionStore<
       cachedExtracts.delete(tabId);
       lastMediaProbeByTab.delete(tabId);
       panelCacheByTabId.delete(tabId);
+      panelCacheGeneration += 1;
+      panelCacheGenerationByTabId.set(tabId, panelCacheGeneration);
     },
   };
 }

--- a/apps/chrome-extension/src/entrypoints/background/panel-state.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-state.ts
@@ -40,6 +40,7 @@ type SettingsLike = {
   slidesParallel: boolean;
   slidesOcrEnabled: boolean;
   slidesLayout: "strip" | "gallery";
+  slideRuntime: "browser" | "daemon";
   fontSize: number;
   lineHeight: number;
   model: string;
@@ -127,6 +128,7 @@ export async function resolvePanelState({
         slidesParallel: settings.slidesParallel,
         slidesOcrEnabled: settings.slidesOcrEnabled,
         slidesLayout: settings.slidesLayout,
+        slideRuntime: settings.slideRuntime,
         fontSize: settings.fontSize,
         lineHeight: settings.lineHeight,
         model: settings.model,

--- a/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
@@ -1,9 +1,11 @@
 import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import type { RunStart } from "../../lib/panel-contracts";
 import type { Settings } from "../../lib/settings";
+import { buildBrowserSummaryMarkdown } from "./browser-summary";
 import type { ExtractResponse } from "./content-script-bridge";
 import type { CachedExtract } from "./extract-cache";
 import { routeExtract, type ExtractorContext, type ExtractorResult } from "./extractors/router";
+import { extractYouTubeTranscriptInTab } from "./youtube-transcript";
 
 type DaemonRecoveryLike = {
   recordFailure: (url: string) => void;
@@ -39,7 +41,10 @@ type StoreLike = {
 };
 
 type SendFn = (
-  msg: { type: "run:error"; message: string } | { type: "run:start"; run: RunStart },
+  msg:
+    | { type: "run:error"; message: string }
+    | { type: "run:start"; run: RunStart }
+    | { type: "run:snapshot"; run: RunStart; markdown: string },
 ) => void;
 
 export async function summarizeActiveTab({
@@ -98,7 +103,8 @@ export async function summarizeActiveTab({
   const settings = await loadSettings();
   const isManual = reason === "manual" || reason === "refresh" || reason === "length-change";
   if (!isManual && !settings.autoSummarize) return;
-  if (!settings.token.trim()) {
+  const useBrowserSummary = settings.slideRuntime === "browser" && !settings.token.trim();
+  if (!useBrowserSummary && !settings.token.trim()) {
     await emitState(session, "Setup required (missing token)");
     return;
   }
@@ -167,6 +173,12 @@ export async function summarizeActiveTab({
     slides: requestedWantsSlides,
   };
   const isSuperseded = () => controller.signal.aborted || session.runController !== controller;
+  const clearCurrentRun = () => {
+    if (session.runController !== controller) return;
+    session.runController = null;
+    session.inflightUrl = null;
+    session.inflightRequest = null;
+  };
 
   const prefersUrlMode = Boolean(tab.url && shouldPreferUrlMode(tab.url));
   const wantsUrlDirectPath =
@@ -174,19 +186,76 @@ export async function summarizeActiveTab({
 
   let extracted: ExtractResponse & { ok: true };
   let routedResult: Pick<ExtractorResult, "source" | "diagnostics"> | null = null;
+  let browserTranscriptTimedText: string | null = null;
   if (wantsUrlDirectPath) {
     logPanel("extractor.route.start", { tabId: tab.id, preferUrl: prefersUrlMode });
     logPanel("extractor.route.preferUrlHardSwitch", { tabId: tab.id });
     sendStatus(`Preparing video… (${reason})`);
     logPanel("extract:url-direct", { reason, tabId: tab.id });
-    extracted = {
-      ok: true,
-      url: tab.url,
-      title: tab.title ?? null,
-      text: "",
-      truncated: false,
-      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-    };
+    const browserTranscript = await extractYouTubeTranscriptInTab(tab.id, settings.maxChars);
+    if (browserTranscript.ok && !urlsMatch(browserTranscript.url, tabUrl)) {
+      logPanel("extract:url-direct:browser-transcript-stale", {
+        expectedUrl: tabUrl,
+        actualUrl: browserTranscript.url,
+      });
+      clearCurrentRun();
+      sendStatus("");
+      return;
+    }
+    browserTranscriptTimedText = browserTranscript.ok
+      ? browserTranscript.transcriptTimedText
+      : null;
+    if (isSuperseded()) return;
+    const extractedAttempt =
+      browserTranscript.ok && browserTranscript.text.trim().length > 0
+        ? null
+        : await extractFromTab(tab.id, settings.maxChars, {
+            timeoutMs: 8_000,
+            inputMode: "video",
+            log: (event, detail) => {
+              logPanel(event, detail);
+            },
+          });
+    if (isSuperseded()) return;
+    extracted =
+      browserTranscript.ok && browserTranscript.text.trim().length > 0
+        ? {
+            ok: true,
+            url: browserTranscript.url,
+            title: tab.title ?? null,
+            text: browserTranscript.text,
+            truncated: browserTranscript.truncated,
+            mediaDurationSeconds: browserTranscript.durationSeconds,
+            media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+          }
+        : extractedAttempt?.ok && extractedAttempt.data.text.trim().length > 0
+          ? {
+              ...extractedAttempt.data,
+              media: extractedAttempt.data.media ?? {
+                hasVideo: true,
+                hasAudio: true,
+                hasCaptions: true,
+              },
+            }
+          : {
+              ok: true,
+              url: tab.url,
+              title: tab.title ?? null,
+              text: "",
+              truncated: false,
+              media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+            };
+    logPanel("extract:url-direct:browser-transcript", {
+      ok: browserTranscript.ok,
+      textLength: extracted.text.length,
+      source:
+        browserTranscript.ok && browserTranscript.text.trim().length > 0
+          ? "browser"
+          : extracted.text.length > 0
+            ? "content-script"
+            : "empty-fallback",
+      error: browserTranscript.ok ? undefined : browserTranscript.error,
+    });
   } else {
     sendStatus(`Extracting… (${reason})`);
     logPanel("extract:start", { reason, tabId: tab.id, maxChars: settings.maxChars });
@@ -209,6 +278,7 @@ export async function summarizeActiveTab({
       logPanel("extractor.route.preferUrlHardSwitch", { tabId: tab.id });
       const extractedAttempt = await extractFromTab(tab.id, settings.maxChars, {
         timeoutMs: 8_000,
+        inputMode: requestedInputMode ?? "video",
         log: (event, detail) => {
           statusFromExtractEvent(event);
           logPanel(event, detail);
@@ -277,6 +347,7 @@ export async function summarizeActiveTab({
     logPanel("extract:retry", { tabId: tab.id, maxChars: settings.maxChars });
     const retry = await extractFromTab(tab.id, settings.maxChars, {
       timeoutMs: 8_000,
+      inputMode: requestedInputMode ?? undefined,
       log: (event, detail) => logPanel(event, detail),
     });
     if (isSuperseded()) return;
@@ -324,6 +395,7 @@ export async function summarizeActiveTab({
     (effectiveInputMode === "video" ||
       resolvedPayload.media?.hasVideo === true ||
       shouldPreferUrlMode(resolvedPayload.url));
+  const wantsDaemonSlides = wantsSlides && settings.slideRuntime === "daemon";
   const summaryTimestamps = wantsSummaryTimestamps || wantsSlides;
 
   logPanel("summarize:start", {
@@ -332,6 +404,8 @@ export async function summarizeActiveTab({
     inputMode: effectiveInputMode ?? null,
     wantsSummaryTimestamps: summaryTimestamps,
     wantsSlides,
+    wantsDaemonSlides,
+    slideRuntime: settings.slideRuntime,
     wantsParallelSlides: false,
   });
 
@@ -349,15 +423,54 @@ export async function summarizeActiveTab({
     transcriptCharacters: null,
     transcriptWordCount: null,
     transcriptLines: null,
-    transcriptTimedText: null,
+    transcriptTimedText: browserTranscriptTimedText,
     mediaDurationSeconds: resolvedPayload.mediaDurationSeconds ?? null,
     slides: null,
     diagnostics: routedResult?.diagnostics ?? null,
   });
 
+  const sendBrowserSummarySnapshot = () => {
+    const random =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const run: RunStart = {
+      id: `browser-summary-${random}`,
+      url: resolvedPayload.url,
+      title: resolvedTitle,
+      model: "Browser",
+      reason,
+      slides: wantsSlides,
+    };
+    session.activeSummaryRun = {
+      run,
+      startedAt: Date.now(),
+      inputMode: requestedInputMode,
+      slides: requestedWantsSlides,
+    };
+    session.inflightRequest = null;
+    session.lastSummarizedUrl = resolvedPayload.url;
+    clearCurrentRun();
+    send({
+      type: "run:snapshot",
+      run,
+      markdown: buildBrowserSummaryMarkdown({
+        title: resolvedTitle,
+        text: resolvedPayload.text,
+        transcriptTimedText: browserTranscriptTimedText,
+      }),
+    });
+    sendStatus("");
+  };
+
+  if (useBrowserSummary) {
+    sendBrowserSummarySnapshot();
+    return;
+  }
+
   sendStatus("Connecting…");
   session.inflightUrl = resolvedPayload.url;
-  const slidesConfig = wantsSlides
+  const slidesConfig = wantsDaemonSlides
     ? {
         enabled: true as const,
         ocr: settings.slidesOcrEnabled,
@@ -369,17 +482,22 @@ export async function summarizeActiveTab({
 
   let id: string;
   try {
+    const requestInputMode =
+      browserTranscriptTimedText && resolvedPayload.text.trim().length > 0
+        ? "page"
+        : effectiveInputMode;
     const body = buildSummarizeRequestBody({
       extracted: resolvedPayload,
       settings,
       noCache: Boolean(opts?.refresh),
-      inputMode: effectiveInputMode,
+      inputMode: requestInputMode,
       timestamps: summaryTimestamps,
       slides: summarySlides,
     });
     logPanel("summarize:request", {
       url: resolvedPayload.url,
-      slides: wantsSlides,
+      slides: wantsDaemonSlides,
+      slideRuntime: settings.slideRuntime,
       slidesParallel: false,
       timestamps: summaryTimestamps,
     });
@@ -401,6 +519,13 @@ export async function summarizeActiveTab({
     id = json.id;
   } catch (err) {
     if (isSuperseded()) return;
+    if (settings.slideRuntime === "browser") {
+      if (isDaemonUnreachableError(err)) {
+        session.daemonRecovery.recordFailure(resolvedPayload.url);
+      }
+      sendBrowserSummarySnapshot();
+      return;
+    }
     const message = friendlyFetchError(err, "Daemon request failed");
     send({ type: "run:error", message });
     sendStatus(`Error: ${message}`);
@@ -418,7 +543,7 @@ export async function summarizeActiveTab({
     title: resolvedTitle,
     model: settings.model,
     reason,
-    slides: wantsSlides,
+    slides: wantsDaemonSlides,
   };
   session.activeSummaryRun = {
     run,

--- a/apps/chrome-extension/src/entrypoints/background/panel-utils.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-utils.ts
@@ -1,13 +1,23 @@
+import type { SummaryLength } from "../../lib/runtime-contracts";
+import {
+  buildSlideTextFallback,
+  parseTranscriptTimedText,
+  resolveSlideTextBudget,
+  type SlideTimelineEntry,
+} from "../../lib/slides-text";
+
 const optionsWindowSize = { width: 940, height: 680 };
 const optionsWindowMin = { width: 820, height: 560 };
 const optionsWindowMargin = 20;
 const MAX_SLIDE_OCR_CHARS = 8000;
+const SUMMARY_LENGTHS = new Set(["short", "medium", "long", "xl", "xxl"]);
 
 export type SlidesPayload = {
   sourceUrl: string;
   sourceId: string;
   sourceKind: string;
   ocrAvailable: boolean;
+  transcriptTimedText?: string | null;
   slides: Array<{
     index: number;
     timestamp: number;
@@ -26,15 +36,51 @@ export function formatSlideTimestamp(seconds: number): string {
   return h > 0 ? `${h}:${mm}:${ss}` : `${m}:${ss}`;
 }
 
+function resolveLengthArg(
+  length: string | null | undefined,
+): { kind: "preset"; preset: SummaryLength } | { kind: "chars"; maxCharacters: number } {
+  const normalized = (length ?? "").trim().toLowerCase();
+  if (SUMMARY_LENGTHS.has(normalized)) {
+    return { kind: "preset", preset: normalized as SummaryLength };
+  }
+  const custom = normalized.match(/^(\d+(?:\.\d+)?)(k|m)?$/);
+  if (!custom) return { kind: "preset", preset: "medium" };
+  const value = Number(custom[1]);
+  if (!Number.isFinite(value) || value <= 0) return { kind: "preset", preset: "medium" };
+  const unit = custom[2] ?? "";
+  const multiplier = unit === "m" ? 1_000_000 : unit === "k" ? 1_000 : 1;
+  return { kind: "chars", maxCharacters: Math.round(value * multiplier) };
+}
+
+function buildTranscriptSlidesText(
+  slides: SlidesPayload,
+  length: string | null | undefined,
+): Map<number, string> {
+  if (parseTranscriptTimedText(slides.transcriptTimedText).length === 0) return new Map();
+  const timeline: SlideTimelineEntry[] = slides.slides.map((slide) => ({
+    index: slide.index,
+    timestamp: Number.isFinite(slide.timestamp) ? slide.timestamp : Number.NaN,
+  }));
+  const lengthArg = resolveLengthArg(length);
+  return buildSlideTextFallback({
+    slides: timeline,
+    transcriptTimedText: slides.transcriptTimedText ?? null,
+    lengthArg,
+  });
+}
+
 export function buildSlidesText(
   slides: SlidesPayload | null,
   allowOcr: boolean,
+  length?: string | null,
 ): { count: number; text: string } | null {
-  if (!allowOcr || !slides || slides.slides.length === 0) return null;
+  if (!slides || slides.slides.length === 0) return null;
   let remaining = MAX_SLIDE_OCR_CHARS;
   const lines: string[] = [];
+  const transcriptTextBySlide = buildTranscriptSlidesText(slides, length);
   for (const slide of slides.slides) {
-    const text = slide.ocrText?.trim();
+    const text =
+      (allowOcr ? slide.ocrText?.trim() : "") || transcriptTextBySlide.get(slide.index)?.trim();
     if (!text) continue;
     const timestamp = Number.isFinite(slide.timestamp)
       ? formatSlideTimestamp(slide.timestamp)
@@ -46,7 +92,8 @@ export function buildSlidesText(
     remaining -= entry.length;
     if (remaining <= 0) break;
   }
-  return lines.length > 0 ? { count: slides.slides.length, text: lines.join("\n\n") } : null;
+  if (lines.length > 0) return { count: slides.slides.length, text: lines.join("\n\n") };
+  return null;
 }
 
 export function resolveOptionsUrl(): string {

--- a/apps/chrome-extension/src/entrypoints/background/youtube-transcript.ts
+++ b/apps/chrome-extension/src/entrypoints/background/youtube-transcript.ts
@@ -1,0 +1,333 @@
+type BrowserYouTubeTranscript =
+  | {
+      ok: true;
+      url: string;
+      text: string;
+      transcriptTimedText: string;
+      truncated: boolean;
+      durationSeconds: number | null;
+    }
+  | { ok: false; error: string };
+
+export async function extractYouTubeTranscriptInTab(
+  tabId: number,
+  maxChars: number,
+): Promise<BrowserYouTubeTranscript> {
+  try {
+    const [result] = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: "MAIN",
+      args: [maxChars],
+      func: async (limit: number): Promise<BrowserYouTubeTranscript> => {
+        type CaptionTrack = {
+          baseUrl?: unknown;
+          languageCode?: unknown;
+          kind?: unknown;
+          name?: { simpleText?: unknown; runs?: Array<{ text?: unknown }> };
+        };
+
+        const clampText = (text: string, maxLength: number) => {
+          if (text.length <= maxLength) return { text, truncated: false };
+          return {
+            text: `${text.slice(0, Math.max(0, maxLength - 24))}\n\n[TRUNCATED]`,
+            truncated: true,
+          };
+        };
+        const labelForTrack = (track: CaptionTrack) => {
+          if (typeof track.name?.simpleText === "string") return track.name.simpleText;
+          if (Array.isArray(track.name?.runs)) {
+            return track.name.runs
+              .map((run) => (typeof run.text === "string" ? run.text : ""))
+              .join("")
+              .trim();
+          }
+          return "";
+        };
+        const sortCaptionTracks = (tracks: CaptionTrack[]) => {
+          const score = (track: CaptionTrack) => {
+            const language =
+              typeof track.languageCode === "string" ? track.languageCode.toLowerCase() : "";
+            const label = labelForTrack(track).toLowerCase();
+            const isAutomatic = track.kind === "asr" || label.includes("auto-generated");
+            return [
+              language === "en" || language.startsWith("en-") ? 0 : 10,
+              isAutomatic ? 1 : 0,
+              label.includes("english") ? 0 : 1,
+            ].join(":");
+          };
+          return tracks
+            .filter((track) => typeof track.baseUrl === "string")
+            .sort((left, right) => score(left).localeCompare(score(right)));
+        };
+        const formatTimestamp = (ms: number) => {
+          const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+          const hours = Math.floor(totalSeconds / 3600);
+          const minutes = Math.floor((totalSeconds % 3600) / 60);
+          const seconds = totalSeconds % 60;
+          const two = (value: number) => String(value).padStart(2, "0");
+          return hours > 0
+            ? `${hours}:${two(minutes)}:${two(seconds)}`
+            : `${minutes}:${two(seconds)}`;
+        };
+        const normalizeCaptionText = (text: string) =>
+          text
+            .replace(/\s+/g, " ")
+            .replace(/&nbsp;/g, " ")
+            .trim();
+        const parseJson3 = (raw: string) => {
+          const data = JSON.parse(raw) as {
+            events?: Array<{ tStartMs?: number; segs?: Array<{ utf8?: string }> }>;
+          };
+          return (data.events ?? [])
+            .map((event) => ({
+              startMs: typeof event.tStartMs === "number" ? event.tStartMs : null,
+              text: normalizeCaptionText((event.segs ?? []).map((seg) => seg.utf8 ?? "").join("")),
+            }))
+            .filter((line) => line.text.length > 0);
+        };
+        const parseXml = (raw: string) =>
+          Array.from(new DOMParser().parseFromString(raw, "text/xml").querySelectorAll("text"))
+            .map((node) => {
+              const start = Number(node.getAttribute("start"));
+              return {
+                startMs: Number.isFinite(start) ? Math.round(start * 1000) : null,
+                text: normalizeCaptionText(node.textContent ?? ""),
+              };
+            })
+            .filter((line) => line.text.length > 0);
+        const parseVtt = (raw: string) => {
+          const lines: Array<{ startMs: number | null; text: string }> = [];
+          let pendingStart: number | null = null;
+          let pendingText: string[] = [];
+          const flush = () => {
+            const text = normalizeCaptionText(pendingText.join(" "));
+            if (text) lines.push({ startMs: pendingStart, text });
+            pendingStart = null;
+            pendingText = [];
+          };
+          for (const line of raw.split(/\r?\n/)) {
+            const trimmed = line.trim();
+            if (!trimmed) {
+              flush();
+              continue;
+            }
+            const timing = trimmed.match(/^(\d{2}:)?(\d{2}):(\d{2})\.(\d{3})\s+-->/);
+            if (timing) {
+              flush();
+              const parts = trimmed.split(/\s+-->\s+/)[0].split(":");
+              const secondsPart = parts.pop() ?? "0";
+              const minutes = Number(parts.pop() ?? "0");
+              const hours = Number(parts.pop() ?? "0");
+              const seconds = Number(secondsPart);
+              pendingStart = Math.round(((hours * 60 + minutes) * 60 + seconds) * 1000);
+              continue;
+            }
+            if (trimmed === "WEBVTT" || /^\d+$/.test(trimmed)) continue;
+            pendingText.push(trimmed);
+          }
+          flush();
+          return lines;
+        };
+        const captionUrls = (baseUrl: string) => {
+          const withFormat = (format: string) => {
+            const url = new URL(baseUrl);
+            url.searchParams.set("fmt", format);
+            return url.toString();
+          };
+          return Array.from(new Set([withFormat("json3"), baseUrl, withFormat("vtt")]));
+        };
+        const fetchWithTimeout = async (url: string, timeoutMs = 5000) => {
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), timeoutMs);
+          try {
+            return await fetch(url, { signal: controller.signal });
+          } finally {
+            clearTimeout(timer);
+          }
+        };
+        const fetchLines = async (track: CaptionTrack) => {
+          if (typeof track.baseUrl !== "string") return [];
+          for (const url of captionUrls(track.baseUrl)) {
+            try {
+              const res = await fetchWithTimeout(url);
+              if (!res.ok) continue;
+              const raw = (await res.text()).trim();
+              if (!raw) continue;
+              const lines = raw.startsWith("{")
+                ? parseJson3(raw)
+                : raw.startsWith("WEBVTT")
+                  ? parseVtt(raw)
+                  : parseXml(raw);
+              if (lines.length > 0) return lines;
+            } catch {
+              // Try the next track/format.
+            }
+          }
+          return [];
+        };
+        const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+        const parseTranscriptPanel = () => {
+          const segments = Array.from(
+            document.querySelectorAll(
+              "ytd-transcript-segment-renderer, transcript-segment-view-model",
+            ),
+          );
+          return segments
+            .map((segment) => {
+              const textEl = segment.querySelector(
+                "#segment-text, .segment-text, .ytAttributedStringHost[role='text'], span[role='text']",
+              );
+              const timestampEl = segment.querySelector(
+                "#timestamp, .segment-timestamp, .ytwTranscriptSegmentViewModelTimestamp",
+              );
+              const text = normalizeCaptionText(textEl?.textContent ?? "");
+              const timestamp = normalizeCaptionText(timestampEl?.textContent ?? "");
+              const timestampMatch = timestamp.match(/^\d{1,2}:\d{2}(?::\d{2})?$/);
+              return {
+                startMs: null,
+                timestamp: timestampMatch ? timestamp : null,
+                text,
+              };
+            })
+            .filter((line) => line.text.length > 0);
+        };
+        const clickTranscriptButton = async () => {
+          document.querySelector("ytd-watch-metadata")?.scrollIntoView({ block: "center" });
+          await delay(120);
+          const buttons = () =>
+            Array.from(
+              document.querySelectorAll("button, tp-yt-paper-button, ytd-button-renderer"),
+            );
+          const expand = buttons().find((el) =>
+            /\bmore\b/i.test(normalizeCaptionText(el.textContent ?? "")),
+          ) as HTMLElement | undefined;
+          expand?.click();
+          await delay(250);
+          const transcriptButton = (document.querySelector(
+            "ytd-video-description-transcript-section-renderer button",
+          ) ??
+            buttons().find((el) =>
+              /show transcript/i.test(normalizeCaptionText(el.textContent ?? "")),
+            )) as HTMLElement | undefined;
+          if (!transcriptButton) return false;
+          transcriptButton?.click();
+          for (let attempt = 0; attempt < 20; attempt += 1) {
+            await delay(200);
+            if (parseTranscriptPanel().length > 0) return true;
+          }
+          return false;
+        };
+
+        const globalData = globalThis as typeof globalThis & {
+          ytInitialPlayerResponse?: unknown;
+        };
+        const flexy = document.querySelector("ytd-watch-flexy") as
+          | (Element & { playerData?: unknown; playerResponse?: unknown })
+          | null;
+        type PlayerResponse = {
+          captions?: {
+            playerCaptionsTracklistRenderer?: { captionTracks?: CaptionTrack[] };
+          };
+          videoDetails?: { lengthSeconds?: unknown; videoId?: unknown };
+        };
+        const activeVideoId = (() => {
+          try {
+            const url = new URL(location.href);
+            const watchId = url.searchParams.get("v");
+            if (watchId) return watchId;
+            const shortsMatch = url.pathname.match(/^\/shorts\/([^/?#]+)/);
+            return shortsMatch?.[1] ?? null;
+          } catch {
+            return null;
+          }
+        })();
+        const asObject = (value: unknown) =>
+          value && typeof value === "object" ? (value as PlayerResponse) : undefined;
+        const initialPlayer = asObject(globalData.ytInitialPlayerResponse);
+        const playerCandidates = [
+          asObject(flexy?.playerData),
+          asObject(flexy?.playerResponse),
+          initialPlayer,
+        ].filter((candidate): candidate is PlayerResponse => Boolean(candidate));
+        const hasCaptionTracks = (playerResponse: PlayerResponse | undefined) =>
+          Boolean(playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks?.length);
+        const player = activeVideoId
+          ? (playerCandidates.find(
+              (candidate) => candidate.videoDetails?.videoId === activeVideoId,
+            ) ??
+            playerCandidates.find(
+              (candidate) =>
+                typeof candidate.videoDetails?.videoId !== "string" && hasCaptionTracks(candidate),
+            ))
+          : (playerCandidates.find(hasCaptionTracks) ?? playerCandidates[0]);
+        const tracks = player?.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? [];
+        for (const track of sortCaptionTracks(tracks)) {
+          const lines = await fetchLines(track);
+          if (lines.length === 0) continue;
+          const raw = lines
+            .map((line) =>
+              typeof line.startMs === "number"
+                ? `[${formatTimestamp(line.startMs)}] ${line.text}`
+                : line.text,
+            )
+            .join("\n")
+            .trim();
+          const clamped = clampText(`Transcript:\n${raw}`, limit);
+          const timed = clampText(raw, limit);
+          const duration =
+            typeof player?.videoDetails?.lengthSeconds === "string"
+              ? Number(player.videoDetails.lengthSeconds)
+              : null;
+          return {
+            ok: true,
+            url: location.href,
+            text: clamped.text,
+            transcriptTimedText: timed.text,
+            truncated: clamped.truncated,
+            durationSeconds: Number.isFinite(duration) ? duration : null,
+          };
+        }
+        const pageWindow = globalThis as typeof globalThis & {
+          scrollX?: number;
+          scrollY?: number;
+          scrollTo?: (x: number, y: number) => void;
+        };
+        const scrollBeforeFallback = {
+          x: pageWindow.scrollX ?? 0,
+          y: pageWindow.scrollY ?? 0,
+        };
+        try {
+          if (await clickTranscriptButton()) {
+            const panelLines = parseTranscriptPanel();
+            if (panelLines.length > 0) {
+              const raw = panelLines
+                .map((line) => (line.timestamp ? `[${line.timestamp}] ${line.text}` : line.text))
+                .join("\n")
+                .trim();
+              const clamped = clampText(`Transcript:\n${raw}`, limit);
+              const timed = clampText(raw, limit);
+              const duration =
+                typeof player?.videoDetails?.lengthSeconds === "string"
+                  ? Number(player.videoDetails.lengthSeconds)
+                  : null;
+              return {
+                ok: true,
+                url: location.href,
+                text: clamped.text,
+                transcriptTimedText: timed.text,
+                truncated: clamped.truncated,
+                durationSeconds: Number.isFinite(duration) ? duration : null,
+              };
+            }
+          }
+        } finally {
+          pageWindow.scrollTo?.(scrollBeforeFallback.x, scrollBeforeFallback.y);
+        }
+        return { ok: false, error: "No YouTube caption transcript found." };
+      },
+    });
+    return result.result ?? { ok: false, error: "No transcript result returned." };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/apps/chrome-extension/src/entrypoints/extract.content.ts
+++ b/apps/chrome-extension/src/entrypoints/extract.content.ts
@@ -4,8 +4,23 @@ import { META_SITE_EXCLUDE_MATCHES } from "../lib/content-script-matches";
 import { resolveMediaDurationSecondsFromData } from "../lib/media-duration";
 import { type SeekResponse, seekToSecondsInDocument } from "../lib/seek";
 
-type ExtractRequest = { type: "extract"; maxChars: number };
+type ExtractRequest = { type: "extract"; maxChars: number; inputMode?: "page" | "video" };
 type SeekRequest = { type: "seek"; seconds: number };
+type SlideFrameRestoreSnapshot = {
+  currentTime: number;
+  paused: boolean;
+  scrollX: number;
+  scrollY: number;
+  pageUrl?: string;
+  mediaSrc?: string;
+};
+type BeginSlideFrameCaptureRequest = {
+  type: "begin-slide-frame-capture";
+  state?: SlideFrameRestoreSnapshot | null;
+};
+type PrepareSlideFrameRequest = { type: "prepare-slide-frame"; seconds: number };
+type PrepareCurrentSlideFrameRequest = { type: "prepare-current-slide-frame" };
+type RestoreSlideFrameRequest = { type: "restore-slide-frame" };
 type ExtractResponse =
   | {
       ok: true;
@@ -21,11 +36,379 @@ type ExtractResponse =
       };
     }
   | { ok: false; error: string };
+type SlideFrameResponse =
+  | {
+      ok: true;
+      url: string;
+      title: string | null;
+      durationSeconds: number | null;
+      currentTimeSeconds?: number | null;
+      rect: { x: number; y: number; width: number; height: number };
+      devicePixelRatio: number;
+    }
+  | { ok: false; error: string };
+type RestoreSlideFrameResponse = { ok: true; restored?: boolean } | { ok: false; error: string };
+type SlideFrameRestoreState = {
+  video: HTMLVideoElement;
+  currentTime: number;
+  paused: boolean;
+  scrollX: number;
+  scrollY: number;
+  pageUrl: string;
+  mediaSrc: string;
+};
+
+let slideFrameRestoreState: SlideFrameRestoreState | null = null;
+
+function beginSlideFrameCapture(
+  snapshot?: SlideFrameRestoreSnapshot | null,
+): RestoreSlideFrameResponse {
+  const video = findBestVideo();
+  if (!video) return { ok: false, error: "No visible video found." };
+  slideFrameRestoreState = {
+    video,
+    currentTime:
+      typeof snapshot?.currentTime === "number" && Number.isFinite(snapshot.currentTime)
+        ? snapshot.currentTime
+        : video.currentTime,
+    paused: typeof snapshot?.paused === "boolean" ? snapshot.paused : video.paused,
+    scrollX:
+      typeof snapshot?.scrollX === "number" && Number.isFinite(snapshot.scrollX)
+        ? snapshot.scrollX
+        : window.scrollX,
+    scrollY:
+      typeof snapshot?.scrollY === "number" && Number.isFinite(snapshot.scrollY)
+        ? snapshot.scrollY
+        : window.scrollY,
+    pageUrl: location.href,
+    mediaSrc: video.currentSrc || video.src || "",
+  };
+  return { ok: true };
+}
+
+type CaptionTrack = {
+  baseUrl?: unknown;
+  languageCode?: unknown;
+  kind?: unknown;
+  name?: { simpleText?: unknown; runs?: Array<{ text?: unknown }> };
+};
+
+type YouTubePlayerResponse = {
+  captions?: {
+    playerCaptionsTracklistRenderer?: {
+      captionTracks?: CaptionTrack[];
+    };
+  };
+  videoDetails?: {
+    lengthSeconds?: unknown;
+    videoId?: unknown;
+  };
+};
 
 function clampText(text: string, maxChars: number): { text: string; truncated: boolean } {
   if (text.length <= maxChars) return { text, truncated: false };
   const sliced = text.slice(0, Math.max(0, maxChars - 24));
   return { text: `${sliced}\n\n[TRUNCATED]`, truncated: true };
+}
+
+function isYouTubeWatchPage() {
+  return /(^|\.)youtube\.com$/i.test(location.hostname) && location.pathname === "/watch";
+}
+
+function findBalancedJsonAfter(source: string, marker: string): string | null {
+  const markerIndex = source.indexOf(marker);
+  if (markerIndex < 0) return null;
+  const start = source.indexOf("{", markerIndex + marker.length);
+  if (start < 0) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let index = start; index < source.length; index += 1) {
+    const char = source[index];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (char === "\\") {
+        escape = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, index + 1);
+    }
+  }
+  return null;
+}
+
+function activeYouTubeVideoId(): string | null {
+  try {
+    const watchId = new URL(location.href).searchParams.get("v");
+    return watchId || null;
+  } catch {
+    return null;
+  }
+}
+
+function isCurrentYouTubePlayerResponse(
+  playerResponse: YouTubePlayerResponse | null,
+  requireVideoId: boolean,
+): playerResponse is YouTubePlayerResponse {
+  if (!playerResponse) return false;
+  const activeVideo = activeYouTubeVideoId();
+  if (!activeVideo) return true;
+  const playerVideo = playerResponse.videoDetails?.videoId;
+  if (typeof playerVideo === "string") return playerVideo === activeVideo;
+  return !requireVideoId;
+}
+
+function hasYouTubeCaptionTracks(playerResponse: YouTubePlayerResponse | null): boolean {
+  return Boolean(playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks?.length);
+}
+
+function asYouTubePlayerResponse(value: unknown): YouTubePlayerResponse | null {
+  return value && typeof value === "object" ? (value as YouTubePlayerResponse) : null;
+}
+
+function parseYouTubePlayerResponse(): YouTubePlayerResponse | null {
+  const flexy = document.querySelector("ytd-watch-flexy") as
+    | (Element & { playerData?: unknown; playerResponse?: unknown })
+    | null;
+  const globalResponse = (globalThis as unknown as { ytInitialPlayerResponse?: unknown })
+    .ytInitialPlayerResponse;
+  const initialResponse = asYouTubePlayerResponse(globalResponse);
+  const activeVideo = activeYouTubeVideoId();
+  const candidates = [
+    asYouTubePlayerResponse(flexy?.playerData),
+    asYouTubePlayerResponse(flexy?.playerResponse),
+    initialResponse,
+  ];
+  if (activeVideo) {
+    const matching = candidates.find(
+      (candidate) => candidate?.videoDetails?.videoId === activeVideo,
+    );
+    if (matching) return matching;
+    const noIdWithTracks = candidates.find(
+      (candidate) =>
+        candidate &&
+        typeof candidate.videoDetails?.videoId !== "string" &&
+        hasYouTubeCaptionTracks(candidate),
+    );
+    if (noIdWithTracks) return noIdWithTracks;
+  } else {
+    const withTracks = candidates.find(hasYouTubeCaptionTracks);
+    if (withTracks) return withTracks;
+    const first = candidates.find((candidate): candidate is YouTubePlayerResponse =>
+      Boolean(candidate),
+    );
+    if (first) return first;
+  }
+
+  for (const script of Array.from(document.querySelectorAll("script"))) {
+    const text = script.textContent ?? "";
+    if (!text.includes("ytInitialPlayerResponse")) continue;
+    const raw = findBalancedJsonAfter(text, "ytInitialPlayerResponse");
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw) as YouTubePlayerResponse;
+      if (isCurrentYouTubePlayerResponse(parsed, true)) return parsed;
+    } catch {
+      // Keep scanning; YouTube has several script shapes.
+    }
+  }
+  return null;
+}
+
+function captionTrackLabel(track: CaptionTrack): string {
+  const name = track.name;
+  if (!name) return "";
+  if (typeof name.simpleText === "string") return name.simpleText;
+  if (Array.isArray(name.runs)) {
+    return name.runs
+      .map((run) => (typeof run.text === "string" ? run.text : ""))
+      .join("")
+      .trim();
+  }
+  return "";
+}
+
+function sortCaptionTracks(tracks: CaptionTrack[]): CaptionTrack[] {
+  const candidates = tracks.filter((track) => typeof track.baseUrl === "string");
+  const score = (track: CaptionTrack) => {
+    const language = typeof track.languageCode === "string" ? track.languageCode.toLowerCase() : "";
+    const label = captionTrackLabel(track).toLowerCase();
+    const isAutomatic = track.kind === "asr" || label.includes("auto-generated");
+    return [
+      language === "en" || language.startsWith("en-") ? 0 : 10,
+      isAutomatic ? 1 : 0,
+      label.includes("english") ? 0 : 1,
+    ].join(":");
+  };
+  return candidates.sort((left, right) => score(left).localeCompare(score(right)));
+}
+
+function formatTimestamp(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const two = (value: number) => String(value).padStart(2, "0");
+  return hours > 0 ? `${hours}:${two(minutes)}:${two(seconds)}` : `${minutes}:${two(seconds)}`;
+}
+
+function normalizeCaptionText(text: string): string {
+  return text
+    .replace(/\s+/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .trim();
+}
+
+function parseJson3Transcript(raw: string): Array<{ startMs: number | null; text: string }> {
+  const data = JSON.parse(raw) as {
+    events?: Array<{ tStartMs?: number; segs?: Array<{ utf8?: string }> }>;
+  };
+  return (data.events ?? [])
+    .map((event) => ({
+      startMs: typeof event.tStartMs === "number" ? event.tStartMs : null,
+      text: normalizeCaptionText((event.segs ?? []).map((seg) => seg.utf8 ?? "").join("")),
+    }))
+    .filter((line) => line.text.length > 0);
+}
+
+function parseXmlTranscript(raw: string): Array<{ startMs: number | null; text: string }> {
+  const doc = new DOMParser().parseFromString(raw, "text/xml");
+  return Array.from(doc.querySelectorAll("text"))
+    .map((node) => {
+      const start = Number(node.getAttribute("start"));
+      return {
+        startMs: Number.isFinite(start) ? Math.round(start * 1000) : null,
+        text: normalizeCaptionText(node.textContent ?? ""),
+      };
+    })
+    .filter((line) => line.text.length > 0);
+}
+
+function parseVttTranscript(raw: string): Array<{ startMs: number | null; text: string }> {
+  const lines: Array<{ startMs: number | null; text: string }> = [];
+  let pendingStart: number | null = null;
+  let pendingText: string[] = [];
+  const flush = () => {
+    const text = normalizeCaptionText(pendingText.join(" "));
+    if (text) lines.push({ startMs: pendingStart, text });
+    pendingStart = null;
+    pendingText = [];
+  };
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      flush();
+      continue;
+    }
+    const timing = trimmed.match(/^(\d{2}:)?(\d{2}):(\d{2})\.(\d{3})\s+-->/);
+    if (timing) {
+      flush();
+      const parts = trimmed.split(/\s+-->\s+/)[0].split(":");
+      const secondsPart = parts.pop() ?? "0";
+      const minutes = Number(parts.pop() ?? "0");
+      const hours = Number(parts.pop() ?? "0");
+      const seconds = Number(secondsPart);
+      pendingStart = Math.round(((hours * 60 + minutes) * 60 + seconds) * 1000);
+      continue;
+    }
+    if (trimmed === "WEBVTT" || /^\d+$/.test(trimmed)) continue;
+    pendingText.push(trimmed);
+  }
+  flush();
+  return lines;
+}
+
+function captionUrls(baseUrl: string): string[] {
+  const urls: string[] = [];
+  const withFormat = (format: string) => {
+    const url = new URL(baseUrl);
+    url.searchParams.set("fmt", format);
+    return url.toString();
+  };
+  urls.push(withFormat("json3"));
+  urls.push(baseUrl);
+  urls.push(withFormat("vtt"));
+  return Array.from(new Set(urls));
+}
+
+async function fetchCaptionUrl(url: string, timeoutMs = 5000): Promise<Response> {
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    window.clearTimeout(timer);
+  }
+}
+
+async function fetchCaptionLines(
+  track: CaptionTrack,
+): Promise<Array<{ startMs: number | null; text: string }>> {
+  if (typeof track.baseUrl !== "string") return [];
+  for (const url of captionUrls(track.baseUrl)) {
+    try {
+      const res = await fetchCaptionUrl(url);
+      if (!res.ok) continue;
+      const raw = (await res.text()).trim();
+      if (!raw) continue;
+      const lines = raw.startsWith("{")
+        ? parseJson3Transcript(raw)
+        : raw.startsWith("WEBVTT")
+          ? parseVttTranscript(raw)
+          : parseXmlTranscript(raw);
+      if (lines.length > 0) return lines;
+    } catch {
+      // Try the next track/format.
+    }
+  }
+  return [];
+}
+
+async function fetchYouTubeTranscript(maxChars: number): Promise<{
+  text: string;
+  truncated: boolean;
+  durationSeconds: number | null;
+} | null> {
+  const playerResponse = parseYouTubePlayerResponse();
+  const tracks = playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? [];
+  let captionLines: Array<{ startMs: number | null; text: string }> | null = null;
+  for (const track of sortCaptionTracks(tracks)) {
+    const lines = await fetchCaptionLines(track);
+    if (lines.length > 0) {
+      captionLines = lines;
+      break;
+    }
+  }
+  if (!captionLines) return null;
+  const lines = captionLines.map((line) =>
+    typeof line.startMs === "number"
+      ? `[${formatTimestamp(line.startMs)}] ${line.text}`
+      : line.text,
+  );
+  const raw = lines.join("\n").trim();
+  if (!raw) return null;
+  const clamped = clampText(`Transcript:\n${raw}`, maxChars);
+  const durationSeconds =
+    typeof playerResponse?.videoDetails?.lengthSeconds === "string"
+      ? Number(playerResponse.videoDetails.lengthSeconds)
+      : null;
+  return {
+    text: clamped.text,
+    truncated: clamped.truncated,
+    durationSeconds: Number.isFinite(durationSeconds) ? durationSeconds : null,
+  };
 }
 
 function resolveMediaDurationSeconds(): number | null {
@@ -99,12 +482,26 @@ function detectMediaInfo(): { hasVideo: boolean; hasAudio: boolean; hasCaptions:
   return { hasVideo, hasAudio, hasCaptions };
 }
 
-function extract(maxChars: number): ExtractResponse {
+async function extract(maxChars: number, inputMode?: "page" | "video"): Promise<ExtractResponse> {
   try {
     const url = location.href;
     const title = document.title || null;
     const mediaDurationSeconds = resolveMediaDurationSeconds();
     const media = detectMediaInfo();
+    if (inputMode === "video" && isYouTubeWatchPage()) {
+      const transcript = await fetchYouTubeTranscript(maxChars);
+      if (transcript) {
+        return {
+          ok: true,
+          url,
+          title,
+          text: transcript.text,
+          truncated: transcript.truncated,
+          mediaDurationSeconds: transcript.durationSeconds ?? mediaDurationSeconds,
+          media: { ...media, hasCaptions: true },
+        };
+      }
+    }
     const cloned = document.cloneNode(true) as Document;
     const reader = new Readability(cloned, { keepClasses: false });
     const parsed = reader.parse();
@@ -142,6 +539,166 @@ function seekToSeconds(seconds: number): SeekResponse {
   return seekToSecondsInDocument(document, seconds);
 }
 
+function findBestVideo(): HTMLVideoElement | null {
+  const videos = Array.from(document.querySelectorAll("video")) as HTMLVideoElement[];
+  let best: { video: HTMLVideoElement; area: number } | null = null;
+  for (const video of videos) {
+    const rect = video.getBoundingClientRect();
+    const area = Math.max(0, rect.width) * Math.max(0, rect.height);
+    if (area <= 0) continue;
+    if (video.readyState <= HTMLMediaElement.HAVE_NOTHING && !Number.isFinite(video.duration)) {
+      continue;
+    }
+    if (!best || area > best.area) best = { video, area };
+  }
+  return best?.video ?? null;
+}
+
+function waitForEventOrTimeout(target: EventTarget, eventName: string, timeoutMs: number) {
+  return new Promise<void>((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const cleanup = () => {
+      if (timer) window.clearTimeout(timer);
+      target.removeEventListener(eventName, onEvent);
+      resolve();
+    };
+    const onEvent = () => cleanup();
+    timer = window.setTimeout(cleanup, timeoutMs);
+    target.addEventListener(eventName, onEvent, { once: true });
+  });
+}
+
+function waitForVideoFrame(video: HTMLVideoElement, timeoutMs = 1200) {
+  return new Promise<void>((resolve) => {
+    const callback = (
+      video as HTMLVideoElement & {
+        requestVideoFrameCallback?: (callback: () => void) => number;
+      }
+    ).requestVideoFrameCallback;
+    if (typeof callback !== "function") {
+      window.setTimeout(resolve, 120);
+      return;
+    }
+    const timer = window.setTimeout(resolve, timeoutMs);
+    callback.call(video, () => {
+      window.clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+async function prepareSlideFrame(seconds: number): Promise<SlideFrameResponse> {
+  try {
+    const video = findBestVideo();
+    if (!video) return { ok: false, error: "No visible video found." };
+    slideFrameRestoreState ??= {
+      video,
+      currentTime: video.currentTime,
+      paused: video.paused,
+      scrollX: window.scrollX,
+      scrollY: window.scrollY,
+      pageUrl: location.href,
+      mediaSrc: video.currentSrc || video.src || "",
+    };
+    video.scrollIntoView({ block: "center", inline: "center" });
+    await new Promise((resolve) => window.setTimeout(resolve, 80));
+
+    const duration = Number.isFinite(video.duration) && video.duration > 0 ? video.duration : null;
+    if (duration === null) return { ok: false, error: "Video duration is not available yet." };
+    const targetSeconds = Math.min(Math.max(0, seconds), Math.max(0, duration - 0.1));
+    video.pause();
+    if (Math.abs(video.currentTime - targetSeconds) > 0.05) {
+      const seekDone = waitForEventOrTimeout(video, "seeked", 1800);
+      video.currentTime = targetSeconds;
+      await seekDone;
+    }
+    await waitForVideoFrame(video);
+
+    const rect = video.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      return { ok: false, error: "Video is not visible." };
+    }
+    return {
+      ok: true,
+      url: location.href,
+      title: document.title || null,
+      durationSeconds: duration,
+      currentTimeSeconds: targetSeconds,
+      rect: {
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+      },
+      devicePixelRatio: window.devicePixelRatio || 1,
+    };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Frame capture failed" };
+  }
+}
+
+async function prepareCurrentSlideFrame(): Promise<SlideFrameResponse> {
+  try {
+    const video = findBestVideo();
+    if (!video) return { ok: false, error: "No visible video found." };
+    await waitForVideoFrame(video, 350);
+    const rect = video.getBoundingClientRect();
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const visible =
+      rect.width > 0 &&
+      rect.height > 0 &&
+      rect.bottom > 0 &&
+      rect.right > 0 &&
+      rect.left < viewportWidth &&
+      rect.top < viewportHeight;
+    if (!visible) return { ok: false, error: "Video is not visible." };
+    const duration = Number.isFinite(video.duration) && video.duration > 0 ? video.duration : null;
+    return {
+      ok: true,
+      url: location.href,
+      title: document.title || null,
+      durationSeconds: duration,
+      currentTimeSeconds: Number.isFinite(video.currentTime) ? video.currentTime : null,
+      rect: {
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+      },
+      devicePixelRatio: window.devicePixelRatio || 1,
+    };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Frame capture failed" };
+  }
+}
+
+async function restoreSlideFrame(): Promise<RestoreSlideFrameResponse> {
+  const state = slideFrameRestoreState;
+  slideFrameRestoreState = null;
+  if (!state) return { ok: true, restored: false };
+  try {
+    const currentMediaSrc = state.video.currentSrc || state.video.src || "";
+    if (location.href !== state.pageUrl || (state.mediaSrc && currentMediaSrc !== state.mediaSrc)) {
+      return { ok: true, restored: false };
+    }
+    const targetSeconds = Math.max(0, state.currentTime);
+    state.video.pause();
+    if (Math.abs(state.video.currentTime - targetSeconds) > 0.05) {
+      const seekDone = waitForEventOrTimeout(state.video, "seeked", 1800);
+      state.video.currentTime = targetSeconds;
+      await seekDone;
+    }
+    if (!state.paused) {
+      await state.video.play().catch(() => undefined);
+    }
+    window.scrollTo(state.scrollX, state.scrollY);
+    return { ok: true, restored: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Frame restore failed" };
+  }
+}
+
 export default defineContentScript({
   matches: ["<all_urls>"],
   excludeMatches: META_SITE_EXCLUDE_MATCHES,
@@ -153,16 +710,40 @@ export default defineContentScript({
 
     chrome.runtime.onMessage.addListener(
       (
-        message: ExtractRequest | SeekRequest,
+        message:
+          | ExtractRequest
+          | SeekRequest
+          | BeginSlideFrameCaptureRequest
+          | PrepareSlideFrameRequest
+          | PrepareCurrentSlideFrameRequest
+          | RestoreSlideFrameRequest,
         _sender,
-        sendResponse: (response: ExtractResponse | SeekResponse) => void,
+        sendResponse: (
+          response: ExtractResponse | SeekResponse | SlideFrameResponse | RestoreSlideFrameResponse,
+        ) => void,
       ) => {
         if (message?.type === "extract") {
-          sendResponse(extract(message.maxChars));
+          void extract(message.maxChars, message.inputMode).then(sendResponse);
           return true;
         }
         if (message?.type === "seek") {
           sendResponse(seekToSeconds(message.seconds));
+          return true;
+        }
+        if (message?.type === "begin-slide-frame-capture") {
+          sendResponse(beginSlideFrameCapture(message.state));
+          return true;
+        }
+        if (message?.type === "prepare-slide-frame") {
+          void prepareSlideFrame(message.seconds).then(sendResponse);
+          return true;
+        }
+        if (message?.type === "prepare-current-slide-frame") {
+          void prepareCurrentSlideFrame().then(sendResponse);
+          return true;
+        }
+        if (message?.type === "restore-slide-frame") {
+          void restoreSlideFrame().then(sendResponse);
           return true;
         }
         return undefined;

--- a/apps/chrome-extension/src/entrypoints/options/boolean-settings.ts
+++ b/apps/chrome-extension/src/entrypoints/options/boolean-settings.ts
@@ -1,4 +1,4 @@
-import type { defaultSettings } from "../../lib/settings";
+import type { defaultSettings, SlideRuntime } from "../../lib/settings";
 import { createBooleanToggleController } from "./toggles";
 
 type BooleanSettingsState = {
@@ -8,6 +8,7 @@ type BooleanSettingsState = {
   hoverSummaries: boolean;
   summaryTimestamps: boolean;
   slidesParallel: boolean;
+  slideRuntime: SlideRuntime;
   slidesOcrEnabled: boolean;
   extendedLogging: boolean;
   autoCliFallback: boolean;
@@ -16,6 +17,44 @@ type BooleanSettingsState = {
 type ToggleController = {
   render: () => void;
 };
+
+function createSlideRuntimeController({
+  root,
+  getValue,
+  setValue,
+  scheduleAutoSave,
+  afterChange,
+}: {
+  root: HTMLElement;
+  getValue: () => SlideRuntime;
+  setValue: (value: SlideRuntime) => void;
+  scheduleAutoSave: (delay?: number) => void;
+  afterChange?: () => void | Promise<void>;
+}): ToggleController {
+  const inputs = Array.from(
+    root.querySelectorAll<HTMLInputElement>('input[name="slideRuntimeMode"]'),
+  );
+
+  for (const input of inputs) {
+    input.addEventListener("change", () => {
+      if (!input.checked) return;
+      setValue(input.value === "daemon" ? "daemon" : "browser");
+      render();
+      scheduleAutoSave(0);
+      void afterChange?.();
+    });
+  }
+
+  function render() {
+    const value = getValue();
+    for (const input of inputs) {
+      input.checked = input.value === value;
+      input.closest(".runtimeModeCard")?.toggleAttribute("data-selected", input.checked);
+    }
+  }
+
+  return { render };
+}
 
 export function createBooleanSettingsRuntime(options: {
   defaults: typeof defaultSettings;
@@ -26,12 +65,14 @@ export function createBooleanSettingsRuntime(options: {
     hoverSummariesToggleRoot: HTMLElement;
     summaryTimestampsToggleRoot: HTMLElement;
     slidesParallelToggleRoot: HTMLElement;
+    slideRuntimeModeRoot: HTMLElement;
     slidesOcrToggleRoot: HTMLElement;
     extendedLoggingToggleRoot: HTMLElement;
     autoCliFallbackToggleRoot: HTMLElement;
   };
   scheduleAutoSave: (delayMs?: number) => void;
   onAutomationChanged?: () => void;
+  onDaemonSlidesModeChanged?: () => void;
 }) {
   const state: BooleanSettingsState = {
     autoSummarize: options.defaults.autoSummarize,
@@ -40,6 +81,7 @@ export function createBooleanSettingsRuntime(options: {
     hoverSummaries: options.defaults.hoverSummaries,
     summaryTimestamps: options.defaults.summaryTimestamps,
     slidesParallel: options.defaults.slidesParallel,
+    slideRuntime: options.defaults.slideRuntime,
     slidesOcrEnabled: options.defaults.slidesOcrEnabled,
     extendedLogging: options.defaults.extendedLogging,
     autoCliFallback: options.defaults.autoCliFallback,
@@ -106,6 +148,15 @@ export function createBooleanSettingsRuntime(options: {
         state.slidesParallel = checked;
       },
       scheduleAutoSave: options.scheduleAutoSave,
+    }),
+    createSlideRuntimeController({
+      root: options.roots.slideRuntimeModeRoot,
+      getValue: () => state.slideRuntime,
+      setValue: (value) => {
+        state.slideRuntime = value;
+      },
+      scheduleAutoSave: options.scheduleAutoSave,
+      afterChange: options.onDaemonSlidesModeChanged,
     }),
     createBooleanToggleController({
       root: options.roots.slidesOcrToggleRoot,

--- a/apps/chrome-extension/src/entrypoints/options/daemon-status.ts
+++ b/apps/chrome-extension/src/entrypoints/options/daemon-status.ts
@@ -14,10 +14,12 @@ export function createDaemonStatusChecker({
   statusEl,
   fetchImpl = fetch,
   getExtensionVersion,
+  isDaemonMode = () => true,
 }: {
   statusEl: HTMLDivElement;
   fetchImpl?: typeof fetch;
   getExtensionVersion: () => string;
+  isDaemonMode?: () => boolean;
 }) {
   const setDaemonStatus = (text: string, state?: "ok" | "warn" | "error") => {
     const textEl = statusEl.querySelector<HTMLElement>(".daemonStatus__text");
@@ -34,6 +36,11 @@ export function createDaemonStatusChecker({
   };
 
   let daemonCheckId = 0;
+
+  const setBrowserStatus = () => {
+    daemonCheckId += 1;
+    setDaemonStatus("Browser mode active", "ok");
+  };
 
   const fetchWithRetry = async (url: string, options: RequestInit = {}) => {
     for (let attempt = 0; attempt < DAEMON_STATUS_MAX_ATTEMPTS; attempt += 1) {
@@ -56,6 +63,10 @@ export function createDaemonStatusChecker({
   };
 
   const checkDaemonStatus = async (token: string) => {
+    if (!isDaemonMode()) {
+      setBrowserStatus();
+      return;
+    }
     daemonCheckId += 1;
     const checkId = daemonCheckId;
     const trimmedToken = token.trim();
@@ -117,5 +128,5 @@ export function createDaemonStatusChecker({
     }
   };
 
-  return { checkDaemonStatus, setDaemonStatus };
+  return { checkDaemonStatus, setBrowserStatus, setDaemonStatus };
 }

--- a/apps/chrome-extension/src/entrypoints/options/elements.ts
+++ b/apps/chrome-extension/src/entrypoints/options/elements.ts
@@ -53,6 +53,8 @@ export function getOptionsElements() {
     fontSizeEl: byId<HTMLInputElement>("fontSize"),
     buildInfoEl: document.getElementById("buildInfo"),
     daemonStatusEl: byId<HTMLDivElement>("daemonStatus"),
+    browserCacheStatusEl: byId<HTMLDivElement>("browserCacheStatus"),
+    browserCacheClearBtn: byId<HTMLButtonElement>("browserCacheClear"),
     logsSourceEl: byId<HTMLSelectElement>("logsSource"),
     logsTailEl: byId<HTMLInputElement>("logsTail"),
     logsRefreshBtn: byId<HTMLButtonElement>("logsRefresh"),

--- a/apps/chrome-extension/src/entrypoints/options/elements.ts
+++ b/apps/chrome-extension/src/entrypoints/options/elements.ts
@@ -34,6 +34,7 @@ export function getOptionsElements() {
     hoverSummariesToggleRoot: byId<HTMLDivElement>("hoverSummariesToggle"),
     summaryTimestampsToggleRoot: byId<HTMLDivElement>("summaryTimestampsToggle"),
     slidesParallelToggleRoot: byId<HTMLDivElement>("slidesParallelToggle"),
+    slideRuntimeModeRoot: byId<HTMLDivElement>("slideRuntimeMode"),
     slidesOcrToggleRoot: byId<HTMLDivElement>("slidesOcrToggle"),
     extendedLoggingToggleRoot: byId<HTMLDivElement>("extendedLoggingToggle"),
     autoCliFallbackToggleRoot: byId<HTMLDivElement>("autoCliFallbackToggle"),

--- a/apps/chrome-extension/src/entrypoints/options/form-state.ts
+++ b/apps/chrome-extension/src/entrypoints/options/form-state.ts
@@ -1,5 +1,5 @@
 import { readPresetOrCustomValue, resolvePresetOrCustom } from "../../lib/combo";
-import type { Settings } from "../../lib/settings";
+import type { Settings, SlideRuntime } from "../../lib/settings";
 import type { ColorMode, ColorScheme } from "../../lib/theme";
 import type { createModelPresetsController } from "./model-presets";
 
@@ -30,6 +30,7 @@ type BooleanFormState = {
   chatEnabled: boolean;
   automationEnabled: boolean;
   slidesParallel: boolean;
+  slideRuntime: SlideRuntime;
   slidesOcrEnabled: boolean;
   summaryTimestamps: boolean;
   extendedLogging: boolean;
@@ -69,6 +70,7 @@ export function buildSavedOptionsSettings({
     chatEnabled: booleans.chatEnabled,
     automationEnabled: booleans.automationEnabled,
     slidesEnabled: current.slidesEnabled,
+    slideRuntime: booleans.slideRuntime,
     slidesParallel: booleans.slidesParallel,
     slidesOcrEnabled: booleans.slidesOcrEnabled,
     slidesLayout: current.slidesLayout,
@@ -143,6 +145,7 @@ export function applyLoadedOptionsSettings({
       chatEnabled: settings.chatEnabled,
       automationEnabled: settings.automationEnabled,
       slidesParallel: settings.slidesParallel,
+      slideRuntime: settings.slideRuntime,
       slidesOcrEnabled: settings.slidesOcrEnabled,
       summaryTimestamps: settings.summaryTimestamps,
       extendedLogging: settings.extendedLogging,

--- a/apps/chrome-extension/src/entrypoints/options/index.html
+++ b/apps/chrome-extension/src/entrypoints/options/index.html
@@ -193,6 +193,17 @@
           </section>
 
           <section class="section">
+            <div class="sectionTitleRow">
+              <h2>Browser cache</h2>
+              <button id="browserCacheClear" type="button" class="miniButton">Clear</button>
+            </div>
+            <div id="browserCacheStatus" class="cacheStatus">Loading...</div>
+            <div class="hint">
+              Browser mode keeps summaries, slide text, transcripts, and thumbnails for 30 days.
+            </div>
+          </section>
+
+          <section class="section">
             <h2>Daemon token</h2>
             <label>
               <span>Token</span>

--- a/apps/chrome-extension/src/entrypoints/options/index.html
+++ b/apps/chrome-extension/src/entrypoints/options/index.html
@@ -44,6 +44,17 @@
             UI
           </button>
           <button
+            id="tab-runtime"
+            class="tabButton"
+            type="button"
+            role="tab"
+            data-tab="runtime"
+            aria-controls="panel-runtime"
+            aria-selected="false"
+          >
+            Runtime
+          </button>
+          <button
             id="tab-model"
             class="tabButton"
             type="button"
@@ -130,9 +141,59 @@
             </div>
             <div id="userScriptsNotice" class="notice" hidden></div>
           </section>
+        </div>
+
+        <div
+          id="panel-runtime"
+          class="tabPanel"
+          role="tabpanel"
+          data-tab-panel="runtime"
+          aria-labelledby="tab-runtime"
+          hidden
+        >
+          <section class="section runtimeSection">
+            <header class="advancedHead">
+              <h2>Runtime</h2>
+              <div class="hint">
+                Browser mode is the default. Switch to daemon mode only when you want the local
+                helper for heavier slide extraction.
+              </div>
+            </header>
+            <div class="advancedFields">
+              <div class="subgroup">
+                <div class="subgroupHead">
+                  <span class="subgroupTitle">Slide extraction backend</span>
+                </div>
+                <div class="subgroupBody">
+                  <div
+                    id="slideRuntimeMode"
+                    class="runtimeModeGrid"
+                    role="radiogroup"
+                    aria-label="Slide extraction backend"
+                  >
+                    <label class="runtimeModeCard">
+                      <input type="radio" name="slideRuntimeMode" value="browser" />
+                      <div class="runtimeModeTitle">Browser</div>
+                      <div class="runtimeModeText">
+                        Runs inside Chrome. Uses browser transcript and frame capture without
+                        requiring the Summarize daemon.
+                      </div>
+                    </label>
+                    <label class="runtimeModeCard">
+                      <input type="radio" name="slideRuntimeMode" value="daemon" />
+                      <div class="runtimeModeTitle">Daemon</div>
+                      <div class="runtimeModeText">
+                        Sends slide extraction to the local daemon for long or expensive videos.
+                      </div>
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
 
           <section class="section">
-            <h2>Token setup</h2>
+            <h2>Daemon token</h2>
             <label>
               <span>Token</span>
               <div class="inputRow">
@@ -155,6 +216,9 @@
                 </button>
               </div>
             </label>
+            <div class="hint">
+              Used only for daemon mode and daemon-backed tools. Browser mode works without it.
+            </div>
           </section>
         </div>
 

--- a/apps/chrome-extension/src/entrypoints/options/main.ts
+++ b/apps/chrome-extension/src/entrypoints/options/main.ts
@@ -1,3 +1,4 @@
+import type { CacheStats } from "../../../../../src/shared/cache-store";
 import { defaultSettings, loadSettings, saveSettings } from "../../lib/settings";
 import { applyTheme, type ColorMode, type ColorScheme } from "../../lib/theme";
 import { bindOptionsInputs } from "./bindings";
@@ -69,6 +70,8 @@ const {
   fontSizeEl,
   buildInfoEl,
   daemonStatusEl,
+  browserCacheStatusEl,
+  browserCacheClearBtn,
   logsSourceEl,
   logsTailEl,
   logsRefreshBtn,
@@ -183,6 +186,8 @@ const processesViewer = createProcessesViewer({
   isActive: () => resolveActiveTab() === "processes",
 });
 
+let refreshBrowserCacheStatus = () => {};
+
 const { resolveActiveTab } = createOptionsTabs({
   root: tabsRoot,
   buttons: tabButtons,
@@ -190,6 +195,7 @@ const { resolveActiveTab } = createOptionsTabs({
   storageKey: optionsTabStorageKey,
   onTabActivated: (tabId) => {
     if (tabId === "skills") loadSkillsTab();
+    if (tabId === "runtime") refreshBrowserCacheStatus();
   },
   onLogsActiveChange: (active) => {
     if (active) {
@@ -300,6 +306,70 @@ refreshRuntimeStatus = (token = tokenEl.value) => {
   void checkDaemonStatus(token);
 };
 
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const precision = value >= 10 || unitIndex === 0 ? 0 : 1;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+async function sendBrowserCacheMessage(type: "browser-cache:stats" | "browser-cache:clear") {
+  return (await chrome.runtime.sendMessage({ type })) as {
+    ok?: boolean;
+    stats?: CacheStats | null;
+  };
+}
+
+function renderBrowserCacheStatus(stats: CacheStats | null | undefined) {
+  if (!stats) {
+    browserCacheStatusEl.textContent = "Unavailable";
+    return;
+  }
+  const entryLabel = stats.totalEntries === 1 ? "entry" : "entries";
+  browserCacheStatusEl.textContent = `${stats.totalEntries} ${entryLabel} · ${formatBytes(
+    stats.sizeBytes,
+  )} · expires after 30 days`;
+}
+
+refreshBrowserCacheStatus = () => {
+  browserCacheStatusEl.textContent = "Loading...";
+  void sendBrowserCacheMessage("browser-cache:stats")
+    .then((response) => {
+      renderBrowserCacheStatus(response.ok ? response.stats : null);
+    })
+    .catch(() => {
+      browserCacheStatusEl.textContent = "Unavailable";
+    });
+};
+
+browserCacheClearBtn.addEventListener("click", () => {
+  browserCacheClearBtn.disabled = true;
+  browserCacheStatusEl.textContent = "Clearing...";
+  void sendBrowserCacheMessage("browser-cache:clear")
+    .then((response) => {
+      if (!response.ok) {
+        renderBrowserCacheStatus(null);
+        setStatus("Failed to clear browser cache");
+        return;
+      }
+      renderBrowserCacheStatus(response.stats);
+      flashStatus("Browser cache cleared");
+    })
+    .catch(() => {
+      browserCacheStatusEl.textContent = "Clear failed";
+      setStatus("Failed to clear browser cache");
+    })
+    .finally(() => {
+      browserCacheClearBtn.disabled = false;
+    });
+});
+
 const modelPresets = createModelPresetsController({
   presetEl: modelPresetEl,
   customEl: modelCustomEl,
@@ -352,6 +422,7 @@ async function load() {
   booleanSettings.setState(loadedState.booleans);
   booleanSettings.render();
   refreshRuntimeStatus(s.token);
+  refreshBrowserCacheStatus();
   currentScheme = loadedState.colorScheme;
   currentMode = loadedState.colorMode;
   pickers.update({ scheme: currentScheme, mode: currentMode, ...pickerHandlers });

--- a/apps/chrome-extension/src/entrypoints/options/main.ts
+++ b/apps/chrome-extension/src/entrypoints/options/main.ts
@@ -50,6 +50,7 @@ const {
   hoverSummariesToggleRoot,
   summaryTimestampsToggleRoot,
   slidesParallelToggleRoot,
+  slideRuntimeModeRoot,
   slidesOcrToggleRoot,
   extendedLoggingToggleRoot,
   autoCliFallbackToggleRoot,
@@ -207,6 +208,7 @@ const { resolveActiveTab } = createOptionsTabs({
 });
 
 let booleanSettings: ReturnType<typeof createBooleanSettingsRuntime> | null = null;
+let refreshRuntimeStatus = (_token = tokenEl.value) => {};
 const settingsElements = {
   tokenEl,
   languagePresetEl,
@@ -247,6 +249,7 @@ const { saveNow, scheduleAutoSave } = createOptionsSaveRuntime({
           hoverSummaries: defaultSettings.hoverSummaries,
           summaryTimestamps: defaultSettings.summaryTimestamps,
           slidesParallel: defaultSettings.slidesParallel,
+          slideRuntime: defaultSettings.slideRuntime,
           slidesOcrEnabled: defaultSettings.slidesOcrEnabled,
           extendedLogging: defaultSettings.extendedLogging,
           autoCliFallback: defaultSettings.autoCliFallback,
@@ -267,6 +270,7 @@ booleanSettings = createBooleanSettingsRuntime({
     hoverSummariesToggleRoot,
     summaryTimestampsToggleRoot,
     slidesParallelToggleRoot,
+    slideRuntimeModeRoot,
     slidesOcrToggleRoot,
     extendedLoggingToggleRoot,
     autoCliFallbackToggleRoot,
@@ -274,6 +278,9 @@ booleanSettings = createBooleanSettingsRuntime({
   scheduleAutoSave,
   onAutomationChanged: () => {
     void automationPermissions.updateUi();
+  },
+  onDaemonSlidesModeChanged: () => {
+    refreshRuntimeStatus();
   },
 });
 
@@ -286,7 +293,12 @@ const resolveExtensionVersion = () => {
 const { checkDaemonStatus } = createDaemonStatusChecker({
   statusEl: daemonStatusEl,
   getExtensionVersion: resolveExtensionVersion,
+  isDaemonMode: () => (booleanSettings?.getState().slideRuntime ?? "browser") === "daemon",
 });
+
+refreshRuntimeStatus = (token = tokenEl.value) => {
+  void checkDaemonStatus(token);
+};
 
 const modelPresets = createModelPresetsController({
   presetEl: modelPresetEl,
@@ -329,7 +341,6 @@ automationPermissionsBtn.addEventListener("click", () => {
 
 async function load() {
   const s = await loadSettings();
-  void checkDaemonStatus(s.token);
   await modelPresets.refreshPresets(s.token);
   modelPresets.setValue(s.model);
   const loadedState = applyLoadedOptionsSettings({
@@ -340,6 +351,7 @@ async function load() {
   });
   booleanSettings.setState(loadedState.booleans);
   booleanSettings.render();
+  refreshRuntimeStatus(s.token);
   currentScheme = loadedState.colorScheme;
   currentMode = loadedState.colorMode;
   pickers.update({ scheme: currentScheme, mode: currentMode, ...pickerHandlers });
@@ -393,7 +405,7 @@ bindOptionsInputs({
   },
   scheduleAutoSave,
   saveNow,
-  checkDaemonStatus,
+  checkDaemonStatus: refreshRuntimeStatus,
   modelPresets,
   logsViewer,
   processesViewer,

--- a/apps/chrome-extension/src/entrypoints/options/style.css
+++ b/apps/chrome-extension/src/entrypoints/options/style.css
@@ -938,6 +938,21 @@ form {
   color: var(--text);
 }
 
+.sectionTitleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.cacheStatus {
+  min-height: 20px;
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--text);
+}
+
 .labelRow {
   display: flex;
   align-items: center;

--- a/apps/chrome-extension/src/entrypoints/options/style.css
+++ b/apps/chrome-extension/src/entrypoints/options/style.css
@@ -482,6 +482,10 @@ form {
   gap: 14px;
 }
 
+.runtimeSection {
+  gap: 14px;
+}
+
 .advancedHead {
   display: grid;
   gap: 4px;
@@ -540,6 +544,58 @@ form {
 }
 
 .toggleField .toggleHint {
+  grid-column: 2;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.runtimeModeGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.runtimeModeCard {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 4px;
+  padding: 10px 12px;
+  min-height: 74px;
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 65%, transparent);
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.runtimeModeCard[data-selected] {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+}
+
+.runtimeModeCard input {
+  grid-row: 1 / span 2;
+  width: 16px;
+  height: 16px;
+  margin: 1px 4px 0 0;
+  accent-color: var(--accent);
+}
+
+.runtimeModeCard:has(input:focus-visible) {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.runtimeModeTitle {
+  grid-column: 2;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.runtimeModeText {
   grid-column: 2;
   color: var(--muted);
   font-size: 11px;
@@ -1034,7 +1090,8 @@ form {
 
 @media (max-width: 760px) {
   .subgroupBody.advancedGrid,
-  .subgroupBody.advancedGrid--thirds {
+  .subgroupBody.advancedGrid--thirds,
+  .runtimeModeGrid {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime.ts
@@ -12,9 +12,11 @@ export function handleSidepanelBgMessage(options: {
   isStreaming: () => boolean;
   handleRunError: (message: string) => void;
   handleSlidesRun: (msg: Extract<BgToPanel, { type: "slides:run" }>) => void;
+  handleSlidesLocal: (msg: Extract<BgToPanel, { type: "slides:local" }>) => void;
   handleSlidesContext: (msg: Extract<BgToPanel, { type: "slides:context" }>) => void;
   handleUiCache: (msg: Extract<BgToPanel, { type: "ui:cache" }>) => void;
   handleRunStart: (run: RunStart) => void;
+  handleRunSnapshot: (payload: Extract<BgToPanel, { type: "run:snapshot" }>) => void;
   handleChatHistory: (msg: Extract<BgToPanel, { type: "chat:history" }>) => void;
   handleAgentChunk: (msg: Extract<BgToPanel, { type: "agent:chunk" }>) => void;
   handleAgentResponse: (msg: Extract<BgToPanel, { type: "agent:response" }>) => void;
@@ -33,6 +35,9 @@ export function handleSidepanelBgMessage(options: {
     case "slides:run":
       options.handleSlidesRun(msg);
       return;
+    case "slides:local":
+      options.handleSlidesLocal(msg);
+      return;
     case "slides:context":
       options.handleSlidesContext(msg);
       return;
@@ -41,6 +46,9 @@ export function handleSidepanelBgMessage(options: {
       return;
     case "run:start":
       options.handleRunStart(msg.run);
+      return;
+    case "run:snapshot":
+      options.handleRunSnapshot(msg);
       return;
     case "chat:history":
       options.handleChatHistory(msg);
@@ -55,6 +63,7 @@ export function handleSidepanelBgMessage(options: {
 }
 
 type SlidesContextMessage = Extract<BgToPanel, { type: "slides:context" }>;
+type SlidesLocalMessage = Extract<BgToPanel, { type: "slides:local" }>;
 type SlidesRunMessage = Extract<BgToPanel, { type: "slides:run" }>;
 type UiCacheMessage = Extract<BgToPanel, { type: "ui:cache" }>;
 
@@ -75,9 +84,13 @@ export function createSidepanelBgMessageRuntime(options: {
   setSlidesBusy: (busy: boolean) => void;
   showSlideNotice: (message: string, opts?: { allowRetry?: boolean }) => void;
   getActiveTabUrl: () => string | null;
-  rememberPendingSlidesRun: (value: { runId: string; url: string | null }) => void;
-  startSlidesStreamForRunId: (runId: string) => void;
+  rememberPendingSlidesRun: (value: { runId: string; url: string | null; local?: boolean }) => void;
+  startSlidesStreamForRunId: (
+    runId: string,
+    meta?: { url?: string | null; local?: boolean },
+  ) => void;
   startSlidesSummaryStreamForRunId: (runId: string, url: string | null) => void;
+  handleSlidesLocal: (msg: SlidesLocalMessage) => void;
   getSlidesContextRequestId: () => number;
   setSlidesContextPending: (value: boolean) => void;
   setSlidesTranscriptTimedText: (value: string | null) => void;
@@ -104,7 +117,9 @@ export function createSidepanelBgMessageRuntime(options: {
   getActiveTabId: () => number | null;
   applyPanelCache: (cache: unknown, opts: { preserveChat?: boolean }) => void;
   rememberPendingSummaryRun: (run: RunStart) => void;
+  rememberPendingSummarySnapshot: (payload: { run: RunStart; markdown: string }) => void;
   attachSummaryRun: (run: RunStart) => void;
+  applySummarySnapshot: (payload: { run: RunStart; markdown: string }) => void;
   handleChatHistory: (msg: Extract<BgMessage, { type: "chat:history" }>) => void;
   handleAgentChunk: (msg: Extract<BgMessage, { type: "agent:chunk" }>) => void;
   handleAgentResponse: (msg: Extract<BgMessage, { type: "agent:response" }>) => void;
@@ -147,12 +162,19 @@ export function createSidepanelBgMessageRuntime(options: {
             options.rememberPendingSlidesRun({
               runId: slidesRun.runId,
               url: targetUrl,
+              local: Boolean(slidesRun.local),
             });
             return;
           }
-          options.startSlidesStreamForRunId(slidesRun.runId);
-          options.startSlidesSummaryStreamForRunId(slidesRun.runId, targetUrl);
+          options.startSlidesStreamForRunId(slidesRun.runId, {
+            url: targetUrl,
+            local: Boolean(slidesRun.local),
+          });
+          if (!slidesRun.local) {
+            options.startSlidesSummaryStreamForRunId(slidesRun.runId, targetUrl);
+          }
         },
+        handleSlidesLocal: options.handleSlidesLocal,
         handleSlidesContext: (slidesContext: SlidesContextMessage) => {
           if (!options.panelState.slides) return;
           const expectedId = `slides-${options.getSlidesContextRequestId()}`;
@@ -204,6 +226,22 @@ export function createSidepanelBgMessageRuntime(options: {
             return;
           }
           options.attachSummaryRun(run);
+        },
+        handleRunSnapshot: (snapshot) => {
+          if (
+            !shouldAcceptRunForCurrentPage({
+              runUrl: snapshot.run.url,
+              activeTabUrl: options.getActiveTabUrl(),
+              currentSourceUrl: options.panelState.currentSource?.url ?? null,
+            })
+          ) {
+            options.rememberPendingSummarySnapshot({
+              run: snapshot.run,
+              markdown: snapshot.markdown,
+            });
+            return;
+          }
+          options.applySummarySnapshot({ run: snapshot.run, markdown: snapshot.markdown });
         },
         handleChatHistory: options.handleChatHistory,
         handleAgentChunk: options.handleAgentChunk,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime.ts
@@ -15,6 +15,7 @@ export function handleSidepanelBgMessage(options: {
   handleSlidesLocal: (msg: Extract<BgToPanel, { type: "slides:local" }>) => void;
   handleSlidesContext: (msg: Extract<BgToPanel, { type: "slides:context" }>) => void;
   handleUiCache: (msg: Extract<BgToPanel, { type: "ui:cache" }>) => void;
+  handleCacheCleared: () => void;
   handleRunStart: (run: RunStart) => void;
   handleRunSnapshot: (payload: Extract<BgToPanel, { type: "run:snapshot" }>) => void;
   handleChatHistory: (msg: Extract<BgToPanel, { type: "chat:history" }>) => void;
@@ -43,6 +44,9 @@ export function handleSidepanelBgMessage(options: {
       return;
     case "ui:cache":
       options.handleUiCache(msg);
+      return;
+    case "ui:cache-cleared":
+      options.handleCacheCleared();
       return;
     case "run:start":
       options.handleRunStart(msg.run);
@@ -114,6 +118,7 @@ export function createSidepanelBgMessageRuntime(options: {
     cache: unknown;
     preserveChat: boolean;
   } | null;
+  clearPanelCache: () => void;
   getActiveTabId: () => number | null;
   applyPanelCache: (cache: unknown, opts: { preserveChat?: boolean }) => void;
   rememberPendingSummaryRun: (run: RunStart) => void;
@@ -214,6 +219,7 @@ export function createSidepanelBgMessageRuntime(options: {
           if (!result.cache) return;
           options.applyPanelCache(result.cache, { preserveChat: result.preserveChat });
         },
+        handleCacheCleared: options.clearPanelCache,
         handleRunStart: (run: RunStart) => {
           if (
             !shouldAcceptRunForCurrentPage({

--- a/apps/chrome-extension/src/entrypoints/sidepanel/dom.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/dom.ts
@@ -24,7 +24,7 @@ export function createSidepanelDom() {
   renderSlidesHostEl.className = "render__slidesHost";
   const renderMarkdownHostEl = document.createElement("div");
   renderMarkdownHostEl.className = "render__markdownHost";
-  renderEl.append(renderMarkdownHostEl, renderSlidesHostEl);
+  renderEl.append(renderSlidesHostEl, renderMarkdownHostEl);
   const mainEl = document.querySelector("main") as HTMLElement | null;
   if (!mainEl) throw new Error("Missing <main>");
   const metricsEl = byId<HTMLDivElement>("metrics");

--- a/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
@@ -180,6 +180,11 @@ const panelState: PanelState = {
   chatStreaming: false,
 };
 
+let retainedSlideSummary: {
+  markdown: string;
+  url: string | null;
+} | null = null;
+
 const panelPortRuntime = createPanelPortRuntime<BgToPanel>({
   onMessage: (msg) => {
     handleBgMessage(msg);
@@ -193,6 +198,34 @@ async function send(message: PanelToBg) {
     lastAction = "chat";
   }
   await panelPortRuntime.send(message);
+}
+
+const pendingLocalSlidesRequests = new Map<
+  string,
+  {
+    resolve: (slides: SseSlidesData | null) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }
+>();
+
+async function resolveLocalSlides(runId: string): Promise<SseSlidesData | null> {
+  const requestId = `local-slides-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return await new Promise<SseSlidesData | null>((resolve) => {
+    const timer = window.setTimeout(() => {
+      pendingLocalSlidesRequests.delete(requestId);
+      resolve(null);
+    }, 2500);
+    pendingLocalSlidesRequests.set(requestId, { resolve, timer });
+    void send({ type: "panel:slides-local", requestId, runId });
+  });
+}
+
+function handleLocalSlidesResponse(message: Extract<BgToPanel, { type: "slides:local" }>) {
+  const pending = pendingLocalSlidesRequests.get(message.requestId);
+  if (!pending) return;
+  window.clearTimeout(pending.timer);
+  pendingLocalSlidesRequests.delete(message.requestId);
+  pending.resolve(message.ok ? (message.slides ?? null) : null);
 }
 
 let autoValue = false;
@@ -239,8 +272,16 @@ const slidesSession = createSlidesSessionStore({
   slidesLayout: defaultSettings.slidesLayout,
 });
 const slidesState = slidesSession.state;
-const pendingSummaryRunsByUrl = new Map<string, RunStart>();
-const pendingSlidesRunsByUrl = new Map<string, { runId: string; url: string }>();
+type PendingSummaryResult =
+  | { type: "run"; run: RunStart }
+  | { type: "snapshot"; run: RunStart; markdown: string };
+
+const pendingSummaryRunsByUrl = new Map<string, PendingSummaryResult>();
+const pendingSlidesRunsByUrl = new Map<
+  string,
+  { runId: string; url: string | null; local?: boolean }
+>();
+let activeSlidesRunMeta: { runId: string; url: string | null; local: boolean } | null = null;
 let lastPlannedSlidesRun: RunStart | null = null;
 const slidesTextController = createSlidesTextController({
   getSlides: () => panelState.slides?.slides ?? null,
@@ -294,6 +335,7 @@ function hideSlideNotice() {
 }
 
 function stopSlidesStream() {
+  activeSlidesRunMeta = null;
   slidesHydrator.stop();
   setSlidesBusy(false);
   panelState.slidesRunId = null;
@@ -321,7 +363,11 @@ function maybeStartPendingSummaryRunForUrl(url: string | null) {
   if (!pending) return false;
   if (streamController.isStreaming()) return false;
   pendingSummaryRunsByUrl.delete(key);
-  attachSummaryRun(pending);
+  if (pending.type === "snapshot") {
+    applySummarySnapshot({ run: pending.run, markdown: pending.markdown });
+  } else {
+    attachSummaryRun(pending.run);
+  }
   return true;
 }
 
@@ -336,12 +382,47 @@ function maybeStartPendingSlidesForUrl(url: string | null) {
   if (slidesHydrator.isStreaming()) return;
   pendingSlidesRunsByUrl.delete(key);
   if (hasResolvedSlidesPayload(panelState.slides, slidesState.slidesSeededSourceId)) return;
-  startSlidesStreamForRunId(pending.runId);
-  startSlidesSummaryStreamForRunId(pending.runId, pending.url);
+  startSlidesStreamForRunId(pending.runId, { url: pending.url, local: Boolean(pending.local) });
+  if (!pending.local) {
+    startSlidesSummaryStreamForRunId(pending.runId, pending.url);
+  }
+}
+
+function getSummaryScopeUrl() {
+  return panelState.currentSource?.url ?? activeTabUrl ?? null;
+}
+
+function rememberSlideSummaryMarkdown(markdown: string) {
+  const trimmed = markdown.trim();
+  if (!trimmed) return;
+  retainedSlideSummary = {
+    markdown,
+    url: getSummaryScopeUrl(),
+  };
+}
+
+function getRetainedSlideSummaryMarkdown() {
+  if (!retainedSlideSummary) return null;
+  const currentUrl = getSummaryScopeUrl();
+  if (
+    retainedSlideSummary.url &&
+    currentUrl &&
+    !panelUrlsMatch(retainedSlideSummary.url, currentUrl)
+  ) {
+    return null;
+  }
+  return retainedSlideSummary.markdown;
 }
 
 function attachSummaryRun(run: RunStart) {
-  stopSlidesStream();
+  const preserveActiveLocalSlideRun = Boolean(
+    activeSlidesRunMeta?.local &&
+    activeSlidesRunMeta.url &&
+    panelUrlsMatch(activeSlidesRunMeta.url, run.url),
+  );
+  if (!preserveActiveLocalSlideRun) {
+    stopSlidesStream();
+  }
   setPhase("connecting");
   lastAction = "summarize";
   window.clearTimeout(autoKickTimer);
@@ -362,7 +443,11 @@ function attachSummaryRun(run: RunStart) {
       slidesState.slidesEnabled &&
       (slidesSession.resolveInputMode() === "video" || slidesState.mediaAvailable));
   panelState.runId = run.id;
-  panelState.slidesRunId = runRequestsSlides ? run.id : null;
+  panelState.slidesRunId = runRequestsSlides
+    ? run.id
+    : preserveActiveLocalSlideRun
+      ? (activeSlidesRunMeta?.runId ?? null)
+      : null;
   panelState.currentSource = { url: run.url, title: run.title };
   currentRunTabId = activeTabId;
   headerController.setBaseTitle(run.title || run.url || "Summarize");
@@ -385,6 +470,45 @@ function attachSummaryRun(run: RunStart) {
     renderMarkdownDisplay();
   }
   void streamController.start(run);
+}
+
+function applySummarySnapshot(payload: { run: RunStart; markdown: string }) {
+  const preserveActiveSlideRun =
+    payload.run.slides === true &&
+    (slidesHydrator.getActiveRunId() === payload.run.id ||
+      Boolean(
+        activeSlidesRunMeta?.local &&
+        activeSlidesRunMeta.url &&
+        panelUrlsMatch(activeSlidesRunMeta.url, payload.run.url),
+      ));
+  const preservedSlides =
+    payload.run.slides &&
+    panelState.slides &&
+    panelState.slides.sourceUrl &&
+    panelUrlsMatch(panelState.slides.sourceUrl, payload.run.url)
+      ? panelState.slides
+      : null;
+  resetSummaryView({
+    preserveChat: false,
+    clearRunId: false,
+    stopSlides: !preserveActiveSlideRun,
+  });
+  panelState.runId = payload.run.id;
+  panelState.slidesRunId =
+    preservedSlides?.sourceId ??
+    (preserveActiveSlideRun ? (activeSlidesRunMeta?.runId ?? null) : null);
+  panelState.currentSource = { url: payload.run.url, title: payload.run.title };
+  currentRunTabId = activeTabId;
+  headerController.setBaseTitle(payload.run.title || payload.run.url || "Summarize");
+  headerController.setBaseSubtitle("");
+  if (preservedSlides) {
+    panelState.slides = preservedSlides;
+    setSlidesTranscriptTimedText(preservedSlides.transcriptTimedText ?? null);
+    updateSlidesTextState();
+  }
+  renderMarkdown(payload.markdown);
+  if (preservedSlides) queueSlidesRender();
+  setPhase("idle");
 }
 
 function maybeSeedPlannedSlidesForPendingRun() {
@@ -707,6 +831,7 @@ async function migrateChatHistory(
 const syncWithActiveTab = () => navigationRuntime.syncWithActiveTab();
 
 async function clearCurrentView() {
+  retainedSlideSummary = null;
   if (panelState.chatStreaming) {
     requestAgentAbort("Cleared");
   }
@@ -788,6 +913,9 @@ const summaryViewRuntime = createSummaryViewRuntime({
   },
   updateSlidesTextState,
   requestSlidesContext,
+  requestSlidesCapture: () => {
+    void send({ type: "panel:slides-capture" });
+  },
   updateSlideSummaryFromMarkdown,
   renderMarkdown,
   renderMarkdownDisplay,
@@ -832,6 +960,7 @@ function renderMarkdownDisplay() {
 }
 
 function renderMarkdown(markdown: string) {
+  rememberSlideSummaryMarkdown(markdown);
   slidesViewRuntime?.renderMarkdown(markdown);
 }
 
@@ -908,6 +1037,7 @@ slidesViewRuntime = createSlidesViewRuntime({
   setSlidesExpanded: (value) => {
     slidesState.slidesExpanded = value;
   },
+  getFallbackSummaryMarkdown: getRetainedSlideSummaryMarkdown,
 });
 
 slidesRenderer = slidesViewRuntime.slidesRenderer;
@@ -920,6 +1050,7 @@ registerSidepanelTestHooks({
   applySlidesPayload,
   getRunId: () => panelState.runId,
   getSummaryMarkdown: () => panelState.summaryMarkdown ?? "",
+  getRetainedSlideSummaryMarkdown: () => getRetainedSlideSummaryMarkdown() ?? "",
   getSlideDescriptions: () => slidesTextController.getDescriptionEntries(),
   getSlideSummaryEntries: () => slidesTextController.getSummaryEntries(),
   getSlideTitleEntries: () => Array.from(slidesTextController.getTitles().entries()),
@@ -964,15 +1095,7 @@ registerSidepanelTestHooks({
     handleBgMessage(message);
   },
   applySummarySnapshot: (payload) => {
-    resetSummaryView({ preserveChat: false, clearRunId: false, stopSlides: false });
-    panelState.runId = payload.run.id;
-    panelState.slidesRunId = payload.run.slides ? payload.run.id : null;
-    panelState.currentSource = { url: payload.run.url, title: payload.run.title };
-    currentRunTabId = activeTabId;
-    headerController.setBaseTitle(payload.run.title || payload.run.url || "Summarize");
-    headerController.setBaseSubtitle("");
-    renderMarkdown(payload.markdown);
-    setPhase("idle");
+    applySummarySnapshot(payload);
   },
   applySummaryMarkdown: (markdown) => {
     renderMarkdown(markdown);
@@ -1133,6 +1256,7 @@ const slidesRuntime = createSidepanelSlidesRuntime({
   getPanelState: () => panelState,
   getSlidesEnabled: () => slidesState.slidesEnabled,
   getToken: async () => (await loadSettings()).token,
+  resolveLocalSlides,
   getTranscriptTimedText: () => slidesTextController.getTranscriptTimedText(),
   getUiState: () => panelState.ui,
   headerSetStatus: (text) => {
@@ -1171,10 +1295,25 @@ const {
   slidesHydrator: activeSlidesHydrator,
   slidesSummaryController,
   startSlidesStream,
-  startSlidesStreamForRunId,
-  startSlidesSummaryStreamForRunId,
+  startSlidesStreamForRunId: startSlidesStreamForRunIdBase,
+  startSlidesSummaryStreamForRunId: startSlidesSummaryStreamForRunIdBase,
 } = slidesRuntime;
 slidesHydrator = activeSlidesHydrator;
+
+function startSlidesStreamForRunId(runId: string, meta?: { url?: string | null; local?: boolean }) {
+  const existing = activeSlidesRunMeta?.runId === runId ? activeSlidesRunMeta : null;
+  activeSlidesRunMeta = {
+    runId,
+    url: meta?.url ?? existing?.url ?? panelState.currentSource?.url ?? activeTabUrl ?? null,
+    local: meta?.local ?? existing?.local ?? false,
+  };
+  startSlidesStreamForRunIdBase(runId, { local: activeSlidesRunMeta.local });
+}
+
+function startSlidesSummaryStreamForRunId(runId: string, url?: string | null) {
+  if (activeSlidesRunMeta?.runId === runId && activeSlidesRunMeta.local) return;
+  startSlidesSummaryStreamForRunIdBase(runId, url ?? null);
+}
 
 const summaryStreamRuntime = createSummaryStreamRuntime({
   friendlyFetchError,
@@ -1250,6 +1389,9 @@ const uiStateRuntime = createUiStateRuntime({
   migrateChatHistory,
   maybeStartPendingSummaryRunForUrl,
   maybeStartPendingSlidesForUrl,
+  requestSlidesCapture: () => {
+    void send({ type: "panel:slides-capture" });
+  },
   resolveActiveSlidesRunId,
   applyPanelCache,
   resetSummaryView,
@@ -1365,12 +1507,14 @@ const bgMessageRuntime = createSidepanelBgMessageRuntime({
   showSlideNotice,
   getActiveTabUrl: () => activeTabUrl,
   rememberPendingSlidesRun: (value) => {
+    if (!value.url) return;
     pendingSlidesRunsByUrl.set(normalizePanelUrl(value.url), value);
   },
   startSlidesStreamForRunId,
   startSlidesSummaryStreamForRunId: (runId, url) => {
     startSlidesSummaryStreamForRunId(runId, url ?? null);
   },
+  handleSlidesLocal: handleLocalSlidesResponse,
   getSlidesContextRequestId: () => slidesState.slidesContextRequestId,
   setSlidesContextPending: (value) => {
     slidesState.slidesContextPending = value;
@@ -1394,9 +1538,19 @@ const bgMessageRuntime = createSidepanelBgMessageRuntime({
     applyPanelCache(cache as PanelCachePayload, opts);
   },
   rememberPendingSummaryRun: (run) => {
-    pendingSummaryRunsByUrl.set(normalizePanelUrl(run.url), run);
+    pendingSummaryRunsByUrl.set(normalizePanelUrl(run.url), { type: "run", run });
+  },
+  rememberPendingSummarySnapshot: (payload) => {
+    pendingSummaryRunsByUrl.set(normalizePanelUrl(payload.run.url), {
+      type: "snapshot",
+      run: payload.run,
+      markdown: payload.markdown,
+    });
   },
   attachSummaryRun,
+  applySummarySnapshot: (payload) => {
+    applySummarySnapshot(payload);
+  },
   handleChatHistory: (chatHistory) => {
     chatSession.handleChatHistoryResponse(chatHistory as never);
   },
@@ -1520,6 +1674,8 @@ summarizeControlRuntime = createSummarizeControlRuntime({
     sendSummarize(opts);
   },
   resolveActiveSlidesRunId,
+  isActiveSlidesRunLocal: (runId) =>
+    activeSlidesRunMeta?.runId === runId && activeSlidesRunMeta.local,
   startSlidesStreamForRunId,
   startSlidesSummaryStreamForRunId: (runId, url) => {
     startSlidesSummaryStreamForRunId(runId, url ?? null);

--- a/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
@@ -1533,6 +1533,9 @@ const bgMessageRuntime = createSidepanelBgMessageRuntime({
     panelCacheController.scheduleSync();
   },
   consumeUiCache: (cacheMessage) => panelCacheController.consumeResponse(cacheMessage),
+  clearPanelCache: () => {
+    panelCacheController.clear();
+  },
   getActiveTabId: () => activeTabId,
   applyPanelCache: (cache, opts) => {
     applyPanelCache(cache as PanelCachePayload, opts);

--- a/apps/chrome-extension/src/entrypoints/sidepanel/panel-cache.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/panel-cache.ts
@@ -27,6 +27,7 @@ export type PanelCacheController = {
   syncNow: () => void;
   request: (tabId: number, url: string, preserveChat: boolean) => PanelCacheRequest;
   consumeResponse: (response: PanelCacheResponse) => PanelCacheResult | null;
+  clear: () => void;
 };
 
 export type PanelCacheControllerOptions = {
@@ -110,5 +111,14 @@ export function createPanelCacheController(
     };
   };
 
-  return { resolve, scheduleSync, syncNow, request, consumeResponse };
+  const clear = () => {
+    cacheByKey.clear();
+    pendingRequest = null;
+    if (syncTimer) {
+      globalThis.clearTimeout(syncTimer);
+      syncTimer = 0;
+    }
+  };
+
+  return { resolve, scheduleSync, syncNow, request, consumeResponse, clear };
 }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/setup-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/setup-runtime.ts
@@ -56,6 +56,10 @@ export function createSetupRuntime(options: {
   };
 
   const maybeShowSetup = (state: UiState) => {
+    if (state.settings.slideRuntime === "browser") {
+      options.setupEl.classList.add("hidden");
+      return false;
+    }
     if (!state.settings.tokenPresent) {
       void options.ensureToken().then((token) => {
         renderSetup(token);

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slide-images.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slide-images.ts
@@ -85,6 +85,7 @@ export function createSlideImageLoader(
 
   const resolveSlideImageUrl = async (imageUrl: string): Promise<string | null> => {
     if (!imageUrl) return null;
+    if (imageUrl.startsWith("data:") || imageUrl.startsWith("blob:")) return imageUrl;
     const cached = slideImageCache.get(imageUrl);
     if (cached) {
       recordCacheUse(imageUrl, cached.objectUrl);

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-hydrator.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-hydrator.ts
@@ -6,9 +6,10 @@ import {
 } from "./slides-stream-controller";
 
 export type SlidesHydrator = {
-  start: (runId: string, opts?: { silent?: boolean }) => Promise<void>;
+  start: (runId: string, opts?: { silent?: boolean; local?: boolean }) => Promise<void>;
   stop: () => void;
   isStreaming: () => boolean;
+  getActiveRunId: () => string | null;
   handlePayload: (payload: SseSlidesData) => void;
   handleSummaryFromCache: (value: boolean | null | undefined) => void;
   syncFromCache: (args: {
@@ -26,6 +27,7 @@ export type SlidesHydratorOptions = {
   onDone?: (() => void) | null;
   onError?: ((error: unknown) => string) | null;
   onSnapshotError?: ((error: unknown) => void) | null;
+  resolveLocalSlides?: ((runId: string) => Promise<SseSlidesData | null>) | null;
   streamFetchImpl?: typeof fetch;
   snapshotFetchImpl?: typeof fetch;
 };
@@ -40,6 +42,7 @@ export function createSlidesHydrator(options: SlidesHydratorOptions): SlidesHydr
     onDone,
     onError,
     onSnapshotError,
+    resolveLocalSlides,
     streamFetchImpl,
     snapshotFetchImpl,
   } = options;
@@ -73,6 +76,11 @@ export function createSlidesHydrator(options: SlidesHydratorOptions): SlidesHydr
     const requestId = ++snapshotRequestId;
     snapshotInFlight = true;
     try {
+      const localSlides = (await resolveLocalSlides?.(runId)) ?? null;
+      if (localSlides && activeRunId === runId && snapshotRequestId === requestId) {
+        handlePayload(localSlides);
+        return;
+      }
       const token = (await getToken()).trim();
       if (!token) return;
       const res = await (snapshotFetchImpl ?? fetch)(
@@ -110,12 +118,23 @@ export function createSlidesHydrator(options: SlidesHydratorOptions): SlidesHydr
     fetchImpl: streamFetchImpl,
   });
 
-  const start = async (runId: string, opts?: { silent?: boolean }) => {
+  const start = async (runId: string, opts?: { silent?: boolean; local?: boolean }) => {
     const requestId = activeStartRequestId + 1;
     activeStartRequestId = requestId;
     setActiveRunId(runId);
     suppressStreamErrors = Boolean(opts?.silent);
     try {
+      const localSlides = (await resolveLocalSlides?.(runId)) ?? null;
+      if (activeStartRequestId !== requestId) return;
+      if (localSlides && activeStartRequestId === requestId) {
+        handlePayload(localSlides);
+        onDone?.();
+        return;
+      }
+      if (opts?.local) {
+        onDone?.();
+        return;
+      }
       await stream.start(runId);
     } finally {
       if (activeStartRequestId === requestId) {
@@ -167,6 +186,7 @@ export function createSlidesHydrator(options: SlidesHydratorOptions): SlidesHydr
     start,
     stop,
     isStreaming: () => stream.isStreaming(),
+    getActiveRunId: () => activeRunId,
     handlePayload,
     handleSummaryFromCache,
     syncFromCache,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-payload.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-payload.ts
@@ -53,6 +53,9 @@ export function normalizeSlidesPayload(data: unknown): SlidesPayload | null {
     sourceUrl: typeof payload.sourceUrl === "string" ? payload.sourceUrl : "",
     sourceId,
     sourceKind: typeof payload.sourceKind === "string" ? payload.sourceKind : "unknown",
+    ...(payload.slideRuntime === "browser" || payload.slideRuntime === "daemon"
+      ? { slideRuntime: payload.slideRuntime }
+      : {}),
     ocrAvailable: payload.ocrAvailable === true,
     ...(transcriptTimedText ? { transcriptTimedText } : {}),
     slides: Array.from(slidesByIndex.values()).sort((a, b) => a.index - b.index),
@@ -90,6 +93,7 @@ export function slidesPayloadChanged(prev: SlidesPayload | null, next: SlidesPay
   }
   if (next.ocrAvailable !== prev.ocrAvailable) return true;
   if ((next.transcriptTimedText ?? null) !== (prev.transcriptTimedText ?? null)) return true;
+  if ((next.slideRuntime ?? "daemon") !== (prev.slideRuntime ?? "daemon")) return true;
   return false;
 }
 

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-run-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-run-runtime.ts
@@ -16,7 +16,7 @@ export function createSlidesRunRuntime(options: {
   hideSlideNotice: () => void;
   setSlidesBusy: (value: boolean) => void;
   schedulePanelCacheSync: () => void;
-  startSlidesHydrator: (runId: string) => void;
+  startSlidesHydrator: (runId: string, opts?: { local?: boolean }) => void;
   startSlidesSummaryController: (payload: {
     id: string;
     url: string;
@@ -49,7 +49,7 @@ export function createSlidesRunRuntime(options: {
     options.headerSetStatus(trimmed);
   };
 
-  const startSlidesStreamForRunId = (runId: string) => {
+  const startSlidesStreamForRunId = (runId: string, opts?: { local?: boolean }) => {
     const ui = options.getUiState();
     const slidesAllowed = options.getSlidesEnabled() || ui?.settings.slidesEnabled;
     if (!slidesAllowed) {
@@ -61,7 +61,7 @@ export function createSlidesRunRuntime(options: {
     options.setSlidesBusy(true);
     options.setSlidesRunId(runId);
     options.schedulePanelCacheSync();
-    options.startSlidesHydrator(runId);
+    options.startSlidesHydrator(runId, opts);
   };
 
   const startSlidesStream = (run: RunStart) => {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-runtime.ts
@@ -14,6 +14,7 @@ export function createSidepanelSlidesRuntime({
   getPanelState,
   getSlidesEnabled,
   getToken,
+  resolveLocalSlides,
   getTranscriptTimedText,
   getUiState,
   headerSetStatus,
@@ -48,6 +49,13 @@ export function createSidepanelSlidesRuntime({
   getPanelState: Parameters<typeof createSlidesSummaryController>[0]["getPanelState"];
   getSlidesEnabled: () => boolean;
   getToken: () => Promise<string>;
+  resolveLocalSlides?: (
+    runId: string,
+  ) => Promise<
+    Parameters<typeof createSlidesHydrator>[0]["onSlides"] extends (value: infer T) => void
+      ? T | null
+      : null
+  >;
   getTranscriptTimedText: () => string | null;
   getUiState: Parameters<typeof createSlidesSummaryController>[0]["getUiState"];
   headerSetStatus: (text: string) => void;
@@ -97,6 +105,7 @@ export function createSidepanelSlidesRuntime({
 
   const slidesHydrator = createSlidesHydrator({
     getToken,
+    resolveLocalSlides,
     onSlides: (data) => {
       applySlidesPayload(data);
       slidesSummaryController.maybeApplyPending();
@@ -146,8 +155,8 @@ export function createSidepanelSlidesRuntime({
     hideSlideNotice,
     setSlidesBusy,
     schedulePanelCacheSync,
-    startSlidesHydrator: (runId) => {
-      void slidesHydrator.start(runId);
+    startSlidesHydrator: (runId, opts) => {
+      void slidesHydrator.start(runId, opts);
     },
     startSlidesSummaryController: (payload) => {
       void slidesSummaryController.start(payload);

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-state.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-state.ts
@@ -1,6 +1,6 @@
 import { SUMMARY_LENGTH_SPECS } from "@steipete/summarize-core/prompts";
 import type { SummaryLength, SseSlidesData } from "../../lib/runtime-contracts";
-import { buildSlidePresentation } from "../../lib/slides-presentation";
+import { buildSlidePresentation, type SlidePresentationCard } from "../../lib/slides-presentation";
 import {
   buildSlideTextFallback,
   resolveSlideTextBudget,
@@ -23,6 +23,12 @@ const SLIDE_CUSTOM_LENGTH_PATTERN = /^(?<value>\d+(?:\.\d+)?)(?<unit>k|m)?$/i;
 export type SlideTextMode = "transcript" | "ocr";
 
 type SlideLike = SseSlidesData["slides"][number];
+
+export type SlideSummaryDerivation = {
+  cards: SlidePresentationCard[];
+  summaries: Map<number, string>;
+  titles: Map<number, string>;
+};
 
 export function splitSlidesMarkdown(markdown: string): { summary: string; slides: string | null } {
   const { summary, slidesSection } = splitSummaryFromSlides(markdown);
@@ -178,6 +184,15 @@ function createTimeline(slides: SlideLike[]): SlideTimelineEntry[] {
   }));
 }
 
+function countSummaryParagraphs(markdown: string): number {
+  const { summary } = splitSlidesMarkdown(markdown);
+  return summary
+    .split(/\n\s*\n+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .filter((part) => !/^#{1,6}\s+\S/.test(part)).length;
+}
+
 export function deriveSlideSummaries({
   markdown,
   slides,
@@ -188,7 +203,7 @@ export function deriveSlideSummaries({
   slides: SlideLike[];
   transcriptTimedText: string | null;
   lengthValue: string;
-}): { summaries: Map<number, string>; titles: Map<number, string> } | null {
+}): SlideSummaryDerivation | null {
   const lengthArg = resolveSlidesLengthArg(lengthValue);
   const directPresentation = buildSlidePresentation({
     markdown,
@@ -198,17 +213,23 @@ export function deriveSlideSummaries({
     coerce: false,
     includeTranscriptFallback: false,
   });
-  const presentation =
-    directPresentation.cards.length > 0
-      ? directPresentation
-      : buildSlidePresentation({
-          markdown,
-          slides: createTimeline(slides),
-          transcriptTimedText,
-          lengthArg,
-          coerce: true,
-          includeTranscriptFallback: false,
-        });
+  const directHasEverySlideBody =
+    slides.length > 0 && slides.every((slide) => directPresentation.summaries.has(slide.index));
+  const summaryParagraphCount = countSummaryParagraphs(markdown);
+  const shouldCoerce =
+    summaryParagraphCount >= 2 &&
+    (directPresentation.cards.length === 0 || !directHasEverySlideBody);
+  const presentation = shouldCoerce
+    ? buildSlidePresentation({
+        markdown,
+        slides: createTimeline(slides),
+        transcriptTimedText,
+        lengthArg,
+        coerce: true,
+        coerceReserveIntro: false,
+        includeTranscriptFallback: false,
+      })
+    : directPresentation;
   const summaries = new Map<number, string>();
   const titles = new Map<number, string>();
   for (const card of presentation.cards) {
@@ -218,7 +239,7 @@ export function deriveSlideSummaries({
     if (hasMeaningfulSlideSummaryText(title)) titles.set(card.index, title);
   }
   if (summaries.size === 0 && titles.size === 0) return null;
-  return { summaries, titles };
+  return { cards: presentation.cards, summaries, titles };
 }
 
 export function buildSlideDescriptions({
@@ -230,6 +251,7 @@ export function buildSlideDescriptions({
   slidesOcrEnabled,
   slidesOcrAvailable,
   slidesTranscriptAvailable,
+  allowTranscriptFallback = true,
 }: {
   slides: SlideLike[];
   slideSummaries?: ReadonlyMap<number, string>;
@@ -239,15 +261,18 @@ export function buildSlideDescriptions({
   slidesOcrEnabled: boolean;
   slidesOcrAvailable: boolean;
   slidesTranscriptAvailable: boolean;
+  allowTranscriptFallback?: boolean;
 }): Map<number, string> {
   const descriptions = new Map<number, string>();
   const lengthArg = resolveSlidesLengthArg(lengthValue);
   const timeline = createTimeline(slides);
-  const fallbackSummaries = buildSlideTextFallback({
-    slides: timeline,
-    transcriptTimedText,
-    lengthArg,
-  });
+  const fallbackSummaries = allowTranscriptFallback
+    ? buildSlideTextFallback({
+        slides: timeline,
+        transcriptTimedText,
+        lengthArg,
+      })
+    : new Map<number, string>();
   const budget = resolveSlideTextBudget({ lengthArg, slideCount: timeline.length });
   const allowOcrFallback = slidesOcrEnabled && slidesOcrAvailable && !slidesTranscriptAvailable;
   for (const slide of slides) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-text-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-text-controller.ts
@@ -1,3 +1,4 @@
+import { logExtensionEvent } from "../../lib/extension-logs";
 import type { SseSlidesData } from "../../lib/runtime-contracts";
 import { parseTranscriptTimedText } from "../../lib/slides-text";
 import {
@@ -23,6 +24,7 @@ export function createSlidesTextController(options: {
   let slideSummaryByIndex = new Map<number, string>();
   let slideTitleByIndex = new Map<number, string>();
   let slideSummarySource: SlideSummarySource = null;
+  let lastDescriptionLogKey = "";
 
   const getSlides = () => options.getSlides() ?? [];
 
@@ -39,7 +41,30 @@ export function createSlidesTextController(options: {
       slidesOcrEnabled: options.getSlidesOcrEnabled(),
       slidesOcrAvailable,
       slidesTranscriptAvailable,
+      allowTranscriptFallback:
+        slideSummarySource !== "summary" || slideSummaryByIndex.size < slides.length,
     });
+    const detail = {
+      slides: slides.length,
+      descriptions: slideDescriptions.size,
+      summaries: slideSummaryByIndex.size,
+      titles: slideTitleByIndex.size,
+      transcriptAvailable: slidesTranscriptAvailable,
+      ocrAvailable: slidesOcrAvailable,
+      textMode: slidesTextMode,
+      source: slideSummarySource ?? (slidesTranscriptAvailable ? "transcript" : "none"),
+    };
+    const logKey = JSON.stringify(detail);
+    if (logKey === lastDescriptionLogKey) return;
+    lastDescriptionLogKey = logKey;
+    if (globalThis.chrome?.storage) {
+      logExtensionEvent({
+        event: "slides:text:rebuilt",
+        scope: "slides:panel",
+        level: "verbose",
+        detail,
+      });
+    }
   };
 
   return {
@@ -53,6 +78,7 @@ export function createSlidesTextController(options: {
       slideSummaryByIndex = new Map();
       slideTitleByIndex = new Map();
       slideSummarySource = null;
+      lastDescriptionLogKey = "";
     },
     clearSummarySource() {
       slideSummarySource = null;
@@ -101,8 +127,8 @@ export function createSlidesTextController(options: {
         slideTitleByIndex = new Map();
         if (source === "slides") {
           slideSummarySource = null;
-        } else if (!slideSummarySource) {
-          slideSummarySource = "summary";
+        } else if (slideSummarySource === source) {
+          slideSummarySource = null;
         }
         rebuildDescriptions();
         return true;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime.ts
@@ -1,5 +1,6 @@
 import { shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import type MarkdownIt from "markdown-it";
+import { logExtensionEvent } from "../../lib/extension-logs";
 import type { SseSlidesData } from "../../lib/runtime-contracts";
 import type { SlidesLayout } from "../../lib/settings";
 import { createSlideImageLoader, normalizeSlideImageUrl } from "./slide-images";
@@ -41,6 +42,7 @@ export function createSlidesViewRuntime({
   resolveActiveSlidesRunId,
   nextSlidesContextRequestId,
   setSlidesExpanded,
+  getFallbackSummaryMarkdown,
 }: {
   renderMarkdownHostEl: HTMLElement;
   renderSlidesHostEl: HTMLElement;
@@ -95,6 +97,7 @@ export function createSlidesViewRuntime({
   resolveActiveSlidesRunId: () => string | null;
   nextSlidesContextRequestId: () => number;
   setSlidesExpanded: (value: boolean) => void;
+  getFallbackSummaryMarkdown?: () => string | null;
 }) {
   const slideImageLoader = createSlideImageLoader();
 
@@ -286,6 +289,20 @@ export function createSlidesViewRuntime({
         imageUrl: normalizeSlideImageUrl(slide.imageUrl, safePayload.sourceId, slide.index),
       })),
     };
+    if (globalThis.chrome?.storage) {
+      logExtensionEvent({
+        event: "slides:payload:applied",
+        scope: "slides:panel",
+        level: "verbose",
+        detail: {
+          slides: normalized.slides.length,
+          sourceKind: normalized.sourceKind,
+          slideRuntime: normalized.slideRuntime ?? "daemon",
+          transcriptAvailable: Boolean(normalized.transcriptTimedText?.trim()),
+          ocrAvailable: normalized.ocrAvailable,
+        },
+      });
+    }
     const shouldReplaceSeeded = getSlidesSeededSourceId() === safePayload.sourceId;
     const merged = resolveSlidesPayload(state.panelState.slides, normalized, {
       seededSourceId: getSlidesSeededSourceId(),
@@ -322,7 +339,12 @@ export function createSlidesViewRuntime({
       setSlidesContextPending(false);
     }
     updateSlidesTextState();
-    if (state.panelState.summaryMarkdown) {
+    const summaryMarkdown = state.panelState.summaryMarkdown || getFallbackSummaryMarkdown?.();
+    if (summaryMarkdown) {
+      updateSlideSummaryFromMarkdown(summaryMarkdown, {
+        preserveIfEmpty: true,
+        source: "summary",
+      });
       renderInlineSlides(renderMarkdownHostEl, { fallback: true });
     }
     hideSlideNotice();

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime.ts
@@ -38,7 +38,7 @@ type SummarizeControlRuntimeOptions = {
   setSlidesEnabled: (value: boolean) => void;
   setSlidesLayoutValue: (value: SlidesLayout) => void;
   patchSettings: (patch: Partial<Settings>) => Promise<void>;
-  loadSettings: () => Promise<Pick<Settings, "token">>;
+  loadSettings: () => Promise<Pick<Settings, "slideRuntime" | "token">>;
   showSlideNotice: (message: string) => void;
   hideSlideNotice: () => void;
   setSlidesBusy: (value: boolean) => void;
@@ -47,6 +47,7 @@ type SummarizeControlRuntimeOptions = {
   maybeStartPendingSlidesForUrl: (url: string | null) => void;
   sendSummarize: (opts?: { refresh?: boolean }) => void;
   resolveActiveSlidesRunId: () => string | null;
+  isActiveSlidesRunLocal?: (runId: string) => boolean;
   startSlidesStreamForRunId: (runId: string) => void;
   startSlidesSummaryStreamForRunId: (runId: string, url: string | null) => void;
   renderMarkdownDisplay: () => void;
@@ -58,10 +59,10 @@ type SummarizeControlRuntimeOptions = {
 type SummarizeControlPayload = { mode: "page" | "video"; slides: boolean };
 
 async function fetchSlideTools(
-  loadSettings: SummarizeControlRuntimeOptions["loadSettings"],
+  tokenValue: string,
   requireOcr: boolean,
 ): Promise<{ ok: boolean; missing: string[] }> {
-  const token = (await loadSettings()).token.trim();
+  const token = tokenValue.trim();
   if (!token) return { ok: false, missing: ["daemon token"] };
   const res = await fetch("http://127.0.0.1:8787/v1/tools", {
     headers: { Authorization: `Bearer ${token}` },
@@ -104,13 +105,16 @@ export function createSummarizeControlRuntime(options: SummarizeControlRuntimeOp
     const prevSlides = state.slidesEnabled;
     const prevMode = state.inputMode;
     if (value.slides && !state.slidesEnabled) {
-      const tools = await fetchSlideTools(options.loadSettings, state.slidesOcrEnabled);
-      if (!tools.ok) {
-        options.showSlideNotice(
-          `Slide extraction requires ${tools.missing.join(", ")}. Install and restart the daemon.`,
-        );
-        refreshSummarizeControl();
-        return;
+      const settings = await options.loadSettings();
+      if (settings.slideRuntime === "daemon") {
+        const tools = await fetchSlideTools(settings.token, state.slidesOcrEnabled);
+        if (!tools.ok) {
+          options.showSlideNotice(
+            `Slide extraction requires ${tools.missing.join(", ")}. Install and restart the daemon.`,
+          );
+          refreshSummarizeControl();
+          return;
+        }
       }
       options.hideSlideNotice();
     } else if (!value.slides) {
@@ -141,8 +145,11 @@ export function createSummarizeControlRuntime(options: SummarizeControlRuntimeOp
     const runId = options.resolveActiveSlidesRunId();
     const targetUrl = state.currentSourceUrl ?? state.activeTabUrl ?? null;
     if (runId) {
+      const isLocalRun = options.isActiveSlidesRunLocal?.(runId) === true;
       options.startSlidesStreamForRunId(runId);
-      options.startSlidesSummaryStreamForRunId(runId, targetUrl);
+      if (!isLocalRun) {
+        options.startSlidesSummaryStreamForRunId(runId, targetUrl);
+      }
       return;
     }
     options.sendSummarize({ refresh: true });

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summary-view-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summary-view-runtime.ts
@@ -1,4 +1,4 @@
-import { shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
+import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import { buildIdleSubtitle } from "../../lib/header";
 import type { PanelCachePayload } from "./panel-cache";
 import { normalizeSlideImageUrl } from "./slide-images";
@@ -70,6 +70,7 @@ type SummaryViewRuntimeOpts = {
   clearSlidesSummaryError: () => void;
   updateSlidesTextState: () => void;
   requestSlidesContext: () => void | Promise<void>;
+  requestSlidesCapture: () => void;
   updateSlideSummaryFromMarkdown: (
     markdown: string,
     opts?: { preserveIfEmpty?: boolean; source?: "summary" | "slides" },
@@ -91,26 +92,28 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
     stopSlides?: boolean;
   } = {}) {
     opts.setCurrentRunTabId(null);
-    opts.renderEl.replaceChildren(opts.renderMarkdownHostEl, opts.renderSlidesHostEl);
+    opts.renderEl.replaceChildren(opts.renderSlidesHostEl, opts.renderMarkdownHostEl);
     opts.renderMarkdownHostEl.innerHTML = "";
     clearSummaryCopyButton(opts.summaryCopyBtn);
-    opts.getSlidesRenderer().clear();
     opts.metricsController.clearForMode("summary");
     opts.panelState.summaryMarkdown = null;
     opts.panelState.summaryFromCache = null;
-    opts.panelState.slides = null;
     if (clearRunId) {
       opts.panelState.runId = null;
-      opts.panelState.slidesRunId = null;
     }
     opts.setSlidesExpanded(true);
-    opts.setSlidesContextPending(false);
-    opts.setSlidesContextUrl(null);
-    opts.setSlidesTranscriptTimedText(null);
-    opts.slidesTextController.reset();
-    opts.setSlidesSeededSourceId(null);
-    opts.setSlidesAppliedRunId(null);
     if (stopSlides) {
+      opts.getSlidesRenderer().clear();
+      opts.panelState.slides = null;
+      if (clearRunId) {
+        opts.panelState.slidesRunId = null;
+      }
+      opts.setSlidesContextPending(false);
+      opts.setSlidesContextUrl(null);
+      opts.setSlidesTranscriptTimedText(null);
+      opts.slidesTextController.reset();
+      opts.setSlidesSeededSourceId(null);
+      opts.setSlidesAppliedRunId(null);
       opts.stopSlidesStream();
     }
     opts.refreshSummarizeControl();
@@ -206,6 +209,9 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
       opts.setSlidesContextUrl(null);
       opts.updateSlidesTextState();
       opts.setSlidesAppliedRunId(null);
+      if (payload.summaryMarkdown && payload.url && isYouTubeVideoUrl(payload.url)) {
+        opts.requestSlidesCapture();
+      }
     }
     opts.getSlidesHydrator().syncFromCache({
       runId: opts.panelState.slidesRunId ?? null,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/test-hooks.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/test-hooks.ts
@@ -9,6 +9,7 @@ type SidepanelTestHooks = {
   applySlidesPayload?: (payload: SseSlidesData) => void;
   getRunId?: () => string | null;
   getSummaryMarkdown?: () => string;
+  getRetainedSlideSummaryMarkdown?: () => string;
   getSlideDescriptions?: () => Array<[number, string]>;
   getSlideSummaryEntries?: () => Array<[number, string]>;
   getSlideTitleEntries?: () => Array<[number, string]>;
@@ -41,6 +42,7 @@ export function registerSidepanelTestHooks(options: {
   applySlidesPayload: (payload: SseSlidesData) => void;
   getRunId: () => string | null;
   getSummaryMarkdown: () => string;
+  getRetainedSlideSummaryMarkdown: () => string;
   getSlideDescriptions: () => Array<[number, string]>;
   getSlideSummaryEntries: () => Array<[number, string]>;
   getSlideTitleEntries: () => Array<[number, string]>;
@@ -78,6 +80,7 @@ export function registerSidepanelTestHooks(options: {
   hooks.applySlidesPayload = options.applySlidesPayload;
   hooks.getRunId = options.getRunId;
   hooks.getSummaryMarkdown = options.getSummaryMarkdown;
+  hooks.getRetainedSlideSummaryMarkdown = options.getRetainedSlideSummaryMarkdown;
   hooks.getSlideDescriptions = options.getSlideDescriptions;
   hooks.getSlideSummaryEntries = options.getSlideSummaryEntries;
   hooks.getSlideTitleEntries = options.getSlideTitleEntries;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
@@ -1,4 +1,4 @@
-import { shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
+import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import type { PanelCachePayload } from "./panel-cache";
 import {
   resolvePanelNavigationDecision,
@@ -61,6 +61,7 @@ type UiStateRuntimeOpts = {
   ) => void | Promise<void>;
   maybeStartPendingSummaryRunForUrl: (url: string | null) => boolean;
   maybeStartPendingSlidesForUrl: (url: string | null) => void;
+  requestSlidesCapture: () => void;
   resolveActiveSlidesRunId: () => string | null;
   applyPanelCache: (payload: PanelCachePayload, opts?: { preserveChat?: boolean }) => void;
   resetSummaryView: (opts?: { preserveChat?: boolean }) => void;
@@ -125,6 +126,7 @@ function applyCachedOrReset(
     | "panelState"
     | "panelCacheController"
     | "applyPanelCache"
+    | "requestSlidesCapture"
     | "resetSummaryView"
     | "setCurrentRunTabId"
   >,
@@ -136,6 +138,14 @@ function applyCachedOrReset(
     const cached = opts.panelCacheController.resolve(tabId, url);
     if (cached) {
       opts.applyPanelCache(cached, { preserveChat });
+      if (
+        cached.summaryMarkdown &&
+        !cached.slides?.slides.length &&
+        cached.url &&
+        isYouTubeVideoUrl(cached.url)
+      ) {
+        opts.requestSlidesCapture();
+      }
     } else {
       opts.panelState.currentSource = null;
       opts.setCurrentRunTabId(null);

--- a/apps/chrome-extension/src/lib/browser-panel-cache.ts
+++ b/apps/chrome-extension/src/lib/browser-panel-cache.ts
@@ -1,0 +1,302 @@
+import {
+  DEFAULT_CACHE_TTL_DAYS,
+  buildPortableCacheRow,
+  isPortableCacheRowExpired,
+  parseCacheJson,
+  summarizePortableCacheRows,
+  type CacheStats,
+  type PortableCacheRow,
+} from "../../../../src/shared/cache-store";
+import type { PanelCachePayload } from "./panel-contracts";
+
+type StoredPanelCacheRow = PortableCacheRow & {
+  format: "panel";
+};
+
+type BrowserStorageArea = {
+  get: (keys: string | string[] | null, callback: (items: Record<string, unknown>) => void) => void;
+  set: (items: Record<string, unknown>, callback?: () => void) => void;
+  remove: (keys: string | string[], callback?: () => void) => void;
+};
+
+const INDEX_KEY = "summarize.browserCache.index.v1";
+const ENTRY_PREFIX = "summarize.browserCache.entry.v1.";
+const CACHE_TTL_MS = DEFAULT_CACHE_TTL_DAYS * 24 * 60 * 60 * 1000;
+const MAX_BROWSER_CACHE_BYTES = 8 * 1024 * 1024;
+
+function normalizeCacheUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) return "";
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.toString();
+  } catch {
+    return trimmed;
+  }
+}
+
+function buildPanelCacheKey(url: string): string {
+  return `panel:${normalizeCacheUrl(url)}`;
+}
+
+function buildStorageKey(cacheKey: string): string {
+  return `${ENTRY_PREFIX}${encodeURIComponent(cacheKey)}`;
+}
+
+async function storageGet<T>(storage: BrowserStorageArea, key: string): Promise<T | undefined> {
+  return await new Promise((resolve, reject) => {
+    storage.get(key, (result) => {
+      const error = chrome.runtime.lastError;
+      if (error) {
+        reject(new Error(error.message));
+        return;
+      }
+      resolve((result as Record<string, T | undefined>)[key]);
+    });
+  });
+}
+
+async function storageGetMany(
+  storage: BrowserStorageArea,
+  keys: string[] | null,
+): Promise<Record<string, unknown>> {
+  return await new Promise((resolve, reject) => {
+    storage.get(keys, (result) => {
+      const error = chrome.runtime.lastError;
+      if (error) {
+        reject(new Error(error.message));
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
+async function storageSet(storage: BrowserStorageArea, values: Record<string, unknown>) {
+  await new Promise<void>((resolve, reject) => {
+    storage.set(values, () => {
+      const error = chrome.runtime.lastError;
+      if (error) {
+        reject(new Error(error.message));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function storageRemove(storage: BrowserStorageArea, keys: string | string[]) {
+  await new Promise<void>((resolve, reject) => {
+    storage.remove(keys, () => {
+      const error = chrome.runtime.lastError;
+      if (error) {
+        reject(new Error(error.message));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function normalizeIndex(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function isStoredPanelCacheRow(value: unknown): value is StoredPanelCacheRow {
+  const row = value as Partial<StoredPanelCacheRow> | null;
+  return (
+    Boolean(row) &&
+    row?.format === "panel" &&
+    row.kind === "summary" &&
+    typeof row.key === "string" &&
+    typeof row.value === "string" &&
+    typeof row.sizeBytes === "number" &&
+    typeof row.createdAt === "number" &&
+    typeof row.lastAccessedAt === "number" &&
+    (typeof row.expiresAt === "number" || row.expiresAt === null)
+  );
+}
+
+export type BrowserPanelCacheStore = {
+  getPanel: (url: string) => Promise<PanelCachePayload | null>;
+  setPanel: (payload: PanelCachePayload) => Promise<void>;
+  stats: () => Promise<CacheStats>;
+  clear: () => Promise<CacheStats>;
+};
+
+export function createBrowserPanelCacheStore(
+  storage: BrowserStorageArea = chrome.storage.local,
+): BrowserPanelCacheStore {
+  let mutationTail: Promise<unknown> = Promise.resolve();
+
+  const runSerialized = async <T>(task: () => Promise<T>): Promise<T> => {
+    const run = mutationTail.then(task, task);
+    mutationTail = run.catch(() => undefined);
+    return await run;
+  };
+
+  const loadIndex = async () => normalizeIndex(await storageGet<unknown>(storage, INDEX_KEY));
+
+  const loadEntryKeys = async () => {
+    const indexed = await loadIndex();
+    const all = await storageGetMany(storage, null);
+    const discovered = Object.keys(all).filter((key) => key.startsWith(ENTRY_PREFIX));
+    return Array.from(new Set([...indexed, ...discovered]));
+  };
+
+  const saveIndex = async (keys: string[]) => {
+    await storageSet(storage, { [INDEX_KEY]: Array.from(new Set(keys)) });
+  };
+
+  const removeEntries = async (keys: string[]) => {
+    if (keys.length === 0) return;
+    await storageRemove(storage, keys);
+    const removeSet = new Set(keys);
+    await saveIndex((await loadIndex()).filter((key) => !removeSet.has(key)));
+  };
+
+  const readRows = async () => {
+    const index = await loadEntryKeys();
+    if (index.length === 0) return [] as Array<{ storageKey: string; row: StoredPanelCacheRow }>;
+    const raw = await storageGetMany(storage, index);
+    const rows: Array<{ storageKey: string; row: StoredPanelCacheRow }> = [];
+    const missing: string[] = [];
+    for (const storageKey of index) {
+      const value = raw[storageKey];
+      if (isStoredPanelCacheRow(value)) {
+        rows.push({ storageKey, row: value });
+      } else {
+        missing.push(storageKey);
+      }
+    }
+    if (missing.length > 0) {
+      await removeEntries(missing);
+    }
+    return rows;
+  };
+
+  const prune = async (now = Date.now()) => {
+    let rows = await readRows();
+    const expired = rows
+      .filter(({ row }) => isPortableCacheRowExpired(row, now))
+      .map(({ storageKey }) => storageKey);
+    if (expired.length > 0) {
+      await removeEntries(expired);
+      rows = rows.filter(({ storageKey }) => !expired.includes(storageKey));
+    }
+
+    let total = rows.reduce((sum, { row }) => sum + Math.max(0, row.sizeBytes), 0);
+    if (total <= MAX_BROWSER_CACHE_BYTES) return;
+    const evicted: string[] = [];
+    for (const { storageKey, row } of rows.sort(
+      (left, right) => left.row.lastAccessedAt - right.row.lastAccessedAt,
+    )) {
+      if (total <= MAX_BROWSER_CACHE_BYTES) break;
+      evicted.push(storageKey);
+      total -= Math.max(0, row.sizeBytes);
+    }
+    await removeEntries(evicted);
+  };
+
+  const pruneBeforeInsert = async (
+    storageKey: string,
+    row: StoredPanelCacheRow,
+    now = Date.now(),
+  ): Promise<boolean> => {
+    if (row.sizeBytes > MAX_BROWSER_CACHE_BYTES) {
+      await removeEntries([storageKey]);
+      return false;
+    }
+    let rows = await readRows();
+    const removeSet = new Set<string>();
+    for (const existing of rows) {
+      if (isPortableCacheRowExpired(existing.row, now)) {
+        removeSet.add(existing.storageKey);
+      }
+    }
+    rows = rows.filter(({ storageKey: key }) => !removeSet.has(key) && key !== storageKey);
+    let total = rows.reduce((sum, existing) => sum + Math.max(0, existing.row.sizeBytes), 0);
+    for (const existing of rows.sort(
+      (left, right) => left.row.lastAccessedAt - right.row.lastAccessedAt,
+    )) {
+      if (total + row.sizeBytes <= MAX_BROWSER_CACHE_BYTES) break;
+      removeSet.add(existing.storageKey);
+      total -= Math.max(0, existing.row.sizeBytes);
+    }
+    await removeEntries(Array.from(removeSet));
+    return true;
+  };
+
+  const buildStats = async () => {
+    await prune();
+    const rows = await readRows();
+    return summarizePortableCacheRows(
+      rows.map(({ row }) => row),
+      `chrome.storage.local (${DEFAULT_CACHE_TTL_DAYS} days)`,
+    );
+  };
+
+  const getPanel = async (url: string): Promise<PanelCachePayload | null> =>
+    runSerialized(async () => {
+      const cacheKey = buildPanelCacheKey(url);
+      const storageKey = buildStorageKey(cacheKey);
+      const row = await storageGet<unknown>(storage, storageKey);
+      if (!isStoredPanelCacheRow(row)) return null;
+      const now = Date.now();
+      if (isPortableCacheRowExpired(row, now)) {
+        await removeEntries([storageKey]);
+        return null;
+      }
+      const payload = parseCacheJson<PanelCachePayload>(row.value);
+      if (!payload || normalizeCacheUrl(payload.url) !== normalizeCacheUrl(url)) {
+        await removeEntries([storageKey]);
+        return null;
+      }
+      await storageSet(storage, {
+        [storageKey]: {
+          ...row,
+          lastAccessedAt: now,
+        },
+      });
+      return payload;
+    });
+
+  const setPanel = async (payload: PanelCachePayload) =>
+    runSerialized(async () => {
+      if (!payload.url.trim()) return;
+      const cacheKey = buildPanelCacheKey(payload.url);
+      const storageKey = buildStorageKey(cacheKey);
+      const row: StoredPanelCacheRow = {
+        ...buildPortableCacheRow({
+          kind: "summary",
+          key: cacheKey,
+          value: JSON.stringify(payload),
+          ttlMs: CACHE_TTL_MS,
+        }),
+        format: "panel",
+      };
+      const shouldStore = await pruneBeforeInsert(storageKey, row);
+      if (!shouldStore) return;
+      const index = await loadIndex();
+      await storageSet(storage, {
+        [storageKey]: row,
+        [INDEX_KEY]: Array.from(new Set([...index, storageKey])),
+      });
+    });
+
+  const stats = async () => runSerialized(buildStats);
+
+  const clear = async () =>
+    runSerialized(async () => {
+      const keys = await loadEntryKeys();
+      if (keys.length > 0) {
+        await storageRemove(storage, keys);
+      }
+      await storageSet(storage, { [INDEX_KEY]: [] });
+      return buildStats();
+    });
+
+  return { getPanel, setPanel, stats, clear };
+}

--- a/apps/chrome-extension/src/lib/chat-context.ts
+++ b/apps/chrome-extension/src/lib/chat-context.ts
@@ -144,7 +144,7 @@ export function buildChatPageContent({
   const cleanTranscript = transcript.trim();
   const metadataBlock = buildMetadataBlock(metadata);
   const slidesText = slides?.text?.trim() ?? "";
-  const slidesBlock = slidesText.length > 0 ? `Slides (OCR):\n${slidesText}\n\n` : "";
+  const slidesBlock = slidesText.length > 0 ? `Slide timeline:\n${slidesText}\n\n` : "";
 
   if (!cleanSummary) {
     return `${metadataBlock}${slidesBlock}Full transcript:\n${cleanTranscript}`.trim();

--- a/apps/chrome-extension/src/lib/panel-contracts.ts
+++ b/apps/chrome-extension/src/lib/panel-contracts.ts
@@ -91,6 +91,7 @@ export type BgToPanel =
   | { type: "run:start"; run: RunStart }
   | { type: "run:snapshot"; run: RunStart; markdown: string }
   | { type: "run:error"; message: string }
+  | { type: "ui:cache-cleared" }
   | {
       type: "slides:run";
       ok: boolean;

--- a/apps/chrome-extension/src/lib/panel-contracts.ts
+++ b/apps/chrome-extension/src/lib/panel-contracts.ts
@@ -16,6 +16,7 @@ export type UiState = {
     slidesParallel: boolean;
     slidesOcrEnabled: boolean;
     slidesLayout: "strip" | "gallery";
+    slideRuntime: "browser" | "daemon";
     fontSize: number;
     lineHeight: number;
     model: string;
@@ -78,6 +79,8 @@ export type PanelToBg =
   | { type: "panel:setAuto"; value: boolean }
   | { type: "panel:setLength"; value: string }
   | { type: "panel:slides-context"; requestId: string; url?: string }
+  | { type: "panel:slides-local"; requestId: string; runId: string }
+  | { type: "panel:slides-capture"; manual?: boolean }
   | { type: "panel:cache"; cache: PanelCachePayload }
   | { type: "panel:get-cache"; requestId: string; tabId: number; url: string }
   | { type: "panel:openOptions" };
@@ -86,8 +89,23 @@ export type BgToPanel =
   | { type: "ui:state"; state: UiState }
   | { type: "ui:status"; status: string }
   | { type: "run:start"; run: RunStart }
+  | { type: "run:snapshot"; run: RunStart; markdown: string }
   | { type: "run:error"; message: string }
-  | { type: "slides:run"; ok: boolean; runId?: string; url?: string; error?: string }
+  | {
+      type: "slides:run";
+      ok: boolean;
+      runId?: string;
+      url?: string;
+      local?: boolean;
+      error?: string;
+    }
+  | {
+      type: "slides:local";
+      requestId: string;
+      ok: boolean;
+      slides?: SseSlidesData;
+      error?: string;
+    }
   | { type: "chat:history"; requestId: string; ok: boolean; messages?: Message[]; error?: string }
   | { type: "agent:chunk"; requestId: string; text: string }
   | {

--- a/apps/chrome-extension/src/lib/settings.ts
+++ b/apps/chrome-extension/src/lib/settings.ts
@@ -14,6 +14,7 @@ export type Settings = {
   chatEnabled: boolean;
   automationEnabled: boolean;
   slidesEnabled: boolean;
+  slideRuntime: SlideRuntime;
   slidesParallel: boolean;
   slidesOcrEnabled: boolean;
   slidesLayout: SlidesLayout;
@@ -44,6 +45,7 @@ export type Settings = {
 };
 
 export type SlidesLayout = "strip" | "gallery";
+export type SlideRuntime = "browser" | "daemon";
 
 const storageKey = "settings";
 const fallbackStorageKey = "summarize.settings";
@@ -185,6 +187,18 @@ function normalizeSlidesLayout(value: unknown): SlidesLayout {
   return defaultSettings.slidesLayout;
 }
 
+function normalizeSlideRuntime(value: unknown, raw?: Record<string, unknown>): SlideRuntime {
+  if (typeof value === "string") {
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed === "browser" || trimmed === "daemon") return trimmed;
+  }
+  const legacyDaemonlessSlides = raw?.daemonlessSlides;
+  if (typeof legacyDaemonlessSlides === "boolean") {
+    return legacyDaemonlessSlides ? "browser" : "daemon";
+  }
+  return defaultSettings.slideRuntime;
+}
+
 function normalizeFirecrawlMode(value: unknown): string {
   if (typeof value !== "string") return defaultSettings.firecrawlMode;
   const trimmed = value.trim().toLowerCase();
@@ -306,6 +320,7 @@ export const defaultSettings: Settings = {
   chatEnabled: true,
   automationEnabled: false,
   slidesEnabled: true,
+  slideRuntime: "browser",
   slidesParallel: true,
   slidesOcrEnabled: false,
   slidesLayout: "gallery",
@@ -355,7 +370,7 @@ export async function loadSettings(): Promise<Settings> {
         }
       })
     : { [storageKey]: loadFallbackSettings() };
-  const raw = (res[storageKey] ?? {}) as Partial<Settings>;
+  const raw = (res[storageKey] ?? {}) as Partial<Settings> & Record<string, unknown>;
   return {
     ...defaultSettings,
     ...raw,
@@ -376,6 +391,7 @@ export async function loadSettings(): Promise<Settings> {
         : defaultSettings.automationEnabled,
     slidesEnabled:
       typeof raw.slidesEnabled === "boolean" ? raw.slidesEnabled : defaultSettings.slidesEnabled,
+    slideRuntime: normalizeSlideRuntime(raw.slideRuntime, raw),
     slidesParallel:
       typeof raw.slidesParallel === "boolean" ? raw.slidesParallel : defaultSettings.slidesParallel,
     slidesOcrEnabled:

--- a/apps/chrome-extension/tests/helpers/extension-harness.ts
+++ b/apps/chrome-extension/tests/helpers/extension-harness.ts
@@ -36,6 +36,7 @@ export type UiState = {
     slidesParallel: boolean;
     slidesOcrEnabled: boolean;
     slidesLayout?: "strip" | "gallery";
+    slideRuntime?: "browser" | "daemon";
     model: string;
     length: string;
     tokenPresent: boolean;
@@ -58,6 +59,7 @@ const defaultUiState: UiState = {
     slidesParallel: true,
     slidesOcrEnabled: false,
     slidesLayout: "strip",
+    slideRuntime: "browser",
     model: "auto",
     length: "xl",
     tokenPresent: true,

--- a/apps/chrome-extension/tests/options.spec.ts
+++ b/apps/chrome-extension/tests/options.spec.ts
@@ -192,8 +192,12 @@ test("options exposes runtime slide backend radios", async ({
     await expect(page.locator("#panel-runtime")).toBeVisible();
     await expect(page.locator("#panel-runtime")).toContainText("Browser");
     await expect(page.locator("#panel-runtime")).toContainText("Daemon");
+    await expect(page.locator("#panel-runtime")).toContainText("Browser cache");
     await expect(page.locator("#panel-runtime")).toContainText("Daemon token");
     await expect(page.locator("#panel-runtime")).not.toContainText("Show summary first");
+    await expect(page.locator("#browserCacheStatus")).toContainText(/entries? · /);
+    await page.locator("#browserCacheClear").click();
+    await expect(page.locator("#browserCacheStatus")).toContainText("0 entries");
 
     const mode = page.locator("#slideRuntimeMode");
     await expect(mode.locator('input[value="browser"]')).toBeChecked();

--- a/apps/chrome-extension/tests/options.spec.ts
+++ b/apps/chrome-extension/tests/options.spec.ts
@@ -176,6 +176,46 @@ test("options persists automation toggle without save", async ({
   }
 });
 
+test("options exposes runtime slide backend radios", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, { slideRuntime: "browser" });
+    const page = await openExtensionPage(harness, "options.html", "#tabs");
+
+    await expect(page.locator("#daemonStatus")).toContainText("Browser mode active");
+    await expect(page.locator("#panel-general")).not.toContainText("Token");
+
+    await page.click("#tab-runtime");
+    await expect(page.locator("#panel-runtime")).toBeVisible();
+    await expect(page.locator("#panel-runtime")).toContainText("Browser");
+    await expect(page.locator("#panel-runtime")).toContainText("Daemon");
+    await expect(page.locator("#panel-runtime")).toContainText("Daemon token");
+    await expect(page.locator("#panel-runtime")).not.toContainText("Show summary first");
+
+    const mode = page.locator("#slideRuntimeMode");
+    await expect(mode.locator('input[value="browser"]')).toBeChecked();
+    await mode.locator('input[value="daemon"]').click();
+    await expect(page.locator("#daemonStatus")).toContainText("Add token to verify daemon");
+
+    await expect
+      .poll(async () => {
+        const settings = await getSettings(harness);
+        return settings.slideRuntime;
+      })
+      .toBe("daemon");
+
+    await page.click("#tab-advanced");
+    await expect(page.locator("#panel-advanced")).toContainText("Show summary first");
+
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
 test("options disables automation permissions button when granted", async ({
   browserName: _browserName,
 }, testInfo) => {

--- a/apps/chrome-extension/tests/sidepanel.browser-slides.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.browser-slides.spec.ts
@@ -1,0 +1,226 @@
+import fs from "node:fs";
+import { createServer as createHttpServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { createSampleVideo, hasFfmpeg } from "./helpers/daemon-fixtures";
+import {
+  activateTabByUrl,
+  assertNoErrors,
+  buildUiState,
+  closeExtension,
+  getActiveTabId,
+  getBackground,
+  getBrowserFromProject,
+  launchExtension,
+  openExtensionPage,
+  seedSettings,
+  sendBgMessage,
+  sendPanelMessage,
+  waitForActiveTabUrl,
+  waitForPanelPort,
+} from "./helpers/extension-harness";
+import { getPanelSlidesTimeline, waitForSettingsHydratedHook } from "./helpers/panel-hooks";
+
+test("sidepanel captures local video slides in browser runtime", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  test.setTimeout(90_000);
+
+  if (testInfo.project.name === "firefox") {
+    test.skip(true, "Browser slide capture is validated in Chromium.");
+  }
+  if (!hasFfmpeg()) {
+    test.skip(true, "ffmpeg is required to generate the local video fixture.");
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "summarize-browser-slides-"));
+  const videoPath = path.join(tmpDir, "sample.mp4");
+  createSampleVideo(videoPath);
+
+  const html = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Browser Slides Test</title>
+    <style>
+      body { margin: 0; padding: 32px; background: #f7f7f7; font-family: sans-serif; }
+      video { display: block; width: 640px; height: 360px; background: black; }
+    </style>
+  </head>
+  <body>
+    <h1>Browser Slides Test</h1>
+    <video controls width="640" height="360" preload="auto" muted>
+      <source src="/sample.mp4" type="video/mp4" />
+    </video>
+  </body>
+</html>`;
+
+  const server = createHttpServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      const body = Buffer.from(html, "utf8");
+      res.writeHead(200, {
+        "content-type": "text/html; charset=utf-8",
+        "content-length": body.length,
+      });
+      res.end(body);
+      return;
+    }
+    if (url.pathname === "/sample.mp4") {
+      const body = fs.readFileSync(videoPath);
+      res.writeHead(200, {
+        "content-type": "video/mp4",
+        "content-length": body.length,
+      });
+      res.end(body);
+      return;
+    }
+    res.writeHead(204);
+    res.end();
+  });
+
+  let serverUrl = "";
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Failed to resolve local server port"));
+        return;
+      }
+      serverUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, {
+      token: "",
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+    });
+
+    const contentPage = await harness.context.newPage();
+    await contentPage.goto(`${serverUrl}/index.html`, { waitUntil: "domcontentloaded" });
+    await contentPage.waitForFunction(() => {
+      const video = document.querySelector("video");
+      return Boolean(video && Number.isFinite(video.duration) && video.duration > 0);
+    });
+    await activateTabByUrl(harness, serverUrl);
+    await waitForActiveTabUrl(harness, serverUrl);
+    const activeTabId = await getActiveTabId(harness);
+
+    const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
+    await waitForPanelPort(panel);
+    await waitForSettingsHydratedHook(panel);
+
+    await activateTabByUrl(harness, serverUrl);
+    await waitForActiveTabUrl(harness, serverUrl);
+    const initialVideoState = await contentPage.evaluate(async () => {
+      const video = document.querySelector("video");
+      if (!(video instanceof HTMLVideoElement)) throw new Error("Missing video element");
+      video.muted = true;
+      await video.play();
+      const startedAt = Date.now();
+      while (video.currentTime < 1 && Date.now() - startedAt < 2500) {
+        await new Promise((resolve) => window.setTimeout(resolve, 50));
+      }
+      return { paused: video.paused, currentTime: video.currentTime };
+    });
+    expect(initialVideoState.paused).toBe(false);
+    expect(initialVideoState.currentTime).toBeGreaterThan(0.75);
+    const background = await getBackground(harness);
+    const activeVideoState = await background.evaluate(async () => {
+      const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+      if (!tab?.id) return null;
+      const [result] = await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        world: "MAIN",
+        func: () => {
+          const video = document.querySelector("video");
+          return video instanceof HTMLVideoElement
+            ? { paused: video.paused, currentTime: video.currentTime }
+            : null;
+        },
+      });
+      return { tabId: tab.id, url: tab.url, video: result.result };
+    });
+    expect(activeVideoState?.video?.currentTime ?? -1).toBeGreaterThan(0.75);
+    await sendBgMessage(harness, {
+      type: "ui:state",
+      state: buildUiState({
+        daemon: { ok: false, authed: false, error: "daemon unavailable" },
+        tab: { id: activeTabId, url: `${serverUrl}/index.html`, title: "Browser Slides Test" },
+        media: { hasVideo: true, hasAudio: false, hasCaptions: false },
+        stats: { pageWords: 3, videoDurationSeconds: 6 },
+        settings: {
+          autoSummarize: false,
+          slidesEnabled: true,
+          slidesParallel: true,
+          tokenPresent: false,
+        },
+      }),
+    });
+
+    await sendPanelMessage(panel, { type: "panel:summarize", refresh: true, inputMode: "video" });
+
+    await expect
+      .poll(
+        async () =>
+          await background.evaluate(() =>
+            JSON.stringify(globalThis.__summarizeBrowserSlidesLastResult ?? null),
+          ),
+        { timeout: 10_000 },
+      )
+      .not.toBe("null");
+    const browserSlidesResult = await background.evaluate(
+      () => globalThis.__summarizeBrowserSlidesLastResult,
+    );
+    if (
+      !browserSlidesResult ||
+      typeof browserSlidesResult !== "object" ||
+      (browserSlidesResult as { ok?: unknown }).ok !== true
+    ) {
+      throw new Error(`Browser slides failed: ${JSON.stringify(browserSlidesResult)}`);
+    }
+
+    await expect
+      .poll(async () => (await getPanelSlidesTimeline(panel)).length, { timeout: 30_000 })
+      .toBeGreaterThan(0);
+    await expect
+      .poll(
+        async () =>
+          await panel.evaluate(
+            () =>
+              Array.from(
+                document.querySelectorAll<HTMLImageElement>("img[data-slide-image-url]"),
+              ).filter((img) => img.dataset.slideImageUrl?.startsWith("data:image/")).length,
+          ),
+        { timeout: 10_000 },
+      )
+      .toBeGreaterThan(0);
+    const restoredVideoState = await contentPage.evaluate(() => {
+      const video = document.querySelector("video");
+      if (!(video instanceof HTMLVideoElement)) return null;
+      return { paused: video.paused, currentTime: video.currentTime };
+    });
+    if (restoredVideoState?.paused !== false) {
+      throw new Error(
+        `Video was not restored: ${JSON.stringify({
+          initialVideoState,
+          restoredVideoState,
+        })}`,
+      );
+    }
+
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/apps/chrome-extension/tests/sidepanel.cache-navigation.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.cache-navigation.spec.ts
@@ -28,7 +28,12 @@ test("sidepanel auto summarizes quickly when switching YouTube tabs", async ({
 
   try {
     await mockDaemonSummarize(harness);
-    await seedSettings(harness, { token: "test-token", autoSummarize: true, slidesEnabled: false });
+    await seedSettings(harness, {
+      token: "test-token",
+      autoSummarize: true,
+      slidesEnabled: false,
+      slideRuntime: "daemon",
+    });
     await harness.context.route("https://www.youtube.com/**", async (route) => {
       await route.fulfill({
         status: 200,
@@ -73,13 +78,14 @@ test("sidepanel auto summarizes quickly when switching YouTube tabs", async ({
     await waitForActiveTabUrl(harness, videoA);
     await mockDaemonSummarize(harness);
 
+    const maxPromptSummarizeDelayMs = 6_000;
     const waitForSummarizeCall = async (sinceCount: number, startedAt: number) => {
       await expect
-        .poll(async () => await getSummarizeCalls(harness), { timeout: 5_000 })
+        .poll(async () => await getSummarizeCalls(harness), { timeout: maxPromptSummarizeDelayMs })
         .toBeGreaterThan(sinceCount);
       const callTimes = await getSummarizeCallTimes(harness);
       const callTime = callTimes[sinceCount] ?? callTimes.at(-1) ?? Date.now();
-      expect(callTime - startedAt).toBeLessThan(4_000);
+      expect(callTime - startedAt).toBeLessThan(maxPromptSummarizeDelayMs);
     };
 
     const callsBeforeReady = await getSummarizeCalls(harness);
@@ -114,7 +120,7 @@ test("sidepanel auto summarizes quickly when switching YouTube tabs", async ({
     if (callsAfterReturn > callsBeforeReturn) {
       const callTimes = await getSummarizeCallTimes(harness);
       const callTime = callTimes[callsAfterReturn - 1] ?? callTimes.at(-1) ?? Date.now();
-      expect(callTime - startA2).toBeLessThan(4_000);
+      expect(callTime - startA2).toBeLessThan(maxPromptSummarizeDelayMs);
     }
 
     assertNoErrors(harness);

--- a/apps/chrome-extension/tests/sidepanel.chat.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.chat.spec.ts
@@ -6,6 +6,7 @@ import {
   buildAgentStream,
   buildUiState,
   closeExtension,
+  getActiveTabId,
   getBackground,
   getBrowserFromProject,
   injectContentScript,
@@ -87,6 +88,103 @@ test("sidepanel chat queue sends next message after stream completes", async ({
 
     await expect.poll(() => agentRequestCount).toBe(2);
     await expect(page.locator("#chatMessages")).toContainText("Second question");
+
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
+test("sidepanel chat sends mixed OCR and transcript slide text to the bot", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, {
+      token: "test-token",
+      autoSummarize: false,
+      chatEnabled: true,
+      slidesOcrEnabled: true,
+      length: "xl",
+    });
+    const contentPage = await harness.context.newPage();
+    await contentPage.goto("https://example.com/slides", { waitUntil: "domcontentloaded" });
+    await contentPage.evaluate(() => {
+      document.body.innerHTML = `<article><p>${"Deck context ".repeat(40)}</p></article>`;
+    });
+    await maybeBringToFront(contentPage);
+    await activateTabByUrl(harness, "https://example.com/slides");
+    await waitForActiveTabUrl(harness, "https://example.com/slides");
+    await injectContentScript(harness, "content-scripts/extract.js", "https://example.com/slides");
+    await waitForExtractReady(harness, "https://example.com/slides");
+    const activeTabId = await getActiveTabId(harness);
+
+    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+    const transcriptTimedText = [
+      "[0:00] First slide transcript context.",
+      "[0:30] More first slide detail.",
+      "[0:42] Second slide transcript should be replaced by OCR.",
+      "[1:28] Lead-in near the third slide.",
+      "[1:32] Third slide transcript context.",
+    ].join("\n");
+    await sendPanelMessage(page, {
+      type: "panel:cache",
+      cache: {
+        tabId: activeTabId,
+        url: "https://example.com/slides",
+        title: "Slides",
+        runId: "summary-run",
+        slidesRunId: "slides-run",
+        summaryMarkdown: "Summary text.",
+        summaryFromCache: false,
+        slidesSummaryMarkdown: null,
+        slidesSummaryComplete: null,
+        slidesSummaryModel: null,
+        lastMeta: { inputSummary: null, model: "test", modelLabel: "Test" },
+        transcriptTimedText,
+        slides: {
+          sourceUrl: "https://example.com/slides",
+          sourceId: "local-slides",
+          sourceKind: "browser-capture",
+          ocrAvailable: false,
+          transcriptTimedText,
+          slides: [
+            { index: 1, timestamp: 1, imageUrl: "", ocrText: null, ocrConfidence: null },
+            {
+              index: 2,
+              timestamp: 40,
+              imageUrl: "",
+              ocrText: "Second slide visual OCR.",
+              ocrConfidence: null,
+            },
+            { index: 3, timestamp: 90, imageUrl: "", ocrText: null, ocrConfidence: null },
+          ],
+        },
+      },
+    });
+
+    let agentPageContent = "";
+    await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
+      const body = route.request().postDataJSON() as { pageContent?: string };
+      agentPageContent = body.pageContent ?? "";
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: buildAgentStream("Slide-aware reply"),
+      });
+    });
+
+    await page.locator("#chatInput").fill("What is on each slide?");
+    await page.locator("#chatSend").click();
+
+    await expect.poll(() => agentPageContent).toContain("Slide timeline:");
+    expect(agentPageContent).toContain("Slide 1 @ 0:01");
+    expect(agentPageContent).toContain("First slide transcript context.");
+    expect(agentPageContent).toContain("Slide 2 @ 0:40");
+    expect(agentPageContent).toContain("Second slide visual OCR.");
+    expect(agentPageContent).toContain("Slide 3 @ 1:30");
+    expect(agentPageContent).toContain("Third slide transcript context.");
 
     assertNoErrors(harness);
   } finally {
@@ -269,7 +367,11 @@ test("auto summarize reruns after panel reopen", async ({
       },
     );
 
-    await seedSettings(harness, { token: "test-token", autoSummarize: true });
+    await seedSettings(harness, {
+      token: "test-token",
+      autoSummarize: true,
+      slideRuntime: "daemon",
+    });
 
     const contentPage = await harness.context.newPage();
     await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });

--- a/apps/chrome-extension/tests/sidepanel.media-selection.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.media-selection.spec.ts
@@ -34,6 +34,7 @@ test("sidepanel video selection forces transcript mode", async ({
       token: "test-token",
       autoSummarize: false,
       slidesEnabled: false,
+      slideRuntime: "daemon",
     });
     const contentPage = await harness.context.newPage();
     await contentPage.route("https://www.youtube.com/**", async (route) => {
@@ -109,7 +110,198 @@ test("sidepanel video selection forces transcript mode", async ({
   }
 });
 
-test("sidepanel video selection requests slides when enabled", async ({
+test("sidepanel page selection on YouTube uses page text instead of captions", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await mockDaemonSummarize(harness);
+    await seedSettings(harness, {
+      token: "test-token",
+      autoSummarize: false,
+      slidesEnabled: false,
+      slideRuntime: "daemon",
+    });
+    const youtubeUrl = "https://www.youtube.com/watch?v=pageMode123";
+    const playerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            {
+              baseUrl: "https://www.youtube.com/api/timedtext?v=pageMode123&lang=en",
+              languageCode: "en",
+              name: { simpleText: "English" },
+            },
+          ],
+        },
+      },
+      videoDetails: { lengthSeconds: "90", videoId: "pageMode123" },
+    };
+    const contentPage = await harness.context.newPage();
+    await contentPage.route("https://www.youtube.com/**", async (route) => {
+      const url = route.request().url();
+      if (url.includes("/api/timedtext")) {
+        await route.fulfill({
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            events: [{ tStartMs: 0, segs: [{ utf8: "Caption text should not be used." }] }],
+          }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: `<html><head><title>Page Mode Video</title></head><body>
+          <script>var ytInitialPlayerResponse = ${JSON.stringify(playerResponse)};</script>
+          <article><h1>Video description</h1><p>Page description text should be used.</p></article>
+        </body></html>`,
+      });
+    });
+    await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
+    await maybeBringToFront(contentPage);
+    await activateTabByUrl(harness, youtubeUrl);
+    await waitForActiveTabUrl(harness, youtubeUrl);
+    await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
+
+    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+    await waitForPanelPort(page);
+    await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: ["event: done", "data: {}", ""].join("\n"),
+      });
+    });
+    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "page", refresh: false });
+
+    await expect.poll(async () => await getSummarizeCalls(harness)).toBeGreaterThan(0);
+    const body = (await getSummarizeLastBody(harness)) as Record<string, unknown>;
+    expect(String(body.text ?? "")).toContain("Page description text should be used.");
+    expect(String(body.text ?? "")).not.toContain("Caption text should not be used.");
+    expect(body.videoMode).toBeUndefined();
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
+test("sidepanel includes browser-fetched YouTube transcript text", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await mockDaemonSummarize(harness);
+    await seedSettings(harness, {
+      token: "test-token",
+      autoSummarize: false,
+      slidesEnabled: false,
+      slideRuntime: "daemon",
+    });
+    const youtubeUrl = "https://www.youtube.com/watch?v=browserTranscript123";
+    const stalePlayerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            {
+              baseUrl: "https://www.youtube.com/api/timedtext?v=previousVideo&lang=en",
+              languageCode: "en",
+              name: { simpleText: "English" },
+            },
+          ],
+        },
+      },
+      videoDetails: { lengthSeconds: "12", videoId: "previousVideo" },
+    };
+    const playerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            {
+              baseUrl: "https://www.youtube.com/api/timedtext?v=browserTranscript123&lang=en",
+              languageCode: "en",
+              name: { simpleText: "English" },
+            },
+          ],
+        },
+      },
+      videoDetails: { lengthSeconds: "90", videoId: "browserTranscript123" },
+    };
+    const contentPage = await harness.context.newPage();
+    await contentPage.route("https://www.youtube.com/**", async (route) => {
+      const url = route.request().url();
+      if (url.includes("/api/timedtext")) {
+        await route.fulfill({
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            events: [
+              { tStartMs: 0, segs: [{ utf8: "First caption line." }] },
+              { tStartMs: 2500, segs: [{ utf8: "Second caption line." }] },
+            ],
+          }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: `<html><body>
+          <script>var ytInitialPlayerResponse = ${JSON.stringify(stalePlayerResponse)};</script>
+          <ytd-watch-flexy id="watch"></ytd-watch-flexy>
+          <script>document.getElementById("watch").playerResponse = ${JSON.stringify(playerResponse)};</script>
+          <article>Video placeholder</article>
+        </body></html>`,
+      });
+    });
+    await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
+    await maybeBringToFront(contentPage);
+    await activateTabByUrl(harness, youtubeUrl);
+    await waitForActiveTabUrl(harness, youtubeUrl);
+    await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
+
+    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+    await waitForPanelPort(page);
+    await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: ["event: done", "data: {}", ""].join("\n"),
+      });
+    });
+    await sendBgMessage(harness, {
+      type: "ui:state",
+      state: buildUiState({
+        tab: { id: 1, url: youtubeUrl, title: "Example" },
+        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+        settings: { slidesEnabled: false },
+        status: "",
+      }),
+    });
+
+    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
+    await expect
+      .poll(async () => {
+        const body = (await getSummarizeLastBody(harness)) as Record<string, unknown> | null;
+        return typeof body?.text === "string" ? body.text : "";
+      })
+      .toContain("First caption line");
+
+    const body = (await getSummarizeLastBody(harness)) as Record<string, unknown>;
+    expect(body.mode).toBe("page");
+    expect(body.text).toContain("[0:00] First caption line.");
+    expect(body.text).toContain("[0:02] Second caption line.");
+    expect(body).not.toHaveProperty("slides");
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
+test("sidepanel falls back to current YouTube transcript panel rows", async ({
   browserName: _browserName,
 }, testInfo) => {
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
@@ -120,6 +312,112 @@ test("sidepanel video selection requests slides when enabled", async ({
       token: "test-token",
       autoSummarize: false,
       slidesEnabled: true,
+      slideRuntime: "daemon",
+    });
+    const youtubeUrl = "https://www.youtube.com/watch?v=panelTranscript123";
+    const playerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            {
+              baseUrl: "https://www.youtube.com/api/timedtext?v=panelTranscript123&lang=en",
+              languageCode: "en",
+              name: { simpleText: "English (auto-generated)" },
+              kind: "asr",
+            },
+          ],
+        },
+      },
+      videoDetails: { lengthSeconds: "90", videoId: "panelTranscript123" },
+    };
+    const contentPage = await harness.context.newPage();
+    await contentPage.route("https://www.youtube.com/**", async (route) => {
+      const url = route.request().url();
+      if (url.includes("/api/timedtext")) {
+        await route.fulfill({
+          status: 200,
+          headers: { "content-type": "text/html; charset=UTF-8" },
+          body: "",
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: `<html><body>
+	          <script>var ytInitialPlayerResponse = ${JSON.stringify(playerResponse)};</script>
+	          <ytd-watch-metadata></ytd-watch-metadata>
+	          <ytd-video-description-transcript-section-renderer>
+	            <button>Show transcript</button>
+	          </ytd-video-description-transcript-section-renderer>
+	          <transcript-segment-view-model>
+            <div class="ytwTranscriptSegmentViewModelTimestamp">0:00</div>
+            <div class="ytwTranscriptSegmentViewModelTimestampA11yLabel">0 minutes, 0 seconds</div>
+            <span class="ytAttributedStringHost" role="text">Panel first caption.</span>
+          </transcript-segment-view-model>
+          <transcript-segment-view-model>
+            <div class="ytwTranscriptSegmentViewModelTimestamp">0:02</div>
+            <div class="ytwTranscriptSegmentViewModelTimestampA11yLabel">0 minutes, 2 seconds</div>
+            <span class="ytAttributedStringHost" role="text">Panel second caption.</span>
+          </transcript-segment-view-model>
+        </body></html>`,
+      });
+    });
+    await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
+    await maybeBringToFront(contentPage);
+    await activateTabByUrl(harness, youtubeUrl);
+    await waitForActiveTabUrl(harness, youtubeUrl);
+    await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
+
+    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+    await waitForPanelPort(page);
+    await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: ["event: done", "data: {}", ""].join("\n"),
+      });
+    });
+    await sendBgMessage(harness, {
+      type: "ui:state",
+      state: buildUiState({
+        tab: { id: 1, url: youtubeUrl, title: "Example" },
+        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+        settings: { slidesEnabled: true },
+        status: "",
+      }),
+    });
+
+    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
+    await expect
+      .poll(async () => {
+        const body = (await getSummarizeLastBody(harness)) as Record<string, unknown> | null;
+        return typeof body?.text === "string" ? body.text : "";
+      })
+      .toContain("Panel first caption");
+
+    const body = (await getSummarizeLastBody(harness)) as Record<string, unknown>;
+    expect(body.mode).toBe("page");
+    expect(body.text).toContain("[0:00] Panel first caption.");
+    expect(body.text).toContain("[0:02] Panel second caption.");
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
+test("sidepanel video selection requests daemon slides when daemon extraction is enabled", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await mockDaemonSummarize(harness);
+    await seedSettings(harness, {
+      token: "test-token",
+      autoSummarize: false,
+      slidesEnabled: true,
+      slideRuntime: "daemon",
     });
     const contentPage = await harness.context.newPage();
     await contentPage.route("https://www.youtube.com/**", async (route) => {
@@ -204,7 +502,7 @@ test("sidepanel video selection requests slides when enabled", async ({
   }
 });
 
-test("sidepanel coalesces duplicate YouTube slide summarize requests", async ({
+test("sidepanel coalesces duplicate YouTube daemon slide summarize requests", async ({
   browserName: _browserName,
 }, testInfo) => {
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
@@ -215,6 +513,7 @@ test("sidepanel coalesces duplicate YouTube slide summarize requests", async ({
       token: "test-token",
       autoSummarize: false,
       slidesEnabled: true,
+      slideRuntime: "daemon",
     });
     const youtubeUrl = "https://www.youtube.com/watch?v=coalesce123";
     const contentPage = await harness.context.newPage();
@@ -278,6 +577,7 @@ test("sidepanel video selection does not request slides when disabled", async ({
       token: "test-token",
       autoSummarize: false,
       slidesEnabled: false,
+      slideRuntime: "daemon",
     });
     const contentPage = await harness.context.newPage();
     await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });

--- a/apps/chrome-extension/tests/sidepanel.slides.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.slides.spec.ts
@@ -17,6 +17,7 @@ import {
   getPanelSlideDescriptions,
   getPanelSlideSummaryEntries,
   getPanelSlideTitleEntries,
+  getPanelSummaryMarkdown,
   getPanelSlidesTimeline,
   waitForApplySlidesHook,
   waitForSlidesRuntimeHooks,
@@ -343,7 +344,7 @@ test("sidepanel does not reseed planned slides over resolved direct video slides
   }
 });
 
-test("sidepanel shows intro before gallery cards and hides gallery heading in slide mode", async ({
+test("sidepanel shows gallery before intro and hides gallery heading in slide mode", async ({
   browserName: _browserName,
 }, testInfo) => {
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
@@ -447,7 +448,7 @@ test("sidepanel shows intro before gallery cards and hides gallery heading in sl
     const renderOrder = await page
       .locator("#render")
       .evaluate((el) => Array.from(el.children).map((child) => child.className));
-    expect(renderOrder).toEqual(["render__markdownHost", "render__slidesHost"]);
+    expect(renderOrder).toEqual(["render__slidesHost", "render__markdownHost"]);
 
     await expect(
       page.locator(
@@ -559,6 +560,146 @@ test("sidepanel replaces partial slide-stream fragments with the final slide sum
     expect(slides[0]?.[1] ?? "").not.toBe("##");
     expect(slides.some(([, text]) => text.includes("Raw transcript"))).toBe(false);
     expect(slides[1]?.[1] ?? "").toContain("remaining guardian");
+
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
+test("sidepanel applies existing summary text when local slides arrive after the summary", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, {
+      token: "test-token",
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      slidesLayout: "gallery",
+    });
+    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+    await waitForPanelPort(page);
+    await waitForSettingsHydratedHook(page);
+    await waitForSlidesRuntimeHooks(page);
+    await waitForTranscriptTimedTextHook(page);
+    await routePlaceholderSlideImages(page);
+
+    const targetUrl = "https://www.youtube.com/watch?v=localrace123";
+    await sendBgMessage(harness, {
+      type: "ui:state",
+      state: buildUiState({
+        tab: {
+          id: 1,
+          url: targetUrl,
+          title: "Local Race Video",
+        },
+        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+        settings: {
+          autoSummarize: false,
+          slidesEnabled: true,
+          slidesParallel: true,
+          slidesOcrEnabled: true,
+          slidesLayout: "gallery",
+          tokenPresent: true,
+        },
+      }),
+    });
+
+    await page.evaluate((markdown) => {
+      const hooks = (
+        window as typeof globalThis & {
+          __summarizeTestHooks?: {
+            applySummaryMarkdown?: (value: string) => void;
+            setTranscriptTimedText?: (value: string | null) => void;
+          };
+        }
+      ).__summarizeTestHooks;
+      hooks?.setTranscriptTimedText?.(
+        [
+          "[00:00] raw transcript one should not become the slide card copy.",
+          "[01:03] raw transcript two should not become the slide card copy.",
+          "[02:07] raw transcript three should not become the slide card copy.",
+          "[03:05] raw transcript four should not become the slide card copy.",
+          "[04:12] raw transcript five should not become the slide card copy.",
+          "[05:01] raw transcript six should not become the slide card copy.",
+        ].join("\n"),
+      );
+      hooks?.applySummaryMarkdown?.(markdown);
+    }, ["This scene contrasts the family's chaotic defensiveness with Dr. Wong's calm patience.", "", "Rick arrives transformed and uses the spectacle to dodge emotional accountability.", "", "Dr. Wong reframes the room as a place for boring, repetitive repair rather than heroics."].join("\n"));
+
+    await page.route("http://127.0.0.1:8787/v1/summarize/localrace-run/events", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: ["event: done", "data: {}", ""].join("\n"),
+      });
+    });
+    await sendBgMessage(harness, {
+      type: "run:start",
+      run: {
+        id: "localrace-run",
+        url: targetUrl,
+        title: "Local Race Video",
+        model: "auto",
+        reason: "manual",
+        slides: false,
+      },
+    });
+    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toBe("");
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const hooks = (
+            window as typeof globalThis & {
+              __summarizeTestHooks?: { getRetainedSlideSummaryMarkdown?: () => string };
+            }
+          ).__summarizeTestHooks;
+          return hooks?.getRetainedSlideSummaryMarkdown?.() ?? "";
+        }),
+      )
+      .toContain("transformed and uses the spectacle");
+
+    await applySlidesPayload(page, {
+      sourceUrl: targetUrl,
+      sourceId: "youtube-localrace123",
+      sourceKind: "youtube",
+      ocrAvailable: false,
+      transcriptTimedText: [
+        "[00:00] raw transcript one should not become the slide card copy.",
+        "[01:03] raw transcript two should not become the slide card copy.",
+        "[02:07] raw transcript three should not become the slide card copy.",
+        "[03:05] raw transcript four should not become the slide card copy.",
+        "[04:12] raw transcript five should not become the slide card copy.",
+        "[05:01] raw transcript six should not become the slide card copy.",
+      ].join("\n"),
+      slides: [
+        { index: 1, timestamp: 0, imageUrl: "", ocrText: null },
+        { index: 2, timestamp: 63, imageUrl: "", ocrText: null },
+        { index: 3, timestamp: 127, imageUrl: "", ocrText: null },
+        { index: 4, timestamp: 185, imageUrl: "", ocrText: null },
+        { index: 5, timestamp: 252, imageUrl: "", ocrText: null },
+        { index: 6, timestamp: 301, imageUrl: "", ocrText: null },
+      ],
+    });
+
+    await expect
+      .poll(
+        async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"),
+        { timeout: 10_000 },
+      )
+      .toContain("transformed and uses the spectacle");
+
+    const slides = await getPanelSlideDescriptions(page);
+    expect(slides).toHaveLength(6);
+    expect(slides.some(([, text]) => text.includes("raw transcript"))).toBe(false);
+    expect(slides[0]?.[1] ?? "").toContain("chaotic defensiveness");
+    expect(slides[1]?.[1] ?? "").toContain("chaotic defensiveness");
+    expect(slides[2]?.[1] ?? "").toContain("transformed and uses the spectacle");
+    expect(slides[4]?.[1] ?? "").toContain("boring, repetitive repair");
 
     assertNoErrors(harness);
   } finally {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/summarize",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "Link → clean text → summary.",
   "bin": {
     "summarize": "./dist/cli.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/summarize-core",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "Summarize core library (content extraction + prompts).",
   "files": [
     "dist",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -14,6 +14,16 @@ import {
   normalizeContentForHash,
   extractTaggedBlock,
 } from "./cache-keys.js";
+import {
+  CACHE_FORMAT_VERSION,
+  DEFAULT_CACHE_MAX_MB,
+  DEFAULT_CACHE_TTL_DAYS,
+  buildPortableCacheRow,
+  createEmptyCacheCounts,
+  parseCacheJson,
+  type CacheKind,
+  type CacheStats,
+} from "./shared/cache-store.js";
 export {
   buildExtractCacheKeyValue,
   buildLanguageKey,
@@ -28,10 +38,15 @@ export {
   normalizeContentForHash,
   extractTaggedBlock,
 } from "./cache-keys.js";
+export {
+  CACHE_FORMAT_VERSION,
+  DEFAULT_CACHE_MAX_MB,
+  DEFAULT_CACHE_TTL_DAYS,
+  type CacheKind,
+  type CacheStats,
+} from "./shared/cache-store.js";
 import { cleanupSlidesPayload, collectSlidesPayloadArtifactPaths } from "./cache-slides-cleanup.js";
 import type { TranscriptCache, TranscriptSource } from "./content/index.js";
-
-export type CacheKind = "extract" | "summary" | "transcript" | "chat" | "slides";
 
 export type CacheConfig = {
   enabled?: boolean;
@@ -39,10 +54,6 @@ export type CacheConfig = {
   ttlDays?: number;
   path?: string;
 };
-
-export const CACHE_FORMAT_VERSION = 2;
-export const DEFAULT_CACHE_MAX_MB = 512;
-export const DEFAULT_CACHE_TTL_DAYS = 30;
 
 type SqliteStatement = {
   get: (...args: unknown[]) => unknown;
@@ -98,13 +109,6 @@ export type CacheState = {
   ttlMs: number;
   maxBytes: number;
   path: string | null;
-};
-
-export type CacheStats = {
-  path: string;
-  sizeBytes: number;
-  totalEntries: number;
-  counts: Record<CacheKind, number>;
 };
 
 const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
@@ -313,21 +317,22 @@ export async function createCacheStore({
   };
 
   const getJson = <T>(kind: CacheKind, key: string): T | null => {
-    const text = getText(kind, key);
-    if (!text) return null;
-    try {
-      return JSON.parse(text) as T;
-    } catch {
-      return null;
-    }
+    return parseCacheJson<T>(getText(kind, key));
   };
 
   const setText = (kind: CacheKind, key: string, value: string, ttlMs: number | null) => {
     const now = Date.now();
     sweepExpired(now);
-    const expiresAt = typeof ttlMs === "number" ? now + ttlMs : null;
-    const sizeBytes = Buffer.byteLength(value, "utf8");
-    stmtUpsert.run(kind, key, value, sizeBytes, now, now, expiresAt);
+    const row = buildPortableCacheRow({ kind, key, value, ttlMs, now });
+    stmtUpsert.run(
+      row.kind,
+      row.key,
+      row.value,
+      row.sizeBytes,
+      row.createdAt,
+      row.lastAccessedAt,
+      row.expiresAt,
+    );
     enforceSize();
   };
 
@@ -508,13 +513,7 @@ export async function readCacheStats(path: string): Promise<CacheStats | null> {
   } catch {
     // ignore
   }
-  const counts: Record<CacheKind, number> = {
-    extract: 0,
-    summary: 0,
-    transcript: 0,
-    chat: 0,
-    slides: 0,
-  };
+  const counts = createEmptyCacheCounts();
   const rows = db.prepare("SELECT kind, COUNT(*) AS count FROM cache_entries GROUP BY kind").all();
   for (const row of rows as Array<{ kind?: string; count?: number }>) {
     if (row?.kind && typeof row.count === "number" && row.kind in counts) {

--- a/src/run/flows/url/slides-text-markdown.ts
+++ b/src/run/flows/url/slides-text-markdown.ts
@@ -445,16 +445,18 @@ export function coerceSummaryWithSlides({
   slides,
   transcriptTimedText,
   lengthArg,
+  reserveIntro = true,
 }: {
   markdown: string;
   slides: SlideTimelineEntry[];
   transcriptTimedText?: string | null;
   lengthArg: { kind: "preset"; preset: SummaryLength } | { kind: "chars"; maxCharacters: number };
+  reserveIntro?: boolean;
 }): string {
   if (!markdown.trim() || slides.length === 0) return markdown;
   const ordered = slides.slice().sort((a, b) => a.index - b.index);
   const { summary, slidesSection } = splitSummaryFromSlides(markdown);
-  const intro = pickIntroParagraph(summary);
+  const intro = reserveIntro ? pickIntroParagraph(summary) : "";
   const slideSummaries = slidesSection ? parseSlideSummariesFromMarkdown(markdown) : new Map();
   const interludeSlideIndexes = new Set(
     Array.from(slideSummaries.entries())
@@ -474,8 +476,52 @@ export function coerceSummaryWithSlides({
   if (slideSummaries.size > 0 && !titleOnlySlideSummaries) {
     const parts: string[] = [];
     if (intro) parts.push(intro);
+    const paragraphs = splitMarkdownParagraphs(summary);
+    const introParagraph = reserveIntro ? intro || paragraphs[0] || "" : "";
+    const introIndex = introParagraph ? paragraphs.indexOf(introParagraph) : -1;
+    const remaining = reserveIntro
+      ? introIndex >= 0
+        ? paragraphs.filter((_, index) => index !== introIndex)
+        : paragraphs.slice(1)
+      : paragraphs;
+    const distributedSummaries = new Map<number, string>();
+    if (remaining.length > 0) {
+      const distributableSlides = ordered.filter(
+        (slide) => !interludeSlideIndexes.has(slide.index),
+      );
+      const distributionSlides = distributableSlides.length > 0 ? distributableSlides : ordered;
+      const total = distributionSlides.length;
+      let distributionIndex = 0;
+      for (const slide of ordered) {
+        if (interludeSlideIndexes.has(slide.index) && distributableSlides.length > 0) continue;
+        const segmentIndex = distributionIndex;
+        const start = Math.round((segmentIndex * remaining.length) / total);
+        const end = Math.round(((segmentIndex + 1) * remaining.length) / total);
+        distributionIndex += 1;
+        const segment =
+          remaining.slice(start, end).join("\n\n").trim() ||
+          remaining[
+            Math.min(remaining.length - 1, Math.floor((segmentIndex * remaining.length) / total))
+          ]?.trim() ||
+          "";
+        if (segment) distributedSummaries.set(slide.index, segment);
+      }
+    }
     for (const slide of ordered) {
-      const text = slideSummaries.get(slide.index) ?? fallbackSummaries.get(slide.index) ?? "";
+      const directText = slideSummaries.get(slide.index);
+      const directBody = directText
+        ? splitSlideTitleFromText({
+            text: directText,
+            slideIndex: slide.index,
+            total: ordered.length,
+          }).body.trim()
+        : "";
+      const distributedText = distributedSummaries.get(slide.index) ?? "";
+      const fallbackText = slideSummaries.has(slide.index)
+        ? ""
+        : (fallbackSummaries.get(slide.index) ?? "");
+      const directOutput = directBody || isInterludeSlideText(directText ?? "") ? directText : "";
+      const text = directOutput || distributedText || fallbackText;
       const withTitle = text ? ensureSlideTitleLine({ text, slide, total: ordered.length }) : "";
       parts.push(withTitle ? `[slide:${slide.index}]\n${withTitle}` : `[slide:${slide.index}]`);
     }
@@ -494,10 +540,13 @@ export function coerceSummaryWithSlides({
     }
     return parts.join("\n\n");
   }
-  const introParagraph = intro || paragraphs[0] || "";
-  const introIndex = paragraphs.indexOf(introParagraph);
-  const remaining =
-    introIndex >= 0 ? paragraphs.filter((_, index) => index !== introIndex) : paragraphs.slice(1);
+  const introParagraph = reserveIntro ? intro || paragraphs[0] || "" : "";
+  const introIndex = introParagraph ? paragraphs.indexOf(introParagraph) : -1;
+  const remaining = reserveIntro
+    ? introIndex >= 0
+      ? paragraphs.filter((_, index) => index !== introIndex)
+      : paragraphs.slice(1)
+    : paragraphs;
   if (introParagraph) parts.push(introParagraph.trim());
   if (remaining.length === 0) {
     for (const slide of ordered) {
@@ -524,10 +573,16 @@ export function coerceSummaryWithSlides({
       parts.push(`[slide:${slideIndex}]\n## Interlude`);
       continue;
     }
-    const start = Math.round((distributionIndex * remaining.length) / total);
-    const end = Math.round(((distributionIndex + 1) * remaining.length) / total);
+    const segmentIndex = distributionIndex;
+    const start = Math.round((segmentIndex * remaining.length) / total);
+    const end = Math.round(((segmentIndex + 1) * remaining.length) / total);
     distributionIndex += 1;
-    const segment = remaining.slice(start, end).join("\n\n").trim();
+    const segment =
+      remaining.slice(start, end).join("\n\n").trim() ||
+      remaining[
+        Math.min(remaining.length - 1, Math.floor((segmentIndex * remaining.length) / total))
+      ]?.trim() ||
+      "";
     const fallback = fallbackSummaries.get(slideIndex) ?? "";
     const text = segment || fallback;
     const withTitle = text ? ensureSlideTitleLine({ text, slide, total: slideTotal }) : "";

--- a/src/shared/cache-store.ts
+++ b/src/shared/cache-store.ts
@@ -1,0 +1,110 @@
+export type CacheKind = "extract" | "summary" | "transcript" | "chat" | "slides";
+
+export type CacheCounts = Record<CacheKind, number>;
+
+export type CacheStats = {
+  path: string;
+  sizeBytes: number;
+  totalEntries: number;
+  counts: CacheCounts;
+};
+
+export type PortableCacheRow = {
+  kind: CacheKind;
+  key: string;
+  value: string;
+  sizeBytes: number;
+  createdAt: number;
+  lastAccessedAt: number;
+  expiresAt: number | null;
+};
+
+export const CACHE_FORMAT_VERSION = 2;
+export const DEFAULT_CACHE_MAX_MB = 512;
+export const DEFAULT_CACHE_TTL_DAYS = 30;
+export const CACHE_KINDS: readonly CacheKind[] = [
+  "extract",
+  "summary",
+  "transcript",
+  "chat",
+  "slides",
+];
+
+export function createEmptyCacheCounts(): CacheCounts {
+  return {
+    extract: 0,
+    summary: 0,
+    transcript: 0,
+    chat: 0,
+    slides: 0,
+  };
+}
+
+export function isCacheKind(value: unknown): value is CacheKind {
+  return typeof value === "string" && CACHE_KINDS.includes(value as CacheKind);
+}
+
+export function measureCacheValueBytes(value: string): number {
+  const maybeBuffer = (globalThis as typeof globalThis & { Buffer?: { byteLength?: unknown } })
+    .Buffer;
+  if (typeof maybeBuffer?.byteLength === "function") {
+    return maybeBuffer.byteLength(value, "utf8") as number;
+  }
+  return new TextEncoder().encode(value).byteLength;
+}
+
+export function buildPortableCacheRow({
+  kind,
+  key,
+  value,
+  ttlMs,
+  now = Date.now(),
+}: {
+  kind: CacheKind;
+  key: string;
+  value: string;
+  ttlMs: number | null;
+  now?: number;
+}): PortableCacheRow {
+  return {
+    kind,
+    key,
+    value,
+    sizeBytes: measureCacheValueBytes(value),
+    createdAt: now,
+    lastAccessedAt: now,
+    expiresAt: typeof ttlMs === "number" ? now + ttlMs : null,
+  };
+}
+
+export function isPortableCacheRowExpired(
+  row: Pick<PortableCacheRow, "expiresAt">,
+  now = Date.now(),
+): boolean {
+  return typeof row.expiresAt === "number" && row.expiresAt <= now;
+}
+
+export function parseCacheJson<T>(value: string | null | undefined): T | null {
+  if (!value) return null;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function summarizePortableCacheRows(
+  rows: Iterable<Pick<PortableCacheRow, "kind" | "sizeBytes">>,
+  path: string,
+): CacheStats {
+  const counts = createEmptyCacheCounts();
+  let sizeBytes = 0;
+  let totalEntries = 0;
+  for (const row of rows) {
+    if (!isCacheKind(row.kind)) continue;
+    counts[row.kind] += 1;
+    sizeBytes += Math.max(0, row.sizeBytes);
+    totalEntries += 1;
+  }
+  return { path, sizeBytes, totalEntries, counts };
+}

--- a/src/shared/slides-presentation.ts
+++ b/src/shared/slides-presentation.ts
@@ -36,6 +36,7 @@ export function buildSlidePresentation({
   transcriptTimedText,
   lengthArg,
   coerce = true,
+  coerceReserveIntro = true,
   includeTranscriptFallback = true,
 }: {
   markdown: string;
@@ -43,6 +44,7 @@ export function buildSlidePresentation({
   transcriptTimedText?: string | null;
   lengthArg: SlidePresentationLength;
   coerce?: boolean;
+  coerceReserveIntro?: boolean;
   includeTranscriptFallback?: boolean;
 }): SlidePresentation {
   const ordered = slides.slice().sort((a, b) => a.index - b.index);
@@ -51,8 +53,9 @@ export function buildSlidePresentation({
       ? coerceSummaryWithSlides({
           markdown,
           slides: ordered,
-          transcriptTimedText,
+          transcriptTimedText: includeTranscriptFallback ? transcriptTimedText : null,
           lengthArg,
+          reserveIntro: coerceReserveIntro,
         })
       : markdown;
   const parsed = parseSlideSummariesFromMarkdown(normalizedMarkdown);

--- a/src/shared/sse-events.ts
+++ b/src/shared/sse-events.ts
@@ -11,6 +11,7 @@ export type SseSlidesData = {
   sourceUrl: string;
   sourceId: string;
   sourceKind: string;
+  slideRuntime?: "browser" | "daemon";
   ocrAvailable: boolean;
   transcriptTimedText?: string | null;
   slides: Array<{

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 declare const __dirname: string | undefined;
 
-export const FALLBACK_VERSION = "0.16.3";
+export const FALLBACK_VERSION = "0.17.0";
 
 export function resolvePackageVersion(importMetaUrl?: string): string {
   const injected =

--- a/tests/cache-store.shared.test.ts
+++ b/tests/cache-store.shared.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPortableCacheRow,
+  isPortableCacheRowExpired,
+  parseCacheJson,
+  summarizePortableCacheRows,
+} from "../src/shared/cache-store.js";
+
+describe("shared cache store primitives", () => {
+  it("builds rows with ttl, size, and stats usable by cache backends", () => {
+    const row = buildPortableCacheRow({
+      kind: "summary",
+      key: "key",
+      value: "hello",
+      ttlMs: 1000,
+      now: 10,
+    });
+
+    expect(row.expiresAt).toBe(1010);
+    expect(row.sizeBytes).toBe(5);
+    expect(isPortableCacheRowExpired(row, 1009)).toBe(false);
+    expect(isPortableCacheRowExpired(row, 1010)).toBe(true);
+
+    const stats = summarizePortableCacheRows([row], "memory");
+    expect(stats).toMatchObject({
+      path: "memory",
+      sizeBytes: 5,
+      totalEntries: 1,
+      counts: { summary: 1 },
+    });
+  });
+
+  it("parses cached json safely", () => {
+    expect(parseCacheJson<{ ok: boolean }>('{"ok":true}')).toEqual({ ok: true });
+    expect(parseCacheJson("{")).toBeNull();
+    expect(parseCacheJson(null)).toBeNull();
+  });
+});

--- a/tests/chrome.browser-panel-cache.test.ts
+++ b/tests/chrome.browser-panel-cache.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBrowserPanelCacheStore } from "../apps/chrome-extension/src/lib/browser-panel-cache.js";
+import type { PanelCachePayload } from "../apps/chrome-extension/src/lib/panel-contracts.js";
+
+function createStorageArea() {
+  const values = new Map<string, unknown>();
+  const area = {
+    get(keys: string | string[] | null, callback: (items: Record<string, unknown>) => void) {
+      const result: Record<string, unknown> = {};
+      if (keys === null) {
+        for (const [key, value] of values) {
+          result[key] = value;
+        }
+        callback(result);
+        return;
+      }
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        if (values.has(key)) result[key] = values.get(key);
+      }
+      callback(result);
+    },
+    set(items: Record<string, unknown>, callback?: () => void) {
+      for (const [key, value] of Object.entries(items)) {
+        values.set(key, value);
+      }
+      callback?.();
+    },
+    remove(keys: string | string[], callback?: () => void) {
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        values.delete(key);
+      }
+      callback?.();
+    },
+    values,
+  };
+  return area;
+}
+
+function samplePayload(overrides: Partial<PanelCachePayload> = {}): PanelCachePayload {
+  return {
+    tabId: 1,
+    url: "https://www.youtube.com/watch?v=abc#ignored",
+    title: "Video",
+    runId: "run",
+    slidesRunId: "slides-run",
+    summaryMarkdown: "Summary",
+    summaryFromCache: false,
+    slidesSummaryMarkdown: "## Slide 1\nSummary",
+    slidesSummaryComplete: true,
+    slidesSummaryModel: "browser",
+    lastMeta: { inputSummary: null, model: null, modelLabel: null },
+    transcriptTimedText: "0:00 hello",
+    slides: {
+      sourceUrl: "https://www.youtube.com/watch?v=abc",
+      sourceId: "slides-run",
+      sourceKind: "browser-capture",
+      slideRuntime: "browser",
+      ocrAvailable: false,
+      transcriptTimedText: "0:00 hello",
+      slides: [
+        {
+          index: 1,
+          timestamp: 0,
+          imageUrl: "data:image/jpeg;base64,AAAA",
+          ocrText: null,
+          ocrConfidence: null,
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("browser panel cache store", () => {
+  beforeEach(() => {
+    vi.stubGlobal("chrome", { runtime: { lastError: null } });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("persists panel snapshots with slide thumbnails and restores by normalized url", async () => {
+    const storage = createStorageArea();
+    const store = createBrowserPanelCacheStore(storage);
+    const payload = samplePayload();
+
+    await store.setPanel(payload);
+    const restored = await store.getPanel("https://www.youtube.com/watch?v=abc#ignored");
+    const stats = await store.stats();
+
+    expect(restored?.slides?.slides[0]?.imageUrl).toBe("data:image/jpeg;base64,AAAA");
+    expect(restored?.summaryMarkdown).toBe("Summary");
+    expect(stats.totalEntries).toBe(1);
+    expect(stats.sizeBytes).toBeGreaterThan(0);
+  });
+
+  it("expires entries after 30 days and clears storage", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const storage = createStorageArea();
+    const store = createBrowserPanelCacheStore(storage);
+
+    await store.setPanel(samplePayload());
+    vi.setSystemTime(31 * 24 * 60 * 60 * 1000);
+
+    expect(await store.getPanel("https://www.youtube.com/watch?v=abc")).toBeNull();
+    expect((await store.stats()).totalEntries).toBe(0);
+
+    await store.setPanel(samplePayload());
+    expect((await store.clear()).totalEntries).toBe(0);
+    expect(storage.values.size).toBe(1);
+  });
+
+  it("serializes concurrent writes so the index keeps every snapshot", async () => {
+    const storage = createStorageArea();
+    const store = createBrowserPanelCacheStore(storage);
+
+    await Promise.all([
+      store.setPanel(samplePayload({ url: "https://example.com/a" })),
+      store.setPanel(samplePayload({ url: "https://example.com/b" })),
+    ]);
+
+    expect((await store.stats()).totalEntries).toBe(2);
+    expect(await store.getPanel("https://example.com/a")).not.toBeNull();
+    expect(await store.getPanel("https://example.com/b")).not.toBeNull();
+  });
+
+  it("discovers orphaned entries for stats and clear", async () => {
+    const storage = createStorageArea();
+    const store = createBrowserPanelCacheStore(storage);
+    await store.setPanel(samplePayload({ url: "https://example.com/orphan" }));
+    const entryKeys = Array.from(storage.values.keys()).filter((key) =>
+      key.startsWith("summarize.browserCache.entry.v1."),
+    );
+    storage.values.set("summarize.browserCache.index.v1", []);
+
+    expect(entryKeys.length).toBe(1);
+    expect((await store.stats()).totalEntries).toBe(1);
+    expect((await store.clear()).totalEntries).toBe(0);
+    expect(Array.from(storage.values.keys()).filter((key) => key.includes("entry.v1")).length).toBe(
+      0,
+    );
+  });
+
+  it("keeps hash-routed pages isolated", async () => {
+    const storage = createStorageArea();
+    const store = createBrowserPanelCacheStore(storage);
+
+    await store.setPanel(samplePayload({ url: "https://example.com/#/doc/a", title: "A" }));
+    await store.setPanel(samplePayload({ url: "https://example.com/#/doc/b", title: "B" }));
+
+    expect((await store.getPanel("https://example.com/#/doc/a"))?.title).toBe("A");
+    expect((await store.getPanel("https://example.com/#/doc/b"))?.title).toBe("B");
+  });
+});

--- a/tests/chrome.browser-slides.test.ts
+++ b/tests/chrome.browser-slides.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runBrowserSlidesForTab } from "../apps/chrome-extension/src/entrypoints/background/browser-slides";
+
+const originalChrome = globalThis.chrome;
+const originalFetch = globalThis.fetch;
+const originalCreateImageBitmap = globalThis.createImageBitmap;
+const originalOffscreenCanvas = globalThis.OffscreenCanvas;
+
+describe("chrome browser slide capture", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(globalThis, "chrome", {
+      configurable: true,
+      value: originalChrome,
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: originalFetch,
+    });
+    Object.defineProperty(globalThis, "createImageBitmap", {
+      configurable: true,
+      value: originalCreateImageBitmap,
+    });
+    Object.defineProperty(globalThis, "OffscreenCanvas", {
+      configurable: true,
+      value: originalOffscreenCanvas,
+    });
+  });
+
+  it("captures the current frame without seek setup or restore", async () => {
+    const query = vi.fn(async () => [{ id: 7, url: "https://example.com/video" }]);
+    const captureVisibleTab = vi.fn(async () => "data:image/png;base64,abc");
+    Object.defineProperty(globalThis, "chrome", {
+      configurable: true,
+      value: {
+        tabs: { query, captureVisibleTab },
+      },
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn(async () => ({ blob: async () => new Blob(["image"]) })),
+    });
+    Object.defineProperty(globalThis, "createImageBitmap", {
+      configurable: true,
+      value: vi.fn(async () => ({ width: 640, height: 360 })),
+    });
+    Object.defineProperty(globalThis, "OffscreenCanvas", {
+      configurable: true,
+      value: class {
+        constructor(
+          public width: number,
+          public height: number,
+        ) {}
+        getContext() {
+          return { drawImage: vi.fn() };
+        }
+        async convertToBlob() {
+          return new Blob(["thumb"], { type: "image/jpeg" });
+        }
+      },
+    });
+    const beginFrameCapture = vi.fn(async () => ({ ok: true as const, state: null }));
+    const prepareFrame = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        ok: true as const,
+        url: "https://example.com/video",
+        title: "Video",
+        durationSeconds: 6,
+        currentTimeSeconds: 3,
+        rect: { x: 0, y: 0, width: 640, height: 360 },
+        devicePixelRatio: 1,
+      },
+    }));
+    const prepareCurrentFrame = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        ok: true as const,
+        url: "https://example.com/video",
+        title: "Video",
+        durationSeconds: 6,
+        currentTimeSeconds: 3,
+        rect: { x: 0, y: 0, width: 640, height: 360 },
+        devicePixelRatio: 1,
+      },
+    }));
+    const restoreFrame = vi.fn(async () => ({ ok: true as const }));
+
+    const result = await runBrowserSlidesForTab({
+      tab: { id: 7, url: "https://example.com/video" },
+      windowId: 1,
+      captureMode: "current",
+      beginFrameCapture,
+      prepareFrame,
+      prepareCurrentFrame,
+      restoreFrame,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.slides.slides).toHaveLength(1);
+      expect(result.slides.slides[0]?.timestamp).toBe(3);
+    }
+    expect(beginFrameCapture).not.toHaveBeenCalled();
+    expect(prepareFrame).not.toHaveBeenCalled();
+    expect(prepareCurrentFrame).toHaveBeenCalledWith(7);
+    expect(restoreFrame).not.toHaveBeenCalled();
+  });
+
+  it("cancels before visible-tab capture when the active tab changes and restores the video", async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 7, url: "https://example.com/video" }])
+      .mockResolvedValueOnce([{ id: 9, url: "https://example.com/other" }]);
+    const captureVisibleTab = vi.fn(async () => "data:image/png;base64,abc");
+    Object.defineProperty(globalThis, "chrome", {
+      configurable: true,
+      value: {
+        tabs: { query, captureVisibleTab },
+      },
+    });
+    const restoreFrame = vi.fn(async () => ({ ok: true as const }));
+
+    const result = await runBrowserSlidesForTab({
+      tab: { id: 7, url: "https://example.com/video" },
+      windowId: 1,
+      maxSlides: 1,
+      prepareFrame: vi.fn(async () => ({
+        ok: true as const,
+        data: {
+          ok: true as const,
+          url: "https://example.com/video",
+          title: "Video",
+          durationSeconds: 6,
+          rect: { x: 0, y: 0, width: 640, height: 360 },
+          devicePixelRatio: 1,
+        },
+      })),
+      restoreFrame,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Slide capture cancelled because the active tab changed.",
+    });
+    expect(captureVisibleTab).not.toHaveBeenCalled();
+    expect(restoreFrame).toHaveBeenCalledWith(7, null);
+  });
+
+  it("cancels before visible-tab capture when the active tab navigates", async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 7, url: "https://example.com/video" }])
+      .mockResolvedValueOnce([{ id: 7, url: "https://example.com/other" }]);
+    const captureVisibleTab = vi.fn(async () => "data:image/png;base64,abc");
+    Object.defineProperty(globalThis, "chrome", {
+      configurable: true,
+      value: {
+        tabs: { query, captureVisibleTab },
+      },
+    });
+
+    const result = await runBrowserSlidesForTab({
+      tab: { id: 7, url: "https://example.com/video" },
+      windowId: 1,
+      maxSlides: 1,
+      prepareFrame: vi.fn(async () => ({
+        ok: true as const,
+        data: {
+          ok: true as const,
+          url: "https://example.com/video",
+          title: "Video",
+          durationSeconds: 6,
+          rect: { x: 0, y: 0, width: 640, height: 360 },
+          devicePixelRatio: 1,
+        },
+      })),
+      restoreFrame: vi.fn(async () => ({ ok: true as const })),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Slide capture cancelled because the active tab changed.",
+    });
+    expect(captureVisibleTab).not.toHaveBeenCalled();
+  });
+});

--- a/tests/chrome.browser-summary.test.ts
+++ b/tests/chrome.browser-summary.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildBrowserSummaryMarkdown } from "../apps/chrome-extension/src/entrypoints/background/browser-summary";
+
+describe("chrome browser summary", () => {
+  it("escapes browser-derived Markdown before rendering in the sidepanel", () => {
+    const markdown = buildBrowserSummaryMarkdown({
+      title: "Demo ![title](https://example.test/title.png)",
+      text: "Intro ![image](https://example.test/pixel.png) and [link](https://example.test).",
+      transcriptTimedText:
+        "[0:01] Moment ![slide](https://example.test/slide.png)\n[0:02] Follow-up [link](https://example.test).",
+    });
+
+    expect(markdown).toContain("## Demo \\!\\[title\\]\\(https://example\\.test/title\\.png\\)");
+    expect(markdown).toContain("\\!\\[slide\\]\\(https://example\\.test/slide\\.png\\)");
+    expect(markdown).toContain("\\[link\\]\\(https://example\\.test\\)");
+    expect(markdown).not.toContain("![");
+    expect(markdown).not.toContain("](https://example.test");
+  });
+});

--- a/tests/chrome.panel-session-store-cache.test.ts
+++ b/tests/chrome.panel-session-store-cache.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPanelSessionStore } from "../apps/chrome-extension/src/entrypoints/background/panel-session-store.js";
+
+describe("panel session persistent cache bridge", () => {
+  it("hydrates panel cache from the persistent backend", async () => {
+    const cached = { tabId: 99, url: "https://example.com", value: "cached" };
+    const persistent = {
+      getPanel: vi.fn(async () => cached),
+      setPanel: vi.fn(async () => undefined),
+      clear: vi.fn(async () => ({ ok: true })),
+      stats: vi.fn(async () => ({ ok: true })),
+    };
+    const store = createPanelSessionStore<
+      { url: string },
+      typeof cached,
+      Record<string, never>,
+      Record<string, never>
+    >({
+      createDaemonRecovery: () => ({}),
+      createDaemonStatus: () => ({}),
+      persistentPanelCache: persistent,
+    });
+
+    const result = await store.getPanelCacheAsync(7, "https://example.com");
+
+    expect(result).toEqual({ ...cached, tabId: 7 });
+    expect(store.getPanelCache(7, "https://example.com")).toEqual({ ...cached, tabId: 7 });
+  });
+
+  it("keeps a fresh in-memory snapshot when persistent hydration returns late", async () => {
+    let resolvePersistent: ((value: typeof stale) => void) | null = null;
+    const stale = { tabId: 99, url: "https://example.com", value: "stale" };
+    const fresh = { tabId: 7, url: "https://example.com", value: "fresh" };
+    const persistent = {
+      getPanel: vi.fn(
+        () =>
+          new Promise<typeof stale>((resolve) => {
+            resolvePersistent = resolve;
+          }),
+      ),
+      setPanel: vi.fn(async () => undefined),
+      clear: vi.fn(async () => ({ ok: true })),
+      stats: vi.fn(async () => ({ ok: true })),
+    };
+    const store = createPanelSessionStore<
+      { url: string },
+      typeof stale,
+      Record<string, never>,
+      Record<string, never>
+    >({
+      createDaemonRecovery: () => ({}),
+      createDaemonStatus: () => ({}),
+      persistentPanelCache: persistent,
+    });
+
+    const hydration = store.getPanelCacheAsync(7, "https://example.com");
+    store.storePanelCache(fresh);
+    resolvePersistent?.(stale);
+
+    expect(await hydration).toEqual(fresh);
+    expect(store.getPanelCache(7, "https://example.com")).toEqual(fresh);
+  });
+
+  it("uses persistent cache only when the runtime gate allows it", async () => {
+    const cached = { tabId: 99, url: "https://example.com", value: "cached" };
+    const persistent = {
+      getPanel: vi.fn(async () => cached),
+      setPanel: vi.fn(async () => undefined),
+      clear: vi.fn(async () => ({ ok: true })),
+      stats: vi.fn(async () => ({ ok: true })),
+    };
+    let enabled = false;
+    const store = createPanelSessionStore<
+      { url: string },
+      typeof cached,
+      Record<string, never>,
+      Record<string, never>
+    >({
+      createDaemonRecovery: () => ({}),
+      createDaemonStatus: () => ({}),
+      persistentPanelCache: persistent,
+      shouldUsePersistentPanelCache: () => enabled,
+    });
+
+    store.storePanelCache(cached);
+    await Promise.resolve();
+    expect(persistent.setPanel).not.toHaveBeenCalled();
+    expect(await store.getPanelCacheAsync(7, "https://other.example")).toBeNull();
+    expect(persistent.getPanel).not.toHaveBeenCalled();
+
+    enabled = true;
+    store.storePanelCache({ ...cached, url: "https://stored.example" });
+    await Promise.resolve();
+    expect(persistent.setPanel).toHaveBeenCalled();
+    expect(await store.getPanelCacheAsync(7, "https://example.com")).toEqual({
+      ...cached,
+      tabId: 7,
+    });
+  });
+
+  it("does not persist a snapshot whose runtime gate resolves after clear", async () => {
+    let resolveGate: ((value: boolean) => void) | null = null;
+    const cached = { tabId: 7, url: "https://example.com", value: "cached" };
+    const persistent = {
+      getPanel: vi.fn(async () => cached),
+      setPanel: vi.fn(async () => undefined),
+      clear: vi.fn(async () => ({ ok: true })),
+      stats: vi.fn(async () => ({ ok: true })),
+    };
+    const store = createPanelSessionStore<
+      { url: string },
+      typeof cached,
+      Record<string, never>,
+      Record<string, never>
+    >({
+      createDaemonRecovery: () => ({}),
+      createDaemonStatus: () => ({}),
+      persistentPanelCache: persistent,
+      shouldUsePersistentPanelCache: () =>
+        new Promise<boolean>((resolve) => {
+          resolveGate = resolve;
+        }),
+    });
+
+    store.storePanelCache(cached);
+    await store.clearPersistentPanelCache();
+    resolveGate?.(true);
+    await Promise.resolve();
+
+    expect(persistent.setPanel).not.toHaveBeenCalled();
+  });
+
+  it("does not hydrate a persistent snapshot whose gate resolves after clear", async () => {
+    let resolveGate: ((value: boolean) => void) | null = null;
+    const cached = { tabId: 9, url: "https://example.com", value: "cached" };
+    const persistent = {
+      getPanel: vi.fn(async () => cached),
+      setPanel: vi.fn(async () => undefined),
+      clear: vi.fn(async () => ({ ok: true })),
+      stats: vi.fn(async () => ({ ok: true })),
+    };
+    const store = createPanelSessionStore<
+      { url: string },
+      typeof cached,
+      Record<string, never>,
+      Record<string, never>
+    >({
+      createDaemonRecovery: () => ({}),
+      createDaemonStatus: () => ({}),
+      persistentPanelCache: persistent,
+      shouldUsePersistentPanelCache: () =>
+        new Promise<boolean>((resolve) => {
+          resolveGate = resolve;
+        }),
+    });
+
+    const hydration = store.getPanelCacheAsync(7, "https://example.com");
+    await store.clearPersistentPanelCache();
+    resolveGate?.(true);
+
+    expect(await hydration).toBeNull();
+    expect(store.getPanelCache(7, "https://example.com")).toBeNull();
+  });
+
+  it("does not let an older async snapshot overwrite a newer persistent write", async () => {
+    const first = { tabId: 7, url: "https://example.com", value: "first" };
+    const second = { tabId: 7, url: "https://example.com", value: "second" };
+    const gateResolvers: Array<(value: boolean) => void> = [];
+    const persistent = {
+      getPanel: vi.fn(async () => null),
+      setPanel: vi.fn(async () => undefined),
+      clear: vi.fn(async () => ({ ok: true })),
+      stats: vi.fn(async () => ({ ok: true })),
+    };
+    const store = createPanelSessionStore<
+      { url: string },
+      typeof first,
+      Record<string, never>,
+      Record<string, never>
+    >({
+      createDaemonRecovery: () => ({}),
+      createDaemonStatus: () => ({}),
+      persistentPanelCache: persistent,
+      shouldUsePersistentPanelCache: () =>
+        new Promise<boolean>((resolve) => {
+          gateResolvers.push(resolve);
+        }),
+    });
+
+    store.storePanelCache(first);
+    store.storePanelCache(second);
+    gateResolvers[1]?.(true);
+    await Promise.resolve();
+    gateResolvers[0]?.(true);
+    await Promise.resolve();
+
+    expect(persistent.setPanel).toHaveBeenCalledTimes(1);
+    expect(persistent.setPanel).toHaveBeenCalledWith(second);
+  });
+
+  it("orders persistent writes by URL across tabs", async () => {
+    const first = { tabId: 7, url: "https://example.com", value: "first" };
+    const second = { tabId: 8, url: "https://example.com", value: "second" };
+    const gateResolvers: Array<(value: boolean) => void> = [];
+    const persistent = {
+      getPanel: vi.fn(async () => null),
+      setPanel: vi.fn(async () => undefined),
+      clear: vi.fn(async () => ({ ok: true })),
+      stats: vi.fn(async () => ({ ok: true })),
+    };
+    const store = createPanelSessionStore<
+      { url: string },
+      typeof first,
+      Record<string, never>,
+      Record<string, never>
+    >({
+      createDaemonRecovery: () => ({}),
+      createDaemonStatus: () => ({}),
+      persistentPanelCache: persistent,
+      shouldUsePersistentPanelCache: () =>
+        new Promise<boolean>((resolve) => {
+          gateResolvers.push(resolve);
+        }),
+    });
+
+    store.storePanelCache(first);
+    store.storePanelCache(second);
+    gateResolvers[1]?.(true);
+    await Promise.resolve();
+    gateResolvers[0]?.(true);
+    await Promise.resolve();
+
+    expect(persistent.setPanel).toHaveBeenCalledTimes(1);
+    expect(persistent.setPanel).toHaveBeenCalledWith(second);
+  });
+
+  it("does not hydrate stale persistent data after the tab cache changes", async () => {
+    let resolvePersistent: ((value: typeof stale) => void) | null = null;
+    const stale = { tabId: 9, url: "https://example.com/old", value: "old" };
+    const fresh = { tabId: 7, url: "https://example.com/new", value: "new" };
+    const persistent = {
+      getPanel: vi.fn(
+        () =>
+          new Promise<typeof stale>((resolve) => {
+            resolvePersistent = resolve;
+          }),
+      ),
+      setPanel: vi.fn(async () => undefined),
+      clear: vi.fn(async () => ({ ok: true })),
+      stats: vi.fn(async () => ({ ok: true })),
+    };
+    const store = createPanelSessionStore<
+      { url: string },
+      typeof stale,
+      Record<string, never>,
+      Record<string, never>
+    >({
+      createDaemonRecovery: () => ({}),
+      createDaemonStatus: () => ({}),
+      persistentPanelCache: persistent,
+      shouldUsePersistentPanelCache: () => true,
+    });
+
+    const hydration = store.getPanelCacheAsync(7, "https://example.com/old");
+    await Promise.resolve();
+    store.storePanelCache(fresh);
+    resolvePersistent?.(stale);
+
+    expect(await hydration).toBeNull();
+    expect(store.getPanelCache(7, "https://example.com/new")).toEqual(fresh);
+  });
+
+  it("passes tab and url to the persistent runtime gate", async () => {
+    const cached = { tabId: 42, url: "https://example.com", value: "cached" };
+    const shouldUsePersistentPanelCache = vi.fn(() => false);
+    const persistent = {
+      getPanel: vi.fn(async () => null),
+      setPanel: vi.fn(async () => undefined),
+      clear: vi.fn(async () => ({ ok: true })),
+      stats: vi.fn(async () => ({ ok: true })),
+    };
+    const store = createPanelSessionStore<
+      { url: string },
+      typeof cached,
+      Record<string, never>,
+      Record<string, never>
+    >({
+      createDaemonRecovery: () => ({}),
+      createDaemonStatus: () => ({}),
+      persistentPanelCache: persistent,
+      shouldUsePersistentPanelCache,
+    });
+
+    store.storePanelCache(cached);
+    await Promise.resolve();
+    await store.getPanelCacheAsync(42, "https://other.example");
+
+    expect(shouldUsePersistentPanelCache).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabId: 42,
+        url: "https://example.com",
+      }),
+    );
+    expect(shouldUsePersistentPanelCache).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabId: 42,
+        url: "https://other.example",
+      }),
+    );
+    expect(persistent.setPanel).not.toHaveBeenCalled();
+    expect(persistent.getPanel).not.toHaveBeenCalled();
+  });
+});

--- a/tests/chrome.panel-summarize.test.ts
+++ b/tests/chrome.panel-summarize.test.ts
@@ -41,6 +41,7 @@ function createHarness() {
           autoSummarize: true,
           slidesEnabled: true,
           slidesParallel: true,
+          slideRuntime: "daemon",
           summaryTimestamps: true,
         })),
         emitState: vi.fn(),
@@ -128,6 +129,7 @@ describe("chrome panel summarize", () => {
         autoSummarize: true,
         slidesEnabled,
         slidesParallel: true,
+        slideRuntime: "daemon",
         summaryTimestamps: true,
       })),
     });
@@ -140,6 +142,7 @@ describe("chrome panel summarize", () => {
         autoSummarize: true,
         slidesEnabled,
         slidesParallel: true,
+        slideRuntime: "daemon",
         summaryTimestamps: true,
       })),
     });
@@ -191,5 +194,203 @@ describe("chrome panel summarize", () => {
     });
     expect(body.mode).toBeUndefined();
     expect(body.videoMode).toBeUndefined();
+  });
+
+  it("uses a local browser summary snapshot without a daemon token in browser runtime", async () => {
+    const harness = createHarness();
+    const url = "https://example.com/article";
+    const emitState = vi.fn();
+    const sendStatus = vi.fn();
+
+    await harness.summarize({
+      reason: "manual",
+      loadSettings: vi.fn(async () => ({
+        ...defaultSettings,
+        token: "",
+        autoSummarize: true,
+        slidesEnabled: false,
+        slideRuntime: "browser",
+      })),
+      emitState,
+      sendStatus,
+      getActiveTab: vi.fn(async () => ({
+        id: 7,
+        windowId: 1,
+        url,
+        title: "Browser Article",
+      })),
+      extractFromTab: vi.fn(async () => ({
+        ok: true,
+        data: {
+          ok: true,
+          url,
+          title: "Browser Article",
+          text: "First sentence. Second sentence. Third sentence.",
+          truncated: false,
+          media: null,
+        },
+      })),
+    });
+
+    expect(emitState).not.toHaveBeenCalledWith(expect.anything(), "Setup required (missing token)");
+    expect(harness.fetchImpl).not.toHaveBeenCalled();
+    expect(harness.sent).toHaveLength(1);
+    expect(harness.sent[0]).toMatchObject({
+      type: "run:snapshot",
+      run: {
+        url,
+        title: "Browser Article",
+        model: "Browser",
+        reason: "manual",
+        slides: false,
+      },
+      markdown: expect.stringContaining("First sentence\\."),
+    });
+    expect(harness.session.lastSummarizedUrl).toBe(url);
+    expect(sendStatus).toHaveBeenLastCalledWith("");
+  });
+
+  it("keeps daemon summaries when browser runtime has a daemon token", async () => {
+    const harness = createHarness();
+    const url = "https://example.com/article";
+
+    await harness.summarize({
+      reason: "manual",
+      loadSettings: vi.fn(async () => ({
+        ...defaultSettings,
+        token: "token",
+        autoSummarize: true,
+        slidesEnabled: false,
+        slideRuntime: "browser",
+      })),
+      getActiveTab: vi.fn(async () => ({
+        id: 7,
+        windowId: 1,
+        url,
+        title: "Browser Article",
+      })),
+      extractFromTab: vi.fn(async () => ({
+        ok: true,
+        data: {
+          ok: true,
+          url,
+          title: "Browser Article",
+          text: "First sentence. Second sentence.",
+          truncated: false,
+          media: null,
+        },
+      })),
+    });
+
+    expect(harness.fetchImpl).toHaveBeenCalledOnce();
+    expect(harness.sent).toEqual([
+      {
+        type: "run:start",
+        run: {
+          id: "summary",
+          url,
+          title: "Browser Article",
+          model: defaultSettings.model,
+          reason: "manual",
+          slides: false,
+        },
+      },
+    ]);
+  });
+
+  it("falls back to a browser summary snapshot when the configured daemon is unreachable", async () => {
+    const harness = createHarness();
+    const url = "https://example.com/article";
+    const sendStatus = vi.fn();
+
+    await harness.summarize({
+      reason: "manual",
+      sendStatus,
+      fetchImpl: vi.fn(async () => {
+        throw new Error("Failed to fetch");
+      }) as unknown as typeof fetch,
+      isDaemonUnreachableError: () => true,
+      loadSettings: vi.fn(async () => ({
+        ...defaultSettings,
+        token: "token",
+        autoSummarize: true,
+        slidesEnabled: false,
+        slideRuntime: "browser",
+      })),
+      getActiveTab: vi.fn(async () => ({
+        id: 7,
+        windowId: 1,
+        url,
+        title: "Browser Article",
+      })),
+      extractFromTab: vi.fn(async () => ({
+        ok: true,
+        data: {
+          ok: true,
+          url,
+          title: "Browser Article",
+          text: "First sentence. Second sentence.",
+          truncated: false,
+          media: null,
+        },
+      })),
+    });
+
+    expect(harness.sent).toHaveLength(1);
+    expect(harness.sent[0]).toMatchObject({
+      type: "run:snapshot",
+      run: { url, model: "Browser", slides: false },
+      markdown: expect.stringContaining("First sentence\\."),
+    });
+    expect(harness.session.daemonRecovery.recordFailure).toHaveBeenCalledWith(url);
+    expect(sendStatus).toHaveBeenLastCalledWith("");
+  });
+
+  it("falls back to a browser summary snapshot when a saved daemon token is stale", async () => {
+    const harness = createHarness();
+    const url = "https://example.com/article";
+
+    await harness.summarize({
+      reason: "manual",
+      fetchImpl: vi.fn(async () => ({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: async () => ({ ok: false, error: "Unauthorized" }),
+      })) as unknown as typeof fetch,
+      isDaemonUnreachableError: () => false,
+      loadSettings: vi.fn(async () => ({
+        ...defaultSettings,
+        token: "stale-token",
+        autoSummarize: true,
+        slidesEnabled: false,
+        slideRuntime: "browser",
+      })),
+      getActiveTab: vi.fn(async () => ({
+        id: 7,
+        windowId: 1,
+        url,
+        title: "Browser Article",
+      })),
+      extractFromTab: vi.fn(async () => ({
+        ok: true,
+        data: {
+          ok: true,
+          url,
+          title: "Browser Article",
+          text: "First sentence. Second sentence.",
+          truncated: false,
+          media: null,
+        },
+      })),
+    });
+
+    expect(harness.sent).toHaveLength(1);
+    expect(harness.sent[0]).toMatchObject({
+      type: "run:snapshot",
+      run: { url, model: "Browser", slides: false },
+      markdown: expect.stringContaining("First sentence\\."),
+    });
+    expect(harness.session.daemonRecovery.recordFailure).not.toHaveBeenCalled();
   });
 });

--- a/tests/chrome.settings.test.ts
+++ b/tests/chrome.settings.test.ts
@@ -54,6 +54,25 @@ describe("chrome/settings", () => {
     expect(loaded.slidesOcrEnabled).toBe(true);
   });
 
+  it("normalizes slide runtime preferences", async () => {
+    await patchSettings({ slideRuntime: "daemon" });
+    expect((await loadSettings()).slideRuntime).toBe("daemon");
+
+    storage.settings = { slideRuntime: "browser" };
+    expect((await loadSettings()).slideRuntime).toBe("browser");
+
+    storage.settings = { slideRuntime: "native" };
+    expect((await loadSettings()).slideRuntime).toBe(defaultSettings.slideRuntime);
+  });
+
+  it("migrates the legacy daemonless slide preference", async () => {
+    storage.settings = { daemonlessSlides: false };
+    expect((await loadSettings()).slideRuntime).toBe("daemon");
+
+    storage.settings = { daemonlessSlides: true };
+    expect((await loadSettings()).slideRuntime).toBe("browser");
+  });
+
   it("normalizes advanced overrides on save", async () => {
     await saveSettings({
       ...defaultSettings,

--- a/tests/chrome.youtube-transcript.test.ts
+++ b/tests/chrome.youtube-transcript.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extractYouTubeTranscriptInTab } from "../apps/chrome-extension/src/entrypoints/background/youtube-transcript";
+
+type ExecuteScriptOptions = Parameters<typeof chrome.scripting.executeScript>[0] & {
+  func: (limit: number) => Promise<unknown>;
+  args: [number];
+};
+
+const originalChrome = globalThis.chrome;
+const originalDocument = globalThis.document;
+const originalFetch = globalThis.fetch;
+const originalLocation = globalThis.location;
+const originalScrollX = (globalThis as { scrollX?: unknown }).scrollX;
+const originalScrollY = (globalThis as { scrollY?: unknown }).scrollY;
+const originalScrollTo = (globalThis as { scrollTo?: unknown }).scrollTo;
+const originalPlayerResponse = (globalThis as { ytInitialPlayerResponse?: unknown })
+  .ytInitialPlayerResponse;
+
+function installDocumentStub(overrides: Partial<Document> = {}) {
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => []),
+      ...overrides,
+    },
+  });
+}
+
+function installExecuteScriptStub() {
+  Object.defineProperty(globalThis, "chrome", {
+    configurable: true,
+    value: {
+      scripting: {
+        executeScript: vi.fn(async (options: ExecuteScriptOptions) => [
+          { result: await options.func(options.args[0]) },
+        ]),
+      },
+    },
+  });
+}
+
+describe("chrome youtube transcript extraction", () => {
+  beforeEach(() => {
+    installDocumentStub();
+    installExecuteScriptStub();
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { href: "https://www.youtube.com/watch?v=test" },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(globalThis, "chrome", {
+      configurable: true,
+      value: originalChrome,
+    });
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: originalFetch,
+    });
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    Object.defineProperty(globalThis, "scrollX", {
+      configurable: true,
+      value: originalScrollX,
+    });
+    Object.defineProperty(globalThis, "scrollY", {
+      configurable: true,
+      value: originalScrollY,
+    });
+    Object.defineProperty(globalThis, "scrollTo", {
+      configurable: true,
+      value: originalScrollTo,
+    });
+    (globalThis as { ytInitialPlayerResponse?: unknown }).ytInitialPlayerResponse =
+      originalPlayerResponse;
+  });
+
+  it("extracts JSON3 captions from the YouTube player response", async () => {
+    (globalThis as { ytInitialPlayerResponse?: unknown }).ytInitialPlayerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            {
+              baseUrl: "https://example.com/caption?lang=en",
+              languageCode: "en",
+              name: { simpleText: "English" },
+            },
+          ],
+        },
+      },
+      videoDetails: { lengthSeconds: "42", videoId: "test" },
+    };
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn(async () => ({
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            events: [
+              { tStartMs: 1000, segs: [{ utf8: "Hello" }, { utf8: " world" }] },
+              { tStartMs: 2500, segs: [{ utf8: "Second line" }] },
+            ],
+          }),
+      })),
+    });
+
+    const result = await extractYouTubeTranscriptInTab(7, 10_000);
+
+    expect(result).toEqual({
+      ok: true,
+      url: "https://www.youtube.com/watch?v=test",
+      text: "Transcript:\n[0:01] Hello world\n[0:02] Second line",
+      transcriptTimedText: "[0:01] Hello world\n[0:02] Second line",
+      truncated: false,
+      durationSeconds: 42,
+    });
+  });
+
+  it("falls back across caption formats and clamps long captions", async () => {
+    (globalThis as { ytInitialPlayerResponse?: unknown }).ytInitialPlayerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            {
+              baseUrl: "https://example.com/caption?lang=en",
+              languageCode: "en-US",
+              kind: "asr",
+              name: { runs: [{ text: "English " }, { text: "auto-generated" }] },
+            },
+          ],
+        },
+      },
+      videoDetails: { lengthSeconds: "bad", videoId: "test" },
+    };
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, text: async () => "" })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nA very long caption line",
+        }),
+    });
+
+    const result = await extractYouTubeTranscriptInTab(7, 36);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.text).toContain("Transcript:");
+      expect(result.text).toContain("[TRUNCATED]");
+      expect(result.url).toBe("https://www.youtube.com/watch?v=test");
+      expect(result.transcriptTimedText).toBe("[0:01] A very long caption line");
+      expect(result.truncated).toBe(true);
+      expect(result.durationSeconds).toBeNull();
+    }
+  });
+
+  it("returns transcript panel text when caption track metadata is unavailable", async () => {
+    (globalThis as { ytInitialPlayerResponse?: unknown }).ytInitialPlayerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [],
+        },
+      },
+      videoDetails: { videoId: "test" },
+    };
+    const segment = {
+      querySelector: vi.fn((selector: string) => ({
+        textContent: selector.includes("timestamp") ? "1:23" : "Panel transcript text",
+      })),
+    };
+    const button = { click: vi.fn(), textContent: "Show transcript" };
+    const scrollTo = vi.fn();
+    Object.defineProperty(globalThis, "scrollX", { configurable: true, value: 13 });
+    Object.defineProperty(globalThis, "scrollY", { configurable: true, value: 37 });
+    Object.defineProperty(globalThis, "scrollTo", { configurable: true, value: scrollTo });
+    installDocumentStub({
+      querySelector: vi.fn((selector: string) =>
+        selector === "ytd-watch-metadata"
+          ? ({ scrollIntoView: vi.fn() } as unknown as Element)
+          : selector.includes("transcript-section")
+            ? button
+            : null,
+      ) as unknown as Document["querySelector"],
+      querySelectorAll: vi.fn((selector: string) =>
+        selector.includes("transcript-segment") ? [segment] : [button],
+      ) as unknown as Document["querySelectorAll"],
+    });
+
+    const result = await extractYouTubeTranscriptInTab(7, 10_000);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.transcriptTimedText).toBe("[1:23] Panel transcript text");
+      expect(result.url).toBe("https://www.youtube.com/watch?v=test");
+      expect(result.durationSeconds).toBeNull();
+    }
+    expect(scrollTo).toHaveBeenCalledWith(13, 37);
+  });
+
+  it("does not reuse already-open transcript panel rows without current transcript control", async () => {
+    (globalThis as { ytInitialPlayerResponse?: unknown }).ytInitialPlayerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [],
+        },
+      },
+      videoDetails: { videoId: "test" },
+    };
+    const segment = {
+      querySelector: vi.fn((selector: string) => ({
+        textContent: selector.includes("timestamp") ? "0:10" : "Stale transcript text",
+      })),
+    };
+    installDocumentStub({
+      querySelector: vi.fn((selector: string) =>
+        selector === "ytd-watch-metadata"
+          ? ({ scrollIntoView: vi.fn() } as unknown as Element)
+          : null,
+      ) as unknown as Document["querySelector"],
+      querySelectorAll: vi.fn((selector: string) =>
+        selector.includes("transcript-segment") ? [segment] : [],
+      ) as unknown as Document["querySelectorAll"],
+    });
+
+    const result = await extractYouTubeTranscriptInTab(7, 10_000);
+
+    expect(result).toEqual({ ok: false, error: "No YouTube caption transcript found." });
+  });
+
+  it("reports wrapper failures", async () => {
+    Object.defineProperty(globalThis, "chrome", {
+      configurable: true,
+      value: {
+        scripting: {
+          executeScript: vi.fn(async () => {
+            throw new Error("cannot inject");
+          }),
+        },
+      },
+    });
+
+    await expect(extractYouTubeTranscriptInTab(7, 1000)).resolves.toEqual({
+      ok: false,
+      error: "cannot inject",
+    });
+  });
+
+  it("prefers current flexy captions over stale bootstrap player data", async () => {
+    (globalThis as { ytInitialPlayerResponse?: unknown }).ytInitialPlayerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            {
+              baseUrl: "https://example.com/stale",
+              languageCode: "en",
+              name: { simpleText: "English" },
+            },
+          ],
+        },
+      },
+      videoDetails: { lengthSeconds: "10", videoId: "old-video" },
+    };
+    installDocumentStub({
+      querySelector: vi.fn((selector: string) =>
+        selector === "ytd-watch-flexy"
+          ? ({
+              playerResponse: {
+                captions: {
+                  playerCaptionsTracklistRenderer: {
+                    captionTracks: [
+                      {
+                        baseUrl: "https://example.com/current",
+                        languageCode: "en",
+                        name: { simpleText: "English" },
+                      },
+                    ],
+                  },
+                },
+                videoDetails: { lengthSeconds: "42", videoId: "test" },
+              },
+            } as unknown as Element)
+          : null,
+      ) as unknown as Document["querySelector"],
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn(async (url: string) => ({
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            events: [
+              { tStartMs: 1000, segs: [{ utf8: url.includes("current") ? "Current" : "Stale" }] },
+            ],
+          }),
+      })),
+    });
+
+    const result = await extractYouTubeTranscriptInTab(7, 10_000);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.transcriptTimedText).toBe("[0:01] Current");
+      expect(result.durationSeconds).toBe(42);
+    }
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("current"), expect.anything());
+  });
+
+  it("skips incomplete flexy playerData when playerResponse has current captions", async () => {
+    installDocumentStub({
+      querySelector: vi.fn((selector: string) =>
+        selector === "ytd-watch-flexy"
+          ? ({
+              playerData: {},
+              playerResponse: {
+                captions: {
+                  playerCaptionsTracklistRenderer: {
+                    captionTracks: [
+                      {
+                        baseUrl: "https://example.com/current",
+                        languageCode: "en",
+                        name: { simpleText: "English" },
+                      },
+                    ],
+                  },
+                },
+                videoDetails: { lengthSeconds: "42", videoId: "test" },
+              },
+            } as unknown as Element)
+          : null,
+      ) as unknown as Document["querySelector"],
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn(async () => ({
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            events: [{ tStartMs: 1000, segs: [{ utf8: "Current response" }] }],
+          }),
+      })),
+    });
+
+    const result = await extractYouTubeTranscriptInTab(7, 10_000);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.transcriptTimedText).toBe("[0:01] Current response");
+    }
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("current"), expect.anything());
+  });
+});

--- a/tests/options.daemon-status.test.ts
+++ b/tests/options.daemon-status.test.ts
@@ -14,6 +14,26 @@ const createDeferred = <T>() => {
 };
 
 describe("options daemon status", () => {
+  it("shows browser mode without probing the daemon", async () => {
+    const statusEl = document.createElement("div");
+    let fetchCalls = 0;
+    const checker = createDaemonStatusChecker({
+      statusEl,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        throw new Error("should not fetch");
+      },
+      getExtensionVersion: () => "0.17.0",
+      isDaemonMode: () => false,
+    });
+
+    await checker.checkDaemonStatus("token");
+
+    expect(statusEl.textContent).toBe("Browser mode active");
+    expect(statusEl.dataset.state).toBe("ok");
+    expect(fetchCalls).toBe(0);
+  });
+
   it("keeps an empty-token warning from being overwritten by an older check", async () => {
     const statusEl = document.createElement("div");
     const health = createDeferred<Response>();
@@ -36,5 +56,32 @@ describe("options daemon status", () => {
 
     expect(statusEl.textContent).toBe("Add token to verify daemon connection");
     expect(statusEl.dataset.state).toBe("warn");
+  });
+
+  it("keeps browser mode from being overwritten by an older daemon check", async () => {
+    const statusEl = document.createElement("div");
+    const health = createDeferred<Response>();
+    let daemonMode = true;
+    const fetchImpl = async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/health") return health.promise;
+      if (url.pathname === "/v1/ping") return jsonResponse({ ok: true });
+      throw new Error(`unexpected request: ${url.pathname}`);
+    };
+    const checker = createDaemonStatusChecker({
+      statusEl,
+      fetchImpl,
+      getExtensionVersion: () => "0.17.0",
+      isDaemonMode: () => daemonMode,
+    });
+
+    const staleCheck = checker.checkDaemonStatus("token");
+    daemonMode = false;
+    await checker.checkDaemonStatus("token");
+    health.resolve(jsonResponse({ version: "0.17.0" }));
+    await staleCheck;
+
+    expect(statusEl.textContent).toBe("Browser mode active");
+    expect(statusEl.dataset.state).toBe("ok");
   });
 });

--- a/tests/sidepanel.bg-message-runtime.test.ts
+++ b/tests/sidepanel.bg-message-runtime.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSidepanelBgMessageRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime";
+import type { BgToPanel, UiState } from "../apps/chrome-extension/src/lib/panel-contracts";
+
+function createRuntime(
+  overrides: Partial<Parameters<typeof createSidepanelBgMessageRuntime>[0]> = {},
+) {
+  const options = {
+    panelState: {
+      ui: null,
+      error: null,
+      chatStreaming: false,
+      currentSource: { url: "https://www.youtube.com/watch?v=current" },
+      summaryMarkdown: null,
+      slides: null,
+    },
+    applyUiState: vi.fn(),
+    setStatus: vi.fn(),
+    isStreaming: vi.fn(() => false),
+    setPhase: vi.fn(),
+    finishStreamingMessage: vi.fn(),
+    setSlidesBusy: vi.fn(),
+    showSlideNotice: vi.fn(),
+    getActiveTabUrl: vi.fn(() => "https://www.youtube.com/watch?v=current"),
+    rememberPendingSlidesRun: vi.fn(),
+    startSlidesStreamForRunId: vi.fn(),
+    startSlidesSummaryStreamForRunId: vi.fn(),
+    handleSlidesLocal: vi.fn(),
+    getSlidesContextRequestId: vi.fn(() => 1),
+    setSlidesContextPending: vi.fn(),
+    setSlidesTranscriptTimedText: vi.fn(),
+    updateSlidesTextState: vi.fn(),
+    getSlidesSummaryState: vi.fn(() => ({ complete: false, markdown: "" })),
+    updateSlideSummaryFromMarkdown: vi.fn(),
+    renderInlineSlidesFallback: vi.fn(),
+    schedulePanelCacheSync: vi.fn(),
+    consumeUiCache: vi.fn(() => null),
+    getActiveTabId: vi.fn(() => 1),
+    applyPanelCache: vi.fn(),
+    rememberPendingSummaryRun: vi.fn(),
+    rememberPendingSummarySnapshot: vi.fn(),
+    attachSummaryRun: vi.fn(),
+    applySummarySnapshot: vi.fn(),
+    handleChatHistory: vi.fn(),
+    handleAgentChunk: vi.fn(),
+    handleAgentResponse: vi.fn(),
+    ...overrides,
+  };
+  return { runtime: createSidepanelBgMessageRuntime(options), options };
+}
+
+describe("sidepanel background message runtime", () => {
+  it("preserves local browser slide runs when deferring for another tab", () => {
+    const { runtime, options } = createRuntime();
+
+    runtime.handle({
+      type: "slides:run",
+      ok: true,
+      runId: "browser-run",
+      url: "https://www.youtube.com/watch?v=other",
+      local: true,
+    });
+
+    expect(options.rememberPendingSlidesRun).toHaveBeenCalledWith({
+      runId: "browser-run",
+      url: "https://www.youtube.com/watch?v=other",
+      local: true,
+    });
+    expect(options.startSlidesStreamForRunId).not.toHaveBeenCalled();
+    expect(options.startSlidesSummaryStreamForRunId).not.toHaveBeenCalled();
+  });
+
+  it("starts local browser slide runs without daemon summary streaming", () => {
+    const { runtime, options } = createRuntime();
+
+    runtime.handle({
+      type: "slides:run",
+      ok: true,
+      runId: "browser-run",
+      url: "https://www.youtube.com/watch?v=current",
+      local: true,
+    });
+
+    expect(options.startSlidesStreamForRunId).toHaveBeenCalledWith("browser-run", {
+      url: "https://www.youtube.com/watch?v=current",
+      local: true,
+    });
+    expect(options.startSlidesSummaryStreamForRunId).not.toHaveBeenCalled();
+  });
+
+  it("starts daemon slide runs with summary streaming", () => {
+    const { runtime, options } = createRuntime();
+
+    runtime.handle({
+      type: "slides:run",
+      ok: true,
+      runId: "daemon-run",
+      url: "https://www.youtube.com/watch?v=current",
+    });
+
+    expect(options.startSlidesStreamForRunId).toHaveBeenCalledWith("daemon-run", {
+      url: "https://www.youtube.com/watch?v=current",
+      local: false,
+    });
+    expect(options.startSlidesSummaryStreamForRunId).toHaveBeenCalledWith(
+      "daemon-run",
+      "https://www.youtube.com/watch?v=current",
+    );
+  });
+
+  it("surfaces slide run failures", () => {
+    const { runtime, options } = createRuntime();
+
+    runtime.handle({ type: "slides:run", ok: false, error: "capture failed" });
+
+    expect(options.setSlidesBusy).toHaveBeenCalledWith(false);
+    expect(options.showSlideNotice).toHaveBeenCalledWith("capture failed", { allowRetry: true });
+  });
+
+  it("gates status updates while streaming and records errors", () => {
+    const { runtime, options } = createRuntime({
+      isStreaming: vi.fn(() => true),
+      panelState: {
+        ui: null,
+        error: null,
+        chatStreaming: true,
+        currentSource: { url: "https://www.youtube.com/watch?v=current" },
+        summaryMarkdown: null,
+        slides: null,
+      },
+    });
+
+    runtime.handle({ type: "ui:status", status: "Working" });
+    runtime.handle({ type: "run:error", message: "no daemon" });
+
+    expect(options.setStatus).toHaveBeenCalledTimes(1);
+    expect(options.setStatus).toHaveBeenCalledWith("Error: no daemon");
+    expect(options.setPhase).toHaveBeenCalledWith("error", { error: "no daemon" });
+    expect(options.finishStreamingMessage).toHaveBeenCalled();
+  });
+
+  it("applies current-tab cache and defers mismatched summary runs", () => {
+    const cache = { summary: "cached" };
+    const { runtime, options } = createRuntime({
+      consumeUiCache: vi.fn(() => ({
+        tabId: 1,
+        url: "https://www.youtube.com/watch?v=current",
+        cache,
+        preserveChat: true,
+      })),
+    });
+
+    runtime.handle({ type: "ui:cache", requestId: "cache-1", ok: true, cache } as BgToPanel);
+    runtime.handle({
+      type: "run:start",
+      run: {
+        id: "run-1",
+        url: "https://www.youtube.com/watch?v=other",
+        title: null,
+        model: "auto",
+        reason: "tab-activated",
+      },
+    });
+
+    expect(options.applyPanelCache).toHaveBeenCalledWith(cache, { preserveChat: true });
+    expect(options.rememberPendingSummaryRun).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "run-1" }),
+    );
+  });
+
+  it("applies local browser summary snapshots without daemon streaming", () => {
+    const { runtime, options } = createRuntime();
+
+    runtime.handle({
+      type: "run:snapshot",
+      run: {
+        id: "browser-summary",
+        url: "https://www.youtube.com/watch?v=current",
+        title: "Current",
+        model: "Browser",
+        reason: "manual",
+        slides: true,
+      },
+      markdown: "## Summary\n\nBrowser summary.",
+    });
+
+    expect(options.applySummarySnapshot).toHaveBeenCalledWith({
+      run: expect.objectContaining({ id: "browser-summary", model: "Browser" }),
+      markdown: "## Summary\n\nBrowser summary.",
+    });
+    expect(options.attachSummaryRun).not.toHaveBeenCalled();
+  });
+
+  it("queues stale local browser summary snapshots for their tab", () => {
+    const { runtime, options } = createRuntime();
+
+    runtime.handle({
+      type: "run:snapshot",
+      run: {
+        id: "browser-summary-other",
+        url: "https://www.youtube.com/watch?v=other",
+        title: "Other",
+        model: "Browser",
+        reason: "tab-activated",
+      },
+      markdown: "Wrong page",
+    });
+
+    expect(options.applySummarySnapshot).not.toHaveBeenCalled();
+    expect(options.rememberPendingSummaryRun).not.toHaveBeenCalled();
+    expect(options.rememberPendingSummarySnapshot).toHaveBeenCalledWith({
+      run: expect.objectContaining({ id: "browser-summary-other" }),
+      markdown: "Wrong page",
+    });
+  });
+
+  it("uses slide context to rebuild rendered fallback text", () => {
+    const { runtime, options } = createRuntime({
+      panelState: {
+        ui: null,
+        error: null,
+        chatStreaming: false,
+        currentSource: { url: "https://www.youtube.com/watch?v=current" },
+        summaryMarkdown: "Summary markdown",
+        slides: {},
+      },
+      getSlidesSummaryState: vi.fn(() => ({ complete: true, markdown: "Slide markdown" })),
+    });
+
+    runtime.handle({
+      type: "slides:context",
+      requestId: "slides-1",
+      ok: true,
+      transcriptTimedText: "[0:00] hello",
+    });
+
+    expect(options.setSlidesContextPending).toHaveBeenCalledWith(false);
+    expect(options.setSlidesTranscriptTimedText).toHaveBeenCalledWith("[0:00] hello");
+    expect(options.updateSlideSummaryFromMarkdown).toHaveBeenCalledWith("Slide markdown", {
+      preserveIfEmpty: false,
+      source: "slides",
+    });
+    expect(options.renderInlineSlidesFallback).toHaveBeenCalled();
+    expect(options.schedulePanelCacheSync).toHaveBeenCalled();
+  });
+
+  it("routes simple delegated messages", () => {
+    const state = { status: "" } as UiState;
+    const { runtime, options } = createRuntime();
+
+    runtime.handle({ type: "ui:state", state });
+    runtime.handle({ type: "slides:local", requestId: "local-1", ok: false, error: "missing" });
+    runtime.handle({ type: "chat:history", requestId: "chat-1", ok: true, messages: [] });
+    runtime.handle({ type: "agent:chunk", requestId: "agent-1", text: "hi" });
+    runtime.handle({ type: "agent:response", requestId: "agent-1", ok: true });
+
+    expect(options.applyUiState).toHaveBeenCalledWith(state);
+    expect(options.handleSlidesLocal).toHaveBeenCalled();
+    expect(options.handleChatHistory).toHaveBeenCalled();
+    expect(options.handleAgentChunk).toHaveBeenCalled();
+    expect(options.handleAgentResponse).toHaveBeenCalled();
+  });
+});

--- a/tests/sidepanel.bg-message-runtime.test.ts
+++ b/tests/sidepanel.bg-message-runtime.test.ts
@@ -35,6 +35,7 @@ function createRuntime(
     renderInlineSlidesFallback: vi.fn(),
     schedulePanelCacheSync: vi.fn(),
     consumeUiCache: vi.fn(() => null),
+    clearPanelCache: vi.fn(),
     getActiveTabId: vi.fn(() => 1),
     applyPanelCache: vi.fn(),
     rememberPendingSummaryRun: vi.fn(),
@@ -259,5 +260,13 @@ describe("sidepanel background message runtime", () => {
     expect(options.handleChatHistory).toHaveBeenCalled();
     expect(options.handleAgentChunk).toHaveBeenCalled();
     expect(options.handleAgentResponse).toHaveBeenCalled();
+  });
+
+  it("clears local panel cache when background broadcasts cache invalidation", () => {
+    const { runtime, options } = createRuntime({ clearPanelCache: vi.fn() });
+
+    runtime.handle({ type: "ui:cache-cleared" });
+
+    expect(options.clearPanelCache).toHaveBeenCalled();
   });
 });

--- a/tests/sidepanel.panel-cache.test.ts
+++ b/tests/sidepanel.panel-cache.test.ts
@@ -134,4 +134,28 @@ describe("panel cache controller", () => {
 
     expect(result).toBeNull();
   });
+
+  it("clears local snapshots, pending requests, and scheduled syncs", () => {
+    vi.useFakeTimers();
+    const sendCache = vi.fn();
+    const sendRequest = vi.fn();
+    const payload = samplePayload();
+    const controller = createPanelCacheController({
+      getSnapshot: () => payload,
+      sendCache,
+      sendRequest,
+    });
+
+    controller.scheduleSync(10);
+    const request = controller.request(2, "https://example.com/2", false);
+    controller.clear();
+    vi.runAllTimers();
+
+    expect(sendCache).not.toHaveBeenCalled();
+    expect(controller.resolve(1, "https://example.com")).toBeNull();
+    expect(
+      controller.consumeResponse({ requestId: request.requestId, ok: true, cache: payload }),
+    ).toBeNull();
+    vi.useRealTimers();
+  });
 });

--- a/tests/sidepanel.setup-runtime.behavior.test.ts
+++ b/tests/sidepanel.setup-runtime.behavior.test.ts
@@ -55,6 +55,7 @@ function makeUiState(overrides?: Partial<UiState>): UiState {
       slidesParallel: false,
       slidesOcrEnabled: false,
       slidesLayout: "strip",
+      slideRuntime: "browser",
       fontSize: 15,
       lineHeight: 1.6,
       model: "auto",
@@ -115,7 +116,7 @@ describe("sidepanel setup runtime behavior", () => {
     expect(
       runtime.maybeShowSetup(
         makeUiState({
-          settings: { ...makeUiState().settings, tokenPresent: false },
+          settings: { ...makeUiState().settings, slideRuntime: "daemon", tokenPresent: false },
         }),
       ),
     ).toBe(true);
@@ -157,6 +158,7 @@ describe("sidepanel setup runtime behavior", () => {
       runtime.maybeShowSetup(
         makeUiState({
           daemon: { ok: false, authed: false },
+          settings: { ...makeUiState().settings, slideRuntime: "daemon" },
         }),
       ),
     ).toBe(true);
@@ -191,5 +193,67 @@ describe("sidepanel setup runtime behavior", () => {
 
     expect(runtime.maybeShowSetup(makeUiState())).toBe(false);
     expect(setupEl.classList.add).toHaveBeenCalledWith("hidden");
+  });
+
+  it("hides setup in browser runtime even when chat is enabled", async () => {
+    const setupEl = makeSetupEl();
+    const ensureToken = vi.fn(async () => "fresh-token");
+    const loadToken = vi.fn(async () => "unused-token");
+
+    const runtime = createSetupRuntime({
+      setupEl,
+      ensureToken,
+      loadToken,
+      patchSettings: vi.fn() as never,
+      generateToken: vi.fn() as never,
+      headerSetStatus: vi.fn(),
+      getStatusResetText: vi.fn(() => "Ready"),
+    });
+
+    expect(
+      runtime.maybeShowSetup(
+        makeUiState({
+          daemon: { ok: false, authed: false },
+          settings: { ...makeUiState().settings, slideRuntime: "browser", tokenPresent: false },
+        }),
+      ),
+    ).toBe(false);
+    await flushPromises();
+    expect(setupEl.classList.add).toHaveBeenCalledWith("hidden");
+    expect(ensureToken).not.toHaveBeenCalled();
+    expect(loadToken).not.toHaveBeenCalled();
+  });
+
+  it("hides setup in browser runtime when daemon-backed chat is disabled", () => {
+    const setupEl = makeSetupEl();
+    const ensureToken = vi.fn(async () => "unused-token");
+    const loadToken = vi.fn(async () => "unused-token");
+
+    const runtime = createSetupRuntime({
+      setupEl,
+      ensureToken,
+      loadToken,
+      patchSettings: vi.fn() as never,
+      generateToken: vi.fn() as never,
+      headerSetStatus: vi.fn(),
+      getStatusResetText: vi.fn(() => "Ready"),
+    });
+
+    expect(
+      runtime.maybeShowSetup(
+        makeUiState({
+          daemon: { ok: false, authed: false },
+          settings: {
+            ...makeUiState().settings,
+            chatEnabled: false,
+            slideRuntime: "browser",
+            tokenPresent: false,
+          },
+        }),
+      ),
+    ).toBe(false);
+    expect(setupEl.classList.add).toHaveBeenCalledWith("hidden");
+    expect(ensureToken).not.toHaveBeenCalled();
+    expect(loadToken).not.toHaveBeenCalled();
   });
 });

--- a/tests/sidepanel.slides-hydrator.test.ts
+++ b/tests/sidepanel.slides-hydrator.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSlidesHydrator } from "../apps/chrome-extension/src/entrypoints/sidepanel/slides-hydrator.js";
 import { encodeSseEvent, type SseEvent, type SseSlidesData } from "../src/shared/sse-events.js";
 
@@ -23,6 +23,31 @@ async function waitFor(check: () => boolean, attempts = 20) {
 }
 
 describe("sidepanel slides hydrator", () => {
+  it("reports and clears the active run id", async () => {
+    let releaseStream: (() => void) | null = null;
+    const streamReleased = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    const hydrator = createSlidesHydrator({
+      getToken: async () => "",
+      onSlides: () => {},
+      streamFetchImpl: async () => {
+        await streamReleased;
+        return new Response(streamFromEvents([{ event: "done", data: {} }]), { status: 200 });
+      },
+      snapshotFetchImpl: async () => new Response(JSON.stringify({ ok: false }), { status: 200 }),
+    });
+
+    const startPromise = hydrator.start("run-active");
+    await waitFor(() => hydrator.getActiveRunId() === "run-active");
+
+    expect(hydrator.getActiveRunId()).toBe("run-active");
+    hydrator.stop();
+    expect(hydrator.getActiveRunId()).toBeNull();
+    releaseStream?.();
+    await startPromise;
+  });
+
   it("hydrates snapshot when the stream finishes without slides", async () => {
     const payload: SseSlidesData = {
       sourceUrl: "https://example.com",
@@ -125,6 +150,49 @@ describe("sidepanel slides hydrator", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(received).toEqual([livePayload]);
+  });
+
+  it("does not start a stale stream after a superseded local lookup misses", async () => {
+    let resolveLocal: ((value: SseSlidesData | null) => void) | null = null;
+    const localPromise = new Promise<SseSlidesData | null>((resolve) => {
+      resolveLocal = resolve;
+    });
+    const streamFetchImpl = vi.fn(async () => {
+      return new Response(streamFromEvents([{ event: "done", data: {} }]), { status: 200 });
+    });
+    const hydrator = createSlidesHydrator({
+      getToken: async () => "",
+      onSlides: () => {},
+      resolveLocalSlides: async (runId) => (runId === "run-1" ? await localPromise : null),
+      streamFetchImpl,
+    });
+
+    const staleStart = hydrator.start("run-1");
+    await waitFor(() => hydrator.getActiveRunId() === "run-1");
+    hydrator.stop();
+    resolveLocal?.(null);
+    await staleStart;
+
+    expect(streamFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("finishes local runs when the in-memory browser payload is missing", async () => {
+    const streamFetchImpl = vi.fn(async () => {
+      return new Response(streamFromEvents([{ event: "done", data: {} }]), { status: 200 });
+    });
+    const onDone = vi.fn();
+    const hydrator = createSlidesHydrator({
+      getToken: async () => "token",
+      onSlides: () => {},
+      onDone,
+      resolveLocalSlides: async () => null,
+      streamFetchImpl,
+    });
+
+    await hydrator.start("browser-run", { local: true });
+
+    expect(streamFetchImpl).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledOnce();
   });
 
   it("hydrates snapshot when cache is loaded without slides", async () => {

--- a/tests/sidepanel.slides-payload.test.ts
+++ b/tests/sidepanel.slides-payload.test.ts
@@ -119,6 +119,35 @@ describe("sidepanel slides payload policy", () => {
     );
   });
 
+  it("preserves explicit slide runtime metadata", () => {
+    const browserPayload = normalizeSlidesPayload({
+      ...buildSlidesPayload({ count: 1, withImages: true }),
+      slideRuntime: "browser",
+    });
+    const daemonPayload = normalizeSlidesPayload({
+      ...buildSlidesPayload({ count: 1, withImages: true }),
+      slideRuntime: "daemon",
+    });
+    const invalidPayload = normalizeSlidesPayload({
+      ...buildSlidesPayload({ count: 1, withImages: true }),
+      slideRuntime: "native",
+    });
+
+    expect(browserPayload?.slideRuntime).toBe("browser");
+    expect(daemonPayload?.slideRuntime).toBe("daemon");
+    expect(invalidPayload).not.toHaveProperty("slideRuntime");
+  });
+
+  it("tracks slide runtime changes while treating missing runtime as daemon", () => {
+    const payload = buildSlidesPayload({ count: 1, withImages: true });
+    const browserPayload = { ...payload, slideRuntime: "browser" as const };
+    const daemonPayload = { ...payload, slideRuntime: "daemon" as const };
+
+    expect(slidesPayloadChanged(payload, browserPayload)).toBe(true);
+    expect(slidesPayloadChanged(payload, daemonPayload)).toBe(false);
+    expect(slidesPayloadChanged(daemonPayload, payload)).toBe(false);
+  });
+
   it("treats repeated malformed timestamps as unchanged after normalization", () => {
     const normalized = normalizeSlidesPayload({
       sourceUrl: "https://example.com",

--- a/tests/sidepanel.slides-runtime.test.ts
+++ b/tests/sidepanel.slides-runtime.test.ts
@@ -47,6 +47,7 @@ vi.mock("../apps/chrome-extension/src/entrypoints/sidepanel/slides-hydrator", ()
       start: vi.fn(async () => {}),
       handlePayload: vi.fn(),
       handleSummaryFromCache: vi.fn(),
+      getActiveRunId: vi.fn(() => null),
       isStreaming: vi.fn(() => false),
       stop: vi.fn(),
       syncFromCache: vi.fn(),

--- a/tests/sidepanel.slides-state.test.ts
+++ b/tests/sidepanel.slides-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildSlideDescriptions,
+  deriveSlideSummaries,
   formatSlideTimestamp,
   resolveSlidesLengthArg,
   resolveSlidesTextState,
@@ -106,6 +107,81 @@ describe("sidepanel slides state", () => {
       slidesTranscriptAvailable: false,
     });
     expect(descriptions.get(1)).toContain("Clear OCR paragraph");
+  });
+
+  it("coerces partial slide summaries so every slide gets summary text", () => {
+    const slides = Array.from({ length: 6 }, (_, index) => ({
+      index: index + 1,
+      timestamp: index * 60,
+      imageUrl: `slide-${index + 1}.png`,
+      ocrText: "",
+    }));
+    const derived = deriveSlideSummaries({
+      markdown: [
+        "Paragraph one summary.",
+        "",
+        "Paragraph two summary.",
+        "",
+        "Paragraph three summary.",
+        "",
+        "### Slides",
+        "[slide:1]",
+        "Direct slide one.",
+        "",
+        "[slide:2]",
+        "Direct slide two.",
+        "",
+        "[slide:3]",
+        "Direct slide three.",
+        "",
+        "[slide:4]",
+        "Direct slide four.",
+        "",
+        "[slide:5]",
+        "Direct slide five.",
+        "",
+        "[slide:6]",
+      ].join("\n"),
+      slides,
+      transcriptTimedText: "[05:00] raw transcript that should not be used",
+      lengthValue: "short",
+    });
+
+    expect(derived?.summaries.get(6)).toBe("Paragraph three summary.");
+    expect(
+      Array.from(derived?.summaries.values() ?? []).some((value) =>
+        value.includes("raw transcript"),
+      ),
+    ).toBe(false);
+  });
+
+  it("uses browser summary paragraphs for local slide card text", () => {
+    const derived = deriveSlideSummaries({
+      markdown: [
+        "## Video title",
+        "",
+        "This browser-generated summary explains the main story in one compact paragraph.",
+        "",
+        "## Key moments",
+        "",
+        "- 0:00 Opening context.",
+        "- 1:00 Middle context.",
+      ].join("\n"),
+      slides: [
+        { index: 1, timestamp: 0, imageUrl: "slide-1.png", ocrText: "" },
+        { index: 2, timestamp: 60, imageUrl: "slide-2.png", ocrText: "" },
+      ],
+      transcriptTimedText: "[00:00] raw transcript text should not win",
+      lengthValue: "short",
+    });
+
+    expect(derived?.summaries.get(1)).toContain("browser-generated summary");
+    expect(derived?.summaries.get(2)).toContain("Opening context");
+    expect(
+      Array.from(derived?.summaries.values() ?? []).some((value) =>
+        value.includes("raw transcript"),
+      ),
+    ).toBe(false);
   });
 
   it("drops gibberish ocr and keeps transcript mode when ocr is not significant", () => {

--- a/tests/sidepanel.slides-text-controller.test.ts
+++ b/tests/sidepanel.slides-text-controller.test.ts
@@ -162,6 +162,33 @@ describe("sidepanel slides text controller", () => {
     expect(controller.getDescriptions().get(2)).toContain("second slide");
   });
 
+  it("keeps transcript fallback for slides not covered by partial summary markdown", () => {
+    const slides = [
+      { index: 1, timestamp: 0, imageUrl: "x", ocrText: null },
+      { index: 2, timestamp: 30, imageUrl: "y", ocrText: null },
+    ];
+    const controller = createSlidesTextController({
+      getSlides: () => slides,
+      getLengthValue: () => "short",
+      getSlidesOcrEnabled: () => true,
+    });
+
+    controller.setTranscriptTimedText(
+      "[00:00] Transcript line for first slide.\n[00:30] Transcript line for second slide.",
+    );
+    controller.syncTextState();
+
+    expect(
+      controller.updateSummaryFromMarkdown(
+        ["[slide:1]", "## First title", "Summary body for the first slide."].join("\n"),
+        { source: "summary" },
+      ),
+    ).toBe(true);
+
+    expect(controller.getDescriptions().get(1)).toBe("Summary body for the first slide.");
+    expect(controller.getDescriptions().get(2)).toContain("Transcript line for second slide");
+  });
+
   it("allows main summary to replace equal-coverage streamed drafts even when shorter", () => {
     const slides = [
       { index: 1, timestamp: 0, imageUrl: "x", ocrText: null },
@@ -247,6 +274,47 @@ describe("sidepanel slides text controller", () => {
     expect(controller.getDescriptions().get(2)).toContain(
       "Refa learns the drink is only lethal once both parts are combined.",
     );
+  });
+
+  it("keeps transcript fallback when a plain summary arrives before local slides", () => {
+    let slides: Array<{
+      index: number;
+      timestamp: number;
+      imageUrl: string;
+      ocrText: string | null;
+    }> = [];
+    const controller = createSlidesTextController({
+      getSlides: () => slides,
+      getLengthValue: () => "short",
+      getSlidesOcrEnabled: () => true,
+    });
+
+    expect(
+      controller.updateSummaryFromMarkdown("A plain video summary without slide markers.", {
+        source: "summary",
+      }),
+    ).toBe(true);
+
+    slides = [
+      { index: 1, timestamp: 0, imageUrl: "x", ocrText: null },
+      { index: 2, timestamp: 30, imageUrl: "y", ocrText: null },
+    ];
+    controller.setTranscriptTimedText(
+      "[00:00] Local slide one transcript text.\n[00:30] Local slide two transcript text.",
+    );
+    controller.syncTextState();
+
+    expect(controller.getDescriptions().get(1)).toContain("Local slide one transcript text");
+    expect(controller.getDescriptions().get(2)).toContain("Local slide two transcript text");
+
+    expect(
+      controller.updateSummaryFromMarkdown("A plain video summary without slide markers.", {
+        source: "summary",
+        preserveIfEmpty: true,
+      }),
+    ).toBe(false);
+    expect(controller.getDescriptions().get(1)).toContain("Local slide one transcript text");
+    expect(controller.getDescriptions().get(2)).toContain("Local slide two transcript text");
   });
 
   it("keeps explicit OCR mode authoritative even after slide summaries arrive", () => {

--- a/tests/sidepanel.summarize-control-runtime.test.ts
+++ b/tests/sidepanel.summarize-control-runtime.test.ts
@@ -60,7 +60,9 @@ function buildRuntime(
   overrides: {
     state?: Partial<ReturnType<typeof baseState>>;
     resolveActiveSlidesRunId?: () => string | null;
+    isActiveSlidesRunLocal?: (runId: string) => boolean;
     slidesTextSetResult?: boolean;
+    settings?: Pick<Settings, "slideRuntime" | "token">;
   } = {},
 ) {
   currentProps = null;
@@ -69,7 +71,9 @@ function buildRuntime(
   const state = buildState(overrides.state);
   const calls = {
     patchSettings: vi.fn(async (_patch: Partial<Settings>) => {}),
-    loadSettings: vi.fn(async () => ({ token: "token" })),
+    loadSettings: vi.fn(
+      async () => overrides.settings ?? { slideRuntime: "browser" as const, token: "token" },
+    ),
     showSlideNotice: vi.fn(),
     hideSlideNotice: vi.fn(),
     setSlidesBusy: vi.fn((value: boolean) => {
@@ -128,6 +132,7 @@ function buildRuntime(
     maybeStartPendingSlidesForUrl: calls.maybeStartPendingSlidesForUrl,
     sendSummarize: calls.sendSummarize,
     resolveActiveSlidesRunId: overrides.resolveActiveSlidesRunId ?? (() => null),
+    isActiveSlidesRunLocal: overrides.isActiveSlidesRunLocal,
     startSlidesStreamForRunId: calls.startSlidesStreamForRunId,
     startSlidesSummaryStreamForRunId: calls.startSlidesSummaryStreamForRunId,
     renderMarkdownDisplay: calls.renderMarkdownDisplay,
@@ -167,7 +172,9 @@ describe("sidepanel summarize control runtime", () => {
         },
       }),
     } as Response);
-    const { state, calls } = buildRuntime();
+    const { state, calls } = buildRuntime({
+      settings: { slideRuntime: "daemon", token: "token" },
+    });
 
     await currentProps?.onChange({ mode: "video", slides: true });
 
@@ -177,6 +184,21 @@ describe("sidepanel summarize control runtime", () => {
     );
     expect(calls.patchSettings).not.toHaveBeenCalled();
     expect(state.slidesEnabled).toBe(false);
+  });
+
+  it("enables browser runtime slides without daemon tool checks", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { state, calls } = buildRuntime({
+      settings: { slideRuntime: "browser", token: "" },
+    });
+
+    await currentProps?.onChange({ mode: "video", slides: true });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(calls.showSlideNotice).not.toHaveBeenCalled();
+    expect(calls.hideSlideNotice).toHaveBeenCalledOnce();
+    expect(calls.patchSettings).toHaveBeenCalledWith({ slidesEnabled: true });
+    expect(state.slidesEnabled).toBe(true);
   });
 
   it("disabling slides stops active work and persists the setting", async () => {
@@ -214,6 +236,20 @@ describe("sidepanel summarize control runtime", () => {
       "slides-run-1",
       "https://example.com/current",
     );
+    expect(calls.sendSummarize).not.toHaveBeenCalled();
+  });
+
+  it("retries local browser slide streams without daemon summary streaming", () => {
+    const { calls, runtime } = buildRuntime({
+      state: { slidesEnabled: true, currentSourceUrl: "https://example.com/current" },
+      resolveActiveSlidesRunId: () => "browser-slides-run",
+      isActiveSlidesRunLocal: (runId) => runId === "browser-slides-run",
+    });
+
+    runtime.retrySlidesStream();
+
+    expect(calls.startSlidesStreamForRunId).toHaveBeenCalledWith("browser-slides-run");
+    expect(calls.startSlidesSummaryStreamForRunId).not.toHaveBeenCalled();
     expect(calls.sendSummarize).not.toHaveBeenCalled();
   });
 

--- a/tests/sidepanel.summary-view-runtime.test.ts
+++ b/tests/sidepanel.summary-view-runtime.test.ts
@@ -87,6 +87,7 @@ describe("summary view runtime", () => {
       clearSlidesSummaryError: vi.fn(),
       updateSlidesTextState: vi.fn(),
       requestSlidesContext: vi.fn(),
+      requestSlidesCapture: vi.fn(),
       updateSlideSummaryFromMarkdown: vi.fn(),
       renderMarkdown: vi.fn(),
       renderMarkdownDisplay: vi.fn(),
@@ -160,6 +161,7 @@ describe("summary view runtime", () => {
       clearSlidesSummaryError: vi.fn(),
       updateSlidesTextState: vi.fn(),
       requestSlidesContext,
+      requestSlidesCapture: vi.fn(),
       updateSlideSummaryFromMarkdown: vi.fn(),
       renderMarkdown: vi.fn(),
       renderMarkdownDisplay: vi.fn(),
@@ -188,6 +190,69 @@ describe("summary view runtime", () => {
 
     expect(setSlidesContextUrl).toHaveBeenCalledWith(null);
     expect(requestSlidesContext).not.toHaveBeenCalled();
+  });
+
+  it("does not request browser slide capture for cached non-YouTube URL-mode pages", () => {
+    const panelState = createPanelState();
+    const requestSlidesCapture = vi.fn();
+    const runtime = createSummaryViewRuntime({
+      panelState,
+      renderEl: document.createElement("div"),
+      renderSlidesHostEl: document.createElement("div"),
+      renderMarkdownHostEl: document.createElement("div"),
+      summaryCopyBtn: document.createElement("button"),
+      getSlidesRenderer: () => ({ clear: vi.fn() }),
+      metricsController: { clearForMode: vi.fn() },
+      headerController: { setBaseTitle: vi.fn(), setBaseSubtitle: vi.fn() },
+      slidesTextController: {
+        reset: vi.fn(),
+        getTranscriptTimedText: vi.fn(() => null),
+        getTranscriptAvailable: vi.fn(() => false),
+      },
+      getSlidesHydrator: () => ({ syncFromCache: vi.fn() }),
+      stopSlidesStream: vi.fn(),
+      refreshSummarizeControl: vi.fn(),
+      resetChatState: vi.fn(),
+      setSlidesTranscriptTimedText: vi.fn(),
+      getSlidesParallelValue: vi.fn(() => true),
+      getCurrentRunTabId: vi.fn(() => null),
+      getActiveTabId: vi.fn(() => 1),
+      getActiveTabUrl: vi.fn(() => "https://x.com/example/status/123"),
+      setCurrentRunTabId: vi.fn(),
+      setSlidesContextPending: vi.fn(),
+      setSlidesContextUrl: vi.fn(),
+      setSlidesSeededSourceId: vi.fn(),
+      setSlidesAppliedRunId: vi.fn(),
+      setSlidesExpanded: vi.fn(),
+      resolveActiveSlidesRunId: vi.fn(() => null),
+      getSlidesSummaryState: vi.fn(() => ({
+        runId: null,
+        markdown: "",
+        complete: false,
+        model: null,
+      })),
+      setSlidesSummaryState: vi.fn(),
+      clearSlidesSummaryPending: vi.fn(),
+      clearSlidesSummaryError: vi.fn(),
+      updateSlidesTextState: vi.fn(),
+      requestSlidesContext: vi.fn(),
+      requestSlidesCapture,
+      updateSlideSummaryFromMarkdown: vi.fn(),
+      renderMarkdown: vi.fn(),
+      renderMarkdownDisplay: vi.fn(),
+      queueSlidesRender: vi.fn(),
+      setPhase: vi.fn(),
+    });
+
+    runtime.applyPanelCache(
+      createCachePayload({
+        url: "https://x.com/example/status/123",
+        summaryMarkdown: "Cached summary",
+        slides: null,
+      }),
+    );
+
+    expect(requestSlidesCapture).not.toHaveBeenCalled();
   });
 
   it("hides the persistent header copy action when resetting the summary view", () => {
@@ -238,6 +303,7 @@ describe("summary view runtime", () => {
       clearSlidesSummaryError: vi.fn(),
       updateSlidesTextState: vi.fn(),
       requestSlidesContext: vi.fn(),
+      requestSlidesCapture: vi.fn(),
       updateSlideSummaryFromMarkdown: vi.fn(),
       renderMarkdown: vi.fn(),
       renderMarkdownDisplay: vi.fn(),

--- a/tests/slides-text.utils.test.ts
+++ b/tests/slides-text.utils.test.ts
@@ -137,6 +137,35 @@ describe("slides text helpers", () => {
     expect(coerced).toContain("Second slide text.");
   });
 
+  it("reuses summary paragraphs instead of transcript filler when slides outnumber paragraphs", () => {
+    const coerced = coerceSummaryWithSlides({
+      markdown: [
+        "The first summary paragraph explains the setup.",
+        "",
+        "The second summary paragraph explains the conflict.",
+        "",
+        "The third summary paragraph explains the resolution.",
+      ].join("\n"),
+      slides: [
+        { index: 1, timestamp: 0 },
+        { index: 2, timestamp: 60 },
+        { index: 3, timestamp: 120 },
+        { index: 4, timestamp: 180 },
+        { index: 5, timestamp: 240 },
+        { index: 6, timestamp: 300 },
+      ],
+      transcriptTimedText:
+        "[00:00] raw transcript one\n[01:00] raw transcript two\n[02:00] raw transcript three",
+      lengthArg: { kind: "preset", preset: "short" },
+      reserveIntro: false,
+    });
+
+    expect(coerced).not.toContain("raw transcript");
+    expect(coerced).toContain("[slide:2]\nThe first summary paragraph explains the setup.");
+    expect(coerced).toContain("[slide:4]\nThe second summary paragraph explains the conflict.");
+    expect(coerced).toContain("[slide:6]\nThe third summary paragraph explains the resolution.");
+  });
+
   it("does not invent slide title lines", () => {
     const slides = [{ index: 1, timestamp: 4 }];
     const coerced = coerceSummaryWithSlides({
@@ -451,6 +480,112 @@ describe("slides text helpers", () => {
     expect(coerced).toContain("[slide:2]");
     expect(coerced).toContain("First body paragraph.");
     expect(coerced).toContain("Second body paragraph.");
+  });
+
+  it("keeps mixed interlude markers when partial slide summaries are present", () => {
+    const slides = [
+      { index: 1, timestamp: 10 },
+      { index: 2, timestamp: 20 },
+    ];
+    const markdown = ["[slide:1]", "Normal slide body.", "", "[slide:2]", "## Interlude"].join(
+      "\n",
+    );
+    const coerced = coerceSummaryWithSlides({
+      markdown,
+      slides,
+      transcriptTimedText: "[00:20] transcript fallback should not replace the interlude",
+      lengthArg: { kind: "preset", preset: "short" },
+    });
+
+    expect(coerced).toContain("[slide:1]\nNormal slide body.");
+    expect(coerced).toContain("[slide:2]\n## Interlude");
+    expect(coerced).not.toContain("[slide:2]\n[slide:2]");
+  });
+
+  it("fills missing partial slide sections from summary paragraphs", () => {
+    const slides = Array.from({ length: 6 }, (_, index) => ({
+      index: index + 1,
+      timestamp: index * 60,
+    }));
+    const markdown = [
+      "Paragraph one summary.",
+      "",
+      "Paragraph two summary.",
+      "",
+      "Paragraph three summary.",
+      "",
+      "### Slides",
+      "[slide:1]",
+      "Direct slide one.",
+      "",
+      "[slide:2]",
+      "Direct slide two.",
+      "",
+      "[slide:3]",
+      "Direct slide three.",
+      "",
+      "[slide:4]",
+      "Direct slide four.",
+      "",
+      "[slide:5]",
+      "Direct slide five.",
+      "",
+      "[slide:6]",
+    ].join("\n");
+    const coerced = coerceSummaryWithSlides({
+      markdown,
+      slides,
+      transcriptTimedText: "[05:00] raw transcript that should not be used",
+      lengthArg: { kind: "preset", preset: "short" },
+      reserveIntro: false,
+    });
+
+    expect(coerced).toContain("[slide:6]\nParagraph three summary.");
+    expect(coerced).not.toContain("raw transcript");
+  });
+
+  it("replaces title-only partial slide sections with summary paragraphs", () => {
+    const slides = Array.from({ length: 6 }, (_, index) => ({
+      index: index + 1,
+      timestamp: index * 60,
+    }));
+    const markdown = [
+      "Paragraph one summary.",
+      "",
+      "Paragraph two summary.",
+      "",
+      "Paragraph three summary.",
+      "",
+      "### Slides",
+      "[slide:1]",
+      "Direct slide one.",
+      "",
+      "[slide:2]",
+      "Direct slide two.",
+      "",
+      "[slide:3]",
+      "Direct slide three.",
+      "",
+      "[slide:4]",
+      "Direct slide four.",
+      "",
+      "[slide:5]",
+      "Direct slide five.",
+      "",
+      "[slide:6]",
+      "Slide 6/6 · 5:17",
+    ].join("\n");
+    const coerced = coerceSummaryWithSlides({
+      markdown,
+      slides,
+      transcriptTimedText: "[05:00] raw transcript that should not be used",
+      lengthArg: { kind: "preset", preset: "short" },
+      reserveIntro: false,
+    });
+
+    expect(coerced).toContain("[slide:6]\nParagraph three summary.");
+    expect(coerced).not.toContain("raw transcript");
+    expect(coerced).not.toContain("Slide 6/6 · 5:17");
   });
 
   it("parses transcript timed text and sorts by timestamp", () => {


### PR DESCRIPTION
## Summary

- add a daemonless Browser runtime path for extension summaries and YouTube slide capture
- persist Browser-mode sidepanel snapshots in Chrome storage for 30 days, including summaries, slide text, transcript context, and data-URL thumbnails
- add Runtime settings cache status/clear controls, durable clear invalidation, Incognito exclusion, and async cache race guards

## Proof

- autoreview clean: no accepted/actionable findings reported
- pnpm -s check
- pnpm -C apps/chrome-extension test:chrome
