### PR TITLE
feat: add pi CLI as a backend provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- CLI providers: add pi CLI as `--cli pi` / `--model cli/pi`, with JSON-mode parsing, stdin prompts, configurable binary/model, and daemon/Chrome model picker support (#247, thanks @Youpen-y).
 - Add Antigravity CLI (`agy`) as a supported CLI provider. (#231, thanks @yetmike)
 - Chrome extension: add Browser slide runtime so YouTube slide summaries can run without the daemon, while keeping Daemon as an optional faster runtime.
 - Chrome extension: persist Browser-mode summaries, slide text, transcripts, and thumbnails in Chrome storage for 30 days, with Runtime settings showing cache status and a clear button.

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Use `summarize --help` or `summarize help` for the full help text.
 - `--length short|medium|long|xl|xxl|s|m|l|<chars>`
 - `--language, --lang <language>`: output language (`auto` = match source)
 - `--max-output-tokens <count>`: hard cap for LLM output tokens
-- `--cli [provider]`: use a CLI provider (`--model cli/<provider>`). Supports `claude`, `gemini`, `codex`, `agent`, `openclaw`, `opencode`, `agy`. If omitted, uses auto selection with CLI enabled.
+- `--cli [provider]`: use a CLI provider (`--model cli/<provider>`). Supports `claude`, `gemini`, `codex`, `agent`, `openclaw`, `opencode`, `agy`, `pi`. If omitted, uses auto selection with CLI enabled.
 - `--stream auto|on|off`: stream LLM output (`auto` = TTY only; disabled in `--json` mode)
 - `--plain`: keep raw output (no ANSI/OSC Markdown rendering)
 - `--no-color`: disable ANSI colors
@@ -365,6 +365,7 @@ Summarize can use common coding CLIs as local model backends:
 - `openclaw` -> `--cli openclaw` / `--model cli/openclaw/<model>` or `--model openclaw/<model>`
 - `opencode` -> `--cli opencode` / `--model cli/opencode/<model>` (`--model cli/opencode` uses the OpenCode runtime default)
 - `agy` (Antigravity CLI) -> `--cli agy` / `--model cli/agy` (uses agy's active session model; per-call model selection is not supported by agy print mode)
+- `pi` (Pi Coding Agent) -> `--cli pi` / `--model cli/pi` or `--model cli/pi/<model>`
 
 Built-in preset:
 
@@ -372,8 +373,8 @@ Built-in preset:
 
 Requirements:
 
-- Binary installed and on `PATH` (or set `CODEX_PATH`, `CLAUDE_PATH`, `GEMINI_PATH`, `AGENT_PATH`, `OPENCLAW_PATH`, `OPENCODE_PATH`, `AGY_PATH`)
-- Provider authenticated (`codex login`, `claude auth`, `gemini` login flow, `agent login` or `CURSOR_API_KEY`, `opencode auth login`, `agy` login flow or `ANTIGRAVITY_API_KEY`)
+- Binary installed and on `PATH` (or set `CODEX_PATH`, `CLAUDE_PATH`, `GEMINI_PATH`, `AGENT_PATH`, `OPENCLAW_PATH`, `OPENCODE_PATH`, `AGY_PATH`, `PI_PATH`)
+- Provider authenticated (`codex login`, `claude auth`, `gemini` login flow, `agent login` or `CURSOR_API_KEY`, `opencode auth login`, `agy` login flow or `ANTIGRAVITY_API_KEY`, `pi` uses configured provider API keys)
 
 Quick smoke test:
 
@@ -387,13 +388,14 @@ summarize --cli agent --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 summarize --cli openclaw --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 summarize --cli opencode --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 summarize --cli agy --plain --timeout 2m /tmp/summarize-cli-smoke.txt
+summarize --cli pi --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 ```
 
 Set explicit CLI allowlist/order:
 
 ```json
 {
-  "cli": { "enabled": ["codex", "claude", "gemini", "agent", "openclaw", "opencode", "agy"] }
+  "cli": { "enabled": ["codex", "claude", "gemini", "agent", "openclaw", "opencode", "agy", "pi"] }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fast summaries from URLs, files, and media. Works in the terminal, a Chrome Side
 - URLs, files, and media: web pages, PDFs, images, audio/video, YouTube, podcasts, RSS.
 - Slide extraction for video sources (YouTube, direct video URLs, local video files) with OCR + timestamped cards.
 - Transcript-first media flow: published transcripts when available, then Groq/ONNX/whisper.cpp/AssemblyAI/Gemini/OpenAI/FAL transcription fallback when not.
-- Coding CLI providers: Claude, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode.
+- Coding CLI providers: Claude, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode, GitHub Copilot, Antigravity, pi.
 - Streaming output with Markdown rendering, metrics, and cache-aware status.
 - Local, paid, and free models: OpenAI‑compatible local endpoints, paid providers, plus an OpenRouter free preset.
 - Output modes: Markdown/text, JSON diagnostics, extract-only, metrics, timing, and cost estimates.
@@ -332,7 +332,7 @@ Use `summarize --help` or `summarize help` for the full help text.
 - `--length short|medium|long|xl|xxl|s|m|l|<chars>`
 - `--language, --lang <language>`: output language (`auto` = match source)
 - `--max-output-tokens <count>`: hard cap for LLM output tokens
-- `--cli [provider]`: use a CLI provider (`--model cli/<provider>`). Supports `claude`, `gemini`, `codex`, `agent`, `openclaw`, `opencode`, `agy`, `pi`. If omitted, uses auto selection with CLI enabled.
+- `--cli [provider]`: use a CLI provider (`--model cli/<provider>`). Supports `claude`, `gemini`, `codex`, `agent`, `openclaw`, `opencode`, `copilot`, `agy`, `pi`. If omitted, uses auto selection with CLI enabled.
 - `--stream auto|on|off`: stream LLM output (`auto` = TTY only; disabled in `--json` mode)
 - `--plain`: keep raw output (no ANSI/OSC Markdown rendering)
 - `--no-color`: disable ANSI colors
@@ -354,7 +354,7 @@ Use `summarize --help` or `summarize help` for the full help text.
 - `--verbose`: debug/diagnostics on stderr
 - `--metrics off|on|detailed`: metrics output (default `on`)
 
-### Coding CLIs (Codex, Claude, Gemini, Agent, OpenClaw, OpenCode, Antigravity)
+### Coding CLIs (Codex, Claude, Gemini, Agent, OpenClaw, OpenCode, Copilot, Antigravity, pi)
 
 Summarize can use common coding CLIs as local model backends:
 
@@ -423,7 +423,7 @@ CLI attempts are prepended when:
 - `cli.enabled` is set (explicit allowlist/order), or
 - implicit auto selection is active and `cli.autoFallback` is enabled.
 
-Default fallback behavior: only when no API keys are configured, order `claude, gemini, codex, agent, openclaw, opencode`, and remember/prioritize last successful provider (`~/.summarize/cli-state.json`).
+Default fallback behavior: only when no API keys are configured, order `claude, gemini, codex, agent, openclaw, opencode, copilot`, and remember/prioritize last successful provider (`~/.summarize/cli-state.json`). Antigravity and pi are opt-in unless you add them to `cli.autoFallback.order`.
 
 Set explicit CLI attempts:
 

--- a/apps/chrome-extension/src/entrypoints/options/index.html
+++ b/apps/chrome-extension/src/entrypoints/options/index.html
@@ -425,11 +425,11 @@
                     <input
                       id="autoCliOrder"
                       type="text"
-                      placeholder="claude,gemini,codex,agent,openclaw,opencode,copilot"
+                      placeholder="claude,gemini,codex,agent,openclaw,opencode,copilot,pi"
                     />
                     <span class="subtitle">
                       Comma-separated providers (claude, gemini, codex, agent, openclaw, opencode,
-                      copilot).
+                      copilot, pi).
                     </span>
                   </label>
                 </div>

--- a/apps/chrome-extension/src/entrypoints/options/model-presets.ts
+++ b/apps/chrome-extension/src/entrypoints/options/model-presets.ts
@@ -46,6 +46,8 @@ export function createModelPresetsController({
       if (p.cliOpenclaw === true) hints.push("cli/openclaw");
       if (p.cliOpencode === true) hints.push("cli/opencode");
       if (p.cliCopilot === true) hints.push("cli/copilot");
+      if (p.cliAgy === true) hints.push("cli/agy");
+      if (p.cliPi === true) hints.push("cli/pi");
     }
     if (discovery.localModelsSource && typeof discovery.localModelsSource === "object") {
       hints.push("local: openai/<id>");

--- a/apps/chrome-extension/src/lib/settings.ts
+++ b/apps/chrome-extension/src/lib/settings.ts
@@ -154,7 +154,8 @@ function normalizeAutoCliOrder(value: unknown): string {
       item !== "openclaw" &&
       item !== "opencode" &&
       item !== "copilot" &&
-      item !== "agy"
+      item !== "agy" &&
+      item !== "pi"
     ) {
       continue;
     }
@@ -327,7 +328,7 @@ export const defaultSettings: Settings = {
   summaryTimestamps: true,
   extendedLogging: false,
   autoCliFallback: true,
-  autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot",
+  autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot,pi",
   hoverPrompt:
     "Plain text only (no Markdown). Summarize the linked page concisely in 1-2 sentences; aim for 100-200 characters.",
   transcriber: "",

--- a/apps/chrome-extension/src/lib/settings.ts
+++ b/apps/chrome-extension/src/lib/settings.ts
@@ -328,7 +328,7 @@ export const defaultSettings: Settings = {
   summaryTimestamps: true,
   extendedLogging: false,
   autoCliFallback: true,
-  autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot,pi",
+  autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot",
   hoverPrompt:
     "Plain text only (no Markdown). Summarize the linked page concisely in 1-2 sentences; aim for 100-200 characters.",
   transcriber: "",

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ summary: "Docs index for summarize behaviors and modes."
 
 - `docs/chrome-extension.md` — Chrome side panel extension + daemon setup/troubleshooting
 - `docs/cache.md` — cache design + config (SQLite)
-- `docs/cli.md` — CLI models (Claude/Codex/Gemini/Agent/OpenClaw/OpenCode/Copilot/Antigravity)
+- `docs/cli.md` — CLI models (Claude/Codex/Gemini/Agent/OpenClaw/OpenCode/Copilot/Antigravity/pi)
 - `docs/config.md` — config file location, precedence, and schema
 - `docs/extract-only.md` — extract mode (no summary LLM call)
 - `docs/firecrawl.md` — Firecrawl mode + API key

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,7 +27,7 @@ Summarize can use installed CLIs (Claude, Codex, Gemini, Cursor Agent, OpenClaw,
 - `cli/pi` (use pi's configured default model)
 
 Use `--cli [provider]` (case-insensitive) for the provider default, or `--model cli/<provider>/<model>` to pin a model.
-Antigravity does not support per-call model selection in print mode, so use `cli/agy` without a model suffix.
+Antigravity does not support per-call model selection in print mode, so use `cli/agy` without a model suffix. pi supports `cli/pi/<model>` or a configured `cli.pi.model`.
 If `--cli` is provided without a provider, auto selection is used with CLI enabled.
 
 Codex GPT Fast:
@@ -46,6 +46,7 @@ Auto mode can prepend CLI attempts in two ways:
   - Applies only to **implicit** auto (when no model is set via flag/env/config).
   - Default behavior: only when no API key is configured.
   - Default order: `claude, gemini, codex, agent, openclaw, opencode, copilot`.
+  - Antigravity and pi are opt-in unless added to `cli.autoFallback.order`.
   - Remembers + prioritizes the last successful CLI provider (`~/.summarize/cli-state.json`).
 
 Gemini CLI performance: summarize sets `GEMINI_CLI_NO_RELAUNCH=true` for Gemini CLI runs to avoid a costly self-relaunch (can be overridden by setting it yourself).
@@ -105,14 +106,24 @@ path-based prompt and enables the required tool flags:
 - OpenCode: `opencode run --format json ... --file <path>` when a file/image path is required
 - Copilot: `copilot -p <prompt>`; passes `--model <model>` when one is configured
 - Antigravity: `agy --print`; does not auto-approve tools for attachment prompts
-- pi: `pi --print --mode json`; passes `--system-prompt` and `--no-tools` for isolated summaries
+- pi: `pi --print --mode json`; passes `--system-prompt`, sends prompt over stdin, and uses `--no-tools` for isolated summaries
 
 ## Config
 
 ```json
 {
   "cli": {
-    "enabled": ["claude", "gemini", "codex", "agent", "openclaw", "opencode", "copilot", "agy", "pi"],
+    "enabled": [
+      "claude",
+      "gemini",
+      "codex",
+      "agent",
+      "openclaw",
+      "opencode",
+      "copilot",
+      "agy",
+      "pi"
+    ],
     "autoFallback": {
       "enabled": true,
       "onlyWhenNoApiKeys": true,
@@ -156,7 +167,7 @@ Notes:
 - Cursor Agent CLI uses the `agent` binary and relies on Cursor CLI auth (login or `CURSOR_API_KEY`).
 - Antigravity CLI uses the active agy session model; `cli.agy.model` is ignored by runtime selection.
 - Antigravity normal text summaries run `agy --print` with no prompt argument in a temporary cwd with `--sandbox`, streaming the prompt over stdin so extracted content is not exposed in argv. Attachment prompts keep the caller cwd so agy can inspect the requested path but do not auto-approve tools.
-- pi runs in JSON mode (`--print --mode json`) with `--no-tools`, `--no-context-files`, `--no-extensions`, `--no-skills`, `--no-session` for isolated summarization. It receives the summarize system prompt via `--system-prompt` and reports usage/cost via JSONL events. Use `PI_PATH` to override the binary path.
+- pi runs in JSON mode (`--print --mode json`) with `--no-tools`, `--no-context-files`, `--no-extensions`, `--no-skills`, `--no-session` for isolated summarization. It receives the summarize system prompt via `--system-prompt`, the summarize prompt over stdin, and reports usage/cost via JSONL events. Use `PI_PATH` to override the binary path.
 - Codex CLI normal text summaries run isolated by default: `codex exec --ephemeral --ignore-user-config --ignore-rules -C <temp-dir> ...` with a sanitized temporary `CODEX_HOME` that carries auth only. Set `cli.codex.isolated` to `false` only when you intentionally need Codex to inherit local config/rules.
 - Gemini CLI is invoked in headless mode with `--prompt` for compatibility with current Gemini CLI releases.
 - OpenClaw uses `openclaw agent --agent <model> --message <prompt> --json` because current OpenClaw requires `-m/--message`; very large extracted inputs are rejected before launch to avoid argv limits.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,14 +1,14 @@
 ---
 title: "CLI providers"
 kicker: "models"
-summary: "CLI model providers and config for Claude, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode, GitHub Copilot, and Antigravity."
+summary: "CLI model providers and config for Claude, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode, GitHub Copilot, Antigravity, and pi."
 read_when:
   - "When changing CLI model integration."
 ---
 
 # CLI models
 
-Summarize can use installed CLIs (Claude, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode, GitHub Copilot, Antigravity) as local model backends.
+Summarize can use installed CLIs (Claude, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode, GitHub Copilot, Antigravity, pi) as local model backends.
 
 ## Model ids
 
@@ -23,6 +23,8 @@ Summarize can use installed CLIs (Claude, Codex, Gemini, Cursor Agent, OpenClaw,
 - `cli/copilot/<model>` (e.g. `cli/copilot/gpt-5.2`)
 - `cli/copilot` (use the Copilot CLI runtime default model)
 - `cli/agy` (use the Antigravity CLI active session model)
+- `cli/pi/<model>` (e.g. `cli/pi/sonnet`)
+- `cli/pi` (use pi's configured default model)
 
 Use `--cli [provider]` (case-insensitive) for the provider default, or `--model cli/<provider>/<model>` to pin a model.
 Antigravity does not support per-call model selection in print mode, so use `cli/agy` without a model suffix.
@@ -103,13 +105,14 @@ path-based prompt and enables the required tool flags:
 - OpenCode: `opencode run --format json ... --file <path>` when a file/image path is required
 - Copilot: `copilot -p <prompt>`; passes `--model <model>` when one is configured
 - Antigravity: `agy --print`; does not auto-approve tools for attachment prompts
+- pi: `pi --print --mode json`; passes `--system-prompt` and `--no-tools` for isolated summaries
 
 ## Config
 
 ```json
 {
   "cli": {
-    "enabled": ["claude", "gemini", "codex", "agent", "openclaw", "opencode", "copilot", "agy"],
+    "enabled": ["claude", "gemini", "codex", "agent", "openclaw", "opencode", "copilot", "agy", "pi"],
     "autoFallback": {
       "enabled": true,
       "onlyWhenNoApiKeys": true,
@@ -138,6 +141,9 @@ path-based prompt and enables the required tool flags:
     },
     "agy": {
       "binary": "/usr/local/bin/agy"
+    },
+    "pi": {
+      "binary": "/usr/local/bin/pi"
     }
   }
 }
@@ -150,6 +156,7 @@ Notes:
 - Cursor Agent CLI uses the `agent` binary and relies on Cursor CLI auth (login or `CURSOR_API_KEY`).
 - Antigravity CLI uses the active agy session model; `cli.agy.model` is ignored by runtime selection.
 - Antigravity normal text summaries run `agy --print` with no prompt argument in a temporary cwd with `--sandbox`, streaming the prompt over stdin so extracted content is not exposed in argv. Attachment prompts keep the caller cwd so agy can inspect the requested path but do not auto-approve tools.
+- pi runs in JSON mode (`--print --mode json`) with `--no-tools`, `--no-context-files`, `--no-extensions`, `--no-skills`, `--no-session` for isolated summarization. It receives the summarize system prompt via `--system-prompt` and reports usage/cost via JSONL events. Use `PI_PATH` to override the binary path.
 - Codex CLI normal text summaries run isolated by default: `codex exec --ephemeral --ignore-user-config --ignore-rules -C <temp-dir> ...` with a sanitized temporary `CODEX_HOME` that carries auth only. Set `cli.codex.isolated` to `false` only when you intentionally need Codex to inherit local config/rules.
 - Gemini CLI is invoked in headless mode with `--prompt` for compatibility with current Gemini CLI releases.
 - OpenClaw uses `openclaw agent --agent <model> --message <prompt> --json` because current OpenClaw requires `-m/--message`; very large extracted inputs are rejected before launch to avoid argv limits.
@@ -170,6 +177,7 @@ summarize --cli agent --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 summarize --cli openclaw --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 summarize --cli opencode --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 summarize --cli copilot --plain --timeout 2m /tmp/summarize-cli-smoke.txt
+summarize --cli pi --plain --timeout 2m /tmp/summarize-cli-smoke.txt
 ```
 
 If Agent fails with auth, run `agent login` (interactive) or set `CURSOR_API_KEY`.

--- a/docs/commands/summarize.md
+++ b/docs/commands/summarize.md
@@ -112,7 +112,7 @@ If `[input]` is omitted, summarize prints concise help and exits.
 : Model id. `auto`, `<config-preset>`, `cli/<provider>/<model>`, `xai/...`, `openai/...`, `nvidia/...`, `google/...`, `anthropic/...`, `zai/...`, `github-copilot/...`, or `openrouter/<author>/<slug>`. Default `auto`. See [LLM overview](../llm.md).
 
 `--cli [provider]`
-: Use a logged-in CLI provider: `claude`, `gemini`, `codex`, `agent`, `openclaw`, `opencode`, `copilot`. Equivalent to `--model cli/<provider>`. Without a value: enable CLI providers in auto-selection.
+: Use a logged-in CLI provider: `claude`, `gemini`, `codex`, `agent`, `openclaw`, `opencode`, `copilot`, `agy`, `pi`. Equivalent to `--model cli/<provider>`. Without a value: enable CLI providers in auto-selection.
 
 `--thinking <effort>`
 : OpenAI reasoning effort. `none`, `low`, `medium`, `high`, `xhigh`. Aliases: `off`, `min`, `mid`. Only affects reasoning-capable OpenAI models.

--- a/docs/config.md
+++ b/docs/config.md
@@ -362,7 +362,7 @@ Examples:
 ```json
 {
   "cli": {
-    "enabled": ["gemini", "agent", "openclaw", "opencode", "copilot", "agy"],
+    "enabled": ["gemini", "agent", "openclaw", "opencode", "copilot", "agy", "pi"],
     "autoFallback": {
       "enabled": true,
       "onlyWhenNoApiKeys": true,
@@ -374,7 +374,8 @@ Examples:
     "openclaw": { "binary": "/usr/local/bin/openclaw", "model": "main" },
     "opencode": { "binary": "/usr/local/bin/opencode", "model": "openai/gpt-5.4" },
     "copilot": { "binary": "/usr/local/bin/copilot", "model": "gpt-5.2" },
-    "agy": { "binary": "/usr/local/bin/agy" }
+    "agy": { "binary": "/usr/local/bin/agy" },
+    "pi": { "binary": "/usr/local/bin/pi" }
   }
 }
 ```
@@ -388,6 +389,7 @@ Notes:
 - `cli.<provider>.binary` overrides CLI binary discovery.
 - `cli.<provider>.extraArgs` appends extra CLI args.
 - Antigravity CLI uses the active agy session model; `cli.agy.model` is ignored by runtime selection.
+- pi CLI runs `pi --print --mode json` with system prompt; use `PI_PATH` to override binary.
 - `cli.codex.isolated` defaults to `true` for normal summaries, adding Codex ephemeral/no-user-config/no-rules flags, a temporary cwd, and a sanitized temporary `CODEX_HOME` that carries auth only. Set it to `false` only when local Codex config/rules are intentional.
 
 ## OpenAI config

--- a/docs/config.md
+++ b/docs/config.md
@@ -385,11 +385,12 @@ Notes:
 - `cli.enabled` is an allowlist (and order) for auto + explicit CLI model ids.
 - `cli.autoFallback` controls implicit-auto CLI fallback when `cli.enabled` is not set.
 - Default auto fallback order: `claude, gemini, codex, agent, openclaw, opencode, copilot`.
+- Antigravity and pi are opt-in unless added to `cli.autoFallback.order`.
 - Auto fallback stores the last successful provider in `~/.summarize/cli-state.json` and prioritizes it on the next run.
 - `cli.<provider>.binary` overrides CLI binary discovery.
 - `cli.<provider>.extraArgs` appends extra CLI args.
 - Antigravity CLI uses the active agy session model; `cli.agy.model` is ignored by runtime selection.
-- pi CLI runs `pi --print --mode json` with system prompt; use `PI_PATH` to override binary.
+- pi CLI runs `pi --print --mode json`, passes extracted content over stdin, and accepts configured or per-call models; use `PI_PATH` to override binary.
 - `cli.codex.isolated` defaults to `true` for normal summaries, adding Codex ephemeral/no-user-config/no-rules flags, a temporary cwd, and a sanitized temporary `CODEX_HOME` that carries auth only. Set it to `false` only when local Codex config/rules are intentional.
 
 ## OpenAI config

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ summarize "https://example.com" --json --metrics detailed
 
 - **Real extraction.** Readability for articles, `markitdown` for files, Firecrawl as a fallback when sites fight back.
 - **Media-aware.** YouTube and podcast pages prefer published transcripts, then `yt-dlp` + Whisper, then optional ONNX models (Parakeet/Canary).
-- **Provider-agnostic models.** xAI, OpenAI, Google, Anthropic, NVIDIA, Z.AI, OpenRouter, GitHub Copilot, Ollama (local) — plus local CLI providers (Claude Code, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode, Copilot CLI).
+- **Provider-agnostic models.** xAI, OpenAI, Google, Anthropic, NVIDIA, Z.AI, OpenRouter, GitHub Copilot, Ollama (local) — plus local CLI providers (Claude Code, Codex, Gemini, Cursor Agent, OpenClaw, OpenCode, Copilot CLI, Antigravity, pi).
 - **Shaped output.** Streamed ANSI Markdown for terminals, plain text for pipes, JSON envelope for scripts, ANSI-stripped under `--no-color`.
 - **Slides for video.** `--slides` extracts scene-change keyframes and renders them inline (Kitty / iTerm) or saves them to disk.
 - **Stays local.** Optional daemon + Chrome Side Panel pair the CLI with the active tab. The daemon binds to `127.0.0.1` only and uses a shared bearer token.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -38,7 +38,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
 - `ANTHROPIC_API_KEY` (required for `anthropic/...` models)
 - `ANTHROPIC_BASE_URL` (optional; override Anthropic API endpoint)
 - `SUMMARIZE_MODEL` (optional; overrides default model selection)
-- `CLAUDE_PATH` / `CODEX_PATH` / `GEMINI_PATH` / `AGENT_PATH` / `OPENCLAW_PATH` / `OPENCODE_PATH` / `COPILOT_PATH` / `AGY_PATH` (optional; override CLI binary paths)
+- `CLAUDE_PATH` / `CODEX_PATH` / `GEMINI_PATH` / `AGENT_PATH` / `OPENCLAW_PATH` / `OPENCODE_PATH` / `COPILOT_PATH` / `AGY_PATH` / `PI_PATH` (optional; override CLI binary paths)
 
 ## Flags
 
@@ -54,6 +54,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
     - `cli/opencode/openai/gpt-5.4`
     - `cli/copilot/gpt-5.2`
     - `cli/agy`
+    - `cli/pi/openai/gpt-5.4`
     - `openai/gpt-5.4`
     - `openai/gpt-5.4-mini`
     - `openai/gpt-5.4-nano`
@@ -70,7 +71,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
     - `anthropic/claude-sonnet-4-5`
     - `openrouter/meta-llama/llama-3.3-70b-instruct:free` (force OpenRouter)
 - `--cli [provider]`
-  - Examples: `--cli claude`, `--cli Gemini`, `--cli codex`, `--cli agent`, `--cli openclaw`, `--cli opencode`, `--cli copilot`, `--cli agy` (equivalent to `--model cli/<provider>`); `--cli` alone uses auto selection with CLI enabled.
+  - Examples: `--cli claude`, `--cli Gemini`, `--cli codex`, `--cli agent`, `--cli openclaw`, `--cli opencode`, `--cli copilot`, `--cli agy`, `--cli pi` (equivalent to `--model cli/<provider>`); `--cli` alone uses auto selection with CLI enabled.
 - `--model auto`
   - See `docs/model-auto.md`
 - `--model <preset>`

--- a/src/config/parse-helpers.ts
+++ b/src/config/parse-helpers.ts
@@ -18,7 +18,8 @@ export function parseCliProvider(value: unknown, path: string): CliProvider {
     trimmed === "openclaw" ||
     trimmed === "opencode" ||
     trimmed === "copilot" ||
-    trimmed === "agy"
+    trimmed === "agy" ||
+    trimmed === "pi"
   ) {
     return trimmed as CliProvider;
   }

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -326,6 +326,7 @@ export function parseCliConfig(root: Record<string, unknown>, path: string): Cli
     ? parseCliProviderConfig(value.copilot, path, "copilot")
     : undefined;
   const agy = value.agy ? parseCliProviderConfig(value.agy, path, "agy") : undefined;
+  const pi = value.pi ? parseCliProviderConfig(value.pi, path, "pi") : undefined;
   if (typeof value.autoFallback !== "undefined" && typeof value.magicAuto !== "undefined") {
     throw new Error(
       `Invalid config file ${path}: use only one of "cli.autoFallback" or legacy "cli.magicAuto".`,
@@ -361,6 +362,7 @@ export function parseCliConfig(root: Record<string, unknown>, path: string): Cli
     opencode ||
     copilot ||
     agy ||
+    pi ||
     autoFallback ||
     promptOverride ||
     typeof allowTools === "boolean" ||
@@ -376,6 +378,7 @@ export function parseCliConfig(root: Record<string, unknown>, path: string): Cli
         ...(opencode ? { opencode } : {}),
         ...(copilot ? { copilot } : {}),
         ...(agy ? { agy } : {}),
+        ...(pi ? { pi } : {}),
         ...(autoFallback ? { autoFallback } : {}),
         ...(promptOverride ? { promptOverride } : {}),
         ...(typeof allowTools === "boolean" ? { allowTools } : {}),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -8,7 +8,8 @@ export type CliProvider =
   | "openclaw"
   | "opencode"
   | "copilot"
-  | "agy";
+  | "agy"
+  | "pi";
 export type OpenAiReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh";
 export type OpenAiTextVerbosity = "low" | "medium" | "high";
 export type ModelRequestOptions = {
@@ -38,6 +39,7 @@ export type CliConfig = {
   opencode?: CliProviderConfig;
   copilot?: CliProviderConfig;
   agy?: CliProviderConfig;
+  pi?: CliProviderConfig;
   autoFallback?: CliAutoFallbackConfig;
   magicAuto?: CliAutoFallbackConfig;
   promptOverride?: string;

--- a/src/daemon/agent-model.ts
+++ b/src/daemon/agent-model.ts
@@ -215,6 +215,7 @@ function buildNoAgentModelAvailableError({
           if (attempt.requiredEnv === "CLI_OPENCODE") return "opencode";
           if (attempt.requiredEnv === "CLI_COPILOT") return "copilot";
           if (attempt.requiredEnv === "CLI_AGY") return "agy";
+          if (attempt.requiredEnv === "CLI_PI") return "pi";
           return "unknown";
         })
         .filter((provider) => !cliAvailability[provider as keyof typeof cliAvailability]),

--- a/src/daemon/chat.ts
+++ b/src/daemon/chat.ts
@@ -47,7 +47,9 @@ function resolveConfiguredCliModel(
                 ? cli?.opencode?.model
                 : provider === "agy"
                   ? null
-                  : cli?.copilot?.model;
+                  : provider === "pi"
+                    ? cli?.pi?.model
+                    : cli?.copilot?.model;
   return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;
 }
 

--- a/src/daemon/models.ts
+++ b/src/daemon/models.ts
@@ -143,6 +143,7 @@ export async function buildModelPickerOptions({
     cliOpencode: boolean;
     cliCopilot: boolean;
     cliAgy: boolean;
+    cliPi: boolean;
   };
   openaiBaseUrl: string | null;
   localModelsSource: { kind: "openai-compatible"; baseUrlHost: string } | null;
@@ -166,6 +167,7 @@ export async function buildModelPickerOptions({
     cliOpencode: false,
     cliCopilot: false,
     cliAgy: false,
+    cliPi: false,
   };
   const cliAvailability = resolveCliAvailability({ env: envForRun, config: configForCli });
   providers.cliClaude = Boolean(cliAvailability.claude);
@@ -176,6 +178,7 @@ export async function buildModelPickerOptions({
   providers.cliOpencode = Boolean(cliAvailability.opencode);
   providers.cliCopilot = Boolean(cliAvailability.copilot);
   providers.cliAgy = Boolean(cliAvailability.agy);
+  providers.cliPi = Boolean(cliAvailability.pi);
 
   const options: ModelPickerOption[] = [
     { id: "auto", label: "Auto" },
@@ -206,6 +209,9 @@ export async function buildModelPickerOptions({
   }
   if (providers.cliAgy) {
     options.push({ id: "cli/agy", label: "CLI: Antigravity (agy)" });
+  }
+  if (providers.cliPi) {
+    options.push({ id: "cli/pi", label: "CLI: pi" });
   }
 
   if (providers.openrouter) {

--- a/src/llm/cli-provider-output.ts
+++ b/src/llm/cli-provider-output.ts
@@ -3,7 +3,7 @@ import type { LlmTokenUsage } from "./generate-text.js";
 
 export type JsonCliProvider = Exclude<
   CliProvider,
-  "codex" | "openclaw" | "opencode" | "copilot" | "agy"
+  "codex" | "openclaw" | "opencode" | "copilot" | "agy" | "pi"
 >;
 
 const JSON_RESULT_FIELDS = ["result", "response", "output", "message", "text"] as const;
@@ -14,7 +14,8 @@ export function isJsonCliProvider(provider: CliProvider): provider is JsonCliPro
     provider !== "openclaw" &&
     provider !== "opencode" &&
     provider !== "copilot" &&
-    provider !== "agy"
+    provider !== "agy" &&
+    provider !== "pi"
   );
 }
 
@@ -453,6 +454,107 @@ export function parseJsonProviderOutput(args: { provider: JsonCliProvider; stdou
         };
       }
     }
+  }
+  return { text: trimmed, usage: null, costUsd: null };
+}
+
+// ── pi CLI parser (JSONL) ────────────────────────────────────────────────
+
+function parsePiUsage(usage: unknown): LlmTokenUsage | null {
+  if (!usage || typeof usage !== "object") return null;
+  const record = usage as Record<string, unknown>;
+  const promptTokens = toNumber(record.input);
+  const completionTokens = toNumber(record.output);
+  const totalTokens = toNumber(record.totalTokens);
+  if (promptTokens === null && completionTokens === null && totalTokens === null) return null;
+  return { promptTokens, completionTokens, totalTokens };
+}
+
+function parsePiCost(usage: unknown): number | null {
+  if (!usage || typeof usage !== "object") return null;
+  const record = usage as Record<string, unknown>;
+  const cost = record.cost;
+  if (!cost || typeof cost !== "object") return null;
+  return toNumber((cost as Record<string, unknown>).total);
+}
+
+function extractPiTextContent(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(
+      (block): block is { type: string; text: string } =>
+        block && typeof block === "object" && (block as Record<string, unknown>).type === "text",
+    )
+    .map((block) => block.text)
+    .filter((text) => typeof text === "string" && text.trim().length > 0)
+    .join("")
+    .trim();
+}
+
+export function parsePiOutputFromJsonl(output: string): {
+  text: string;
+  usage: LlmTokenUsage | null;
+  costUsd: number | null;
+} {
+  const trimmed = output.trim();
+  if (!trimmed) {
+    throw new Error("CLI returned empty output");
+  }
+
+  const lines = trimmed
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const textDeltaParts: string[] = [];
+  let fullText: string | null = null;
+  let usage: LlmTokenUsage | null = null;
+  let costUsd: number | null = null;
+  let sawStructuredEvent = false;
+
+  for (const line of lines) {
+    if (!line.startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      sawStructuredEvent = true;
+
+      // Collect text deltas from streaming events.
+      if (parsed.type === "message_update") {
+        const event = parsed.assistantMessageEvent as Record<string, unknown> | undefined;
+        if (
+          event?.type === "text_delta" &&
+          typeof event.delta === "string" &&
+          event.delta.length > 0
+        ) {
+          textDeltaParts.push(event.delta);
+        }
+        continue;
+      }
+
+      // Extract full text and usage from the final message events.
+      if (parsed.type === "message_end" || parsed.type === "turn_end") {
+        const message = parsed.message as Record<string, unknown> | undefined;
+        if (message) {
+          const extracted = extractPiTextContent(message.content);
+          if (extracted) fullText = extracted;
+          const parsedUsage = parsePiUsage(message.usage);
+          if (parsedUsage) usage = parsedUsage;
+          const parsedCost = parsePiCost(message.usage);
+          if (parsedCost !== null) costUsd = parsedCost;
+        }
+      }
+    } catch {
+      // ignore malformed JSON lines
+    }
+  }
+
+  const deltaText = textDeltaParts.join("").trim();
+  const text = fullText ?? deltaText;
+  if (text) {
+    return { text, usage, costUsd };
+  }
+  if (sawStructuredEvent) {
+    throw new Error("CLI returned empty output");
   }
   return { text: trimmed, usage: null, costUsd: null };
 }

--- a/src/llm/cli-provider-output.ts
+++ b/src/llm/cli-provider-output.ts
@@ -511,9 +511,14 @@ export function parsePiOutputFromJsonl(output: string): {
   let usage: LlmTokenUsage | null = null;
   let costUsd: number | null = null;
   let sawStructuredEvent = false;
+  const errorMessages: string[] = [];
+  const plainLines: string[] = [];
 
   for (const line of lines) {
-    if (!line.startsWith("{")) continue;
+    if (!line.startsWith("{")) {
+      plainLines.push(line);
+      continue;
+    }
     try {
       const parsed = JSON.parse(line) as Record<string, unknown>;
       sawStructuredEvent = true;
@@ -535,6 +540,11 @@ export function parsePiOutputFromJsonl(output: string): {
       if (parsed.type === "message_end" || parsed.type === "turn_end") {
         const message = parsed.message as Record<string, unknown> | undefined;
         if (message) {
+          if (message.role !== "assistant") continue;
+          if (typeof message.errorMessage === "string" && message.errorMessage.trim().length > 0) {
+            const errorMessage = message.errorMessage.trim();
+            if (!errorMessages.includes(errorMessage)) errorMessages.push(errorMessage);
+          }
           const extracted = extractPiTextContent(message.content);
           if (extracted) fullText = extracted;
           const parsedUsage = parsePiUsage(message.usage);
@@ -552,6 +562,12 @@ export function parsePiOutputFromJsonl(output: string): {
   const text = fullText ?? deltaText;
   if (text) {
     return { text, usage, costUsd };
+  }
+  if (errorMessages.length > 0) {
+    throw new Error(errorMessages.join("\n"));
+  }
+  if (sawStructuredEvent && plainLines.length > 0) {
+    throw new Error(plainLines.join("\n"));
   }
   if (sawStructuredEvent) {
     throw new Error("CLI returned empty output");

--- a/src/llm/cli.ts
+++ b/src/llm/cli.ts
@@ -432,19 +432,25 @@ export async function runCliModel({
       if (!allowTools) {
         piArgs.push("--no-tools");
       }
-      piArgs.push("--no-context-files", "--no-extensions", "--no-skills", "--no-session", "--thinking", "off");
+      piArgs.push(
+        "--no-context-files",
+        "--no-extensions",
+        "--no-skills",
+        "--no-session",
+        "--thinking",
+        "off",
+      );
       if (systemPrompt) {
         piArgs.push("--system-prompt", systemPrompt);
       }
       if (requestedModel) {
         piArgs.push("--model", requestedModel);
       }
-      piArgs.push(prompt);
       const { stdout } = await execCliWithInput({
         execFileImpl: execFileFn,
         cmd: binary,
         args: piArgs,
-        input: "",
+        input: prompt,
         timeoutMs,
         env: effectiveEnv,
         cwd: isolatedCwd ?? cwd,

--- a/src/llm/cli.ts
+++ b/src/llm/cli.ts
@@ -11,6 +11,7 @@ import {
   parseCodexUsageFromJsonl,
   parseOpenCodeOutputFromJsonl,
   parseJsonProviderOutput,
+  parsePiOutputFromJsonl,
   type JsonCliProvider,
 } from "./cli-provider-output.js";
 import type { LlmTokenUsage } from "./generate-text.js";
@@ -24,6 +25,7 @@ const DEFAULT_BINARIES: Record<CliProvider, string> = {
   opencode: "opencode",
   copilot: "copilot",
   agy: "agy",
+  pi: "pi",
 };
 
 const CLI_MAX_MESSAGE_ARG_BYTES = 120 * 1024;
@@ -39,6 +41,7 @@ const PROVIDER_PATH_ENV: Record<CliProvider, string> = {
   opencode: "OPENCODE_PATH",
   copilot: "COPILOT_PATH",
   agy: "AGY_PATH",
+  pi: "PI_PATH",
 };
 
 type RunCliModelOptions = {
@@ -52,6 +55,7 @@ type RunCliModelOptions = {
   config: CliConfig | null;
   cwd?: string;
   extraArgs?: string[];
+  systemPrompt?: string | null;
 };
 
 type CliRunResult = {
@@ -75,6 +79,7 @@ function getCliProviderConfig(
   if (provider === "openclaw") return config.openclaw;
   if (provider === "opencode") return config.opencode;
   if (provider === "agy") return config.agy;
+  if (provider === "pi") return config.pi;
   return config.copilot;
 }
 
@@ -193,6 +198,7 @@ export async function runCliModel({
   config,
   cwd,
   extraArgs,
+  systemPrompt,
 }: RunCliModelOptions): Promise<CliRunResult> {
   const execFileFn = execFileImpl ?? execFile;
   const binary = resolveCliBinary(provider, config, env);
@@ -411,6 +417,39 @@ export async function runCliModel({
       const text = stdout.trim();
       if (!text) throw new Error("CLI returned empty output");
       return { text, usage: null, costUsd: null };
+    } finally {
+      if (isolatedCwd) {
+        await fs.rm(isolatedCwd, { recursive: true, force: true }).catch(() => {});
+      }
+    }
+  }
+
+  if (provider === "pi") {
+    const isolatedCwd = !allowTools ? await fs.mkdtemp(path.join(tmpdir(), "summarize-pi-")) : null;
+    try {
+      const piArgs: string[] = [...providerExtraArgs];
+      piArgs.push("--print", "--mode", "json");
+      if (!allowTools) {
+        piArgs.push("--no-tools");
+      }
+      piArgs.push("--no-context-files", "--no-extensions", "--no-skills", "--no-session");
+      if (systemPrompt) {
+        piArgs.push("--system-prompt", systemPrompt);
+      }
+      if (requestedModel) {
+        piArgs.push("--model", requestedModel);
+      }
+      piArgs.push(prompt);
+      const { stdout } = await execCliWithInput({
+        execFileImpl: execFileFn,
+        cmd: binary,
+        args: piArgs,
+        input: "",
+        timeoutMs,
+        env: effectiveEnv,
+        cwd: isolatedCwd ?? cwd,
+      });
+      return parsePiOutputFromJsonl(stdout);
     } finally {
       if (isolatedCwd) {
         await fs.rm(isolatedCwd, { recursive: true, force: true }).catch(() => {});

--- a/src/llm/cli.ts
+++ b/src/llm/cli.ts
@@ -432,7 +432,7 @@ export async function runCliModel({
       if (!allowTools) {
         piArgs.push("--no-tools");
       }
-      piArgs.push("--no-context-files", "--no-extensions", "--no-skills", "--no-session");
+      piArgs.push("--no-context-files", "--no-extensions", "--no-skills", "--no-session", "--thinking", "off");
       if (systemPrompt) {
         piArgs.push("--system-prompt", systemPrompt);
       }

--- a/src/llm/provider-profile.ts
+++ b/src/llm/provider-profile.ts
@@ -36,7 +36,8 @@ export type RequiredModelEnv =
   | "CLI_OPENCLAW"
   | "CLI_OPENCODE"
   | "CLI_COPILOT"
-  | "CLI_AGY";
+  | "CLI_AGY"
+  | "CLI_PI";
 
 type GatewayProviderProfile = {
   requiredEnv: RequiredModelEnv;
@@ -107,6 +108,7 @@ export const DEFAULT_CLI_MODELS: Record<CliProvider, string | null> = {
   opencode: null,
   copilot: null,
   agy: null,
+  pi: null,
 };
 
 export const DEFAULT_AUTO_CLI_ORDER: CliProvider[] = [
@@ -119,6 +121,7 @@ export const DEFAULT_AUTO_CLI_ORDER: CliProvider[] = [
   "copilot",
   // agy is intentionally excluded from the default auto-fallback order.
   // Use --cli agy or --model cli/agy to opt in explicitly.
+  // pi is also excluded; use --cli pi or --model cli/pi explicitly.
 ];
 
 export function parseCliProviderName(raw: string): CliProvider | null {
@@ -131,6 +134,7 @@ export function parseCliProviderName(raw: string): CliProvider | null {
   if (normalized === "opencode") return "opencode";
   if (normalized === "copilot") return "copilot";
   if (normalized === "agy") return "agy";
+  if (normalized === "pi") return "pi";
   return null;
 }
 
@@ -149,7 +153,9 @@ export function requiredEnvForCliProvider(provider: CliProvider): RequiredModelE
               ? "CLI_COPILOT"
               : provider === "agy"
                 ? "CLI_AGY"
-                : "CLI_CLAUDE";
+                : provider === "pi"
+                  ? "CLI_PI"
+                  : "CLI_CLAUDE";
 }
 
 export function getGatewayProviderProfile(provider: GatewayProvider): GatewayProviderProfile {

--- a/src/model-auto-cli.ts
+++ b/src/model-auto-cli.ts
@@ -116,7 +116,9 @@ export function prependCliCandidates({
                   ? cli?.copilot?.model
                   : provider === "agy"
                     ? undefined
-                    : cli?.claude?.model;
+                    : provider === "pi"
+                      ? cli?.pi?.model
+                      : cli?.claude?.model;
     add(provider, modelOverride);
   }
 

--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -55,7 +55,8 @@ export type FixedModelSpec =
         | "CLI_OPENCLAW"
         | "CLI_OPENCODE"
         | "CLI_COPILOT"
-        | "CLI_AGY";
+        | "CLI_AGY"
+        | "CLI_PI";
       cliProvider: CliProvider;
       cliModel: string | null;
     };
@@ -193,7 +194,8 @@ export function parseRequestedModelId(raw: string): RequestedModel {
       providerRaw !== "openclaw" &&
       providerRaw !== "opencode" &&
       providerRaw !== "copilot" &&
-      providerRaw !== "agy"
+      providerRaw !== "agy" &&
+      providerRaw !== "pi"
     ) {
       throw new Error(`Invalid CLI model id "${trimmed}". Expected cli/<provider>/<model>.`);
     }
@@ -215,6 +217,7 @@ export function parseRequestedModelId(raw: string): RequestedModel {
       | "CLI_OPENCODE"
       | "CLI_COPILOT"
       | "CLI_AGY"
+      | "CLI_PI"
     >;
     const userModelId = cliModel ? `cli/${cliProvider}/${cliModel}` : `cli/${cliProvider}`;
     return {

--- a/src/run/cli-fallback-state.ts
+++ b/src/run/cli-fallback-state.ts
@@ -19,7 +19,8 @@ function parseCliProvider(value: unknown): CliProvider | null {
     value === "openclaw" ||
     value === "opencode" ||
     value === "copilot" ||
-    value === "agy"
+    value === "agy" ||
+    value === "pi"
   ) {
     return value;
   }

--- a/src/run/env.ts
+++ b/src/run/env.ts
@@ -85,6 +85,7 @@ export function resolveCliAvailability({
     "opencode",
     "copilot",
     "agy",
+    "pi",
   ];
   const availability: Partial<Record<CliProvider, boolean>> = {};
   for (const provider of providers) {
@@ -115,7 +116,8 @@ export function parseCliUserModelId(modelId: string): {
     provider !== "openclaw" &&
     provider !== "opencode" &&
     provider !== "copilot" &&
-    provider !== "agy"
+    provider !== "agy" &&
+    provider !== "pi"
   ) {
     throw new Error(`Invalid CLI model id "${modelId}". Expected cli/<provider>/<model>.`);
   }
@@ -133,7 +135,8 @@ export function parseCliProviderArg(raw: string): CliProvider {
     normalized === "openclaw" ||
     normalized === "opencode" ||
     normalized === "copilot" ||
-    normalized === "agy"
+    normalized === "agy" ||
+    normalized === "pi"
   ) {
     return normalized as CliProvider;
   }

--- a/src/run/help.ts
+++ b/src/run/help.ts
@@ -149,7 +149,7 @@ export function buildProgram() {
     .addOption(
       new Option(
         "--cli [provider]",
-        "Use a CLI provider: claude, gemini, codex, agent, openclaw, opencode, copilot, agy (equivalent to --model cli/<provider>). If omitted, use auto selection with CLI enabled.",
+        "Use a CLI provider: claude, gemini, codex, agent, openclaw, opencode, copilot, agy, pi (equivalent to --model cli/<provider>). If omitted, use auto selection with CLI enabled.",
       ),
     )
     .option("--extract", "Print extracted content and exit (no LLM summary)", false)

--- a/src/run/help.ts
+++ b/src/run/help.ts
@@ -305,6 +305,7 @@ ${heading("Env Vars")}
   OPENCODE_PATH         optional (path to OpenCode CLI binary)
   COPILOT_PATH          optional (path to GitHub Copilot CLI binary)
   AGY_PATH              optional (path to Antigravity CLI binary)
+  PI_PATH               optional (path to pi CLI binary)
   SUMMARIZE_MODEL       optional (overrides default model selection)
   SUMMARIZE_THEME       optional (${CLI_THEME_NAMES.join(", ")})
   SUMMARIZE_TRUECOLOR   optional (force 24-bit color)

--- a/src/run/run-models.ts
+++ b/src/run/run-models.ts
@@ -17,6 +17,7 @@ function resolveConfiguredCliModel(
     if (provider === "openclaw") return cli?.openclaw?.model;
     if (provider === "opencode") return cli?.opencode?.model;
     if (provider === "agy") return null;
+    if (provider === "pi") return null;
     return cli?.copilot?.model;
   })();
   return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;

--- a/src/run/run-models.ts
+++ b/src/run/run-models.ts
@@ -17,7 +17,7 @@ function resolveConfiguredCliModel(
     if (provider === "openclaw") return cli?.openclaw?.model;
     if (provider === "opencode") return cli?.opencode?.model;
     if (provider === "agy") return null;
-    if (provider === "pi") return null;
+    if (provider === "pi") return cli?.pi?.model;
     return cli?.copilot?.model;
   })();
   return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;

--- a/src/run/run-settings-parse.ts
+++ b/src/run/run-settings-parse.ts
@@ -45,6 +45,7 @@ export const parseCliProvider = (raw: string): CliProvider | null => {
   if (normalized === "opencode") return "opencode";
   if (normalized === "copilot") return "copilot";
   if (normalized === "agy") return "agy";
+  if (normalized === "pi") return "pi";
   return null;
 };
 

--- a/src/run/summary-engine.ts
+++ b/src/run/summary-engine.ts
@@ -167,6 +167,9 @@ export function createSummaryEngine(deps: SummaryEngineDeps) {
     if (requiredEnv === "CLI_AGY") {
       return Boolean(deps.cliAvailability.agy);
     }
+    if (requiredEnv === "CLI_PI") {
+      return Boolean(deps.cliAvailability.pi);
+    }
     if (requiredEnv === "GEMINI_API_KEY") {
       return deps.keyFlags.googleConfigured;
     }
@@ -218,6 +221,9 @@ export function createSummaryEngine(deps: SummaryEngineDeps) {
     }
     if (attempt.requiredEnv === "CLI_AGY") {
       return `Antigravity CLI not found for model ${attempt.userModelId}. Install agy or set AGY_PATH.`;
+    }
+    if (attempt.requiredEnv === "CLI_PI") {
+      return `pi CLI not found for model ${attempt.userModelId}. Install pi or set PI_PATH.`;
     }
     return `Missing ${attempt.requiredEnv} for model ${attempt.userModelId}. Set the env var or choose a different --model.`;
   };
@@ -275,6 +281,7 @@ export function createSummaryEngine(deps: SummaryEngineDeps) {
         config: deps.cliConfigForRun ?? null,
         cwd: cli?.cwd,
         extraArgs: cli?.extraArgsByProvider?.[attempt.cliProvider],
+        systemPrompt: prompt.system ?? null,
       });
       const summary = result.text.trim();
       if (!summary) throw new Error("CLI returned an empty summary");

--- a/src/run/types.ts
+++ b/src/run/types.ts
@@ -19,7 +19,8 @@ export type ModelAttemptRequiredEnv =
   | "CLI_OPENCLAW"
   | "CLI_OPENCODE"
   | "CLI_COPILOT"
-  | "CLI_AGY";
+  | "CLI_AGY"
+  | "CLI_PI";
 
 export type ModelAttempt = {
   transport: "native" | "openrouter" | "cli";

--- a/tests/chrome.daemon-payload.test.ts
+++ b/tests/chrome.daemon-payload.test.ts
@@ -26,7 +26,7 @@ describe("chrome/daemon-payload", () => {
       length: "xl",
       language: "auto",
       autoCliFallback: true,
-      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot,pi",
+      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot",
       maxCharacters: defaultSettings.maxChars,
     });
   });
@@ -70,7 +70,7 @@ describe("chrome/daemon-payload", () => {
       retries: 2,
       maxOutputTokens: "2k",
       autoCliFallback: true,
-      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot,pi",
+      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot",
       maxCharacters: defaultSettings.maxChars,
     });
   });

--- a/tests/chrome.daemon-payload.test.ts
+++ b/tests/chrome.daemon-payload.test.ts
@@ -26,7 +26,7 @@ describe("chrome/daemon-payload", () => {
       length: "xl",
       language: "auto",
       autoCliFallback: true,
-      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot",
+      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot,pi",
       maxCharacters: defaultSettings.maxChars,
     });
   });
@@ -70,7 +70,7 @@ describe("chrome/daemon-payload", () => {
       retries: 2,
       maxOutputTokens: "2k",
       autoCliFallback: true,
-      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot",
+      autoCliOrder: "claude,gemini,codex,agent,openclaw,opencode,copilot,pi",
       maxCharacters: defaultSettings.maxChars,
     });
   });

--- a/tests/chrome.settings.test.ts
+++ b/tests/chrome.settings.test.ts
@@ -142,15 +142,15 @@ describe("chrome/settings", () => {
     await saveSettings({
       ...defaultSettings,
       autoCliFallback: false,
-      autoCliOrder: " GeMiNi,openclaw,opencode,copilot,unknown,CLAUDE,gemini,COPILOT ",
+      autoCliOrder: " GeMiNi,openclaw,opencode,copilot,agy,pi,unknown,CLAUDE,gemini,COPILOT ",
     });
 
     const raw = storage.settings as Record<string, unknown>;
     expect(raw.autoCliFallback).toBe(false);
-    expect(raw.autoCliOrder).toBe("gemini,openclaw,opencode,copilot,claude");
+    expect(raw.autoCliOrder).toBe("gemini,openclaw,opencode,copilot,agy,pi,claude");
 
     const loaded = await loadSettings();
     expect(loaded.autoCliFallback).toBe(false);
-    expect(loaded.autoCliOrder).toBe("gemini,openclaw,opencode,copilot,claude");
+    expect(loaded.autoCliOrder).toBe("gemini,openclaw,opencode,copilot,agy,pi,claude");
   });
 });

--- a/tests/daemon.chat.test.ts
+++ b/tests/daemon.chat.test.ts
@@ -276,6 +276,42 @@ describe("daemon/chat", () => {
     expect(meta[0]?.model).toBe("cli/agy");
   });
 
+  it("resolves configured pi models before emitting chat metadata", async () => {
+    const home = mkdtempSync(join(tmpdir(), "summarize-daemon-chat-pi-fixed-"));
+    const meta: Array<{ model?: string | null }> = [];
+
+    await streamChatResponse({
+      env: { HOME: home },
+      fetchImpl: fetch,
+      configForCli: {
+        cli: {
+          pi: {
+            model: "anthropic/claude-sonnet-4-5",
+          },
+        },
+      },
+      session: {
+        id: "s-pi-fixed",
+        lastMeta: { model: null, modelLabel: null, inputSummary: null, summaryFromCache: null },
+      },
+      pageUrl: "https://example.com",
+      pageTitle: "Example",
+      pageContent: "Hello world",
+      messages: [{ role: "user", content: "Hi" }],
+      modelOverride: "cli/pi",
+      pushToSession: () => {},
+      emitMeta: (patch) => meta.push(patch),
+    });
+
+    expect(runCliModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "pi",
+        model: "anthropic/claude-sonnet-4-5",
+      }),
+    );
+    expect(meta[0]?.model).toBe("cli/pi/anthropic/claude-sonnet-4-5");
+  });
+
   it("routes openrouter overrides through openrouter transport", async () => {
     const home = mkdtempSync(join(tmpdir(), "summarize-daemon-chat-openrouter-"));
     const meta: Array<{ model?: string | null }> = [];

--- a/tests/daemon.models.test.ts
+++ b/tests/daemon.models.test.ts
@@ -52,12 +52,15 @@ describe("daemon /v1/models", () => {
     const claudePath = path.join(binDir, "claude");
     const opencodePath = path.join(binDir, "opencode");
     const copilotPath = path.join(binDir, "copilot");
+    const piPath = path.join(binDir, "pi");
     writeFileSync(claudePath, "#!/bin/sh\nexit 0\n", "utf8");
     writeFileSync(opencodePath, "#!/bin/sh\nexit 0\n", "utf8");
     writeFileSync(copilotPath, "#!/bin/sh\nexit 0\n", "utf8");
+    writeFileSync(piPath, "#!/bin/sh\nexit 0\n", "utf8");
     chmodSync(claudePath, 0o755);
     chmodSync(opencodePath, 0o755);
     chmodSync(copilotPath, 0o755);
+    chmodSync(piPath, 0o755);
 
     const result = await buildModelPickerOptions({
       env: {},
@@ -70,9 +73,11 @@ describe("daemon /v1/models", () => {
     expect(result.providers.cliClaude).toBe(true);
     expect(result.providers.cliOpencode).toBe(true);
     expect(result.providers.cliCopilot).toBe(true);
+    expect(result.providers.cliPi).toBe(true);
     expect(result.options.some((o) => o.id === "cli/claude")).toBe(true);
     expect(result.options.some((o) => o.id === "cli/opencode")).toBe(true);
     expect(result.options.some((o) => o.id === "cli/copilot")).toBe(true);
+    expect(result.options.some((o) => o.id === "cli/pi")).toBe(true);
   });
 
   it("includes Ollama models when OLLAMA_BASE_URL is set", async () => {

--- a/tests/llm.cli.pi.test.ts
+++ b/tests/llm.cli.pi.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import { parsePiOutputFromJsonl } from "../src/llm/cli-provider-output.js";
+import { resolveCliBinary, runCliModel } from "../src/llm/cli.js";
+import type { ExecFileFn } from "../src/markitdown.js";
+
+describe("runCliModel - pi provider", () => {
+  it("invokes pi in JSON print mode and passes prompts over stdin", async () => {
+    const prompt = "Summarize a short local proof document.";
+    let seenCmd = "";
+    let seenCwd = "";
+    let seenInput = "";
+    const seenArgs: string[][] = [];
+    const stdout = [
+      JSON.stringify({
+        type: "message_end",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: prompt }],
+        },
+      }),
+      JSON.stringify({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "draft text" },
+      }),
+      JSON.stringify({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Final pi summary." }],
+          usage: { input: 4, output: 5, totalTokens: 9, cost: { total: 0.0012 } },
+        },
+      }),
+    ].join("\n");
+    const execFileImpl: ExecFileFn = ((cmd, args, options, cb) => {
+      seenCmd = String(cmd);
+      seenArgs.push(args);
+      seenCwd = typeof options?.cwd === "string" ? options.cwd : "";
+      cb?.(null, stdout, "");
+      return {
+        stdin: {
+          write: (chunk: unknown) => {
+            seenInput += String(chunk);
+          },
+          end: () => {},
+        },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    const result = await runCliModel({
+      provider: "pi",
+      prompt,
+      model: null,
+      allowTools: false,
+      timeoutMs: 1000,
+      env: { PI_PATH: "/env/pi" },
+      execFileImpl,
+      config: {
+        pi: {
+          binary: "/configured/pi",
+          model: "anthropic/claude-sonnet-4-5",
+          extraArgs: ["--provider", "anthropic"],
+        },
+      },
+      cwd: "/tmp/pi-original-cwd",
+      extraArgs: ["--profile", "quiet"],
+      systemPrompt: "System prompt",
+    });
+
+    expect(result).toEqual({
+      text: "Final pi summary.",
+      usage: { promptTokens: 4, completionTokens: 5, totalTokens: 9 },
+      costUsd: 0.0012,
+    });
+    expect(seenCmd).toBe("/configured/pi");
+    expect(seenArgs[0]?.slice(0, 4)).toEqual(["--provider", "anthropic", "--profile", "quiet"]);
+    expect(seenArgs[0]).toEqual(
+      expect.arrayContaining([
+        "--print",
+        "--mode",
+        "json",
+        "--no-tools",
+        "--no-context-files",
+        "--no-extensions",
+        "--no-skills",
+        "--no-session",
+        "--thinking",
+        "off",
+        "--system-prompt",
+        "System prompt",
+        "--model",
+        "anthropic/claude-sonnet-4-5",
+      ]),
+    );
+    expect(seenArgs[0]).not.toContain(prompt);
+    expect(seenInput).toBe(prompt);
+    expect(seenCwd).toContain("summarize-pi-");
+    expect(seenCwd).not.toBe("/tmp/pi-original-cwd");
+  });
+
+  it("keeps tools enabled when requested while still isolating pi context flags", async () => {
+    let seenInput = "";
+    let seenCwd = "";
+    const seenArgs: string[][] = [];
+    const execFileImpl: ExecFileFn = ((_cmd, args, options, cb) => {
+      seenArgs.push(args);
+      seenCwd = typeof options?.cwd === "string" ? options.cwd : "";
+      cb?.(
+        null,
+        JSON.stringify({
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", delta: "tool-enabled answer" },
+        }),
+        "",
+      );
+      return {
+        stdin: {
+          write: (chunk: unknown) => {
+            seenInput += String(chunk);
+          },
+          end: () => {},
+        },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    const result = await runCliModel({
+      provider: "pi",
+      prompt: "Prompt from stdin",
+      model: "openai/gpt-5.4",
+      allowTools: true,
+      timeoutMs: 1000,
+      env: {},
+      execFileImpl,
+      config: null,
+      cwd: "/tmp/pi-tools-cwd",
+    });
+
+    expect(result.text).toBe("tool-enabled answer");
+    expect(seenArgs[0]).not.toContain("--no-tools");
+    expect(seenArgs[0]).toEqual(
+      expect.arrayContaining([
+        "--print",
+        "--mode",
+        "json",
+        "--no-context-files",
+        "--no-extensions",
+        "--no-skills",
+        "--no-session",
+        "--model",
+        "openai/gpt-5.4",
+      ]),
+    );
+    expect(seenInput).toBe("Prompt from stdin");
+    expect(seenCwd).toBe("/tmp/pi-tools-cwd");
+  });
+
+  it("resolves pi binaries from PI_PATH when config binary is absent", () => {
+    expect(resolveCliBinary("pi", null, { PI_PATH: "/custom/pi" })).toBe("/custom/pi");
+  });
+});
+
+describe("parsePiOutputFromJsonl", () => {
+  it("uses streamed text deltas when no final message text exists", () => {
+    const parsed = parsePiOutputFromJsonl(
+      [
+        "non-json prelude",
+        JSON.stringify({
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", delta: "Hello " },
+        }),
+        JSON.stringify({
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", delta: "pi" },
+        }),
+      ].join("\n"),
+    );
+
+    expect(parsed).toEqual({ text: "Hello pi", usage: null, costUsd: null });
+  });
+
+  it("falls back to plain stdout only when there were no structured events", () => {
+    expect(parsePiOutputFromJsonl("  plain stdout  \n")).toEqual({
+      text: "plain stdout",
+      usage: null,
+      costUsd: null,
+    });
+  });
+
+  it("throws on structured pi output without assistant text", () => {
+    expect(() =>
+      parsePiOutputFromJsonl(
+        JSON.stringify({
+          type: "message_update",
+          assistantMessageEvent: { type: "thinking_delta", delta: "hidden" },
+        }),
+      ),
+    ).toThrow(/empty output/);
+  });
+
+  it("surfaces assistant error messages instead of user prompt echoes", () => {
+    expect(() =>
+      parsePiOutputFromJsonl(
+        [
+          JSON.stringify({
+            type: "message_end",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "Prompt text" }],
+            },
+          }),
+          JSON.stringify({
+            type: "message_end",
+            message: {
+              role: "assistant",
+              content: [],
+              errorMessage: "No API key for provider: anthropic",
+            },
+          }),
+        ].join("\n"),
+      ),
+    ).toThrow(/No API key for provider: anthropic/);
+  });
+
+  it("surfaces plain pi startup errors after JSON session lines", () => {
+    expect(() =>
+      parsePiOutputFromJsonl(
+        [
+          JSON.stringify({ type: "session", id: "s1" }),
+          "No API key found for openai.",
+          "Use /login to log into a provider via OAuth or API key.",
+        ].join("\n"),
+      ),
+    ).toThrow(/No API key found for openai/);
+  });
+});

--- a/tests/llm.provider-capabilities.test.ts
+++ b/tests/llm.provider-capabilities.test.ts
@@ -28,16 +28,22 @@ describe("llm provider capabilities", () => {
     expect(DEFAULT_CLI_MODELS.openclaw).toBe("main");
     expect(DEFAULT_CLI_MODELS.opencode).toBeNull();
     expect(DEFAULT_CLI_MODELS.copilot).toBeNull();
+    expect(DEFAULT_CLI_MODELS.agy).toBeNull();
+    expect(DEFAULT_CLI_MODELS.pi).toBeNull();
     expect(parseCliProviderName(" GeMiNi ")).toBe("gemini");
     expect(parseCliProviderName(" openclaw ")).toBe("openclaw");
     expect(parseCliProviderName(" opencode ")).toBe("opencode");
     expect(parseCliProviderName(" OpenCode ")).toBe("opencode");
     expect(parseCliProviderName(" Copilot ")).toBe("copilot");
+    expect(parseCliProviderName(" Agy ")).toBe("agy");
+    expect(parseCliProviderName(" Pi ")).toBe("pi");
     expect(parseCliProviderName("nope")).toBeNull();
     expect(requiredEnvForCliProvider("agent")).toBe("CLI_AGENT");
     expect(requiredEnvForCliProvider("openclaw")).toBe("CLI_OPENCLAW");
     expect(requiredEnvForCliProvider("opencode")).toBe("CLI_OPENCODE");
     expect(requiredEnvForCliProvider("copilot")).toBe("CLI_COPILOT");
+    expect(requiredEnvForCliProvider("agy")).toBe("CLI_AGY");
+    expect(requiredEnvForCliProvider("pi")).toBe("CLI_PI");
   });
 
   it("tracks native provider capabilities centrally", () => {
@@ -71,6 +77,9 @@ describe("llm provider capabilities", () => {
     expect(resolveRequiredEnvForModelId("openclaw/main")).toBe("CLI_OPENCLAW");
     expect(resolveRequiredEnvForModelId("cli/opencode")).toBe("CLI_OPENCODE");
     expect(resolveRequiredEnvForModelId("cli/opencode/openai/gpt-5.4")).toBe("CLI_OPENCODE");
+    expect(resolveRequiredEnvForModelId("cli/agy")).toBe("CLI_AGY");
+    expect(resolveRequiredEnvForModelId("cli/pi")).toBe("CLI_PI");
+    expect(resolveRequiredEnvForModelId("cli/pi/openai/gpt-5.4")).toBe("CLI_PI");
     expect(resolveRequiredEnvForModelId("cli/nope/test")).toBe("CLI_CLAUDE");
     expect(resolveRequiredEnvForModelId("openrouter/openai/gpt-5-mini")).toBe("OPENROUTER_API_KEY");
     expect(resolveRequiredEnvForModelId("nvidia/meta/llama-3.1-8b-instruct")).toBe(

--- a/tests/model-auto.test.ts
+++ b/tests/model-auto.test.ts
@@ -550,6 +550,53 @@ describe("auto model selection", () => {
     expect(attempts[0]?.userModelId).toBe("cli/opencode/openai/gpt-5.4");
   });
 
+  it("keeps pi out of the default auto CLI fallback order", () => {
+    const attempts = buildAutoModelAttempts({
+      kind: "text",
+      promptTokens: 100,
+      desiredOutputTokens: 50,
+      requiresVideoUnderstanding: false,
+      env: {},
+      config: null,
+      catalog: null,
+      openrouterProvidersFromEnv: null,
+      cliAvailability: { pi: true },
+      isImplicitAutoSelection: true,
+    });
+
+    expect(attempts.some((attempt) => attempt.userModelId.startsWith("cli/pi"))).toBe(false);
+  });
+
+  it("uses configured pi models when pi is explicitly enabled for CLI fallback", () => {
+    const config: SummarizeConfig = {
+      model: { mode: "auto", rules: [{ candidates: ["openai/gpt-5-mini"] }] },
+      cli: {
+        autoFallback: {
+          enabled: true,
+          onlyWhenNoApiKeys: false,
+          order: ["pi"],
+        },
+        pi: {
+          model: "anthropic/claude-sonnet-4-5",
+        },
+      },
+    };
+    const attempts = buildAutoModelAttempts({
+      kind: "text",
+      promptTokens: 100,
+      desiredOutputTokens: 50,
+      requiresVideoUnderstanding: false,
+      env: {},
+      config,
+      catalog: null,
+      openrouterProvidersFromEnv: null,
+      cliAvailability: { pi: true },
+      isImplicitAutoSelection: true,
+    });
+
+    expect(attempts[0]?.userModelId).toBe("cli/pi/anthropic/claude-sonnet-4-5");
+  });
+
   it("dedupes configured CLI auto-fallback order", () => {
     const config: SummarizeConfig = {
       cli: {

--- a/tests/model-spec.test.ts
+++ b/tests/model-spec.test.ts
@@ -87,6 +87,24 @@ describe("model spec parsing", () => {
     );
   });
 
+  it("uses the pi runtime default model and accepts model suffixes", () => {
+    const runtimeDefault = parseRequestedModelId("cli/pi");
+    expect(runtimeDefault.kind).toBe("fixed");
+    expect(runtimeDefault.transport).toBe("cli");
+    expect(runtimeDefault.userModelId).toBe("cli/pi");
+    expect(runtimeDefault.cliProvider).toBe("pi");
+    expect(runtimeDefault.cliModel).toBeNull();
+    expect(runtimeDefault.requiredEnv).toBe("CLI_PI");
+
+    const explicitModel = parseRequestedModelId("cli/pi/openai/gpt-5.4");
+    expect(explicitModel.kind).toBe("fixed");
+    expect(explicitModel.transport).toBe("cli");
+    expect(explicitModel.userModelId).toBe("cli/pi/openai/gpt-5.4");
+    expect(explicitModel.cliProvider).toBe("pi");
+    expect(explicitModel.cliModel).toBe("openai/gpt-5.4");
+    expect(explicitModel.requiredEnv).toBe("CLI_PI");
+  });
+
   it("rejects invalid cli providers", () => {
     expect(() => parseRequestedModelId("cli/unknown/model")).toThrow(/Invalid CLI model id/);
   });

--- a/tests/run.env.test.ts
+++ b/tests/run.env.test.ts
@@ -71,9 +71,19 @@ describe("run/env", () => {
       provider: "opencode",
       model: "openai/gpt-5.4",
     });
+    expect(parseCliUserModelId("cli/agy")).toEqual({
+      provider: "agy",
+      model: null,
+    });
+    expect(parseCliUserModelId("cli/pi/openai/gpt-5.4")).toEqual({
+      provider: "pi",
+      model: "openai/gpt-5.4",
+    });
     expect(parseCliProviderArg("  AGENT ")).toBe("agent");
     expect(parseCliProviderArg(" openclaw ")).toBe("openclaw");
     expect(parseCliProviderArg(" opencode ")).toBe("opencode");
+    expect(parseCliProviderArg(" agy ")).toBe("agy");
+    expect(parseCliProviderArg(" pi ")).toBe("pi");
   });
 
   it("detects OpenCode availability from PATH and respects cli.enabled", () => {

--- a/tests/run.models.test.ts
+++ b/tests/run.models.test.ts
@@ -116,6 +116,32 @@ describe("run model selection", () => {
     }
   });
 
+  it("resolves provider-default pi CLI ids through summarize config", () => {
+    const config = {
+      cli: {
+        pi: {
+          model: "anthropic/claude-sonnet-4-5",
+        },
+      },
+    };
+
+    const result = resolveModelSelection({
+      config,
+      configForCli: config,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: "cli/pi",
+    });
+
+    expect(result.requestedModel.kind).toBe("fixed");
+    expect(result.requestedModel.userModelId).toBe("cli/pi/anthropic/claude-sonnet-4-5");
+    expect(result.requestedModelLabel).toBe("cli/pi/anthropic/claude-sonnet-4-5");
+    if (result.requestedModel.kind === "fixed" && result.requestedModel.transport === "cli") {
+      expect(result.requestedModel.cliProvider).toBe("pi");
+      expect(result.requestedModel.cliModel).toBe("anthropic/claude-sonnet-4-5");
+    }
+  });
+
   it("keeps bare OpenCode ids when no configured model is available", () => {
     const result = resolveModelSelection({
       config: { cli: { opencode: { model: "   " } } },
@@ -156,6 +182,32 @@ describe("run model selection", () => {
     expect(result.requestedModelLabel).toBe("cli/opencode/openai/gpt-5.4");
     if (result.requestedModel.kind === "fixed" && result.requestedModel.transport === "cli") {
       expect(result.requestedModel.cliProvider).toBe("opencode");
+      expect(result.requestedModel.cliModel).toBe("openai/gpt-5.4");
+    }
+  });
+
+  it("does not override explicit pi model ids from config defaults", () => {
+    const config = {
+      cli: {
+        pi: {
+          model: "anthropic/claude-sonnet-4-5",
+        },
+      },
+    };
+
+    const result = resolveModelSelection({
+      config,
+      configForCli: config,
+      configPath: null,
+      envForRun: {},
+      explicitModelArg: "cli/pi/openai/gpt-5.4",
+    });
+
+    expect(result.requestedModel.kind).toBe("fixed");
+    expect(result.requestedModel.userModelId).toBe("cli/pi/openai/gpt-5.4");
+    expect(result.requestedModelLabel).toBe("cli/pi/openai/gpt-5.4");
+    if (result.requestedModel.kind === "fixed" && result.requestedModel.transport === "cli") {
+      expect(result.requestedModel.cliProvider).toBe("pi");
       expect(result.requestedModel.cliModel).toBe("openai/gpt-5.4");
     }
   });


### PR DESCRIPTION
## Add pi CLI as a backend provider

I recently migrated to a new machine where pi is the only coding agent CLI installed. This PR adds pi as a supported `--cli` provider so that summarize can use it as a local model backend, alongside the existing providers (claude, codex, gemini, etc.).

> This PR was co-authored by pi + GLM-5.1.

### Usage

```bash
summarize --cli pi "https://example.com"
summarize --model cli/pi/sonnet "https://example.com"
```

### Implementation

- Invokes pi with `--print --mode json --no-tools --no-context-files --no-extensions --no-skills --no-session` for isolated summarization
- Passes the summarize system prompt via `--system-prompt`
- Parses JSONL event stream (`text_delta`, `message_end`, `turn_end`) to extract text, token usage, and cost
- Supports `PI_PATH` env var for custom binary location

### Scope

| Area | Changes |
|------|---------|
| Backend | `CliProvider` type, config parsing, CLI invocation, JSONL parser, auto-fallback system |
| Daemon | Expose `cliPi` provider and `cli/pi` model option in `/v1/models` |
| Extension | Auto CLI order filter and model preset picker in settings UI |
| Docs | README, `docs/cli.md`, `docs/config.md` |

### Notes

- Like agy, pi is **excluded from the default auto-fallback order** — use `--cli pi`, `--model cli/pi`, or configure `cli.autoFallback.order` to opt in
- Unlike agy, pi supports per-call model selection via `--model`