### PR TITLE
fix: cache local image summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- CLI cache: derive summary content hashes from binary attachment bytes so repeated local image summaries can hit the cache (#244, thanks @alfozan).
 - YouTube transcripts: let `--diarize auto` and matching explicit provider requests reuse the same compatible cached speaker-labelled transcript instead of re-transcribing the same video.
 - CLI cache: include local media `fileMtime` when writing transcript cache entries so repeated unchanged audio/video extraction can hit cache (#240, #241, thanks @alfozan).
 - CLI: pass Codex image attachments to `codex exec` so local image summaries no longer fail before starting (#242, #243, thanks @alfozan).

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -43,7 +43,7 @@ Separate file cache for downloaded media (yt-dlp, direct media URLs). This is **
 - **Summaries**
   - key: `sha256({contentHash, promptHash, model, length, language, formatVersion})`
   - cache hit even if URL differs (content hash wins).
-  - `contentHash` comes from the `<content>` block actually sent to the model (so slide timelines / transcript extras affect the key).
+  - `contentHash` comes from the `<content>` block actually sent to the model (so slide timelines / transcript extras affect the key), or from attached binary bytes when the prompt content is empty.
 - **Slides** (manifest + on-disk images in the slides output dir)
   - key: `sha256({url, slideSettings, formatVersion})`
 

--- a/src/cache-keys.ts
+++ b/src/cache-keys.ts
@@ -6,6 +6,10 @@ export function hashString(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+export function hashBytes(value: Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
 export function hashJson(value: unknown): string {
   return hashString(JSON.stringify(value));
 }
@@ -52,6 +56,22 @@ export function buildPromptContentHash({
   const content = extractTaggedBlock(prompt, "content") ?? fallbackContent ?? null;
   if (!content || content.trim().length === 0) return null;
   return hashString(normalizeContentForHash(content));
+}
+
+export function buildAttachmentContentHash({
+  attachments,
+}: {
+  attachments: Array<{ kind: string; mediaType: string; bytes: Uint8Array }>;
+}): string | null {
+  if (attachments.length === 0) return null;
+  return hashJson({
+    attachments: attachments.map((attachment) => ({
+      kind: attachment.kind,
+      mediaType: attachment.mediaType.toLowerCase(),
+      byteLength: attachment.bytes.byteLength,
+      byteHash: hashBytes(attachment.bytes),
+    })),
+  });
 }
 
 export function buildLengthKey(lengthArg: LengthArg): string {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import {
+  buildAttachmentContentHash,
   buildExtractCacheKeyValue,
   buildLanguageKey,
   buildLengthKey,
@@ -11,6 +12,7 @@ import {
   buildTranscriptCacheKeyValue,
   hashJson,
   hashString,
+  hashBytes,
   normalizeContentForHash,
   extractTaggedBlock,
 } from "./cache-keys.js";
@@ -25,6 +27,7 @@ import {
   type CacheStats,
 } from "./shared/cache-store.js";
 export {
+  buildAttachmentContentHash,
   buildExtractCacheKeyValue,
   buildLanguageKey,
   buildLengthKey,
@@ -35,6 +38,7 @@ export {
   buildTranscriptCacheKeyValue,
   hashJson,
   hashString,
+  hashBytes,
   normalizeContentForHash,
   extractTaggedBlock,
 } from "./cache-keys.js";

--- a/src/run/flows/asset/summary.ts
+++ b/src/run/flows/asset/summary.ts
@@ -1,6 +1,7 @@
 import { countTokens } from "gpt-tokenizer";
 import { render as renderMarkdownAnsi } from "markdansi";
 import {
+  buildAttachmentContentHash,
   buildLanguageKey,
   buildLengthKey,
   buildPromptContentHash,
@@ -456,7 +457,10 @@ export async function summarizeAsset(ctx: AssetSummaryContext, args: SummarizeAs
 
   const cacheStore =
     ctx.cache.mode === "default" && !ctx.summaryCacheBypass ? ctx.cache.store : null;
-  const contentHash = cacheStore ? buildPromptContentHash({ prompt: promptText }) : null;
+  const contentHash = cacheStore
+    ? (buildPromptContentHash({ prompt: promptText }) ??
+      buildAttachmentContentHash({ attachments }))
+    : null;
   const promptHash = cacheStore ? buildPromptHash(promptText) : null;
   const lengthKey = buildLengthKey(ctx.lengthArg);
   const languageKey = buildLanguageKey(ctx.outputLanguage);

--- a/tests/cache.keys.test.ts
+++ b/tests/cache.keys.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildAttachmentContentHash,
   buildExtractCacheKey,
   buildPromptContentHash,
   buildPromptHash,
@@ -138,5 +139,26 @@ describe("cache keys and tags", () => {
     expect(base).not.toBeNull();
     expect(withSlides).not.toBeNull();
     expect(withSlides).not.toBe(base);
+  });
+
+  it("hashes attachment bytes as binary content identity", () => {
+    const base = buildAttachmentContentHash({
+      attachments: [{ kind: "image", mediaType: "image/png", bytes: new Uint8Array([1, 2, 3]) }],
+    });
+    const same = buildAttachmentContentHash({
+      attachments: [{ kind: "image", mediaType: "IMAGE/PNG", bytes: new Uint8Array([1, 2, 3]) }],
+    });
+    const differentBytes = buildAttachmentContentHash({
+      attachments: [{ kind: "image", mediaType: "image/png", bytes: new Uint8Array([1, 2, 4]) }],
+    });
+    const differentMediaType = buildAttachmentContentHash({
+      attachments: [{ kind: "image", mediaType: "image/jpeg", bytes: new Uint8Array([1, 2, 3]) }],
+    });
+
+    expect(base).not.toBeNull();
+    expect(same).toBe(base);
+    expect(differentBytes).not.toBe(base);
+    expect(differentMediaType).not.toBe(base);
+    expect(buildAttachmentContentHash({ attachments: [] })).toBeNull();
   });
 });

--- a/tests/cli.cache.summary.test.ts
+++ b/tests/cli.cache.summary.test.ts
@@ -12,6 +12,11 @@ const htmlResponse = (html: string, status = 200) =>
     headers: { "Content-Type": "text/html" },
   });
 
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64",
+);
+
 function collectStream() {
   let text = "";
   const stream = new Writable({
@@ -138,6 +143,80 @@ describe("cli cache summary", () => {
 
     expect(mocks.streamSimple).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(stdout2.getText()).toBe(first);
+
+    globalFetchSpy.mockRestore();
+  }, 30_000);
+
+  it("reuses cached summaries for local images", async () => {
+    mocks.streamSimple.mockClear();
+
+    const root = mkdtempSync(join(tmpdir(), "summarize-cache-image-cli-"));
+    const summarizeDir = join(root, ".summarize");
+    const cacheDir = join(summarizeDir, "cache");
+    mkdirSync(cacheDir, { recursive: true });
+
+    writeFileSync(
+      join(summarizeDir, "config.json"),
+      JSON.stringify({ cache: { enabled: true, maxMb: 32, ttlDays: 30 } }),
+      "utf8",
+    );
+    writeFileSync(join(root, "fixture.png"), PNG_1X1);
+    writeFileSync(
+      join(cacheDir, "litellm-model_prices_and_context_window.json"),
+      JSON.stringify({ "gpt-5.2": { max_input_tokens: 999_999 } }),
+      "utf8",
+    );
+    writeFileSync(
+      join(cacheDir, "litellm-model_prices_and_context_window.meta.json"),
+      JSON.stringify({ fetchedAtMs: Date.now() }),
+      "utf8",
+    );
+
+    const globalFetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      throw new Error("unexpected LiteLLM catalog fetch");
+    });
+    const fetchMock = vi.fn(async () => {
+      throw new Error("unexpected fetch");
+    });
+    const input = join(root, "fixture.png");
+    const args = [
+      "--model",
+      "openai/gpt-5.2",
+      "--timeout",
+      "2s",
+      "--stream",
+      "on",
+      "--metrics",
+      "off",
+      input,
+    ];
+
+    const stdout1 = collectStream();
+    (stdout1.stream as unknown as { isTTY?: boolean }).isTTY = false;
+    const stderr1 = collectStream();
+    await runCli(args, {
+      env: { HOME: root, OPENAI_API_KEY: "test" },
+      fetch: fetchMock as unknown as typeof fetch,
+      stdout: stdout1.stream,
+      stderr: stderr1.stream,
+    });
+
+    expect(mocks.streamSimple).toHaveBeenCalledTimes(1);
+    const first = stdout1.getText();
+
+    const stdout2 = collectStream();
+    (stdout2.stream as unknown as { isTTY?: boolean }).isTTY = false;
+    const stderr2 = collectStream();
+    await runCli(args, {
+      env: { HOME: root, OPENAI_API_KEY: "test" },
+      fetch: fetchMock as unknown as typeof fetch,
+      stdout: stdout2.stream,
+      stderr: stderr2.stream,
+    });
+
+    expect(mocks.streamSimple).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(stdout2.getText()).toBe(first);
 
     globalFetchSpy.mockRestore();


### PR DESCRIPTION
## Summary

- Derive summary cache content identity from attachment bytes when binary asset prompts have an empty `<content>` block.
- Keep existing prompt/model/length/language cache dimensions unchanged.
- Add regression coverage for the key helper and repeated local PNG CLI runs.

Fixes #244.

## Proof

- `pnpm -s test tests/cache.keys.test.ts tests/cli.cache.summary.test.ts tests/asset.summary-branches.test.ts` -> 3 files, 21 tests passed.
- `pnpm -s check` -> format, lint, typecheck, coverage; 447 files, 2215 tests passed; coverage 83.73% statements / 75.36% branches.
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --engine codex` -> clean, no accepted/actionable findings.
- Live Codex-backed image cache proof using `docs/assets/summarize-cli.png`, `--model cli/codex/kindle-alpha`, and prompt token `issue-244-20260611-0318`:
  - first identical run: `[summarize] cache miss summary` then `[summarize] cache write summary`
  - second identical run: `[summarize] cache hit summary` then `Cached · cli/codex/kindle-alpha`

Caveat: the local ChatGPT Codex account rejected the repo's default Codex model `gpt-5.2` and also `gpt-5.1`, so the live proof used the configured local Codex model `kindle-alpha`.
