### PR TITLE
fix: deliver Pi prompts through file attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Pi CLI: pass summary prompts through private temporary file attachments because current Pi print mode does not read stdin.
 - Dependencies: update Markdansi to 0.3.1 and refresh the dependency lockfile.
 - Release: allow exact-version smoke tests to bypass the minimum release age for freshly published packages.
 

--- a/src/llm/cli.ts
+++ b/src/llm/cli.ts
@@ -426,7 +426,12 @@ export async function runCliModel({
 
   if (provider === "pi") {
     const isolatedCwd = !allowTools ? await fs.mkdtemp(path.join(tmpdir(), "summarize-pi-")) : null;
+    let promptDir: string | null = null;
     try {
+      promptDir = await fs.mkdtemp(path.join(tmpdir(), "summarize-pi-prompt-"));
+      const promptPath = path.join(promptDir, "prompt.txt");
+      await fs.writeFile(promptPath, prompt, { mode: 0o600 });
+
       const piArgs: string[] = [...providerExtraArgs];
       piArgs.push("--print", "--mode", "json");
       if (!allowTools) {
@@ -446,17 +451,21 @@ export async function runCliModel({
       if (requestedModel) {
         piArgs.push("--model", requestedModel);
       }
+      piArgs.push(`@${promptPath}`);
       const { stdout } = await execCliWithInput({
         execFileImpl: execFileFn,
         cmd: binary,
         args: piArgs,
-        input: prompt,
+        input: "",
         timeoutMs,
         env: effectiveEnv,
         cwd: isolatedCwd ?? cwd,
       });
       return parsePiOutputFromJsonl(stdout);
     } finally {
+      if (promptDir) {
+        await fs.rm(promptDir, { recursive: true, force: true }).catch(() => {});
+      }
       if (isolatedCwd) {
         await fs.rm(isolatedCwd, { recursive: true, force: true }).catch(() => {});
       }

--- a/tests/llm.cli.pi.test.ts
+++ b/tests/llm.cli.pi.test.ts
@@ -1,14 +1,18 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parsePiOutputFromJsonl } from "../src/llm/cli-provider-output.js";
 import { resolveCliBinary, runCliModel } from "../src/llm/cli.js";
 import type { ExecFileFn } from "../src/markitdown.js";
 
 describe("runCliModel - pi provider", () => {
-  it("invokes pi in JSON print mode and passes prompts over stdin", async () => {
+  it("invokes pi in JSON print mode with a private prompt attachment", async () => {
     const prompt = "Summarize a short local proof document.";
     let seenCmd = "";
     let seenCwd = "";
     let seenInput = "";
+    let seenPromptPath = "";
+    let seenPrompt = "";
+    let seenPromptMode = 0;
     const seenArgs: string[][] = [];
     const stdout = [
       JSON.stringify({
@@ -35,6 +39,9 @@ describe("runCliModel - pi provider", () => {
       seenCmd = String(cmd);
       seenArgs.push(args);
       seenCwd = typeof options?.cwd === "string" ? options.cwd : "";
+      seenPromptPath = args.find((arg) => arg.startsWith("@"))?.slice(1) ?? "";
+      seenPrompt = readFileSync(seenPromptPath, "utf8");
+      seenPromptMode = statSync(seenPromptPath).mode & 0o777;
       cb?.(null, stdout, "");
       return {
         stdin: {
@@ -92,7 +99,11 @@ describe("runCliModel - pi provider", () => {
       ]),
     );
     expect(seenArgs[0]).not.toContain(prompt);
-    expect(seenInput).toBe(prompt);
+    expect(seenPromptPath).toContain("summarize-pi-prompt-");
+    expect(seenPrompt).toBe(prompt);
+    expect(seenPromptMode).toBe(0o600);
+    expect(existsSync(seenPromptPath)).toBe(false);
+    expect(seenInput).toBe("");
     expect(seenCwd).toContain("summarize-pi-");
     expect(seenCwd).not.toBe("/tmp/pi-original-cwd");
   });
@@ -100,10 +111,14 @@ describe("runCliModel - pi provider", () => {
   it("keeps tools enabled when requested while still isolating pi context flags", async () => {
     let seenInput = "";
     let seenCwd = "";
+    let seenPromptPath = "";
+    let seenPrompt = "";
     const seenArgs: string[][] = [];
     const execFileImpl: ExecFileFn = ((_cmd, args, options, cb) => {
       seenArgs.push(args);
       seenCwd = typeof options?.cwd === "string" ? options.cwd : "";
+      seenPromptPath = args.find((arg) => arg.startsWith("@"))?.slice(1) ?? "";
+      seenPrompt = readFileSync(seenPromptPath, "utf8");
       cb?.(
         null,
         JSON.stringify({
@@ -149,7 +164,9 @@ describe("runCliModel - pi provider", () => {
         "openai/gpt-5.4",
       ]),
     );
-    expect(seenInput).toBe("Prompt from stdin");
+    expect(seenPrompt).toBe("Prompt from stdin");
+    expect(existsSync(seenPromptPath)).toBe(false);
+    expect(seenInput).toBe("");
     expect(seenCwd).toBe("/tmp/pi-tools-cwd");
   });
 


### PR DESCRIPTION
## Summary

- deliver Pi prompts through private mode-0600 temporary file attachments because current Pi print mode does not read stdin
- preserve isolated working directories, tool-enabled working directories, configured provider/model arguments, and prompt cleanup
- document the Pi runtime correction in the 0.17.1 Unreleased changelog

## Reproduction

The exact built 0.17.0 candidate from current main invoked through `--cli pi` exited with `CLI returned empty output`. Direct Pi 0.73.1 emitted only a session event when the prompt was sent on stdin. The same authenticated invocation completed when the prompt was passed through Pi's documented `@file` input.

This fixes the provider path landed through https://github.com/steipete/summarize/pull/247.

## Verification

- focused tests: 14 passed
- full `pnpm -s check`: 426 files passed, 2,240 tests passed, branch coverage 75.08%
- autoreview: clean, no accepted/actionable findings
- authenticated real Pi completion through the built summarize CLI: exit 0, nonempty summary, `via model cli/pi`, real usage/cost
- real ElevenLabs diarization: 97 speaker-labelled segments written to a fresh isolated cache
- forced transcript-cache rerun after deleting only the extract row and removing all provider keys: exit 0 in 3 seconds, `cacheStatus=hit`, zero attempted providers, `Served transcript from cache`, 97 segments, provider `elevenlabs`
