### PR TITLE
chore: release 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.17.1 - Unreleased
+## 0.17.1 - 2026-06-11
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/summarize",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Link → clean text → summary.",
   "bin": {
     "summarize": "./dist/cli.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/summarize-core",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Summarize core library (content extraction + prompts).",
   "files": [
     "dist",

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 declare const __dirname: string | undefined;
 
-export const FALLBACK_VERSION = "0.17.0";
+export const FALLBACK_VERSION = "0.17.1";
 
 export function resolvePackageVersion(importMetaUrl?: string): string {
   const injected =


### PR DESCRIPTION
## Summary

- release the post-0.17.0 Pi prompt-delivery correction and current patch fixes as 0.17.1
- date the changelog section
- bump the published CLI/core versions and CLI fallback version in lockstep

## Verification

- merged runtime fix: https://github.com/steipete/summarize/pull/253
- current-main CI #1491: successful
- exact merged-main authenticated Pi completion: exit 0, nonempty summary, `via model cli/pi`, 5.9 seconds, real usage/cost
- repeated real ElevenLabs diarization cache proof: 97 speaker-labelled segments; forced transcript-cache rerun with no provider keys returned `cacheStatus=hit` and attempted zero providers
- full `pnpm -s check`: 426 files passed, 2,240 tests passed, branch coverage 75.07%
