### PR TITLE
fix: harden Chrome fallback workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Fixes
 
+- Chrome extension: cancel pending summary starts when switching tabs and recover from stalled WebGPU Whisper initialization with a bounded CPU fallback.
+- CLI: use the Codex runtime default model instead of pinning auto fallback to an obsolete model.
+- Daemon: defer cache shutdown until in-flight summary work drains, preventing late writes through finalized SQLite statements.
 - Dependencies: replace Ora, tslog, and the FAL SDK with focused local implementations while retaining spinner, daemon logging, retry, multipart upload, and FAL transcription behavior.
 
 ## 0.17.1 - 2026-06-11

--- a/apps/chrome-extension/src/entrypoints/background/youtube-local-transcript.ts
+++ b/apps/chrome-extension/src/entrypoints/background/youtube-local-transcript.ts
@@ -18,6 +18,7 @@ export type BrowserYoutubeLocalTranscript =
   | { ok: false; error: string };
 
 const progressCallbacks = new Map<string, (status: string) => void>();
+const LOCAL_TRANSCRIPTION_TIMEOUT_MS = 180_000;
 let progressListenerStarted = false;
 
 export function startYoutubeLocalTranscriptionRuntime(): void {
@@ -58,17 +59,27 @@ export async function transcribeYoutubeAudioInTab({
 
     const requestId = crypto.randomUUID();
     if (onStatus) progressCallbacks.set(requestId, onStatus);
+    let timeout: ReturnType<typeof setTimeout> | null = null;
     try {
-      const response = (await chrome.runtime.sendMessage({
-        target: "offscreen",
-        type: "youtube-local:transcribe",
-        requestId,
-        context,
-        capturedSabr: getCapturedYoutubeSabrRequest(tabId),
-        maxChars,
-      })) as BrowserYoutubeLocalTranscript | undefined;
+      const response = (await Promise.race([
+        chrome.runtime.sendMessage({
+          target: "offscreen",
+          type: "youtube-local:transcribe",
+          requestId,
+          context,
+          capturedSabr: getCapturedYoutubeSabrRequest(tabId),
+          maxChars,
+        }),
+        new Promise<never>((_resolve, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("Local YouTube transcription timed out.")),
+            LOCAL_TRANSCRIPTION_TIMEOUT_MS,
+          );
+        }),
+      ])) as BrowserYoutubeLocalTranscript | undefined;
       return response ?? { ok: false, error: "Local YouTube transcription returned no result." };
     } finally {
+      if (timeout) clearTimeout(timeout);
       progressCallbacks.delete(requestId);
     }
   } catch (error) {

--- a/apps/chrome-extension/src/entrypoints/offscreen/whisper.ts
+++ b/apps/chrome-extension/src/entrypoints/offscreen/whisper.ts
@@ -6,11 +6,18 @@ import {
 } from "@huggingface/transformers";
 
 const WHISPER_MODEL = "onnx-community/whisper-tiny";
+const WEBGPU_MODEL_LOAD_TIMEOUT_MS = 30_000;
+const WASM_MODEL_LOAD_TIMEOUT_MS = 90_000;
 const ORT_WASM_URL = new URL(
   "../../../node_modules/@huggingface/transformers/dist/ort-wasm-simd-threaded.jsep.wasm",
   import.meta.url,
 ).href;
 let transcriberPromise: Promise<AutomaticSpeechRecognitionPipelineType> | null = null;
+type WhisperDevice = "webgpu" | "wasm";
+type WhisperPipelineFactory = (
+  device: WhisperDevice,
+  onStatus: (status: string) => void,
+) => Promise<AutomaticSpeechRecognitionPipelineType>;
 
 export async function transcribePcmWithWhisper({
   audio,
@@ -49,26 +56,90 @@ async function getTranscriber(
       };
       env.backends.onnx.wasm.proxy = false;
     }
-    onStatus(hasWebGpu ? "Loading local Whisper model..." : "Loading local Whisper model (CPU)...");
-    transcriberPromise = pipeline("automatic-speech-recognition", WHISPER_MODEL, {
-      device: hasWebGpu ? "webgpu" : "wasm",
-      dtype: hasWebGpu
-        ? { encoder_model: "fp16", decoder_model_merged: "q4" }
-        : { encoder_model: "q8", decoder_model_merged: "q8" },
-      progress_callback: (progress: unknown) => {
-        if (!progress || typeof progress !== "object") return;
-        const value = (progress as { progress?: unknown }).progress;
-        if (typeof value !== "number" || !Number.isFinite(value)) return;
-        onStatus(
-          `Loading local Whisper model... ${Math.max(0, Math.min(100, Math.round(value)))}%`,
-        );
-      },
+    transcriberPromise = loadWhisperTranscriber({
+      hasWebGpu,
+      onStatus,
     }).catch((error) => {
       transcriberPromise = null;
       throw error;
     });
   }
   return await transcriberPromise;
+}
+
+export async function loadWhisperTranscriber({
+  hasWebGpu,
+  onStatus,
+  createPipeline = createWhisperPipeline,
+  webGpuTimeoutMs = WEBGPU_MODEL_LOAD_TIMEOUT_MS,
+  wasmTimeoutMs = WASM_MODEL_LOAD_TIMEOUT_MS,
+}: {
+  hasWebGpu: boolean;
+  onStatus: (status: string) => void;
+  createPipeline?: WhisperPipelineFactory;
+  webGpuTimeoutMs?: number;
+  wasmTimeoutMs?: number;
+}): Promise<AutomaticSpeechRecognitionPipelineType> {
+  let activeAttempt = 0;
+  const load = async (device: WhisperDevice, timeoutMs: number, timeoutMessage: string) => {
+    const attempt = ++activeAttempt;
+    return await withTimeout(
+      createPipeline(device, (status) => {
+        if (attempt === activeAttempt) onStatus(status);
+      }),
+      timeoutMs,
+      timeoutMessage,
+    );
+  };
+
+  if (hasWebGpu) {
+    onStatus("Loading local Whisper model...");
+    try {
+      return await load(
+        "webgpu",
+        webGpuTimeoutMs,
+        "WebGPU Whisper model initialization timed out.",
+      );
+    } catch {
+      onStatus("WebGPU model load stalled; retrying on CPU...");
+    }
+  }
+
+  onStatus("Loading local Whisper model (CPU)...");
+  return await load("wasm", wasmTimeoutMs, "CPU Whisper model initialization timed out.");
+}
+
+async function createWhisperPipeline(
+  device: WhisperDevice,
+  onStatus: (status: string) => void,
+): Promise<AutomaticSpeechRecognitionPipelineType> {
+  return await pipeline("automatic-speech-recognition", WHISPER_MODEL, {
+    device,
+    dtype:
+      device === "webgpu"
+        ? { encoder_model: "fp16", decoder_model_merged: "q4" }
+        : { encoder_model: "q8", decoder_model_merged: "q8" },
+    progress_callback: (progress: unknown) => {
+      if (!progress || typeof progress !== "object") return;
+      const value = (progress as { progress?: unknown }).progress;
+      if (typeof value !== "number" || !Number.isFinite(value)) return;
+      onStatus(`Loading local Whisper model... ${Math.max(0, Math.min(100, Math.round(value)))}%`);
+    },
+  });
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function formatWhisperOutput(

--- a/apps/chrome-extension/src/entrypoints/sidepanel/appearance-controls.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/appearance-controls.ts
@@ -89,6 +89,7 @@ export function createAppearanceControls(options: {
     getLengthValue: () => pickerSettings.length,
     getFontFamily: () => pickerSettings.fontFamily,
     setAutoValue: (checked: boolean) => {
+      if (autoValue === checked) return;
       autoValue = checked;
       updateAutoToggle();
     },

--- a/apps/chrome-extension/src/entrypoints/sidepanel/stream-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/stream-controller.ts
@@ -72,6 +72,7 @@ export function createStreamController(options: StreamControllerOptions): Stream
   let renderQueued = 0;
   let streamedAnyNonWhitespace = false;
   let rememberedUrl = false;
+  let starting = false;
   let streaming = false;
   let hadError = false;
   let sawDone = false;
@@ -110,29 +111,46 @@ export function createStreamController(options: StreamControllerOptions): Stream
     onRender?.(markdown);
   };
 
-  const abort = () => {
+  const abortActive = (settlePhase: boolean) => {
     activeGeneration += 1;
-    if (!controller) return;
-    if (activeAbortState) activeAbortState.reason = "manual";
-    controller.abort();
-    controller = null;
-    activeAbortState = null;
+    const wasActive = starting || streaming;
+    starting = false;
+    if (controller) {
+      if (activeAbortState) activeAbortState.reason = "manual";
+      controller.abort();
+      controller = null;
+      activeAbortState = null;
+    }
     clearQueuedRender();
-    if (streaming) {
-      streaming = false;
+    streaming = false;
+    if (wasActive && settlePhase) {
       onPhaseChange("idle");
     }
   };
 
+  const abort = () => abortActive(true);
+
   const start = async (run: RunStart) => {
-    const generation = activeGeneration + 1;
-    activeGeneration = generation;
-    abort();
-    activeGeneration = generation;
-    const token = (await getToken()).trim();
+    abortActive(false);
+    const generation = activeGeneration;
+    starting = true;
+    let token = "";
+    try {
+      token = (await getToken()).trim();
+    } catch (err) {
+      if (generation !== activeGeneration) return;
+      starting = false;
+      const message = onError ? onError(err) : err instanceof Error ? err.message : String(err);
+      onStatus(`Error: ${message}`);
+      onPhaseChange("error");
+      onDone?.();
+      return;
+    }
     if (generation !== activeGeneration) return;
+    starting = false;
     if (!token) {
       onStatus("Setup required (missing token)");
+      onPhaseChange("idle");
       return;
     }
 
@@ -281,6 +299,6 @@ export function createStreamController(options: StreamControllerOptions): Stream
   return {
     start,
     abort,
-    isStreaming: () => streaming,
+    isStreaming: () => starting || streaming,
   };
 }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
@@ -166,6 +166,8 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
       opts.clearInlineError();
     }
     opts.setLastPanelOpen(state.panelOpen);
+    opts.setAutoValue(state.settings.autoSummarize);
+    opts.appearanceControls.setAutoValue(state.settings.autoSummarize);
 
     const activeTabId = opts.getActiveTabId();
     const activeTabUrl = opts.getActiveTabUrl();
@@ -241,9 +243,7 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
       if (navigation.resetInputModeOverride) {
         opts.setInputModeOverride(null);
       }
-      if (opts.isStreaming()) {
-        opts.abortSummaryStream();
-      }
+      opts.abortSummaryStream();
       if (!opts.maybeStartPendingSummaryRunForUrl(nextTabUrl)) {
         applyCachedOrReset(opts, nextTabId, nextTabUrl, navigation.preserveChat);
       }
@@ -255,9 +255,7 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
         void opts.clearChatHistoryForActiveTab();
         opts.resetChatState();
       }
-      if (opts.isStreaming()) {
-        opts.abortSummaryStream();
-      }
+      opts.abortSummaryStream();
       if (!opts.maybeStartPendingSummaryRunForUrl(nextTabUrl)) {
         applyCachedOrReset(opts, opts.getActiveTabId(), nextTabUrl, navigation.preserveChat);
       }
@@ -266,8 +264,6 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
       }
     }
 
-    opts.setAutoValue(state.settings.autoSummarize);
-    opts.appearanceControls.setAutoValue(state.settings.autoSummarize);
     opts.setChatEnabledValue(state.settings.chatEnabled);
     opts.setAutomationEnabledValue(state.settings.automationEnabled);
     opts.setSlidesEnabledValue(state.settings.slidesEnabled);

--- a/apps/chrome-extension/tests/extension.spec.ts
+++ b/apps/chrome-extension/tests/extension.spec.ts
@@ -646,19 +646,32 @@ test("sidepanel auto summarize toggle stays inline", async ({
 
     const label = page.locator("#autoToggle .checkboxRoot");
     await expect(label).toBeVisible();
-    const labelBox = await label.boundingBox();
-    const controlBox = await page.locator("#autoToggle .checkboxControl").boundingBox();
-    const textBox = await page.locator("#autoToggle .checkboxLabel").boundingBox();
+    const layout = await label.evaluate((element) => {
+      const control = element.querySelector(".checkboxControl");
+      const text = element.querySelector(".checkboxLabel");
+      if (!(control instanceof HTMLElement) || !(text instanceof HTMLElement)) return null;
+      const labelRect = element.getBoundingClientRect();
+      const controlRect = control.getBoundingClientRect();
+      const textRect = text.getBoundingClientRect();
+      return {
+        labelTop: labelRect.top,
+        labelBottom: labelRect.bottom,
+        controlTop: controlRect.top,
+        controlBottom: controlRect.bottom,
+        controlCenter: controlRect.top + controlRect.height / 2,
+        textTop: textRect.top,
+        textBottom: textRect.bottom,
+        textCenter: textRect.top + textRect.height / 2,
+      };
+    });
 
-    expect(labelBox).not.toBeNull();
-    expect(controlBox).not.toBeNull();
-    expect(textBox).not.toBeNull();
-
-    if (labelBox && controlBox && textBox) {
-      expect(controlBox.y).toBeGreaterThanOrEqual(labelBox.y - 1);
-      expect(controlBox.y).toBeLessThanOrEqual(labelBox.y + labelBox.height - 1);
-      expect(textBox.y).toBeGreaterThanOrEqual(labelBox.y - 1);
-      expect(textBox.y).toBeLessThanOrEqual(labelBox.y + labelBox.height - 1);
+    expect(layout).not.toBeNull();
+    if (layout) {
+      expect(layout.controlTop).toBeGreaterThanOrEqual(layout.labelTop - 1);
+      expect(layout.controlBottom).toBeLessThanOrEqual(layout.labelBottom + 1);
+      expect(layout.textTop).toBeGreaterThanOrEqual(layout.labelTop - 1);
+      expect(layout.textBottom).toBeLessThanOrEqual(layout.labelBottom + 1);
+      expect(Math.abs(layout.controlCenter - layout.textCenter)).toBeLessThanOrEqual(1);
     }
 
     assertNoErrors(harness);

--- a/apps/chrome-extension/tests/sidepanel.youtube-e2e.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.youtube-e2e.spec.ts
@@ -35,7 +35,6 @@ import {
   getPanelSlideDescriptions,
   getPanelSlidesSummaryComplete,
   getPanelSlidesSummaryMarkdown,
-  getPanelSlidesSummaryModel,
   getPanelSlidesTimeline,
   getPanelSummaryMarkdown,
   getPanelTranscriptTimedText,
@@ -141,7 +140,6 @@ test.describe("youtube e2e", () => {
 
         await expect.poll(async () => await getPanelPhase(page), { timeout: 420_000 }).toBe("idle");
 
-        const model = (await getPanelModel(page))?.trim() || "auto";
         const cliSummary = runCliSummary(url, [
           "--json",
           "--length",
@@ -149,7 +147,7 @@ test.describe("youtube e2e", () => {
           "--language",
           "auto",
           "--model",
-          model,
+          "auto",
           "--video-mode",
           "transcript",
           "--timestamps",
@@ -253,7 +251,6 @@ test.describe("youtube e2e", () => {
         await expect
           .poll(async () => (await getPanelModel(page)) ?? "", { timeout: 120_000 })
           .not.toBe("");
-        const model = (await getPanelModel(page)) ?? "auto";
 
         await expect
           .poll(async () => (await getPanelSlidesTimeline(page)).length, { timeout: 600_000 })
@@ -294,7 +291,6 @@ test.describe("youtube e2e", () => {
           path: testInfo.outputPath(`youtube-slides-${videoId}.png`),
           fullPage: true,
         });
-        const slidesModel = (await getPanelSlidesSummaryModel(page))?.trim() || model;
         const slidesSummaryMarkdown = await getPanelSlidesSummaryMarkdown(page);
         const cliSummary = runCliSummary(url, [
           "--slides",
@@ -307,7 +303,7 @@ test.describe("youtube e2e", () => {
           "--language",
           "auto",
           "--model",
-          slidesModel,
+          "auto",
           "--video-mode",
           "transcript",
           "--timestamps",

--- a/apps/chrome-extension/tests/youtube-local.live.spec.ts
+++ b/apps/chrome-extension/tests/youtube-local.live.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   activateTabByUrl,
   closeExtension,
+  getBackground,
   getBrowserFromProject,
   launchExtension,
   openExtensionPage,
@@ -66,7 +67,7 @@ test("transcribes a captionless YouTube video through the extension runtime", as
       inputMode: "video",
     });
     const panelTransitions: string[] = [];
-    const deadline = Date.now() + 90_000;
+    const deadline = Date.now() + 180_000;
     while (Date.now() < deadline) {
       const state = {
         model: await getPanelModel(panel),
@@ -90,8 +91,35 @@ test("transcribes a captionless YouTube video through the extension runtime", as
       );
     }
     const summary = await getPanelSummaryMarkdown(panel);
+    const background = await getBackground(harness);
+    const readLocalTranscriptLog = async () =>
+      await background.evaluate(async () => {
+        const stored = await chrome.storage.session.get("summarize:extension-logs");
+        const lines = Array.isArray(stored["summarize:extension-logs"])
+          ? (stored["summarize:extension-logs"] as string[])
+          : [];
+        return lines
+          .toReversed()
+          .map((line) => {
+            try {
+              return JSON.parse(line) as {
+                event?: unknown;
+                mediaSource?: unknown;
+                textLength?: unknown;
+              };
+            } catch {
+              return null;
+            }
+          })
+          .find((entry) => entry?.event === "extract:url-direct:local-transcript");
+      });
+    await expect.poll(readLocalTranscriptLog, { timeout: 10_000 }).not.toBeNull();
+    const localTranscriptLog = await readLocalTranscriptLog();
     expect(playerState.captionTrackCount).toBe(0);
-    expect(summary.length).toBeGreaterThan(500);
+    expect(localTranscriptLog?.textLength).toEqual(expect.any(Number));
+    expect(localTranscriptLog?.textLength as number).toBeGreaterThan(20);
+    expect(["android-vr", "sabr"]).toContain(localTranscriptLog?.mediaSource);
+    expect(summary.length).toBeGreaterThan(50);
     expect(summary).not.toContain("No transcript text was available from the browser");
     expect(
       consoleMessages.some((message) => message.includes("extract:url-direct:local-transcript")),

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -108,23 +108,45 @@ export function resolveDaemonMaxActiveSummaries(env: Record<string, string | und
   return clampNumber(Math.floor(parsed), 1, DAEMON_MAX_ACTIVE_SUMMARIES_LIMIT);
 }
 
-async function waitForActiveTasks(
-  activeTasks: Set<Promise<void>>,
-  timeoutMs: number,
-): Promise<void> {
-  if (activeTasks.size === 0) return;
+async function drainActiveTasks(activeTasks: Set<Promise<void>>): Promise<void> {
+  while (activeTasks.size > 0) {
+    const tasks = [...activeTasks];
+    await Promise.allSettled(tasks);
+    for (const task of tasks) {
+      activeTasks.delete(task);
+    }
+  }
+}
+
+export async function closeAfterActiveTasks({
+  activeTasks,
+  timeoutMs,
+  close,
+}: {
+  activeTasks: Set<Promise<void>>;
+  timeoutMs: number;
+  close: () => void;
+}): Promise<boolean> {
+  const drainPromise = drainActiveTasks(activeTasks);
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let drained = false;
   try {
-    await Promise.race([
-      Promise.allSettled([...activeTasks]).then(() => undefined),
-      new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, timeoutMs);
+    drained = await Promise.race([
+      drainPromise.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
         timer.unref?.();
       }),
     ]);
   } finally {
     if (timer) clearTimeout(timer);
   }
+  if (drained) {
+    close();
+  } else {
+    void drainPromise.then(close).catch(() => {});
+  }
+  return drained;
 }
 
 export function resolveDaemonListenHost(env: Record<string, string | undefined>): string {
@@ -641,7 +663,10 @@ export async function runDaemonServer({
       }
     });
   } finally {
-    await waitForActiveTasks(activeTasks, DAEMON_SHUTDOWN_ACTIVE_SESSION_GRACE_MS);
-    cacheState.store?.close();
+    await closeAfterActiveTasks({
+      activeTasks,
+      timeoutMs: DAEMON_SHUTDOWN_ACTIVE_SESSION_GRACE_MS,
+      close: () => cacheState.store?.close(),
+    });
   }
 }

--- a/src/llm/provider-profile.ts
+++ b/src/llm/provider-profile.ts
@@ -111,7 +111,7 @@ export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
 
 export const DEFAULT_CLI_MODELS: Record<CliProvider, string | null> = {
   claude: "sonnet",
-  codex: "gpt-5.2",
+  codex: null,
   gemini: "flash",
   agent: "auto",
   openclaw: "main",

--- a/tests/chrome.whisper-loader.test.ts
+++ b/tests/chrome.whisper-loader.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadWhisperTranscriber } from "../apps/chrome-extension/src/entrypoints/offscreen/whisper";
+
+describe("Chrome local Whisper loader", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("falls back to WASM when WebGPU initialization stalls", async () => {
+    vi.useFakeTimers();
+    const statuses: string[] = [];
+    const transcriber = vi.fn();
+    const createPipeline = vi
+      .fn()
+      .mockImplementationOnce(async () => await new Promise(() => {}))
+      .mockResolvedValueOnce(transcriber);
+
+    const result = loadWhisperTranscriber({
+      hasWebGpu: true,
+      onStatus: (status) => statuses.push(status),
+      createPipeline,
+      webGpuTimeoutMs: 100,
+      wasmTimeoutMs: 100,
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(result).resolves.toBe(transcriber);
+    expect(createPipeline.mock.calls.map(([device]) => device)).toEqual(["webgpu", "wasm"]);
+    expect(statuses).toContain("WebGPU model load stalled; retrying on CPU...");
+  });
+
+  it("fails instead of hanging when CPU initialization stalls", async () => {
+    vi.useFakeTimers();
+    const result = loadWhisperTranscriber({
+      hasWebGpu: false,
+      onStatus: vi.fn(),
+      createPipeline: async () => await new Promise(() => {}),
+      wasmTimeoutMs: 100,
+    });
+    const rejection = expect(result).rejects.toThrow("CPU Whisper model initialization timed out.");
+    await vi.advanceTimersByTimeAsync(100);
+
+    await rejection;
+  });
+});

--- a/tests/daemon.shutdown.test.ts
+++ b/tests/daemon.shutdown.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { closeAfterActiveTasks } from "../src/daemon/server.js";
+
+describe("daemon shutdown", () => {
+  it("defers resource close until active tasks and their descendants settle", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveParent: (() => void) | null = null;
+      let resolveChild: (() => void) | null = null;
+      const parent = new Promise<void>((resolve) => {
+        resolveParent = resolve;
+      });
+      const child = new Promise<void>((resolve) => {
+        resolveChild = resolve;
+      });
+      const activeTasks = new Set<Promise<void>>([parent]);
+      let resolveClosed: (() => void) | null = null;
+      const closed = new Promise<void>((resolve) => {
+        resolveClosed = resolve;
+      });
+      const close = vi.fn(() => resolveClosed?.());
+
+      const shutdown = closeAfterActiveTasks({ activeTasks, timeoutMs: 100, close });
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(shutdown).resolves.toBe(false);
+      expect(close).not.toHaveBeenCalled();
+
+      activeTasks.add(child);
+      resolveParent?.();
+      await vi.runAllTicks();
+      expect(close).not.toHaveBeenCalled();
+
+      resolveChild?.();
+      await closed;
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/llm.provider-capabilities.test.ts
+++ b/tests/llm.provider-capabilities.test.ts
@@ -24,6 +24,7 @@ describe("llm provider capabilities", () => {
       "opencode",
       "copilot",
     ]);
+    expect(DEFAULT_CLI_MODELS.codex).toBeNull();
     expect(DEFAULT_CLI_MODELS.gemini).toBe("flash");
     expect(DEFAULT_CLI_MODELS.openclaw).toBe("main");
     expect(DEFAULT_CLI_MODELS.opencode).toBeNull();

--- a/tests/model-spec.test.ts
+++ b/tests/model-spec.test.ts
@@ -19,12 +19,13 @@ describe("model spec parsing", () => {
     expect(parsed.cliModel).toBe("sonnet");
   });
 
-  it("defaults cli models when missing", () => {
+  it("uses the Codex runtime default model when missing", () => {
     const parsed = parseRequestedModelId("cli/codex");
     expect(parsed.kind).toBe("fixed");
     expect(parsed.transport).toBe("cli");
+    expect(parsed.userModelId).toBe("cli/codex");
     expect(parsed.cliProvider).toBe("codex");
-    expect(parsed.cliModel).toBe("gpt-5.2");
+    expect(parsed.cliModel).toBeNull();
     expect(parsed.requiredEnv).toBe("CLI_CODEX");
   });
 

--- a/tests/sidepanel.stream-controller.error.test.ts
+++ b/tests/sidepanel.stream-controller.error.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createStreamController } from "../apps/chrome-extension/src/entrypoints/sidepanel/stream-controller.js";
 import { encodeSseEvent, type SseEvent } from "../src/shared/sse-events.js";
 
@@ -43,6 +43,32 @@ const run = {
 };
 
 describe("sidepanel stream controller error handling", () => {
+  it("returns to idle when aborted during token lookup", async () => {
+    let releaseToken: ((value: string) => void) | null = null;
+    const token = new Promise<string>((resolve) => {
+      releaseToken = resolve;
+    });
+    const phases: string[] = [];
+    const fetchImpl = vi.fn();
+    const controller = createStreamController({
+      getToken: async () => await token,
+      onStatus: () => {},
+      onPhaseChange: (phase) => phases.push(phase),
+      onMeta: () => {},
+      fetchImpl,
+    });
+
+    const pendingStart = controller.start(run);
+    expect(controller.isStreaming()).toBe(true);
+    controller.abort();
+    expect(controller.isStreaming()).toBe(false);
+    expect(phases.at(-1)).toBe("idle");
+
+    releaseToken?.("token");
+    await pendingStart;
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("does not let stale starts cancel newer streams after token lookup races", async () => {
     let releaseFirstToken: ((value: string) => void) | null = null;
     const firstToken = new Promise<string>((resolve) => {


### PR DESCRIPTION
## Summary

- cancel Chrome extension summary startup cleanly across tab navigation
- bound local Whisper initialization and fall back from stalled WebGPU to WASM
- use the Codex runtime default model for CLI auto fallback
- defer daemon cache close until active work drains
- strengthen Chrome live and daemon-backed YouTube coverage

## Verification

- `pnpm -s check` (432 files passed, 2263 tests passed)
- `SUMMARIZE_LIVE_TESTS=1 pnpm -C apps/chrome-extension test:chrome` (70 passed, 2 gated tests skipped)
- daemon-backed YouTube summary and slides parity tests (2 passed)
- pending summary navigation regression repeated 50 times
- daemon shutdown/cache race reproduction passed
