### PR TITLE
fix: speed up browser slide encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Daemon: defer cache shutdown until in-flight summary work drains, preventing late writes through finalized SQLite statements.
 - Dependencies: replace Ora, tslog, and the FAL SDK with focused local implementations while retaining spinner, daemon logging, retry, multipart upload, and FAL transcription behavior.
 - Chrome extension: replace the bundled browser FFmpeg WebAssembly runtime with MediaBunny and native WebCodecs, adding AV1 frame extraction while reducing the packaged extension size.
+- Chrome extension: avoid throttled offscreen canvas blob callbacks so MediaBunny slide JPEGs encode in milliseconds instead of roughly one second per frame.
 
 ## 0.17.1 - 2026-06-11
 

--- a/apps/chrome-extension/src/entrypoints/background/browser-media.ts
+++ b/apps/chrome-extension/src/entrypoints/background/browser-media.ts
@@ -94,7 +94,7 @@ export async function extractBrowserMediaFramesInDocument({
       index += 1;
       if (!wrapped) continue;
       frames.push({
-        imageUrl: await canvasToDataUrl(wrapped),
+        imageUrl: await browserMediaCanvasToDataUrl(wrapped),
         timestamp,
       });
     }
@@ -234,17 +234,15 @@ function createMediaInput(bytes: Uint8Array, mimeType: string | null): Input {
   });
 }
 
-async function canvasToDataUrl({ canvas }: WrappedCanvas): Promise<string> {
-  const blob =
-    typeof OffscreenCanvas !== "undefined" && canvas instanceof OffscreenCanvas
-      ? await canvas.convertToBlob({ type: FRAME_IMAGE_TYPE, quality: FRAME_IMAGE_QUALITY })
-      : await new Promise<Blob>((resolve, reject) =>
-          canvas.toBlob(
-            (value) => (value ? resolve(value) : reject(new Error("Canvas encoding failed."))),
-            FRAME_IMAGE_TYPE,
-            FRAME_IMAGE_QUALITY,
-          ),
-        );
+export async function browserMediaCanvasToDataUrl({ canvas }: WrappedCanvas): Promise<string> {
+  if (!(typeof OffscreenCanvas !== "undefined" && canvas instanceof OffscreenCanvas)) {
+    // Chrome throttles HTMLCanvasElement.toBlob() to roughly one callback per second in offscreen documents.
+    return canvas.toDataURL(FRAME_IMAGE_TYPE, FRAME_IMAGE_QUALITY);
+  }
+  const blob = await canvas.convertToBlob({
+    type: FRAME_IMAGE_TYPE,
+    quality: FRAME_IMAGE_QUALITY,
+  });
   return await bytesToDataUrl(new Uint8Array(await blob.arrayBuffer()), blob.type);
 }
 

--- a/apps/chrome-extension/tests/youtube-local.live.spec.ts
+++ b/apps/chrome-extension/tests/youtube-local.live.spec.ts
@@ -98,7 +98,7 @@ test("transcribes a captionless YouTube video through the extension runtime", as
         const lines = Array.isArray(stored["summarize:extension-logs"])
           ? (stored["summarize:extension-logs"] as string[])
           : [];
-        return lines
+        const entry = lines
           .toReversed()
           .map((line) => {
             try {
@@ -111,7 +111,8 @@ test("transcribes a captionless YouTube video through the extension runtime", as
               return null;
             }
           })
-          .find((entry) => entry?.event === "extract:url-direct:local-transcript");
+          .find((candidate) => candidate?.event === "extract:url-direct:local-transcript");
+        return entry ?? null;
       });
     await expect.poll(readLocalTranscriptLog, { timeout: 10_000 }).not.toBeNull();
     const localTranscriptLog = await readLocalTranscriptLog();

--- a/tests/chrome.browser-media.test.ts
+++ b/tests/chrome.browser-media.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  browserMediaCanvasToDataUrl,
   extractBrowserMediaFrames,
   extractBrowserMediaFramesInDocument,
   isBrowserMediaUrl,
@@ -129,6 +130,20 @@ describe("chrome browser media decoding", () => {
         ),
       }),
     ).rejects.toThrow("too large");
+  });
+
+  it("encodes offscreen-document HTML canvases without the throttled blob callback", async () => {
+    const toDataURL = vi.fn(() => "data:image/jpeg;base64,AQID");
+    const canvas = { toDataURL } as unknown as HTMLCanvasElement;
+
+    await expect(
+      browserMediaCanvasToDataUrl({
+        canvas,
+        duration: 1,
+        timestamp: 0,
+      }),
+    ).resolves.toBe("data:image/jpeg;base64,AQID");
+    expect(toDataURL).toHaveBeenCalledWith("image/jpeg", 0.82);
   });
 
   it("incrementally downmixes and resamples timestamped PCM", () => {


### PR DESCRIPTION
## Summary

- encode MediaBunny HTML canvas frames with `toDataURL` in Chrome offscreen documents
- preserve the existing `OffscreenCanvas.convertToBlob` path
- fix the live YouTube E2E log poll so it waits for the structured transcript event
- document the browser-slide performance fix

## Root cause

Chrome throttles `HTMLCanvasElement.toBlob()` callbacks in extension offscreen documents to roughly one callback per second. The synchronous JPEG data URL path takes about 4 ms in the same context.

## Verification

- `pnpm -s check` (2264 passed, 42 skipped)
- Chromium extension suite: 69 passed, 3 skipped
- browser slide E2E repeated 10 times: 10 passed
- live captionless YouTube + local Whisper E2E: passed
- codec stress: H.264 MP4/MOV, VP9, AV1, HEVC, real YouTube H.264/VP9/AV1
- load stress: 20 serial frame runs, 9 concurrent mixed-codec runs, 30 serial audio runs, 8 concurrent audio runs
- real audio comparison: AAC, Opus, MP3, FLAC, WAV, 5.1 AAC, 5-minute YouTube audio, 17-minute podcast
- autoreview: clean, no actionable findings

Measured three-frame offscreen capture improved from about 3.1 seconds to 103 ms.