### PR TITLE
[codex] Harden daemonless browser media

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,27 @@ jobs:
         run: |
           xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
             pnpm -C apps/chrome-extension exec playwright test -c playwright.config.ts --project=chromium
+
+  extension-firefox-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.33.2 --activate
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Firefox
+        run: pnpm -C apps/chrome-extension exec playwright install --with-deps firefox
+
+      - name: Firefox extension smoke
+        run: pnpm -C apps/chrome-extension test:firefox

--- a/.github/workflows/media-live.yml
+++ b/.github/workflows/media-live.yml
@@ -1,0 +1,77 @@
+name: Media Live
+
+on:
+  schedule:
+    - cron: "23 7 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: media-live
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  youtube-resolver:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.33.2 --activate
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Live YouTube resolver
+        env:
+          SUMMARIZE_LIVE_TESTS: "1"
+          VITEST_MAX_THREADS: "1"
+        run: |
+          pnpm exec vitest run \
+            tests/youtube.android-vr.live.test.ts \
+            tests/youtube.no-transcript.live.test.ts
+
+  chrome-daemonless-youtube:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.33.2 --activate
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm -C apps/chrome-extension exec playwright install --with-deps chromium
+
+      - name: Build extension
+        run: pnpm -C apps/chrome-extension build
+
+      - name: Live daemonless YouTube transcription
+        env:
+          SUMMARIZE_LIVE_TESTS: "1"
+        run: |
+          xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
+            pnpm -C apps/chrome-extension exec playwright test \
+              -c playwright.config.ts \
+              --project=chromium \
+              tests/youtube-local.live.spec.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - CLI media: allow `--diarize` and speaker identification for local and direct audio/video inputs, including MP3 and MP4, instead of limiting speaker-labelled transcription to YouTube.
 - YouTube transcripts: fall back to Android VR direct audio resolution and configured transcription when `yt-dlp` is missing or fails, while preserving explicit `--youtube yt-dlp` and diarization requirements.
-- Chrome extension: transcribe captionless YouTube videos without the daemon using same-origin Android VR audio, captured SABR fallback, WebAudio with MediaBunny fallback, and browser-cached multilingual Whisper Tiny.
+- Chrome extension: transcribe captionless YouTube videos without the daemon using active-player/watch-page or Android VR direct audio, captured SABR fallback, MediaBunny/WebCodecs, and browser-cached multilingual Whisper Tiny.
+- Chrome extension: transcribe fetchable direct and embedded media without the daemon using ranged MediaBunny/WebCodecs decoding, bounded audio chunks, and an idle-evictable browser Whisper runtime.
 
 ### Fixes
 
@@ -16,6 +17,8 @@
 - Dependencies: replace Ora, tslog, and the FAL SDK with focused local implementations while retaining spinner, daemon logging, retry, multipart upload, and FAL transcription behavior.
 - Chrome extension: replace the bundled browser FFmpeg WebAssembly runtime with MediaBunny and native WebCodecs, adding AV1 frame extraction while reducing the packaged extension size.
 - Chrome extension: avoid throttled offscreen canvas blob callbacks so MediaBunny slide JPEGs encode in milliseconds instead of roughly one second per frame.
+- YouTube media: prefer direct audio already exposed by the active player or watch page before requesting Android VR media, with resolver and browser decoder diagnostics in extension logs.
+- Extension tests: load the Firefox build through Mozilla `web-ext` in CI and run daily live YouTube resolver plus daemonless Chrome transcription checks.
 
 ## 0.17.1 - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ YouTube slide screenshots (from the browser):
 
 Why a daemon/service?
 
-- Browser mode works without the daemon for page summaries, fetchable video slides through MediaBunny/WebCodecs, and captionless YouTube transcription through WebAudio or MediaBunny plus browser-cached Whisper.
+- Browser mode works without the daemon for page summaries, ranged video slides through MediaBunny/WebCodecs, and fetchable YouTube/direct/embedded media transcription with browser-cached Whisper.
 - The optional daemon on `127.0.0.1` is faster and adds native ffmpeg, configurable transcription providers, OCR, and broader media support.
 - The service autostarts (launchd/systemd/Scheduled Task) so the Side Panel is always ready.
 
@@ -71,7 +71,7 @@ More:
 - Select **Video + Slides** in the Summarize picker.
 - Slides render at the top; expand to full‑width cards with timestamps.
 - Click a slide to seek the video; toggle **Transcript/OCR** when OCR is significant.
-- Browser mode uses MediaBunny with native WebCodecs for fetchable videos up to 128 MB, then falls back to visible-tab capture.
+- Browser mode uses MediaBunny with native WebCodecs and ranged network reads for fetchable videos, then falls back to visible-tab capture when the source or codec is unavailable.
 - Daemon mode adds `yt-dlp`, native ffmpeg, and optional `tesseract` OCR.
 
 ### Advanced (unpacked / dev)

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -13,8 +13,9 @@
     "test": "pnpm test:e2e",
     "test:chrome": "env -u NO_COLOR pnpm build && env -u NO_COLOR playwright test -c playwright.config.ts --project=chromium",
     "test:e2e": "env -u NO_COLOR pnpm build && env -u NO_COLOR playwright test -c playwright.config.ts --project=chromium",
-    "test:firefox": "env -u NO_COLOR pnpm build:firefox && env -u NO_COLOR playwright test -c playwright.config.ts --project=firefox",
-    "test:firefox:force": "env -u NO_COLOR ALLOW_FIREFOX_EXTENSION_TESTS=1 pnpm build:firefox && env -u NO_COLOR ALLOW_FIREFOX_EXTENSION_TESTS=1 playwright test -c playwright.config.ts --project=firefox"
+    "test:firefox": "env -u NO_COLOR pnpm build:firefox && env -u NO_COLOR node scripts/firefox-smoke.mjs",
+    "test:firefox:force": "env -u NO_COLOR ALLOW_FIREFOX_EXTENSION_TESTS=1 pnpm build:firefox && env -u NO_COLOR ALLOW_FIREFOX_EXTENSION_TESTS=1 playwright test -c playwright.config.ts --project=firefox",
+    "test:firefox:lint": "env -u NO_COLOR pnpm build:firefox && env -u NO_COLOR web-ext lint --source-dir .output/firefox-mv3 --self-hosted --boring"
   },
   "dependencies": {
     "@huggingface/transformers": "3.8.1",
@@ -29,6 +30,7 @@
     "@playwright/test": "1.60.0",
     "@types/chrome": "^0.1.43",
     "typescript": "^6.0.3",
+    "web-ext": "10.3.0",
     "wxt": "0.20.26"
   }
 }

--- a/apps/chrome-extension/scripts/firefox-smoke.mjs
+++ b/apps/chrome-extension/scripts/firefox-smoke.mjs
@@ -1,0 +1,139 @@
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourceDir = path.join(appDir, ".output", "firefox-mv3");
+const startupTimeoutMs = 45_000;
+const readyHoldMs = 3_000;
+
+if (!fs.existsSync(path.join(sourceDir, "manifest.json"))) {
+  throw new Error("Missing Firefox extension build. Run pnpm build:firefox first.");
+}
+
+const firefoxBinary = await resolveFirefoxBinary();
+if (!firefoxBinary) {
+  throw new Error(
+    "Firefox binary not found. Install Firefox, run Playwright's Firefox install, or set FIREFOX_BINARY.",
+  );
+}
+
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const args = [
+  "exec",
+  "web-ext",
+  "run",
+  "--source-dir",
+  sourceDir,
+  "--firefox",
+  firefoxBinary,
+  "--no-reload",
+  "--no-input",
+  "--start-url",
+  "about:blank",
+  "--args=-headless",
+  "--pref=browser.shell.checkDefaultBrowser=false",
+  "--pref=datareporting.policy.dataSubmissionEnabled=false",
+];
+const child = spawn(pnpm, args, {
+  cwd: appDir,
+  env: { ...process.env, NO_COLOR: "1" },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+let output = "";
+let ready = false;
+let settled = false;
+let startupTimer;
+let holdTimer;
+
+const finish = (error) => {
+  if (settled) return;
+  settled = true;
+  clearTimeout(startupTimer);
+  clearTimeout(holdTimer);
+  if (!child.killed) child.kill("SIGINT");
+  if (error) {
+    console.error(output.trim());
+    process.exitCode = 1;
+    console.error(error.message);
+  }
+};
+
+const onOutput = (chunk) => {
+  const text = chunk.toString();
+  output += text;
+  process.stdout.write(text);
+  if (
+    !ready &&
+    /extension will reload|installed .*temporary|running web extension|launching firefox/i.test(
+      output,
+    )
+  ) {
+    ready = true;
+    holdTimer = setTimeout(() => finish(), readyHoldMs);
+  }
+};
+
+child.stdout.on("data", onOutput);
+child.stderr.on("data", onOutput);
+child.once("error", (error) => finish(error));
+child.once("exit", (code, signal) => {
+  if (settled) return;
+  if (ready && (code === 0 || code === null || signal === "SIGINT")) {
+    finish();
+    return;
+  }
+  finish(
+    new Error(`Firefox extension smoke exited before startup (code=${code}, signal=${signal}).`),
+  );
+});
+
+startupTimer = setTimeout(
+  () => finish(new Error(`Firefox extension smoke did not start within ${startupTimeoutMs}ms.`)),
+  startupTimeoutMs,
+);
+
+await new Promise((resolve) => {
+  const poll = setInterval(() => {
+    if (!settled) return;
+    clearInterval(poll);
+    resolve();
+  }, 50);
+});
+
+async function resolveFirefoxBinary() {
+  const configured = process.env.FIREFOX_BINARY?.trim();
+  if (configured && fs.existsSync(configured)) return configured;
+
+  const candidates =
+    process.platform === "darwin"
+      ? [
+          "/Applications/Firefox.app/Contents/MacOS/firefox",
+          "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox",
+          path.join(process.env.HOME ?? "", "Applications/Firefox.app/Contents/MacOS/firefox"),
+        ]
+      : process.platform === "win32"
+        ? [
+            path.join(process.env.PROGRAMFILES ?? "", "Mozilla Firefox", "firefox.exe"),
+            path.join(process.env["PROGRAMFILES(X86)"] ?? "", "Mozilla Firefox", "firefox.exe"),
+          ]
+        : ["/usr/bin/firefox", "/usr/bin/firefox-esr"];
+  const installed = candidates.find((candidate) => candidate && fs.existsSync(candidate));
+  if (installed) return installed;
+
+  const command = process.platform === "win32" ? "where" : "which";
+  const discovered = spawnSync(command, ["firefox"], { encoding: "utf8" });
+  const commandPath = discovered.status === 0 ? discovered.stdout.trim().split(/\r?\n/)[0] : "";
+  if (commandPath && fs.existsSync(commandPath)) return commandPath;
+
+  try {
+    const { firefox } = await import("@playwright/test");
+    const playwrightPath = firefox.executablePath();
+    return fs.existsSync(playwrightPath) ? playwrightPath : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/chrome-extension/src/entrypoints/background.ts
+++ b/apps/chrome-extension/src/entrypoints/background.ts
@@ -8,6 +8,7 @@ import { createDaemonStatusTracker } from "../lib/daemon-status";
 import { logExtensionEvent } from "../lib/extension-logs";
 import type { BgToPanel, PanelCachePayload, PanelToBg } from "../lib/panel-contracts";
 import { loadSettings, patchSettings } from "../lib/settings";
+import { transcribeBrowserMediaInTab } from "./background/browser-local-transcript";
 import { runBrowserSlidesForTab, takeBrowserSlidesPayload } from "./background/browser-slides";
 import {
   beginSlideFrameCaptureInTab,
@@ -136,6 +137,8 @@ export default defineBackground(() => {
       isDaemonUnreachableError,
       fetchImpl: (...args) => fetch(...args),
       resolveLogLevel,
+      transcribeMediaLocally:
+        import.meta.env.BROWSER === "chrome" ? transcribeBrowserMediaInTab : undefined,
       transcribeYouTubeLocally:
         import.meta.env.BROWSER === "chrome" ? transcribeYoutubeAudioInTab : undefined,
     });

--- a/apps/chrome-extension/src/entrypoints/background/browser-local-transcript.ts
+++ b/apps/chrome-extension/src/entrypoints/background/browser-local-transcript.ts
@@ -1,0 +1,117 @@
+import { isDirectMediaUrl } from "@steipete/summarize-core/content/url";
+import type { BrowserMediaTranscriptionDiagnostics } from "../offscreen/media-transcription";
+import { ensureOffscreenDocument, isBrowserMediaUrl } from "./browser-media";
+import { getPrimaryMediaInfoInTab } from "./content-script-bridge";
+
+export type BrowserLocalMediaTranscript =
+  | {
+      diagnostics: BrowserMediaTranscriptionDiagnostics;
+      durationSeconds: number | null;
+      ok: true;
+      source: "direct" | "embedded";
+      text: string;
+      transcriptTimedText: string;
+      truncated: boolean;
+      url: string;
+    }
+  | { ok: false; error: string };
+
+const progressCallbacks = new Map<string, (status: string) => void>();
+const LOCAL_MEDIA_TRANSCRIPTION_TIMEOUT_MS = 15 * 60 * 1000;
+let progressListenerStarted = false;
+
+export async function transcribeBrowserMediaInTab({
+  maxChars,
+  onStatus,
+  tabId,
+  tabUrl,
+}: {
+  maxChars: number;
+  onStatus?: ((status: string) => void) | null;
+  tabId: number;
+  tabUrl: string;
+}): Promise<BrowserLocalMediaTranscript> {
+  try {
+    startBrowserMediaProgressRuntime();
+    onStatus?.("Resolving browser media...");
+    const inspected = await getPrimaryMediaInfoInTab(tabId);
+    const direct = isDirectMediaUrl(tabUrl);
+    const mediaUrl = direct ? tabUrl : inspected.ok ? inspected.mediaSrc : null;
+    if (!mediaUrl || !isBrowserMediaUrl(mediaUrl)) {
+      return {
+        ok: false,
+        error: inspected.ok
+          ? "The active media source is not fetchable outside the page."
+          : inspected.error,
+      };
+    }
+    await ensureOffscreenDocument();
+
+    const requestId = crypto.randomUUID();
+    if (onStatus) progressCallbacks.set(requestId, onStatus);
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    try {
+      const response = (await Promise.race([
+        chrome.runtime.sendMessage({
+          target: "offscreen",
+          type: "browser-media:transcribe",
+          credentials: "include",
+          requestId,
+          mediaUrl,
+          maxChars,
+        }),
+        new Promise<never>((_resolve, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("Local browser media transcription timed out.")),
+            LOCAL_MEDIA_TRANSCRIPTION_TIMEOUT_MS,
+          );
+        }),
+      ])) as
+        | {
+            diagnostics: BrowserMediaTranscriptionDiagnostics;
+            ok: true;
+            text: string;
+            transcriptTimedText: string;
+            truncated: boolean;
+          }
+        | { ok: false; error: string }
+        | undefined;
+      if (!response?.ok) {
+        return {
+          ok: false,
+          error: response?.error ?? "Local browser media transcription returned no result.",
+        };
+      }
+      return {
+        ...response,
+        durationSeconds:
+          inspected.ok && inspected.durationSeconds
+            ? inspected.durationSeconds
+            : response.diagnostics.durationSeconds,
+        source: direct ? "direct" : "embedded",
+        url: tabUrl,
+      };
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      progressCallbacks.delete(requestId);
+    }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function startBrowserMediaProgressRuntime(): void {
+  if (progressListenerStarted) return;
+  progressListenerStarted = true;
+  chrome.runtime.onMessage.addListener((message: unknown) => {
+    if (!message || typeof message !== "object") return;
+    const typed = message as { requestId?: unknown; status?: unknown; type?: unknown };
+    if (
+      typed.type === "browser-media:progress" &&
+      typeof typed.requestId === "string" &&
+      typeof typed.status === "string"
+    ) {
+      progressCallbacks.get(typed.requestId)?.(typed.status);
+    }
+  });
+}

--- a/apps/chrome-extension/src/entrypoints/background/browser-media-audio.ts
+++ b/apps/chrome-extension/src/entrypoints/background/browser-media-audio.ts
@@ -8,6 +8,7 @@ export class BrowserPcmAccumulator {
     durationSeconds: number,
     private readonly targetSampleRate: number,
     private readonly maxBytes: number,
+    private readonly startTimestamp = 0,
   ) {
     if (!Number.isFinite(durationSeconds) || durationSeconds < 0) {
       throw new Error("Decoded audio has an invalid duration.");
@@ -41,16 +42,17 @@ export class BrowserPcmAccumulator {
 
     const effectiveDuration =
       Number.isFinite(duration) && duration > 0 ? duration : numberOfFrames / sampleRate;
-    const outputStart = Math.max(0, Math.floor(timestamp * this.targetSampleRate));
+    const relativeTimestamp = timestamp - this.startTimestamp;
+    const outputStart = Math.max(0, Math.floor(relativeTimestamp * this.targetSampleRate));
     const outputEnd = Math.max(
       outputStart,
-      Math.ceil((timestamp + effectiveDuration) * this.targetSampleRate),
+      Math.ceil((relativeTimestamp + effectiveDuration) * this.targetSampleRate),
     );
     if (outputEnd === 0) return;
     this.ensureCapacity(outputEnd);
 
     for (let outputFrame = outputStart; outputFrame < outputEnd; outputFrame += 1) {
-      const sourcePosition = (outputFrame / this.targetSampleRate - timestamp) * sampleRate;
+      const sourcePosition = (outputFrame / this.targetSampleRate - relativeTimestamp) * sampleRate;
       const lowerFrame = Math.floor(sourcePosition);
       const upperFrame = Math.ceil(sourcePosition);
       const fraction = sourcePosition - lowerFrame;

--- a/apps/chrome-extension/src/entrypoints/background/browser-media.ts
+++ b/apps/chrome-extension/src/entrypoints/background/browser-media.ts
@@ -5,18 +5,43 @@ import {
   CanvasSink,
   Input,
   type WrappedCanvas,
+  UrlSource,
 } from "mediabunny";
 import { BrowserPcmAccumulator } from "./browser-media-audio";
 
 const MAX_BROWSER_MEDIA_BYTES = 128 * 1024 * 1024;
 const MAX_BROWSER_PCM_BYTES = 512 * 1024 * 1024;
+const MAX_BROWSER_PCM_CHUNK_BYTES = 64 * 1024 * 1024;
+const BROWSER_AUDIO_CHUNK_SECONDS = 15 * 60;
+const BROWSER_MEDIA_URL_CACHE_BYTES = 24 * 1024 * 1024;
 const TARGET_AUDIO_SAMPLE_RATE = 16_000;
 const FRAME_IMAGE_TYPE = "image/jpeg";
 const FRAME_IMAGE_QUALITY = 0.82;
 
+class BrowserMediaLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BrowserMediaLimitError";
+  }
+}
+
 export type BrowserMediaFrame = {
   imageUrl: string;
   timestamp: number;
+};
+
+export type BrowserAudioChunk = {
+  audio: Float32Array;
+  chunkCount: number;
+  chunkIndex: number;
+  endSeconds: number;
+  startSeconds: number;
+};
+
+export type BrowserAudioProcessResult = {
+  chunkCount: number;
+  codec: string;
+  durationSeconds: number;
 };
 
 export function isBrowserMediaUrl(value: string): boolean {
@@ -26,6 +51,62 @@ export function isBrowserMediaUrl(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+export async function fetchBrowserMediaWithLimit(
+  fetchImpl: typeof fetch,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  maxNonRangedBytes = MAX_BROWSER_MEDIA_BYTES,
+): Promise<Response> {
+  const response = await fetchImpl(input, init);
+  if (response.status !== 200 || !response.body) {
+    return response;
+  }
+
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > maxNonRangedBytes) {
+    await response.body.cancel();
+    throw new BrowserMediaLimitError(
+      `Media response returned ${contentLength} bytes without partial content; limit is ${maxNonRangedBytes} bytes`,
+    );
+  }
+
+  const reader = response.body.getReader();
+  let receivedBytes = 0;
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+        if (result.done) {
+          controller.close();
+          return;
+        }
+        receivedBytes += result.value.byteLength;
+        if (receivedBytes > maxNonRangedBytes) {
+          await reader.cancel();
+          controller.error(
+            new BrowserMediaLimitError(
+              `Media response streamed more than ${maxNonRangedBytes} bytes without partial content`,
+            ),
+          );
+          return;
+        }
+        controller.enqueue(result.value);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      await reader.cancel(reason);
+    },
+  });
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 }
 
 export async function extractBrowserMediaFrames({
@@ -65,16 +146,7 @@ export async function extractBrowserMediaFramesInDocument({
   }
   if (timestamps.length === 0) return [];
 
-  const response = await fetchImpl(mediaUrl, { credentials: "include" });
-  if (!response.ok) {
-    throw new Error(`Media download failed (${response.status} ${response.statusText}).`);
-  }
-  const contentLength = Number(response.headers.get("content-length"));
-  if (Number.isFinite(contentLength) && contentLength > MAX_BROWSER_MEDIA_BYTES) {
-    throw new Error("Media is too large for in-browser decoding.");
-  }
-  const inputBytes = await readResponseWithLimit(response, MAX_BROWSER_MEDIA_BYTES);
-  const input = createMediaInput(inputBytes, response.headers.get("content-type"));
+  const input = createMediaUrlInput(mediaUrl, fetchImpl, "include");
   try {
     const track = await input.getPrimaryVideoTrack();
     if (!track) throw new Error("Media contains no video track.");
@@ -105,6 +177,41 @@ export async function extractBrowserMediaFramesInDocument({
   }
 }
 
+export async function processBrowserAudioUrlWithMediaBunny({
+  mediaUrl,
+  credentials = "include",
+  fetchImpl = fetch,
+  onChunk,
+}: {
+  mediaUrl: string;
+  credentials?: RequestCredentials;
+  fetchImpl?: typeof fetch;
+  onChunk: (chunk: BrowserAudioChunk) => Promise<boolean | void>;
+}): Promise<BrowserAudioProcessResult> {
+  if (!isBrowserMediaUrl(mediaUrl)) {
+    throw new Error("Browser audio decoding requires a fetchable HTTP media URL.");
+  }
+  const input = createMediaUrlInput(mediaUrl, fetchImpl, credentials);
+  return await processBrowserAudioInput({ input, onChunk });
+}
+
+export async function processBrowserAudioBytesWithMediaBunny({
+  inputBytes,
+  mimeType,
+  onChunk,
+}: {
+  inputBytes: Uint8Array;
+  mimeType: string;
+  onChunk: (chunk: BrowserAudioChunk) => Promise<boolean | void>;
+}): Promise<BrowserAudioProcessResult> {
+  if (inputBytes.byteLength === 0) throw new Error("The resolved audio stream is empty.");
+  if (inputBytes.byteLength > MAX_BROWSER_MEDIA_BYTES) {
+    throw new Error("Audio is too large for buffered in-browser decoding.");
+  }
+  const input = createMediaInput(inputBytes, mimeType);
+  return await processBrowserAudioInput({ input, onChunk });
+}
+
 export async function decodeBrowserAudioBytesWithMediaBunny({
   inputBytes,
   mimeType,
@@ -117,45 +224,20 @@ export async function decodeBrowserAudioBytesWithMediaBunny({
     throw new Error("Audio is too large for in-browser decoding.");
   }
 
-  const input = createMediaInput(inputBytes, mimeType);
-  try {
-    const track = await input.getPrimaryAudioTrack();
-    if (!track) throw new Error("Media contains no audio track.");
-    if (!(await track.canDecode())) {
-      throw new Error(`Browser cannot decode the ${await track.getCodec()} audio track.`);
-    }
-
-    const duration = await track.computeDuration();
-    const output = new BrowserPcmAccumulator(
-      duration,
-      TARGET_AUDIO_SAMPLE_RATE,
-      MAX_BROWSER_PCM_BYTES,
-    );
-    const sink = new AudioSampleSink(track);
-    for await (const sample of sink.samples()) {
-      try {
-        const interleaved = new Float32Array(
-          sample.allocationSize({ format: "f32", planeIndex: 0 }) / Float32Array.BYTES_PER_ELEMENT,
-        );
-        sample.copyTo(interleaved, { format: "f32", planeIndex: 0 });
-        output.add({
-          duration: sample.duration,
-          interleaved,
-          numberOfChannels: sample.numberOfChannels,
-          numberOfFrames: sample.numberOfFrames,
-          sampleRate: sample.sampleRate,
-          timestamp: sample.timestamp,
-        });
-      } finally {
-        sample.close();
+  const chunks: Float32Array[] = [];
+  let totalBytes = 0;
+  await processBrowserAudioBytesWithMediaBunny({
+    inputBytes,
+    mimeType,
+    onChunk: async ({ audio }) => {
+      totalBytes += audio.byteLength;
+      if (totalBytes > MAX_BROWSER_PCM_BYTES) {
+        throw new Error("Decoded audio is too long for buffered in-browser transcription.");
       }
-    }
-    const audio = output.finish();
-    if (audio.length === 0) throw new Error("Browser media decoder produced no PCM audio.");
-    return audio;
-  } finally {
-    input.dispose();
-  }
+      chunks.push(audio);
+    },
+  });
+  return concatenateFloat32(chunks);
 }
 
 export async function decodeBrowserAudioBytesWithWebAudio(
@@ -197,34 +279,6 @@ export async function ensureOffscreenDocument(): Promise<void> {
   await creatingOffscreenDocument;
 }
 
-async function readResponseWithLimit(response: Response, maxBytes: number): Promise<Uint8Array> {
-  if (!response.body) {
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    if (bytes.byteLength > maxBytes) throw new Error("Media is too large for in-browser decoding.");
-    return bytes;
-  }
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      await reader.cancel();
-      throw new Error("Media is too large for in-browser decoding.");
-    }
-    chunks.push(value);
-  }
-  const result = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return result;
-}
-
 function createMediaInput(bytes: Uint8Array, mimeType: string | null): Input {
   const normalizedType = mimeType?.split(";")[0]?.trim().toLowerCase() || "";
   const blob = new Blob([exactArrayBuffer(bytes)], { type: normalizedType });
@@ -232,6 +286,104 @@ function createMediaInput(bytes: Uint8Array, mimeType: string | null): Input {
     source: new BlobSource(blob),
     formats: ALL_FORMATS,
   });
+}
+
+function createMediaUrlInput(
+  mediaUrl: string,
+  fetchImpl: typeof fetch,
+  credentials: RequestCredentials,
+): Input {
+  return new Input({
+    source: new UrlSource(mediaUrl, {
+      fetchFn: (input, init) => fetchBrowserMediaWithLimit(fetchImpl, input, init),
+      getRetryDelay: (previousAttempts, error) =>
+        error instanceof BrowserMediaLimitError ? null : previousAttempts < 2 ? 0.1 : null,
+      maxCacheSize: BROWSER_MEDIA_URL_CACHE_BYTES,
+      parallelism: 2,
+      requestInit: { credentials },
+    }),
+    formats: ALL_FORMATS,
+  });
+}
+
+async function processBrowserAudioInput({
+  input,
+  onChunk,
+}: {
+  input: Input;
+  onChunk: (chunk: BrowserAudioChunk) => Promise<boolean | void>;
+}): Promise<BrowserAudioProcessResult> {
+  try {
+    const track = await input.getPrimaryAudioTrack();
+    if (!track) throw new Error("Media contains no audio track.");
+    const codec = await track.getCodec();
+    if (!(await track.canDecode())) {
+      throw new Error(`Browser cannot decode the ${codec} audio track.`);
+    }
+
+    const durationSeconds = await track.computeDuration();
+    if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+      throw new Error("Media audio duration is unavailable.");
+    }
+    const chunkCount = Math.max(1, Math.ceil(durationSeconds / BROWSER_AUDIO_CHUNK_SECONDS));
+    const sink = new AudioSampleSink(track);
+
+    for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+      const startSeconds = chunkIndex * BROWSER_AUDIO_CHUNK_SECONDS;
+      const endSeconds = Math.min(durationSeconds, startSeconds + BROWSER_AUDIO_CHUNK_SECONDS);
+      const output = new BrowserPcmAccumulator(
+        endSeconds - startSeconds,
+        TARGET_AUDIO_SAMPLE_RATE,
+        MAX_BROWSER_PCM_CHUNK_BYTES,
+        startSeconds,
+      );
+      for await (const sample of sink.samples(startSeconds, endSeconds)) {
+        try {
+          const interleaved = new Float32Array(
+            sample.allocationSize({ format: "f32", planeIndex: 0 }) /
+              Float32Array.BYTES_PER_ELEMENT,
+          );
+          sample.copyTo(interleaved, { format: "f32", planeIndex: 0 });
+          output.add({
+            duration: sample.duration,
+            interleaved,
+            numberOfChannels: sample.numberOfChannels,
+            numberOfFrames: sample.numberOfFrames,
+            sampleRate: sample.sampleRate,
+            timestamp: sample.timestamp,
+          });
+        } finally {
+          sample.close();
+        }
+      }
+      const audio = output.finish();
+      if (audio.length === 0) {
+        throw new Error(`Browser media decoder produced no PCM audio for chunk ${chunkIndex + 1}.`);
+      }
+      const shouldContinue = await onChunk({
+        audio,
+        chunkCount,
+        chunkIndex,
+        endSeconds,
+        startSeconds,
+      });
+      if (shouldContinue === false) break;
+    }
+    return { chunkCount, codec, durationSeconds };
+  } finally {
+    input.dispose();
+  }
+}
+
+function concatenateFloat32(chunks: Float32Array[]): Float32Array {
+  const length = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const combined = new Float32Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return combined;
 }
 
 export async function browserMediaCanvasToDataUrl({ canvas }: WrappedCanvas): Promise<string> {

--- a/apps/chrome-extension/src/entrypoints/background/content-script-bridge.ts
+++ b/apps/chrome-extension/src/entrypoints/background/content-script-bridge.ts
@@ -355,23 +355,26 @@ export async function getPrimaryMediaInfoInTab(tabId: number): Promise<PrimaryMe
       target: { tabId },
       world: "MAIN",
       func: (): PrimaryMediaInfo => {
-        const best = Array.from(document.querySelectorAll("video")).reduce<{
-          video: HTMLVideoElement;
-          area: number;
+        const best = Array.from(
+          document.querySelectorAll<HTMLMediaElement>("video, audio"),
+        ).reduce<{
+          media: HTMLMediaElement;
+          score: number;
         } | null>((current, video) => {
           const rect = video.getBoundingClientRect();
           const area = Math.max(0, rect.width) * Math.max(0, rect.height);
-          if (area <= 0) return current;
-          return !current || area > current.area ? { video, area } : current;
+          const score = video instanceof HTMLVideoElement ? area : area || 1;
+          if (score <= 0 || !(video.currentSrc || video.src)) return current;
+          return !current || score > current.score ? { media: video, score } : current;
         }, null);
-        if (!best) return { ok: false, error: "No video element found." };
-        const duration = best.video.duration;
-        const currentTime = best.video.currentTime;
+        if (!best) return { ok: false, error: "No audio or video element found." };
+        const duration = best.media.duration;
+        const currentTime = best.media.currentTime;
         return {
           ok: true,
           currentTimeSeconds: Number.isFinite(currentTime) ? currentTime : null,
           durationSeconds: Number.isFinite(duration) && duration > 0 ? duration : null,
-          mediaSrc: best.video.currentSrc || best.video.src || "",
+          mediaSrc: best.media.currentSrc || best.media.src || "",
           title: document.title || null,
           url: location.href,
         };

--- a/apps/chrome-extension/src/entrypoints/background/panel-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-runtime.ts
@@ -26,6 +26,7 @@ export function createBackgroundPanelRuntime<
   isDaemonUnreachableError: typeof import("../../lib/daemon-recovery").isDaemonUnreachableError;
   fetchImpl: typeof fetch;
   resolveLogLevel: (event: string) => "verbose" | "warn" | "error";
+  transcribeMediaLocally?: Parameters<typeof runPanelSummarize>[0]["transcribeMediaLocally"];
   transcribeYouTubeLocally?: Parameters<typeof runPanelSummarize>[0]["transcribeYouTubeLocally"];
 }) {
   const {
@@ -43,6 +44,7 @@ export function createBackgroundPanelRuntime<
     isDaemonUnreachableError,
     fetchImpl,
     resolveLogLevel,
+    transcribeMediaLocally,
     transcribeYouTubeLocally,
   } = options;
 
@@ -125,6 +127,7 @@ export function createBackgroundPanelRuntime<
       buildSummarizeRequestBody,
       friendlyFetchError,
       isDaemonUnreachableError,
+      transcribeMediaLocally,
       transcribeYouTubeLocally,
       logPanel: (event, detail) => {
         void (async () => {

--- a/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
@@ -1,6 +1,7 @@
 import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import type { RunStart } from "../../lib/panel-contracts";
 import type { Settings } from "../../lib/settings";
+import type { BrowserLocalMediaTranscript } from "./browser-local-transcript";
 import { buildBrowserSummaryMarkdown } from "./browser-summary";
 import type { ExtractResponse } from "./content-script-bridge";
 import type { CachedExtract } from "./extract-cache";
@@ -70,6 +71,10 @@ export async function summarizeActiveTab({
     ok: false,
     error: "Local YouTube transcription is unavailable in this browser.",
   }),
+  transcribeMediaLocally = async () => ({
+    ok: false,
+    error: "Local browser media transcription is unavailable in this browser.",
+  }),
   extractYouTubeTranscript = extractYouTubeTranscriptInTab,
   youtubeTranscriptTimeoutMs = 12_000,
 }: {
@@ -109,6 +114,12 @@ export async function summarizeActiveTab({
     maxChars: number;
     onStatus?: ((status: string) => void) | null;
   }) => Promise<BrowserYoutubeLocalTranscript>;
+  transcribeMediaLocally?: (args: {
+    maxChars: number;
+    onStatus?: ((status: string) => void) | null;
+    tabId: number;
+    tabUrl: string;
+  }) => Promise<BrowserLocalMediaTranscript>;
   extractYouTubeTranscript?: typeof extractYouTubeTranscriptInTab;
   youtubeTranscriptTimeoutMs?: number;
 }) {
@@ -395,19 +406,33 @@ export async function summarizeActiveTab({
   if (isSuperseded()) return;
   const resolvedTitle = tab.title?.trim() || resolvedExtracted.title || null;
   let resolvedPayload = { ...resolvedExtracted, title: resolvedTitle };
-  const ensureLocalYoutubeTranscript = async () => {
-    if (!tab.id || !isYouTubeVideoUrl(resolvedPayload.url) || browserTranscriptTimedText?.trim()) {
+  const ensureLocalBrowserTranscript = async () => {
+    if (!tab.id || browserTranscriptTimedText?.trim()) {
       return false;
     }
-    const localTranscript = await transcribeYouTubeLocally({
-      tabId: tab.id,
-      maxChars: settings.maxChars,
-      onStatus: sendStatus,
-    });
+    const isYoutube = isYouTubeVideoUrl(resolvedPayload.url);
+    if (!isYoutube && requestedInputMode !== "video" && !prefersUrlMode) return false;
+    const localTranscript = isYoutube
+      ? await transcribeYouTubeLocally({
+          tabId: tab.id,
+          maxChars: settings.maxChars,
+          onStatus: sendStatus,
+        })
+      : await transcribeMediaLocally({
+          tabId: tab.id,
+          tabUrl,
+          maxChars: settings.maxChars,
+          onStatus: sendStatus,
+        });
     if (!localTranscript.ok) {
-      logPanel("extract:url-direct:local-transcript-failed", {
-        error: localTranscript.error,
-      });
+      logPanel(
+        isYoutube
+          ? "extract:url-direct:local-transcript-failed"
+          : "extract:browser-media:local-transcript-failed",
+        {
+          error: localTranscript.error,
+        },
+      );
       return false;
     }
     if (!urlsMatch(localTranscript.url, tabUrl)) return false;
@@ -419,14 +444,26 @@ export async function summarizeActiveTab({
       mediaDurationSeconds: localTranscript.durationSeconds,
       media: { hasVideo: true, hasAudio: true, hasCaptions: false },
     };
-    logPanel("extract:url-direct:local-transcript", {
-      textLength: localTranscript.text.length,
-      mediaSource: localTranscript.mediaSource,
-    });
+    logPanel(
+      isYoutube ? "extract:url-direct:local-transcript" : "extract:browser-media:transcript",
+      {
+        textLength: localTranscript.text.length,
+        mediaSource:
+          "mediaSource" in localTranscript ? localTranscript.mediaSource : localTranscript.source,
+        decoder: localTranscript.diagnostics.decoder,
+        mediaChunksProcessed: localTranscript.diagnostics.chunksProcessed,
+        mediaChunksTotal: localTranscript.diagnostics.chunksTotal,
+        mediaCodec: localTranscript.diagnostics.codec,
+        mediaInput: localTranscript.diagnostics.input,
+        whisperDevice: localTranscript.diagnostics.whisper.device,
+        whisperLoadMs: Math.round(localTranscript.diagnostics.whisper.loadMs),
+        whisperReused: localTranscript.diagnostics.whisper.reused,
+      },
+    );
     return true;
   };
   if (useBrowserSummary) {
-    await ensureLocalYoutubeTranscript();
+    await ensureLocalBrowserTranscript();
     if (isSuperseded()) return;
   }
   const effectiveInputMode =
@@ -586,7 +623,7 @@ export async function summarizeActiveTab({
       if (isDaemonUnreachableError(err)) {
         session.daemonRecovery.recordFailure(resolvedPayload.url);
       }
-      await ensureLocalYoutubeTranscript();
+      await ensureLocalBrowserTranscript();
       if (isSuperseded()) return;
       cacheResolvedPayload();
       sendBrowserSummarySnapshot();

--- a/apps/chrome-extension/src/entrypoints/background/youtube-local-transcript.ts
+++ b/apps/chrome-extension/src/entrypoints/background/youtube-local-transcript.ts
@@ -1,3 +1,4 @@
+import type { BrowserMediaTranscriptionDiagnostics } from "../offscreen/media-transcription";
 import { ensureOffscreenDocument } from "./browser-media";
 import { getYoutubeMediaContextInTab } from "./youtube-media";
 import {
@@ -8,17 +9,18 @@ import {
 export type BrowserYoutubeLocalTranscript =
   | {
       ok: true;
+      diagnostics: BrowserMediaTranscriptionDiagnostics;
       url: string;
       text: string;
       transcriptTimedText: string;
       truncated: boolean;
       durationSeconds: number | null;
-      mediaSource: "sabr" | "android-vr";
+      mediaSource: "sabr" | "player" | "android-vr";
     }
   | { ok: false; error: string };
 
 const progressCallbacks = new Map<string, (status: string) => void>();
-const LOCAL_TRANSCRIPTION_TIMEOUT_MS = 180_000;
+const LOCAL_TRANSCRIPTION_TIMEOUT_MS = 15 * 60 * 1000;
 let progressListenerStarted = false;
 
 export function startYoutubeLocalTranscriptionRuntime(): void {

--- a/apps/chrome-extension/src/entrypoints/background/youtube-media.ts
+++ b/apps/chrome-extension/src/entrypoints/background/youtube-media.ts
@@ -22,6 +22,7 @@ export type BrowserYoutubeMediaContext = {
     url: string;
     mimeType: string;
     contentLength: number | null;
+    resolver: "player" | "android-vr";
   } | null;
   sabr: {
     serverAbrStreamingUrl: string;
@@ -117,6 +118,29 @@ export async function getYoutubeMediaContextInTab(
       const adaptiveFormats = Array.isArray(streamingData?.adaptiveFormats)
         ? streamingData.adaptiveFormats
         : [];
+      const directAudioCandidates = adaptiveFormats.filter(isRecord).flatMap((format) => {
+        const url = stringValue(format.url);
+        const mimeType = stringValue(format.mimeType);
+        if (!url || !mimeType?.toLowerCase().startsWith("audio/")) return [];
+        return [
+          {
+            url,
+            mimeType,
+            bitrate: numberValue(format.bitrate) ?? 0,
+            contentLength: numberValue(format.contentLength),
+          },
+        ];
+      });
+      directAudioCandidates.sort((left, right) => {
+        const mimeRank = (mimeType: string) =>
+          mimeType.toLowerCase().startsWith("audio/mp4")
+            ? 0
+            : mimeType.toLowerCase().startsWith("audio/webm")
+              ? 1
+              : 2;
+        return mimeRank(left.mimeType) - mimeRank(right.mimeType) || right.bitrate - left.bitrate;
+      });
+      const directAudio = directAudioCandidates[0] ?? null;
       const formats = adaptiveFormats.filter(isRecord).flatMap((format) => {
         const itag = numberValue(format.itag);
         const mimeType = stringValue(format.mimeType);
@@ -159,7 +183,14 @@ export async function getYoutubeMediaContextInTab(
         durationSeconds,
         apiKey,
         visitorData,
-        directAudio: null,
+        directAudio: directAudio
+          ? {
+              url: directAudio.url,
+              mimeType: directAudio.mimeType,
+              contentLength: directAudio.contentLength,
+              resolver: "player",
+            }
+          : null,
         sabr:
           serverAbrStreamingUrl && videoPlaybackUstreamerConfig && formats.length > 0
             ? {
@@ -175,7 +206,8 @@ export async function getYoutubeMediaContextInTab(
   });
   const context = result?.result ?? null;
   if (!context) return null;
-  const directAudio = await resolveYoutubeDirectAudioInTab(tabId, context).catch(() => null);
+  const directAudio =
+    context.directAudio ?? (await resolveYoutubeDirectAudioInTab(tabId, context).catch(() => null));
   return { ...context, directAudio };
 }
 
@@ -279,6 +311,7 @@ async function resolveYoutubeDirectAudioInTab(
         mimeType: selected.mimeType,
         contentLength:
           Number.isSafeInteger(contentLength) && contentLength > 0 ? contentLength : null,
+        resolver: "android-vr" as const,
       };
     },
   });

--- a/apps/chrome-extension/src/entrypoints/offscreen/main.ts
+++ b/apps/chrome-extension/src/entrypoints/offscreen/main.ts
@@ -1,12 +1,8 @@
-import {
-  decodeBrowserAudioBytesWithMediaBunny,
-  decodeBrowserAudioBytesWithWebAudio,
-  extractBrowserMediaFramesInDocument,
-} from "../background/browser-media";
+import { extractBrowserMediaFramesInDocument } from "../background/browser-media";
 import type { BrowserYoutubeMediaContext } from "../background/youtube-media";
 import type { CapturedYoutubeSabrRequest } from "../background/youtube-sabr-capture";
-import { transcribePcmWithWhisper } from "./whisper";
-import { downloadYoutubeAudio } from "./youtube-audio";
+import { transcribeBrowserMediaBytes, transcribeBrowserMediaUrl } from "./media-transcription";
+import { downloadYoutubeAudio, resolveYoutubeDirectAudio } from "./youtube-audio";
 
 type BrowserMediaRequest = {
   target?: string;
@@ -17,6 +13,7 @@ type BrowserMediaRequest = {
   context?: BrowserYoutubeMediaContext;
   capturedSabr?: CapturedYoutubeSabrRequest | null;
   maxChars?: number;
+  credentials?: RequestCredentials;
 };
 
 chrome.runtime.onMessage.addListener((message: BrowserMediaRequest, _sender, sendResponse) => {
@@ -38,33 +35,78 @@ chrome.runtime.onMessage.addListener((message: BrowserMediaRequest, _sender, sen
       });
     };
     void (async () => {
-      report("Downloading YouTube audio...");
-      const downloaded = await downloadYoutubeAudio({
-        context: message.context as BrowserYoutubeMediaContext,
-        capturedSabr: message.capturedSabr ?? null,
-      });
-      report("Preparing audio in the browser...");
-      const audio = await decodeBrowserAudioBytesWithWebAudio(downloaded.bytes).catch(async () => {
-        report("Preparing audio with browser media decoder...");
-        return await decodeBrowserAudioBytesWithMediaBunny({
-          inputBytes: downloaded.bytes,
-          mimeType: downloaded.mimeType,
+      const context = message.context as BrowserYoutubeMediaContext;
+      let mediaSource: "sabr" | "player" | "android-vr";
+      let transcript;
+      try {
+        const direct = await resolveYoutubeDirectAudio(context);
+        mediaSource = direct.mediaSource;
+        transcript = await transcribeBrowserMediaUrl({
+          credentials: "omit",
+          maxChars: message.maxChars as number,
+          mediaUrl: direct.url,
+          onStatus: report,
         });
-      });
-      const transcript = await transcribePcmWithWhisper({
-        audio,
-        maxChars: message.maxChars as number,
-        onStatus: report,
-      });
+      } catch (directError) {
+        report("Direct audio streaming failed; downloading fallback audio...");
+        const downloaded = await downloadYoutubeAudio({
+          context,
+          capturedSabr: message.capturedSabr ?? null,
+          ignoreContextDirect: true,
+        });
+        mediaSource = downloaded.mediaSource;
+        transcript = await transcribeBrowserMediaBytes({
+          inputBytes: downloaded.bytes,
+          maxChars: message.maxChars as number,
+          mimeType: downloaded.mimeType,
+          onStatus: report,
+        }).catch((bufferedError) => {
+          const directMessage =
+            directError instanceof Error ? directError.message : String(directError);
+          const bufferedMessage =
+            bufferedError instanceof Error ? bufferedError.message : String(bufferedError);
+          throw new Error(
+            `Direct audio streaming failed: ${directMessage} Buffered fallback failed: ${bufferedMessage}`,
+          );
+        });
+      }
       return {
         ok: true as const,
-        url: (message.context as BrowserYoutubeMediaContext).url,
+        url: context.url,
         ...transcript,
-        durationSeconds: (message.context as BrowserYoutubeMediaContext).durationSeconds,
-        mediaSource: downloaded.mediaSource,
+        durationSeconds: context.durationSeconds ?? transcript.diagnostics.durationSeconds,
+        mediaSource,
       };
     })().then(
       (result) => sendResponse(result),
+      (error: unknown) =>
+        sendResponse({ ok: false, error: error instanceof Error ? error.message : String(error) }),
+    );
+    return true;
+  }
+  if (message.type === "browser-media:transcribe") {
+    if (
+      typeof message.requestId !== "string" ||
+      typeof message.mediaUrl !== "string" ||
+      typeof message.maxChars !== "number"
+    ) {
+      sendResponse({ ok: false, error: "Invalid browser media transcription request." });
+      return;
+    }
+    const report = (status: string) => {
+      void chrome.runtime.sendMessage({
+        type: "browser-media:progress",
+        requestId: message.requestId,
+        status,
+      });
+    };
+    void transcribeBrowserMediaUrl({
+      credentials: message.credentials ?? "include",
+      maxChars: message.maxChars,
+      mediaUrl: message.mediaUrl,
+      onStatus: report,
+    }).then(
+      (transcript) => sendResponse({ ok: true, ...transcript }),
       (error: unknown) =>
         sendResponse({ ok: false, error: error instanceof Error ? error.message : String(error) }),
     );

--- a/apps/chrome-extension/src/entrypoints/offscreen/media-transcription.ts
+++ b/apps/chrome-extension/src/entrypoints/offscreen/media-transcription.ts
@@ -1,0 +1,134 @@
+import {
+  processBrowserAudioBytesWithMediaBunny,
+  processBrowserAudioUrlWithMediaBunny,
+  type BrowserAudioChunk,
+  type BrowserAudioProcessResult,
+} from "../background/browser-media";
+import {
+  clampWhisperTranscript,
+  transcribePcmChunkWithWhisper,
+  type WhisperRuntimeDiagnostics,
+} from "./whisper";
+
+export type BrowserMediaTranscriptionDiagnostics = {
+  chunksProcessed: number;
+  chunksTotal: number;
+  codec: string;
+  decoder: "mediabunny-webcodecs";
+  durationSeconds: number;
+  input: "buffer" | "url-range";
+  whisper: WhisperRuntimeDiagnostics;
+};
+
+export type BrowserMediaTranscription = {
+  diagnostics: BrowserMediaTranscriptionDiagnostics;
+  text: string;
+  transcriptTimedText: string;
+  truncated: boolean;
+};
+
+export async function transcribeBrowserMediaUrl({
+  credentials = "include",
+  maxChars,
+  mediaUrl,
+  onStatus,
+}: {
+  credentials?: RequestCredentials;
+  maxChars: number;
+  mediaUrl: string;
+  onStatus: (status: string) => void;
+}): Promise<BrowserMediaTranscription> {
+  return await transcribeBrowserMedia({
+    input: "url-range",
+    maxChars,
+    onStatus,
+    process: async (onChunk) =>
+      await processBrowserAudioUrlWithMediaBunny({
+        credentials,
+        mediaUrl,
+        onChunk,
+      }),
+  });
+}
+
+export async function transcribeBrowserMediaBytes({
+  inputBytes,
+  maxChars,
+  mimeType,
+  onStatus,
+}: {
+  inputBytes: Uint8Array;
+  maxChars: number;
+  mimeType: string;
+  onStatus: (status: string) => void;
+}): Promise<BrowserMediaTranscription> {
+  return await transcribeBrowserMedia({
+    input: "buffer",
+    maxChars,
+    onStatus,
+    process: async (onChunk) =>
+      await processBrowserAudioBytesWithMediaBunny({
+        inputBytes,
+        mimeType,
+        onChunk,
+      }),
+  });
+}
+
+async function transcribeBrowserMedia({
+  input,
+  maxChars,
+  onStatus,
+  process,
+}: {
+  input: BrowserMediaTranscriptionDiagnostics["input"];
+  maxChars: number;
+  onStatus: (status: string) => void;
+  process: (
+    onChunk: (chunk: BrowserAudioChunk) => Promise<boolean | void>,
+  ) => Promise<BrowserAudioProcessResult>;
+}): Promise<BrowserMediaTranscription> {
+  const textParts: string[] = [];
+  const timedLines: string[] = [];
+  let chunksProcessed = 0;
+  let whisper: WhisperRuntimeDiagnostics | null = null;
+  const normalizedMaxChars =
+    Number.isFinite(maxChars) && maxChars > 0 ? Math.floor(maxChars) : Number.POSITIVE_INFINITY;
+
+  onStatus("Preparing audio with browser media decoder...");
+  const media = await process(async (chunk) => {
+    const current = chunk.chunkIndex + 1;
+    const transcript = await transcribePcmChunkWithWhisper({
+      audio: chunk.audio,
+      timestampOffsetSeconds: chunk.startSeconds,
+      transcribingStatus: `Transcribing audio locally (${current}/${chunk.chunkCount})...`,
+      onStatus,
+    });
+    chunksProcessed += 1;
+    whisper ??= transcript.diagnostics;
+    if (transcript.text) textParts.push(transcript.text);
+    timedLines.push(...transcript.timedLines);
+    return textParts.join(" ").length < normalizedMaxChars;
+  });
+
+  const clamped = clampWhisperTranscript(
+    textParts.join(" ").replace(/\s+/g, " ").trim(),
+    timedLines.join("\n"),
+    maxChars,
+  );
+  if (!clamped.text) throw new Error("Local Whisper returned an empty transcript.");
+  if (!whisper) throw new Error("Local Whisper did not process any audio.");
+
+  return {
+    ...clamped,
+    diagnostics: {
+      chunksProcessed,
+      chunksTotal: media.chunkCount,
+      codec: media.codec,
+      decoder: "mediabunny-webcodecs",
+      durationSeconds: media.durationSeconds,
+      input,
+      whisper,
+    },
+  };
+}

--- a/apps/chrome-extension/src/entrypoints/offscreen/whisper.ts
+++ b/apps/chrome-extension/src/entrypoints/offscreen/whisper.ts
@@ -8,16 +8,38 @@ import {
 const WHISPER_MODEL = "onnx-community/whisper-tiny";
 const WEBGPU_MODEL_LOAD_TIMEOUT_MS = 30_000;
 const WASM_MODEL_LOAD_TIMEOUT_MS = 90_000;
+const WHISPER_IDLE_DISPOSE_MS = 5 * 60 * 1000;
 const ORT_WASM_URL = new URL(
   "../../../node_modules/@huggingface/transformers/dist/ort-wasm-simd-threaded.jsep.wasm",
   import.meta.url,
 ).href;
-let transcriberPromise: Promise<AutomaticSpeechRecognitionPipelineType> | null = null;
 type WhisperDevice = "webgpu" | "wasm";
 type WhisperPipelineFactory = (
   device: WhisperDevice,
   onStatus: (status: string) => void,
 ) => Promise<AutomaticSpeechRecognitionPipelineType>;
+type WhisperRuntime = {
+  device: WhisperDevice;
+  loadMs: number;
+  transcriber: AutomaticSpeechRecognitionPipelineType;
+};
+
+export type WhisperRuntimeDiagnostics = {
+  device: WhisperDevice;
+  loadMs: number;
+  reused: boolean;
+};
+
+export type WhisperChunkTranscript = {
+  diagnostics: WhisperRuntimeDiagnostics;
+  text: string;
+  timedLines: string[];
+};
+
+let transcriberPromise: Promise<WhisperRuntime> | null = null;
+let transcriberRuntime: WhisperRuntime | null = null;
+let transcriberIdleTimer: ReturnType<typeof setTimeout> | null = null;
+let activeTranscriptions = 0;
 
 export async function transcribePcmWithWhisper({
   audio,
@@ -28,22 +50,50 @@ export async function transcribePcmWithWhisper({
   maxChars: number;
   onStatus: (status: string) => void;
 }): Promise<{ text: string; transcriptTimedText: string; truncated: boolean }> {
-  if (audio.length === 0) throw new Error("The decoded YouTube audio is empty.");
-  const transcriber = await getTranscriber(onStatus);
-  onStatus("Transcribing YouTube audio locally...");
-  const output = await transcriber(audio, {
-    chunk_length_s: 30,
-    stride_length_s: 5,
-    return_timestamps: true,
+  const chunk = await transcribePcmChunkWithWhisper({
+    audio,
+    onStatus,
+    timestampOffsetSeconds: 0,
   });
-  const resolved = Array.isArray(output) ? output[0] : output;
-  if (!resolved) throw new Error("Local Whisper returned no transcript.");
-  return formatWhisperOutput(resolved, maxChars);
+  return clampWhisperTranscript(chunk.text, chunk.timedLines.join("\n"), maxChars);
 }
 
-async function getTranscriber(
-  onStatus: (status: string) => void,
-): Promise<AutomaticSpeechRecognitionPipelineType> {
+export async function transcribePcmChunkWithWhisper({
+  audio,
+  onStatus,
+  transcribingStatus = "Transcribing audio locally...",
+  timestampOffsetSeconds,
+}: {
+  audio: Float32Array;
+  onStatus: (status: string) => void;
+  transcribingStatus?: string;
+  timestampOffsetSeconds: number;
+}): Promise<WhisperChunkTranscript> {
+  if (audio.length === 0) throw new Error("The decoded YouTube audio is empty.");
+  clearTranscriberIdleTimer();
+  activeTranscriptions += 1;
+  try {
+    const { diagnostics, transcriber } = await getTranscriber(onStatus);
+    onStatus(transcribingStatus);
+    const output = await transcriber(audio, {
+      chunk_length_s: 30,
+      stride_length_s: 5,
+      return_timestamps: true,
+    });
+    const resolved = Array.isArray(output) ? output[0] : output;
+    if (!resolved) throw new Error("Local Whisper returned no transcript.");
+    return { ...formatWhisperOutput(resolved, timestampOffsetSeconds), diagnostics };
+  } finally {
+    activeTranscriptions = Math.max(0, activeTranscriptions - 1);
+    scheduleTranscriberDisposal();
+  }
+}
+
+async function getTranscriber(onStatus: (status: string) => void): Promise<{
+  diagnostics: WhisperRuntimeDiagnostics;
+  transcriber: AutomaticSpeechRecognitionPipelineType;
+}> {
+  const reused = Boolean(transcriberPromise);
   if (!transcriberPromise) {
     const hasWebGpu = "gpu" in navigator;
     env.allowLocalModels = false;
@@ -56,15 +106,39 @@ async function getTranscriber(
       };
       env.backends.onnx.wasm.proxy = false;
     }
+    const startedAt = performance.now();
+    let loadedDevice: WhisperDevice = hasWebGpu ? "webgpu" : "wasm";
     transcriberPromise = loadWhisperTranscriber({
       hasWebGpu,
       onStatus,
-    }).catch((error) => {
-      transcriberPromise = null;
-      throw error;
-    });
+      onDevice: (device) => {
+        loadedDevice = device;
+      },
+    })
+      .then((transcriber) => {
+        const runtime = {
+          device: loadedDevice,
+          loadMs: Math.max(0, performance.now() - startedAt),
+          transcriber,
+        };
+        transcriberRuntime = runtime;
+        return runtime;
+      })
+      .catch((error) => {
+        transcriberPromise = null;
+        transcriberRuntime = null;
+        throw error;
+      });
   }
-  return await transcriberPromise;
+  const runtime = await transcriberPromise;
+  return {
+    transcriber: runtime.transcriber,
+    diagnostics: {
+      device: runtime.device,
+      loadMs: runtime.loadMs,
+      reused,
+    },
+  };
 }
 
 export async function loadWhisperTranscriber({
@@ -73,23 +147,31 @@ export async function loadWhisperTranscriber({
   createPipeline = createWhisperPipeline,
   webGpuTimeoutMs = WEBGPU_MODEL_LOAD_TIMEOUT_MS,
   wasmTimeoutMs = WASM_MODEL_LOAD_TIMEOUT_MS,
+  onDevice,
 }: {
   hasWebGpu: boolean;
   onStatus: (status: string) => void;
   createPipeline?: WhisperPipelineFactory;
   webGpuTimeoutMs?: number;
   wasmTimeoutMs?: number;
+  onDevice?: (device: WhisperDevice) => void;
 }): Promise<AutomaticSpeechRecognitionPipelineType> {
   let activeAttempt = 0;
   const load = async (device: WhisperDevice, timeoutMs: number, timeoutMessage: string) => {
     const attempt = ++activeAttempt;
-    return await withTimeout(
-      createPipeline(device, (status) => {
-        if (attempt === activeAttempt) onStatus(status);
-      }),
+    const pipelinePromise = createPipeline(device, (status) => {
+      if (attempt === activeAttempt) onStatus(status);
+    });
+    const loaded = await withTimeout(
+      pipelinePromise,
       timeoutMs,
       timeoutMessage,
+      async (latePipeline) => {
+        await latePipeline.dispose();
+      },
     );
+    onDevice?.(device);
+    return loaded;
   };
 
   if (hasWebGpu) {
@@ -128,35 +210,53 @@ async function createWhisperPipeline(
   });
 }
 
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | null = null;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_resolve, reject) => {
-        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+  onLateResolve?: (value: T) => Promise<void> | void,
+): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      reject(new Error(message));
+    }, timeoutMs);
+    void promise.then(
+      (value) => {
+        if (settled) {
+          void onLateResolve?.(value);
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
 }
 
 function formatWhisperOutput(
   output: AutomaticSpeechRecognitionOutput,
-  maxChars: number,
-): { text: string; transcriptTimedText: string; truncated: boolean } {
+  timestampOffsetSeconds: number,
+): { text: string; timedLines: string[] } {
   const text = normalizeText(output.text);
   const timedLines = (output.chunks ?? []).flatMap((chunk) => {
     const chunkText = normalizeText(chunk.text);
     const start = Array.isArray(chunk.timestamp) ? chunk.timestamp[0] : null;
     if (!chunkText || typeof start !== "number" || !Number.isFinite(start)) return [];
-    return [`[${formatTimestamp(start)}] ${chunkText}`];
+    return [`[${formatTimestamp(start + timestampOffsetSeconds)}] ${chunkText}`];
   });
-  return clampTranscript(text, timedLines.join("\n"), maxChars);
+  return { text, timedLines };
 }
 
-function clampTranscript(
+export function clampWhisperTranscript(
   text: string,
   timedText: string,
   maxChars: number,
@@ -171,6 +271,32 @@ function clampTranscript(
     return timedLength <= limit;
   });
   return { text: clamped, transcriptTimedText: timedLines.join("\n"), truncated: true };
+}
+
+export async function disposeWhisperTranscriber(): Promise<boolean> {
+  clearTranscriberIdleTimer();
+  if (activeTranscriptions > 0) return false;
+  const runtime = transcriberRuntime;
+  transcriberRuntime = null;
+  transcriberPromise = null;
+  if (!runtime) return false;
+  await runtime.transcriber.dispose();
+  return true;
+}
+
+function clearTranscriberIdleTimer(): void {
+  if (!transcriberIdleTimer) return;
+  clearTimeout(transcriberIdleTimer);
+  transcriberIdleTimer = null;
+}
+
+function scheduleTranscriberDisposal(): void {
+  clearTranscriberIdleTimer();
+  if (activeTranscriptions > 0 || !transcriberRuntime) return;
+  transcriberIdleTimer = setTimeout(() => {
+    transcriberIdleTimer = null;
+    void disposeWhisperTranscriber();
+  }, WHISPER_IDLE_DISPOSE_MS);
 }
 
 function normalizeText(value: string): string {

--- a/apps/chrome-extension/src/entrypoints/offscreen/youtube-audio.ts
+++ b/apps/chrome-extension/src/entrypoints/offscreen/youtube-audio.ts
@@ -10,19 +10,28 @@ const RANGE_ATTEMPTS = 3;
 export type DownloadedYoutubeAudio = {
   bytes: Uint8Array;
   mimeType: string;
-  mediaSource: "sabr" | "android-vr";
+  mediaSource: "sabr" | "player" | "android-vr";
+};
+
+export type ResolvedYoutubeDirectAudio = {
+  contentLength: number | null;
+  mediaSource: "player" | "android-vr";
+  mimeType: string;
+  url: string;
 };
 
 export async function downloadYoutubeAudio({
   context,
   capturedSabr,
+  ignoreContextDirect = false,
 }: {
   context: BrowserYoutubeMediaContext;
   capturedSabr: CapturedYoutubeSabrRequest | null;
+  ignoreContextDirect?: boolean;
 }): Promise<DownloadedYoutubeAudio> {
   let directError: unknown;
   try {
-    return await downloadViaAndroidVr(context);
+    return await downloadViaDirectAudio(context, ignoreContextDirect);
   } catch (error) {
     directError = error;
   }
@@ -37,18 +46,19 @@ export async function downloadYoutubeAudio({
     }
   }
 
-  throw directError;
+  throw directError ?? new Error("Captured YouTube SABR media is unavailable.");
 }
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-async function downloadViaAndroidVr(
+export async function resolveYoutubeDirectAudio(
   context: BrowserYoutubeMediaContext,
-): Promise<DownloadedYoutubeAudio> {
+  { ignoreContextDirect = false }: { ignoreContextDirect?: boolean } = {},
+): Promise<ResolvedYoutubeDirectAudio> {
   const media =
-    context.directAudio ??
+    (!ignoreContextDirect ? context.directAudio : null) ??
     (await resolveYoutubeAudioWithAndroidVr({
       fetchImpl: fetch,
       videoId: context.videoId,
@@ -57,6 +67,20 @@ async function downloadViaAndroidVr(
       originalUrl: context.url,
       preferredMimeTypes: ["audio/mp4", "audio/webm"],
     }));
+  return {
+    contentLength: media.contentLength,
+    mediaSource:
+      !ignoreContextDirect && context.directAudio ? context.directAudio.resolver : "android-vr",
+    mimeType: media.mimeType,
+    url: media.url,
+  };
+}
+
+async function downloadViaDirectAudio(
+  context: BrowserYoutubeMediaContext,
+  ignoreContextDirect: boolean,
+): Promise<DownloadedYoutubeAudio> {
+  const media = await resolveYoutubeDirectAudio(context, { ignoreContextDirect });
   let bytes: Uint8Array;
   if (media.contentLength && media.contentLength > 0) {
     bytes = await downloadYoutubeBytesWithRanges({
@@ -71,7 +95,7 @@ async function downloadViaAndroidVr(
   return {
     bytes,
     mimeType: media.mimeType,
-    mediaSource: "android-vr",
+    mediaSource: media.mediaSource,
   };
 }
 

--- a/apps/chrome-extension/tests/README-firefox.md
+++ b/apps/chrome-extension/tests/README-firefox.md
@@ -1,219 +1,29 @@
-# Firefox Extension Testing Notes
+# Firefox Extension Testing
 
-## Current Status
+## Supported smoke path
 
-### Chrome/Chromium Tests: ✅ Working (39 passed, 2 skipped)
+`pnpm -C apps/chrome-extension test:firefox`
 
-Latest local run:
+This builds `.output/firefox-mv3`, finds an installed Firefox or Playwright Firefox binary, and uses Mozilla `web-ext` to install the build as a temporary add-on in headless Firefox. CI runs the same command.
 
-- `39 passed`
-- `2 skipped` (YouTube E2E opt-in)
+Set `FIREFOX_BINARY=/path/to/firefox` when automatic discovery is unsuitable.
 
-### Firefox Tests: ⚠️ Blocked by Playwright Limitation
+## Advisory lint
 
-**Status:** Infrastructure complete, but Playwright's Firefox driver has limitations.
-CI only runs Chromium E2E; Firefox tests are skipped by default.
+`pnpm -C apps/chrome-extension test:firefox:lint`
 
-**What Works:**
+`web-ext lint` reports known warnings for Chrome-only APIs that remain in dead Firefox bundle branches and for the current minimum-version metadata. Treat this as advisory until the browser-specific bundles remove those symbols.
 
-- ✅ Browser detection (`getBrowserFromProject`)
-- ✅ Dynamic extension paths (`.output/firefox-mv3`)
-- ✅ URL scheme switching (`moz-extension://` vs `chrome-extension://`)
-- ✅ Extension ID detection via manifest
-- ✅ Firefox manifest configuration with explicit ID
+## Playwright diagnostics
 
-**What Doesn't Work:**
+`pnpm -C apps/chrome-extension test:firefox:force`
 
-- ❌ Playwright's Firefox driver cannot load temporary extensions reliably
-- ❌ Navigation to `moz-extension://` URLs fails with `NS_ERROR_NOT_AVAILABLE`
+Playwright still cannot reliably load and navigate temporary Firefox extensions. The forced project remains available for upstream diagnostics, but it is not the supported Firefox gate.
 
-**Error:**
+Known limitations:
 
-```
-Error: page.goto: NS_ERROR_NOT_AVAILABLE
-navigating to "moz-extension://summarize-test@steipete.com/sidepanel.html"
-```
+- no Firefox extension service-worker events
+- unreliable `--load-extension` behavior
+- `moz-extension://` navigation can fail with `NS_ERROR_NOT_AVAILABLE`
 
-## Technical Details
-
-### The Service Worker Problem
-
-**Chromium:**
-
-```typescript
-// ✅ Works - Playwright exposes service worker events
-const background = await context.waitForEvent("serviceworker", { timeout: 15_000 });
-const extensionId = new URL(background.url()).host;
-```
-
-**Firefox:**
-
-```typescript
-// ❌ Playwright doesn't expose serviceworker event in Firefox
-// Solution: Use explicit ID from manifest
-const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-const extensionId = manifest.browser_specific_settings?.gecko?.id;
-```
-
-### Our Solution
-
-**wxt.config.ts:**
-
-```typescript
-// Firefox builds get an explicit, predictable ID
-browser_specific_settings: {
-  gecko: {
-    id: 'summarize-test@steipete.com',
-    strict_min_version: '131.0',
-  }
-}
-```
-
-**tests/extension.spec.ts:**
-
-```typescript
-if (browser === "firefox") {
-  // Read ID from manifest instead of service worker detection
-  extensionId = manifest.browser_specific_settings?.gecko?.id;
-} else {
-  // Chromium uses service worker detection
-  extensionId = new URL(background.url()).host;
-}
-```
-
-## Known Playwright/Firefox Limitations
-
-1. **Service Worker Detection:** `context.waitForEvent('serviceworker')` not supported
-2. **Extension Loading:** `--load-extension` flag doesn't work reliably with Firefox
-3. **Extension Navigation:** Cannot navigate to `moz-extension://` URLs in tests
-4. **Background Pages:** `context.backgroundPages()` returns empty array
-
-These are **upstream Playwright issues**, not bugs in our code.
-
-## Workarounds & Alternatives
-
-### Option 1: Manual Testing (Current Approach)
-
-Firefox extension works perfectly when tested manually:
-
-```bash
-cd apps/chrome-extension
-BROWSER=firefox pnpm build:firefox
-# Load .output/firefox-mv3 in about:debugging
-```
-
-### Option 2: Use web-ext for Firefox Testing
-
-Mozilla's official testing tool works better:
-
-```bash
-pnpm add -D web-ext
-web-ext run --source-dir=.output/firefox-mv3
-```
-
-But this requires separate test infrastructure.
-
-### Option 3: Skip Firefox Tests Until Playwright Improves
-
-```typescript
-const allowFirefoxExtensionTests = process.env.ALLOW_FIREFOX_EXTENSION_TESTS === "1";
-
-test.skip(
-  ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
-  "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
-);
-```
-
-Default/force scripts:
-
-```bash
-pnpm -C apps/chrome-extension test:firefox
-pnpm -C apps/chrome-extension test:firefox:force
-```
-
-## Test Results Summary
-
-### Chromium (before and after cross-browser work)
-
-**Passing (16 tests):**
-
-- ✓ Sidepanel loading and UI rendering
-- ✓ Settings persistence and updates
-- ✓ Chat dock visibility
-- ✓ UI pickers (scheme, mode, length)
-- ✓ Model refresh functionality
-- ✓ Stream handling and title updates
-- ✓ Tab navigation
-- ✓ Content script extraction
-- ✓ Auto-summarize functionality
-- ✓ Hover tooltips
-
-**Failing (9 tests - pre-existing):**
-
-- ✗ Agent request error handling (11.9s timeout)
-- ✗ Chat queue tests (11.6s timeouts)
-- ✗ Automation notice (11.0s timeout)
-- ✗ Options page tests (60s timeouts)
-
-These failures are **pre-existing** and not related to the Firefox work.
-
-### Firefox (current state)
-
-**Infrastructure:** ✅ Complete
-**Test Execution:** ❌ Blocked by Playwright
-
-Extension ID detection works:
-
-```bash
-✓ Reads 'summarize-test@steipete.com' from manifest
-✓ Constructs correct moz-extension:// URLs
-✗ Cannot navigate to extension pages (Playwright limitation)
-```
-
-## CI Configuration
-
-### Chrome CI (working)
-
-```yaml
-extension-e2e:
-  runs-on: ubuntu-latest
-  steps:
-    - Install Playwright (Chromium)
-    - Run: playwright test --project=chromium
-```
-
-### Firefox CI (disabled due to Playwright limitations)
-
-```yaml
-extension-e2e-firefox:
-  runs-on: ubuntu-latest
-  steps:
-    - Install Playwright (Firefox)
-    - Run: playwright test --project=firefox
-    # Expected to fail until Playwright improves Firefox support
-```
-
-## Conclusion
-
-**Cross-browser infrastructure: ✅ Complete and working**
-
-- All tests are browser-aware
-- Automatic browser detection from Playwright projects
-- Correct extension paths and URL schemes
-
-**Chromium tests: ✅ Green**
-
-- 39 passed, 2 skipped in latest local run
-- No Firefox-related regressions
-
-**Firefox tests: ⚠️ Waiting on Playwright**
-
-- Default run: skipped (known Playwright limitation)
-- Force run: expected to fail with `NS_ERROR_NOT_AVAILABLE` on `moz-extension://` navigation
-- Manual Firefox testing remains the reliable path
-
-## References
-
-- [Playwright Firefox Extension Support](https://github.com/microsoft/playwright/issues/7500)
-- [MDN: browser_specific_settings](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings)
-- [Mozilla web-ext](https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/)
+Page-level extension behavior remains covered by Chromium E2E. Firefox-specific manifest behavior is covered by unit tests, and native Firefox loading is covered by the `web-ext` smoke.

--- a/apps/chrome-extension/tests/browser-media-local.live.spec.ts
+++ b/apps/chrome-extension/tests/browser-media-local.live.spec.ts
@@ -1,0 +1,177 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import {
+  activateTabByUrl,
+  closeExtension,
+  getBackground,
+  getBrowserFromProject,
+  launchExtension,
+  openExtensionPage,
+  seedSettings,
+  sendPanelMessage,
+} from "./helpers/extension-harness";
+import { getPanelModel, getPanelSummaryMarkdown } from "./helpers/panel-hooks";
+
+const LIVE = process.env.SUMMARIZE_LIVE_BROWSER_MEDIA === "1";
+const SPEECH =
+  "Summarize browser media transcription works without a daemon. The purple telescope is beside the orange piano.";
+
+test("transcribes embedded browser media through MediaBunny and local Whisper", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  test.skip(!LIVE, "Set SUMMARIZE_LIVE_BROWSER_MEDIA=1 to run local browser media transcription.");
+  test.skip(testInfo.project.name !== "chromium", "Local browser Whisper is Chrome-only.");
+  test.skip(!hasCommand("say") || !hasCommand("ffmpeg"), "macOS say and ffmpeg are required.");
+  test.setTimeout(10 * 60 * 1000);
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "summarize-browser-media-"));
+  const aiffPath = path.join(tmpDir, "speech.aiff");
+  const mediaPath = path.join(tmpDir, "speech.m4a");
+  run("say", ["-v", "Samantha", "-o", aiffPath, SPEECH]);
+  run("ffmpeg", [
+    "-y",
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-i",
+    aiffPath,
+    "-c:a",
+    "aac",
+    "-b:a",
+    "96k",
+    mediaPath,
+  ]);
+
+  const media = fs.readFileSync(mediaPath);
+  const html = `<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Browser Media Speech</title></head>
+  <body>
+    <h1>Browser Media Speech</h1>
+    <audio controls preload="auto" src="/speech.m4a"></audio>
+  </body>
+</html>`;
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (url.pathname === "/speech.m4a") {
+      const range = request.headers.range?.match(/^bytes=(\d+)-(\d*)$/u);
+      if (range) {
+        const start = Number(range[1]);
+        const end = range[2] ? Math.min(media.length - 1, Number(range[2])) : media.length - 1;
+        const body = media.subarray(start, end + 1);
+        response.writeHead(206, {
+          "accept-ranges": "bytes",
+          "content-length": body.length,
+          "content-range": `bytes ${start}-${end}/${media.length}`,
+          "content-type": "audio/mp4",
+        });
+        response.end(body);
+        return;
+      }
+      response.writeHead(200, {
+        "accept-ranges": "bytes",
+        "content-length": media.length,
+        "content-type": "audio/mp4",
+      });
+      response.end(media);
+      return;
+    }
+    const body = Buffer.from(html);
+    response.writeHead(200, {
+      "content-length": body.length,
+      "content-type": "text/html; charset=utf-8",
+    });
+    response.end(body);
+  });
+  const serverUrl = await listen(server);
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, {
+      token: "",
+      autoSummarize: false,
+      extendedLogging: true,
+      slidesEnabled: false,
+      slideRuntime: "browser",
+      maxChars: 20_000,
+    });
+    const contentPage = await harness.context.newPage();
+    await contentPage.goto(serverUrl, { waitUntil: "domcontentloaded" });
+    await contentPage.waitForFunction(() => {
+      const media = document.querySelector("audio");
+      return Boolean(media && Number.isFinite(media.duration) && media.duration > 0);
+    });
+    const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
+    await activateTabByUrl(harness, serverUrl);
+    await sendPanelMessage(panel, {
+      type: "panel:summarize",
+      refresh: true,
+      inputMode: "video",
+    });
+
+    await expect
+      .poll(async () => await getPanelModel(panel), { timeout: 8 * 60 * 1000 })
+      .toBe("Browser");
+    const summary = (await getPanelSummaryMarkdown(panel)).toLowerCase();
+    expect(summary).toMatch(/purple|telescope|orange piano/u);
+
+    const background = await getBackground(harness);
+    const readDiagnostic = async () =>
+      await background.evaluate(async () => {
+        const stored = await chrome.storage.session.get("summarize:extension-logs");
+        const lines = Array.isArray(stored["summarize:extension-logs"])
+          ? (stored["summarize:extension-logs"] as string[])
+          : [];
+        return lines
+          .toReversed()
+          .map((line) => {
+            try {
+              return JSON.parse(line) as Record<string, unknown>;
+            } catch {
+              return null;
+            }
+          })
+          .find((entry) => entry?.event === "extract:browser-media:transcript");
+      });
+    await expect.poll(readDiagnostic, { timeout: 5_000 }).not.toBeUndefined();
+    const diagnostic = await readDiagnostic();
+    expect(diagnostic).toMatchObject({
+      decoder: "mediabunny-webcodecs",
+      mediaInput: "url-range",
+      mediaSource: "embedded",
+    });
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    fs.rmSync(tmpDir, { force: true, recursive: true });
+  }
+});
+
+function hasCommand(command: string): boolean {
+  const locator = process.platform === "win32" ? "where" : "which";
+  return spawnSync(locator, [command], { stdio: "ignore" }).status === 0;
+}
+
+function run(command: string, args: string[]): void {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  if (result.status === 0) return;
+  throw new Error(`${command} failed: ${result.stderr || result.stdout}`);
+}
+
+async function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Failed to resolve local media server port."));
+        return;
+      }
+      resolve(`http://127.0.0.1:${address.port}/`);
+    });
+  });
+}

--- a/apps/chrome-extension/tests/youtube-local.live.spec.ts
+++ b/apps/chrome-extension/tests/youtube-local.live.spec.ts
@@ -119,7 +119,7 @@ test("transcribes a captionless YouTube video through the extension runtime", as
     expect(playerState.captionTrackCount).toBe(0);
     expect(localTranscriptLog?.textLength).toEqual(expect.any(Number));
     expect(localTranscriptLog?.textLength as number).toBeGreaterThan(20);
-    expect(["android-vr", "sabr"]).toContain(localTranscriptLog?.mediaSource);
+    expect(["player", "android-vr", "sabr"]).toContain(localTranscriptLog?.mediaSource);
     expect(summary.length).toBeGreaterThan(50);
     expect(summary).not.toContain("No transcript text was available from the browser");
     expect(

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -13,7 +13,7 @@ Goal: Chrome **Side Panel** (“real sidebar”) summarizes **what you see** on 
 Quickstart:
 
 - Build/load extension: `apps/chrome-extension/README.md`
-- Chrome Browser mode works immediately without a daemon for page summaries, fetchable video slides, and captionless YouTube transcription.
+- Chrome Browser mode works immediately without a daemon for page summaries, fetchable video slides, and fetchable YouTube/direct/embedded media transcription.
 - Optional: install summarize for daemon-backed media support:
   - `npm i -g @steipete/summarize`
   - `brew install summarize` (macOS, Linux)
@@ -27,7 +27,7 @@ Quickstart:
 Firefox notes:
 
 - Sidebar UX differs from Chrome’s side panel (persistent sidebar instead of slide-in panel).
-- Firefox testing is limited in Playwright; see `apps/chrome-extension/tests/README-firefox.md`.
+- Firefox loading is smoke-tested with Mozilla `web-ext`; Playwright page-level Firefox tests remain diagnostic-only. See `apps/chrome-extension/tests/README-firefox.md`.
 - Compatibility details: `apps/chrome-extension/docs/firefox.md`.
 
 Dev (repo checkout):
@@ -85,7 +85,7 @@ Dev (repo checkout):
 - **Extension (MV3, WXT)**
   - Side Panel UI: length + typography controls (font family + size), auto/manual toggle.
   - Background service worker: tab + navigation tracking, content extraction, starts summarize runs.
-  - Chrome offscreen page: runs MediaBunny with native WebCodecs for daemonless video slides and YouTube audio preparation, plus local Whisper transcription.
+  - Chrome offscreen page: runs MediaBunny with native WebCodecs for ranged video slides and chunked local media transcription, plus an idle-evictable Whisper runtime.
   - Content script: extract readable article text from the **rendered DOM** via Readability; also detect SPA URL changes.
   - Panel page streams SSE directly (MV3 service workers can be flaky for long-lived streams).
 - **Daemon (local, autostart service)**
@@ -98,7 +98,7 @@ Dev (repo checkout):
 1. User opens side panel (click extension icon).
 2. Panel sends a “ready” message to the background (plus periodic “ping” heartbeats while open).
 3. On nav/tab change (and auto enabled): background asks the content script to extract `{ url, title, text }` (best-effort).
-4. In Chrome Browser mode, captionless YouTube audio is resolved through same-origin Android VR media with captured SABR fallback, decoded through WebAudio or MediaBunny/WebCodecs, and transcribed locally.
+4. In Chrome Browser mode, fetchable audio is decoded in bounded chunks through MediaBunny/WebCodecs and transcribed locally. YouTube prefers active-player/watch-page direct audio, then Android VR, buffered direct audio, and captured SABR.
 5. In Daemon mode, background `POST`s payload to `/v1/summarize` with `Authorization: Bearer <token>`.
 6. Panel opens `/v1/summarize/<id>/events` (SSE) and renders streamed Markdown.
 
@@ -125,7 +125,7 @@ See `docs/media.md` for detection and transcript rules.
 ## Slides (Side Panel)
 
 - The slides toggle lights up on media-friendly URLs (YouTube/watch|shorts, youtu.be, direct media) or when the page reports video/audio. Defaults to Video on those pages.
-- Turning slides **on** refreshes the current summary and requests slide extraction. Chrome Browser mode uses MediaBunny with native WebCodecs for fetchable videos up to 128 MB and falls back to visible-tab capture. Daemon mode adds `yt-dlp`, native ffmpeg, and optional `tesseract` OCR.
+- Turning slides **on** refreshes the current summary and requests slide extraction. Chrome Browser mode uses MediaBunny with native WebCodecs and ranged reads for fetchable videos, then falls back to visible-tab capture. Daemon mode adds `yt-dlp`, native ffmpeg, and optional `tesseract` OCR.
 - Active slide mode is slide-first:
   - vertical image/text cards
   - transcript-first text; OCR fallback

--- a/docs/media.md
+++ b/docs/media.md
@@ -44,7 +44,8 @@ read_when:
 - When media is detected on a page, the Summarize button gains a dropdown caret (Page/Video or Page/Audio).
 - Selecting Video/Audio forces URL mode + transcript-first extraction for that run only.
 - Selection is not stored.
-- Chrome Browser mode resolves captionless YouTube audio through same-origin Android VR media with captured SABR fallback, decodes it through WebAudio or MediaBunny/WebCodecs, and transcribes with browser-cached multilingual Whisper Tiny.
+- Chrome Browser mode transcribes fetchable direct and embedded media in bounded MediaBunny/WebCodecs chunks with browser-cached multilingual Whisper Tiny. YouTube prefers active-player/watch-page direct audio, then Android VR, buffered direct audio, and captured SABR.
+- Browser slide extraction uses ranged MediaBunny URL reads instead of buffering the complete video. The Whisper runtime is disposed after an idle period while the downloaded model remains in browser cache.
 
 ## Known limits
 

--- a/packages/core/src/content/transcript/providers/youtube/native-media.ts
+++ b/packages/core/src/content/transcript/providers/youtube/native-media.ts
@@ -1,7 +1,4 @@
-import {
-  extractYoutubePlayerBootstrap,
-  resolveYoutubeAudioWithAndroidVr,
-} from "../../../youtube.js";
+import { extractYoutubePlayerBootstrap, resolveYoutubeAudio } from "../../../youtube.js";
 import { normalizeTranscriptText } from "../../normalize.js";
 import type { ProviderResult } from "../../types.js";
 import { transcribeMediaUrl } from "../podcast/media.js";
@@ -21,12 +18,13 @@ export async function tryNativeYoutubeMediaTranscript(
   flow.pushHint("YouTube: resolving audio without yt-dlp");
   flow.attemptedProviders.push("youtube-media");
   try {
-    const media = await resolveYoutubeAudioWithAndroidVr({
+    const media = await resolveYoutubeAudio({
       fetchImpl: flow.options.fetch,
       videoId: flow.effectiveVideoId,
       apiKey: bootstrap.apiKey,
       visitorData: bootstrap.visitorData,
       originalUrl: flow.context.url,
+      watchHtml: flow.htmlText,
     });
     const result = await transcribeMediaUrl({
       fetchImpl: flow.options.fetch,
@@ -51,7 +49,7 @@ export async function tryNativeYoutubeMediaTranscript(
       source: "youtube-media",
       metadata: {
         provider: "youtube-media",
-        resolver: "android-vr",
+        resolver: media.resolver,
         transcriptionProvider: result.provider,
         ...(flow.durationMetadata ??
           (media.durationSeconds ? { durationSeconds: media.durationSeconds } : {})),

--- a/packages/core/src/content/youtube.ts
+++ b/packages/core/src/content/youtube.ts
@@ -1,3 +1,5 @@
+import { extractInitialPlayerResponse } from "./transcript/providers/youtube/captions-player.js";
+
 const ANDROID_VR_CLIENT_NAME = "ANDROID_VR";
 const ANDROID_VR_CLIENT_ID = "28";
 const ANDROID_VR_CLIENT_VERSION = "1.65.10";
@@ -12,6 +14,10 @@ export type YoutubeAudioFormat = {
   contentLength: number | null;
   durationSeconds: number | null;
   filename: string;
+};
+
+export type ResolvedYoutubeAudioFormat = YoutubeAudioFormat & {
+  resolver: "watch-page" | "android-vr";
 };
 
 export type YoutubePlayerBootstrap = {
@@ -102,6 +108,60 @@ export async function resolveYoutubeAudioWithAndroidVr({
     );
   }
 
+  const selected = selectAudioFormat(payload, preferredMimeTypes);
+  if (!selected) {
+    throw new Error("YouTube Android VR returned no direct audio format");
+  }
+  return selected;
+}
+
+export function extractYoutubeAudioFromWatchHtml(
+  html: string,
+  preferredMimeTypes: readonly string[] = [],
+): YoutubeAudioFormat | null {
+  const playerResponse = extractInitialPlayerResponse(html);
+  return playerResponse ? selectAudioFormat(playerResponse, preferredMimeTypes) : null;
+}
+
+export async function resolveYoutubeAudio({
+  fetchImpl,
+  videoId,
+  apiKey,
+  visitorData = null,
+  originalUrl = `https://www.youtube.com/watch?v=${videoId}`,
+  preferredMimeTypes = [],
+  watchHtml = null,
+}: {
+  fetchImpl: typeof fetch;
+  videoId: string;
+  apiKey: string;
+  visitorData?: string | null;
+  originalUrl?: string;
+  preferredMimeTypes?: readonly string[];
+  watchHtml?: string | null;
+}): Promise<ResolvedYoutubeAudioFormat> {
+  const embedded = watchHtml
+    ? extractYoutubeAudioFromWatchHtml(watchHtml, preferredMimeTypes)
+    : null;
+  if (embedded) return { ...embedded, resolver: "watch-page" };
+
+  return {
+    ...(await resolveYoutubeAudioWithAndroidVr({
+      fetchImpl,
+      videoId,
+      apiKey,
+      visitorData,
+      originalUrl,
+      preferredMimeTypes,
+    })),
+    resolver: "android-vr",
+  };
+}
+
+function selectAudioFormat(
+  payload: RecordLike,
+  preferredMimeTypes: readonly string[],
+): YoutubeAudioFormat | null {
   const streamingData = isRecord(payload.streamingData) ? payload.streamingData : null;
   const adaptiveFormats = Array.isArray(streamingData?.adaptiveFormats)
     ? streamingData.adaptiveFormats
@@ -116,11 +176,7 @@ export async function resolveYoutubeAudioWithAndroidVr({
         mimePreferenceIndex(right.mimeType, preferredMimeTypes);
       return mimePreference || (right.bitrate ?? 0) - (left.bitrate ?? 0);
     });
-  const selected = candidates[0];
-  if (!selected) {
-    throw new Error("YouTube Android VR returned no direct audio format");
-  }
-  return selected;
+  return candidates[0] ?? null;
 }
 
 function mimePreferenceIndex(mimeType: string, preferredMimeTypes: readonly string[]): number {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,9 +122,12 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      web-ext:
+        specifier: 10.3.0
+        version: 10.3.0(jiti@2.7.0)
       wxt:
         specifier: 0.20.26
-        version: 0.20.26(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.2)(tsx@4.22.4)
+        version: 0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(jiti@2.7.0)(rollup@4.60.2)(tsx@4.22.4)
 
   packages/core:
     dependencies:
@@ -298,6 +301,10 @@ packages:
 
   '@babel/runtime@7.28.2':
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
@@ -657,6 +664,52 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fluent/syntax@0.19.0':
+    resolution: {integrity: sha512-5D2qVpZrgpjtqU4eNOcWGp1gnUCgjfM+vKGE2y03kKN6z5EBhtx0qdRFbg8QuNNj8wXNoX93KJoYb+NqoxswmQ==}
+    engines: {node: '>=14.0.0', npm: '>=7.0.0'}
+
+  '@fregante/relaxed-json@2.0.0':
+    resolution: {integrity: sha512-PyUXQWB42s4jBli435TDiYuVsadwRHnMc27YaLouINktvTWsL3FcKrRMGawTayFk46X+n5bE23RjUTWQwrukWw==}
+    engines: {node: '>= 0.10.0'}
+
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
     engines: {node: '>=20.0.0'}
@@ -672,6 +725,26 @@ packages:
 
   '@huggingface/transformers@3.8.1':
     resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -845,6 +918,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mdn/browser-compat-data@7.3.16':
+    resolution: {integrity: sha512-JQ6SGcHeyqSYGVwWe7NzOeXfp/vZgo2yz+fsEbMOyWLyNRVP4RoG8+dqaF/VTx1zPtF4J8XvxiWXH1l2cMZTwQ==}
 
   '@mistralai/mistralai@2.2.1':
     resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
@@ -1142,6 +1218,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -1509,6 +1588,9 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
@@ -1633,10 +1715,34 @@ packages:
   '@wxt-dev/storage@1.2.8':
     resolution: {integrity: sha512-GWCFKgF5+d7eslOxUDFC70ypA9njupmJb1nQM8uZoX0J3sWT2BO5xJLzb1sYahWAfID9p2BMtnUBN1lkWxPsbQ==}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  addons-linter@10.6.0:
+    resolution: {integrity: sha512-8T+Rj4U1lGwtC4OIInsEoxty3H0iZMtvkI+Wvo5+EFfnWhknPBOexusM0o7mi00keNk4dq/2tVZVRSE62SdRsA==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  addons-moz-compare@1.3.0:
+    resolution: {integrity: sha512-/rXpQeaY0nOKhNx00pmZXdk5Mu+KhVlL3/pSBuAYwrxRrNiTvI/9xfQI8Lmm7DMMl+PDhtfAHY/0ibTpdeoQQQ==}
+
+  addons-scanner-utils@15.2.0:
+    resolution: {integrity: sha512-SkjE3jE7Sfx67KuL8nI5DolqqQ35G1GMcMrgT9LufKnBJUW4YnoBO1sLAILj3N/FLhfSAT0hwWK1MSVLmgbASQ==}
+    peerDependencies:
+      express: 5.2.1
+      safe-compare: 1.1.4
+    peerDependenciesMeta:
+      express:
+        optional: true
+      safe-compare:
+        optional: true
 
   adm-zip@0.5.17:
     resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
@@ -1645,6 +1751,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -1740,6 +1852,9 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
@@ -1770,6 +1885,10 @@ packages:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
@@ -1778,12 +1897,23 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -1821,12 +1951,20 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  columnify@1.6.0:
+    resolution: {integrity: sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==}
+    engines: {node: '>=8.0.0'}
 
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
@@ -1839,6 +1977,10 @@ packages:
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+
+  common-tags@1.8.2:
+    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
+    engines: {node: '>=4.0.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1869,6 +2011,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -1908,12 +2054,19 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@6.0.1:
+    resolution: {integrity: sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -1926,6 +2079,9 @@ packages:
   default-browser@5.5.0:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
+
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -1998,8 +2154,15 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   entities@7.0.1:
@@ -2053,8 +2216,68 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  eslint-plugin-no-unsanitized@4.1.5:
+    resolution: {integrity: sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==}
+    peerDependencies:
+      eslint: ^9 || ^10
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
@@ -2069,9 +2292,24 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-patch@3.1.1:
+    resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -2093,6 +2331,10 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   file-type@22.0.1:
     resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
     engines: {node: '>=22'}
@@ -2101,13 +2343,28 @@ packages:
     resolution: {integrity: sha512-oHLTvMLw6imZUl1se/RBQrFlyy50nXce4sU7yGR6Qc0JgCwqnfiFsAnEwotdGmfKLD7SArGUk2/5STU0k8LOBQ==}
     engines: {node: '>= 10.8.0'}
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   firefox-profile@4.7.0:
     resolution: {integrity: sha512-aGApEu5bfCNbA4PGUZiRJAIU6jKmghV2UVdklXAofnNtiDjqYw0czLS46W7IfFqVKgKhFB8Ao2YoNGHY4BoIMQ==}
     engines: {node: '>=18'}
     hasBin: true
 
+  first-chunk-stream@3.0.0:
+    resolution: {integrity: sha512-LNRvR4hr/S8cXXkIY5pTgVP7L3tq6LlYWcg9nWBuW7o1NMxKZo6oOVa/6GIekMGI0Iw7uC+HWimMe9u/VAeKqw==}
+    engines: {node: '>=8'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
   flatbuffers@25.9.23:
     resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   form-data-encoder@4.1.0:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
@@ -2162,6 +2419,10 @@ packages:
     resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
     hasBin: true
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
@@ -2175,6 +2436,10 @@ packages:
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
+    engines: {node: '>=18'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -2246,14 +2511,39 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  image-size@2.0.2:
+    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
+    engines: {node: '>=16.x'}
+    hasBin: true
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2286,6 +2576,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -2293,6 +2587,10 @@ packages:
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-in-ci@1.0.0:
     resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
@@ -2339,6 +2637,9 @@ packages:
     resolution: {integrity: sha512-wBOr+rNM4gkAZqoLRJI4myw5WzzIdQosFAAbnvfXP5z1LyzgAI3ivOKehC5KfqlQJZoihVhirgtCBj378Eg8GA==}
     engines: {node: '>=0.10.0'}
 
+  is-utf8@0.2.1:
+    resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
+
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
@@ -2376,6 +2677,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@5.9.6:
+    resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -2385,8 +2689,18 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-merge-patch@1.0.2:
+    resolution: {integrity: sha512-M6Vp2GN9L7cfuMXiWOmHj9bEFbeC250iVtcKQbqVgEsDVYnIsrNsbU+h/Y/PkbBQCtEa4Bez+Ebv0zfbC8ObLg==}
 
   json-parse-even-better-errors@3.0.2:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
@@ -2395,6 +2709,15 @@ packages:
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -2420,6 +2743,9 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -2434,6 +2760,10 @@ packages:
 
   launder@1.7.1:
     resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -2538,6 +2868,10 @@ packages:
   local-pkg@1.2.1:
     resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
     engines: {node: '>=14'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -2667,6 +3001,9 @@ packages:
   nanospinner@1.2.2:
     resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -2752,6 +3089,10 @@ packages:
       zod:
         optional: true
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   os-shim@0.1.3:
     resolution: {integrity: sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==}
     engines: {node: '>= 0.4.0'}
@@ -2790,6 +3131,14 @@ packages:
       vite-plus:
         optional: true
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
@@ -2804,19 +3153,44 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
   parse-json@7.1.1:
     resolution: {integrity: sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==}
     engines: {node: '>=16'}
 
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
+
   parse-srcset@1.0.2:
     resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -2824,6 +3198,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
@@ -2842,8 +3219,15 @@ packages:
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
   pino-std-serializers@7.1.0:
     resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pino@9.7.0:
     resolution: {integrity: sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==}
@@ -2879,6 +3263,10 @@ packages:
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -2909,6 +3297,10 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   pupa@3.3.0:
     resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
     engines: {node: '>=12.20'}
@@ -2937,6 +3329,9 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
+
   registry-auth-token@5.1.1:
     resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
     engines: {node: '>=14'}
@@ -2948,6 +3343,14 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -2993,6 +3396,9 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sanitize-html@2.17.4:
     resolution: {integrity: sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==}
 
@@ -3005,6 +3411,11 @@ packages:
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   semver@7.8.1:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
@@ -3025,6 +3436,14 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   shell-quote@1.8.4:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
@@ -3115,6 +3534,14 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-bom-buf@2.0.0:
+    resolution: {integrity: sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==}
+    engines: {node: '>=8'}
+
+  strip-bom-stream@4.0.0:
+    resolution: {integrity: sha512-0ApK3iAkHv6WbgLICw/J4nhwHeDZsBxIIsOD+gHgZICL6SeJ0S9f/WZqemka9cjkTyMN5geId6e8U5WGFAn3cQ==}
+    engines: {node: '>=8'}
+
   strip-bom@5.0.0:
     resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
     engines: {node: '>=12'}
@@ -3123,8 +3550,16 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
   strip-json-comments@5.0.2:
     resolution: {integrity: sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==}
+    engines: {node: '>=14.16'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
   strip-literal@3.1.0:
@@ -3161,6 +3596,10 @@ packages:
 
   thread-stream@3.2.0:
     resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
+
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -3207,6 +3646,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
@@ -3249,6 +3692,10 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici@7.27.1:
+    resolution: {integrity: sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==}
+    engines: {node: '>=20.18.1'}
+
   undici@8.4.1:
     resolution: {integrity: sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==}
     engines: {node: '>=22.19.0'}
@@ -3277,9 +3724,16 @@ packages:
     resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  upath@3.0.7:
+    resolution: {integrity: sha512-VjBBquch25nUGMuVBpOb2Cj3gc8Kb7lJBqbsXR/0anZ/5uJsL14Kpth9JKfnBsckxCfgIp6hPvcvvmZ97R9X7g==}
+    engines: {node: '>=20'}
+
   update-notifier@7.3.1:
     resolution: {integrity: sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==}
     engines: {node: '>=18'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3381,9 +3835,21 @@ packages:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
 
+  watchpack@2.5.1:
+    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+    engines: {node: '>=10.13.0'}
+
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
   web-ext-run@0.2.4:
     resolution: {integrity: sha512-rQicL7OwuqWdQWI33JkSXKcp7cuv1mJG8u3jRQwx/8aDsmhbTHs9ZRmNYOL+LX0wX8edIEQX8jj4bB60GoXtKA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+
+  web-ext@10.3.0:
+    resolution: {integrity: sha512-pDt0/TQcVSanKKypzW2gpy8dhzXMWyP33dz38HkSEWLJI7o+FvkDyE3wFFcSAE6m/tsbwZcHGxBA09A1H/iZ5w==}
+    engines: {node: '>=20.0.0', npm: '>=8.0.0'}
+    hasBin: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -3392,9 +3858,18 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
@@ -3422,6 +3897,10 @@ packages:
 
   winreg@0.0.12:
     resolution: {integrity: sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ==}
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   wrap-ansi@10.0.0:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
@@ -3492,6 +3971,14 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@3.3.0:
+    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+    engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   zip-dir@2.0.0:
     resolution: {integrity: sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg==}
@@ -3765,6 +4252,8 @@ snapshots:
 
   '@babel/runtime@7.28.2': {}
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/runtime@7.29.7': {}
 
   '@babel/types@7.29.7':
@@ -3986,6 +4475,56 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@fluent/syntax@0.19.0': {}
+
+  '@fregante/relaxed-json@2.0.0': {}
+
   '@google/genai@1.52.0':
     dependencies:
       google-auth-library: 10.6.2
@@ -4005,6 +4544,22 @@ snapshots:
       onnxruntime-node: 1.21.0
       onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
       sharp: 0.34.5
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/colour@1.1.0': {}
 
@@ -4124,6 +4679,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mdn/browser-compat-data@7.3.16': {}
 
   '@mistralai/mistralai@2.2.1':
     dependencies:
@@ -4281,6 +4838,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.69.0':
     optional: true
+
+  '@pinojs/redact@0.4.0': {}
 
   '@playwright/test@1.60.0':
     dependencies:
@@ -4547,6 +5106,8 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/minimatch@3.0.5': {}
 
   '@types/node@24.13.1':
@@ -4556,6 +5117,7 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
+    optional: true
 
   '@types/retry@0.12.0': {}
 
@@ -4679,11 +5241,72 @@ snapshots:
       async-mutex: 0.5.0
       dequal: 2.0.3
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
+
+  addons-linter@10.6.0(jiti@2.7.0):
+    dependencies:
+      '@fluent/syntax': 0.19.0
+      '@fregante/relaxed-json': 2.0.0
+      '@mdn/browser-compat-data': 7.3.16
+      addons-moz-compare: 1.3.0
+      addons-scanner-utils: 15.2.0
+      ajv: 8.20.0
+      cheerio: 1.2.0
+      columnify: 1.6.0
+      common-tags: 1.8.2
+      deepmerge: 4.3.1
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-plugin-no-unsanitized: 4.1.5(eslint@9.39.4(jiti@2.7.0))
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esprima: 4.0.1
+      fast-json-patch: 3.1.1
+      image-size: 2.0.2
+      json-merge-patch: 1.0.2
+      pino: 10.3.1
+      semver: 7.8.0
+      source-map-support: 0.5.21
+      upath: 3.0.7
+      yargs: 17.7.2
+      yauzl: 3.3.0
+    transitivePeerDependencies:
+      - express
+      - jiti
+      - safe-compare
+      - supports-color
+
+  addons-moz-compare@1.3.0: {}
+
+  addons-scanner-utils@15.2.0:
+    dependencies:
+      common-tags: 1.8.2
+      first-chunk-stream: 3.0.0
+      jsonwebtoken: 9.0.3
+      strip-bom-stream: 4.0.0
+      upath: 3.0.7
+      yauzl: 3.3.0
 
   adm-zip@0.5.17: {}
 
   agent-base@7.1.4: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-align@3.0.1:
     dependencies:
@@ -4768,6 +5391,8 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  buffer-crc32@0.2.13: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
@@ -4801,13 +5426,43 @@ snapshots:
 
   cac@7.0.0: {}
 
+  callsites@3.1.0: {}
+
   camelcase@8.0.0: {}
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@5.6.2: {}
 
   character-entities@2.0.2: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.27.1
+      whatwg-mimetype: 4.0.0
 
   chokidar@5.0.0:
     dependencies:
@@ -4817,7 +5472,7 @@ snapshots:
 
   chrome-launcher@1.2.0:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -4845,11 +5500,18 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clone@1.0.4: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  columnify@1.6.0:
+    dependencies:
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
 
   commander@15.0.0: {}
 
@@ -4858,6 +5520,8 @@ snapshots:
       graceful-readlink: 1.0.1
 
   commander@9.5.0: {}
+
+  common-tags@1.8.2: {}
 
   concat-map@0.0.1: {}
 
@@ -4890,6 +5554,12 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   css-select@5.2.2:
     dependencies:
       boolbase: 1.0.0
@@ -4916,11 +5586,15 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@6.0.1: {}
+
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
 
   deep-extend@0.6.0: {}
+
+  deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
 
@@ -4930,6 +5604,10 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
+
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
 
   define-data-property@1.1.4:
     dependencies:
@@ -4995,7 +5673,14 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   entities@7.0.1: {}
 
@@ -5079,9 +5764,91 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  eslint-plugin-no-unsanitized@4.1.5(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4(jiti@2.7.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
+  esprima@4.0.1: {}
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
 
   eventemitter3@5.0.4: {}
 
@@ -5091,7 +5858,17 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-patch@3.1.1: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fast-redact@3.5.0: {}
+
+  fast-uri@3.1.2: {}
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -5114,6 +5891,10 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   file-type@22.0.1:
     dependencies:
       '@tokenizer/inflate': 0.4.1
@@ -5125,6 +5906,11 @@ snapshots:
 
   filesize@11.0.17: {}
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
   firefox-profile@4.7.0:
     dependencies:
       adm-zip: 0.5.17
@@ -5133,7 +5919,16 @@ snapshots:
       minimist: 1.2.8
       xml2js: 0.6.2
 
+  first-chunk-stream@3.0.0: {}
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
   flatbuffers@25.9.23: {}
+
+  flatted@3.4.2: {}
 
   form-data-encoder@4.1.0: {}
 
@@ -5188,6 +5983,10 @@ snapshots:
 
   giget@3.2.0: {}
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob-to-regexp@0.4.1: {}
 
   glob@13.0.6:
@@ -5208,6 +6007,8 @@ snapshots:
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
+
+  globals@14.0.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -5291,11 +6092,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
+
+  ignore@5.3.2: {}
+
+  image-size@2.0.2: {}
 
   immediate@3.0.6: {}
 
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
   import-meta-resolve@4.2.0: {}
+
+  imurmurhash@0.1.4: {}
+
+  index-to-position@1.2.0: {}
 
   inherits@2.0.4: {}
 
@@ -5315,11 +6133,17 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.6.0
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-in-ci@1.0.0: {}
 
@@ -5349,6 +6173,8 @@ snapshots:
   is-primitive@3.0.1: {}
 
   is-relative@0.1.3: {}
+
+  is-utf8@0.2.1: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -5381,15 +6207,27 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@5.9.6: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
 
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
+
+  json-buffer@3.0.1: {}
+
+  json-merge-patch@1.0.2:
+    dependencies:
+      fast-deep-equal: 3.1.3
 
   json-parse-even-better-errors@3.0.2: {}
 
@@ -5397,6 +6235,12 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
+
+  json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
 
@@ -5439,6 +6283,10 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   kleur@3.0.3: {}
 
   ky@1.14.3: {}
@@ -5450,6 +6298,11 @@ snapshots:
   launder@1.7.1:
     dependencies:
       dayjs: 1.11.21
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lie@3.3.0:
     dependencies:
@@ -5538,6 +6391,10 @@ snapshots:
       mlly: 1.8.2
       pkg-types: 2.3.1
       quansync: 0.2.11
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
 
   lodash.includes@4.3.0: {}
 
@@ -5663,6 +6520,8 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
 
+  natural-compare@1.4.0: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch-native@1.6.7: {}
@@ -5753,6 +6612,15 @@ snapshots:
       ws: 8.21.0
       zod: 4.4.3
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
   os-shim@0.1.3: {}
 
   osc-progress@0.3.0: {}
@@ -5813,6 +6681,14 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.69.0
       oxlint-tsgolint: 0.23.0
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
@@ -5829,6 +6705,10 @@ snapshots:
 
   pako@1.0.11: {}
 
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
   parse-json@7.1.1:
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -5837,11 +6717,34 @@ snapshots:
       lines-and-columns: 2.0.4
       type-fest: 3.13.1
 
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
+
   parse-srcset@1.0.2: {}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   partial-json@0.1.7: {}
 
+  path-exists@4.0.0: {}
+
   path-expression-matcher@1.5.0: {}
+
+  path-key@3.1.1: {}
 
   path-scurry@2.0.2:
     dependencies:
@@ -5849,6 +6752,8 @@ snapshots:
       minipass: 7.1.3
 
   pathe@2.0.3: {}
+
+  pend@1.2.0: {}
 
   perfect-debounce@2.1.0: {}
 
@@ -5862,7 +6767,25 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
 
   pino@9.7.0:
     dependencies:
@@ -5910,6 +6833,8 @@ snapshots:
 
   preact@10.29.2: {}
 
+  prelude-ls@1.2.1: {}
+
   process-nextick-args@2.0.1: {}
 
   process-warning@5.0.0: {}
@@ -5954,6 +6879,8 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
+  punycode@2.3.1: {}
+
   pupa@3.3.0:
     dependencies:
       escape-goat: 4.0.0
@@ -5988,6 +6915,8 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  real-require@1.0.0: {}
+
   registry-auth-token@5.1.1:
     dependencies:
       '@pnpm/npm-conf': 3.0.2
@@ -5997,6 +6926,10 @@ snapshots:
       rc: 1.2.8
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-from@4.0.0: {}
 
   restore-cursor@5.1.0:
     dependencies:
@@ -6082,6 +7015,8 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
+  safer-buffer@2.1.2: {}
+
   sanitize-html@2.17.4:
     dependencies:
       deepmerge: 4.3.1
@@ -6097,6 +7032,8 @@ snapshots:
   scule@1.3.0: {}
 
   semver-compare@1.0.0: {}
+
+  semver@7.8.0: {}
 
   semver@7.8.1: {}
 
@@ -6141,6 +7078,12 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   shell-quote@1.8.4: {}
 
@@ -6228,11 +7171,24 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-bom-buf@2.0.0:
+    dependencies:
+      is-utf8: 0.2.1
+
+  strip-bom-stream@4.0.0:
+    dependencies:
+      first-chunk-stream: 3.0.0
+      strip-bom-buf: 2.0.0
+
   strip-bom@5.0.0: {}
 
   strip-json-comments@2.0.1: {}
 
+  strip-json-comments@3.1.1: {}
+
   strip-json-comments@5.0.2: {}
+
+  strip-json-comments@5.0.3: {}
 
   strip-literal@3.1.0:
     dependencies:
@@ -6273,6 +7229,10 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
+
   through@2.3.8: {}
 
   tinybench@2.9.0: {}
@@ -6308,6 +7268,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-fest@0.13.1: {}
 
   type-fest@3.13.1: {}
@@ -6330,7 +7294,10 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@7.24.6: {}
+  undici-types@7.24.6:
+    optional: true
+
+  undici@7.27.1: {}
 
   undici@8.4.1: {}
 
@@ -6364,6 +7331,8 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
+  upath@3.0.7: {}
+
   update-notifier@7.3.1:
     dependencies:
       boxen: 8.0.1
@@ -6376,6 +7345,10 @@ snapshots:
       pupa: 3.3.0
       semver: 7.8.1
       xdg-basedir: 5.1.0
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
 
@@ -6465,6 +7438,15 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
+  watchpack@2.5.1:
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+
   web-ext-run@0.2.4:
     dependencies:
       '@babel/runtime': 7.28.2
@@ -6490,11 +7472,51 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  web-ext@10.3.0(jiti@2.7.0):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@devicefarmer/adbkit': 3.3.8
+      addons-linter: 10.6.0(jiti@2.7.0)
+      camelcase: 8.0.0
+      chrome-launcher: 1.2.0
+      debounce: 1.2.1
+      decamelize: 6.0.1
+      es6-error: 4.1.1
+      firefox-profile: 4.7.0
+      fx-runner: 1.4.0
+      https-proxy-agent: 7.0.6
+      jose: 5.9.6
+      jszip: 3.10.1
+      multimatch: 6.0.0
+      open: 11.0.0
+      parse-json: 8.3.0
+      pino: 10.3.1
+      promise-toolbox: 0.21.0
+      source-map-support: 0.5.21
+      strip-bom: 5.0.0
+      strip-json-comments: 5.0.3
+      tmp: 0.2.6
+      update-notifier: 7.3.1
+      watchpack: 2.5.1
+      yargs: 17.7.2
+      zip-dir: 2.0.0
+    transitivePeerDependencies:
+      - express
+      - jiti
+      - safe-compare
+      - supports-color
+
   web-streams-polyfill@3.3.3: {}
 
   webpack-virtual-modules@0.6.2: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-mimetype@3.0.0: {}
+
+  whatwg-mimetype@4.0.0: {}
 
   when-exit@2.1.5: {}
 
@@ -6519,6 +7541,8 @@ snapshots:
       string-width: 7.2.0
 
   winreg@0.0.12: {}
+
+  word-wrap@1.2.5: {}
 
   wrap-ansi@10.0.0:
     dependencies:
@@ -6545,7 +7569,7 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.26(@types/node@25.9.1)(jiti@2.7.0)(rollup@4.60.2)(tsx@4.22.4):
+  wxt@0.20.26(@types/node@25.9.1)(eslint@9.39.4(jiti@2.7.0))(jiti@2.7.0)(rollup@4.60.2)(tsx@4.22.4):
     dependencies:
       '@1natsu/wait-element': 4.2.0
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.60.2)
@@ -6589,6 +7613,8 @@ snapshots:
       vite: 8.0.10(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)
       vite-node: 6.0.0(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)
       web-ext-run: 0.2.4
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -6633,6 +7659,13 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@3.3.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
+
+  yocto-queue@0.1.0: {}
 
   zip-dir@2.0.0:
     dependencies:

--- a/tests/chrome.browser-media.test.ts
+++ b/tests/chrome.browser-media.test.ts
@@ -3,6 +3,7 @@ import {
   browserMediaCanvasToDataUrl,
   extractBrowserMediaFrames,
   extractBrowserMediaFramesInDocument,
+  fetchBrowserMediaWithLimit,
   isBrowserMediaUrl,
 } from "../apps/chrome-extension/src/entrypoints/background/browser-media";
 import { BrowserPcmAccumulator } from "../apps/chrome-extension/src/entrypoints/background/browser-media-audio";
@@ -40,6 +41,71 @@ describe("chrome browser media decoding", () => {
         fetchImpl,
       }),
     ).rejects.toThrow("fetchable HTTP media URL");
+  });
+
+  it("preserves compliant ranged responses regardless of total media size", async () => {
+    const response = new Response(new Uint8Array([1, 2, 3]), {
+      status: 206,
+      headers: {
+        "content-length": "3",
+        "content-range": "bytes 0-2/999999999",
+      },
+    });
+    const fetchImpl = vi.fn(async () => response);
+
+    await expect(
+      fetchBrowserMediaWithLimit(
+        fetchImpl as unknown as typeof fetch,
+        "https://example.com/video.mp4",
+        { headers: { Range: "bytes=0-" } },
+        2,
+      ),
+    ).resolves.toBe(response);
+  });
+
+  it("rejects oversized full responses before MediaBunny sees them", async () => {
+    const cancel = vi.fn(async () => {});
+    const response = {
+      body: { cancel },
+      headers: new Headers({ "content-length": "4" }),
+      status: 200,
+    } as unknown as Response;
+    const fetchImpl = vi.fn(async () => response);
+
+    await expect(
+      fetchBrowserMediaWithLimit(
+        fetchImpl as unknown as typeof fetch,
+        "https://example.com/video.mp4",
+        undefined,
+        3,
+      ),
+    ).rejects.toThrow("without partial content");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("bounds streamed full responses with missing or incorrect content lengths", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2]));
+          controller.enqueue(new Uint8Array([3, 4]));
+          controller.close();
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-length": "2" },
+      },
+    );
+    const fetchImpl = vi.fn(async () => response);
+    const guarded = await fetchBrowserMediaWithLimit(
+      fetchImpl as unknown as typeof fetch,
+      "https://example.com/video.mp4",
+      { headers: { Range: "bytes=0-" } },
+      3,
+    );
+
+    await expect(guarded.arrayBuffer()).rejects.toThrow("streamed more than 3 bytes");
   });
 
   it("creates the offscreen document and requests MediaBunny frames", async () => {
@@ -107,31 +173,6 @@ describe("chrome browser media decoding", () => {
     ).rejects.toThrow("decoder failed");
   });
 
-  it("rejects failed and oversized media downloads before decoding", async () => {
-    await expect(
-      extractBrowserMediaFramesInDocument({
-        mediaUrl: "https://example.com/video.mp4",
-        timestamps: [1],
-        fetchImpl: vi.fn(
-          async () => new Response("missing", { status: 404, statusText: "Not Found" }),
-        ),
-      }),
-    ).rejects.toThrow("404 Not Found");
-
-    await expect(
-      extractBrowserMediaFramesInDocument({
-        mediaUrl: "https://example.com/video.mp4",
-        timestamps: [1],
-        fetchImpl: vi.fn(
-          async () =>
-            new Response("video", {
-              headers: { "content-length": String(128 * 1024 * 1024 + 1) },
-            }),
-        ),
-      }),
-    ).rejects.toThrow("too large");
-  });
-
   it("encodes offscreen-document HTML canvases without the throttled blob callback", async () => {
     const toDataURL = vi.fn(() => "data:image/jpeg;base64,AQID");
     const canvas = { toDataURL } as unknown as HTMLCanvasElement;
@@ -173,5 +214,18 @@ describe("chrome browser media decoding", () => {
     expect(
       () => new BrowserPcmAccumulator(1, 8_000, Float32Array.BYTES_PER_ELEMENT * 7_999),
     ).toThrow("too long");
+  });
+
+  it("writes later media chunks relative to their own start time", () => {
+    const output = new BrowserPcmAccumulator(0.0005, 8_000, 1024, 900);
+    output.add({
+      duration: 0.0005,
+      interleaved: new Float32Array([1, 2, 3, 4]),
+      numberOfChannels: 1,
+      numberOfFrames: 4,
+      sampleRate: 8_000,
+      timestamp: 900,
+    });
+    expect(Array.from(output.finish())).toEqual([1, 2, 3, 4]);
   });
 });

--- a/tests/chrome.panel-summarize.test.ts
+++ b/tests/chrome.panel-summarize.test.ts
@@ -4,6 +4,15 @@ import { buildSummarizeRequestBody } from "../apps/chrome-extension/src/lib/daem
 import { defaultSettings } from "../apps/chrome-extension/src/lib/settings.js";
 
 const youtubeUrl = "https://www.youtube.com/watch?v=KnUFH5GX_fI";
+const browserMediaDiagnostics = {
+  chunksProcessed: 1,
+  chunksTotal: 1,
+  codec: "opus",
+  decoder: "mediabunny-webcodecs" as const,
+  durationSeconds: 42,
+  input: "url-range" as const,
+  whisper: { device: "wasm" as const, loadMs: 10, reused: false },
+};
 
 function createHarness() {
   const session = {
@@ -260,6 +269,7 @@ describe("chrome panel summarize", () => {
       truncated: false,
       durationSeconds: 42,
       mediaSource: "sabr" as const,
+      diagnostics: browserMediaDiagnostics,
     }));
 
     await harness.summarize({
@@ -307,6 +317,7 @@ describe("chrome panel summarize", () => {
       truncated: false,
       durationSeconds: 42,
       mediaSource: "android-vr" as const,
+      diagnostics: browserMediaDiagnostics,
     }));
 
     await harness.summarize({
@@ -338,6 +349,61 @@ describe("chrome panel summarize", () => {
     expect(harness.sent[0]).toMatchObject({
       type: "run:snapshot",
       markdown: expect.stringContaining("Timed fallback transcript"),
+    });
+  });
+
+  it("transcribes direct media locally in browser runtime", async () => {
+    const harness = createHarness();
+    const url = "https://media.example/episode.mp3";
+    const transcribeMediaLocally = vi.fn(async () => ({
+      ok: true as const,
+      url,
+      text: "Direct media transcript.",
+      transcriptTimedText: "[0:00] Direct media transcript.",
+      truncated: false,
+      durationSeconds: 42,
+      source: "direct" as const,
+      diagnostics: browserMediaDiagnostics,
+    }));
+
+    await harness.summarize({
+      reason: "manual",
+      loadSettings: vi.fn(async () => ({
+        ...defaultSettings,
+        token: "",
+        autoSummarize: true,
+        slidesEnabled: false,
+        slideRuntime: "browser",
+      })),
+      getActiveTab: vi.fn(async () => ({
+        id: 7,
+        windowId: 1,
+        url,
+        title: "Episode",
+      })),
+      extractFromTab: vi.fn(async () => ({
+        ok: true,
+        data: {
+          ok: true,
+          url,
+          title: "Episode",
+          text: "",
+          truncated: false,
+          media: { hasVideo: false, hasAudio: true, hasCaptions: false },
+        },
+      })),
+      transcribeMediaLocally,
+    });
+
+    expect(transcribeMediaLocally).toHaveBeenCalledWith({
+      tabId: 7,
+      tabUrl: url,
+      maxChars: defaultSettings.maxChars,
+      onStatus: expect.any(Function),
+    });
+    expect(harness.sent[0]).toMatchObject({
+      type: "run:snapshot",
+      markdown: expect.stringContaining("Direct media transcript"),
     });
   });
 

--- a/tests/chrome.whisper-loader.test.ts
+++ b/tests/chrome.whisper-loader.test.ts
@@ -42,4 +42,36 @@ describe("Chrome local Whisper loader", () => {
 
     await rejection;
   });
+
+  it("disposes a WebGPU pipeline that resolves after the CPU fallback wins", async () => {
+    vi.useFakeTimers();
+    let resolveWebGpu:
+      | ((value: ReturnType<typeof vi.fn> & { dispose: ReturnType<typeof vi.fn> }) => void)
+      | null = null;
+    const lateWebGpu = Object.assign(vi.fn(), { dispose: vi.fn(async () => {}) });
+    const cpu = Object.assign(vi.fn(), { dispose: vi.fn(async () => {}) });
+    const createPipeline = vi
+      .fn()
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<typeof lateWebGpu>((resolve) => {
+            resolveWebGpu = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(cpu);
+
+    const result = loadWhisperTranscriber({
+      hasWebGpu: true,
+      onStatus: vi.fn(),
+      createPipeline,
+      webGpuTimeoutMs: 100,
+      wasmTimeoutMs: 100,
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(result).resolves.toBe(cpu);
+
+    resolveWebGpu?.(lateWebGpu);
+    await vi.runAllTimersAsync();
+    expect(lateWebGpu.dispose).toHaveBeenCalledOnce();
+  });
 });

--- a/tests/chrome.youtube-audio.test.ts
+++ b/tests/chrome.youtube-audio.test.ts
@@ -1,79 +1,63 @@
-import { describe, expect, it, vi } from "vitest";
-import { downloadYoutubeBytesWithRanges } from "../apps/chrome-extension/src/entrypoints/offscreen/youtube-audio.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserYoutubeMediaContext } from "../apps/chrome-extension/src/entrypoints/background/youtube-media";
 
-describe("Chrome YouTube ranged audio download", () => {
-  it("downloads the complete byte range", async () => {
-    const source = Uint8Array.from({ length: 600_000 }, (_, index) => index % 251);
-    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
-      const range = new Headers(init?.headers).get("range");
-      const match = /^bytes=(\d+)-(\d+)$/u.exec(range ?? "");
-      if (!match) return new Response(null, { status: 400 });
-      const start = Number(match[1]);
-      const end = Number(match[2]);
-      return new Response(source.slice(start, end + 1), { status: 206 });
-    });
+const mocks = vi.hoisted(() => ({
+  resolveYoutubeAudioWithAndroidVr: vi.fn(),
+}));
 
-    const downloaded = await downloadYoutubeBytesWithRanges({
-      url: "https://example.invalid/audio",
-      contentLength: source.byteLength,
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-    });
+vi.mock("@steipete/summarize-core/content/youtube", () => ({
+  resolveYoutubeAudioWithAndroidVr: mocks.resolveYoutubeAudioWithAndroidVr,
+}));
 
-    expect(downloaded).toEqual(source);
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-    expect(new Headers(fetchImpl.mock.calls[0]?.[1]?.headers).get("range")).toBe("bytes=0-599999");
+import { resolveYoutubeDirectAudio } from "../apps/chrome-extension/src/entrypoints/offscreen/youtube-audio";
+
+describe("Chrome YouTube audio fallback", () => {
+  beforeEach(() => {
+    mocks.resolveYoutubeAudioWithAndroidVr.mockReset();
   });
 
-  it("rejects media larger than the browser limit before fetching", async () => {
-    const fetchImpl = vi.fn();
+  it("uses active player audio before making another resolver request", async () => {
+    await expect(resolveYoutubeDirectAudio(createContext())).resolves.toMatchObject({
+      mediaSource: "player",
+      url: "https://player.example/audio.m4a",
+    });
+    expect(mocks.resolveYoutubeAudioWithAndroidVr).not.toHaveBeenCalled();
+  });
+
+  it("refreshes through Android VR after active player audio fails", async () => {
+    mocks.resolveYoutubeAudioWithAndroidVr.mockResolvedValue({
+      contentLength: 456,
+      mimeType: "audio/webm",
+      resolver: "android-vr",
+      url: "https://android-vr.example/audio.webm",
+    });
 
     await expect(
-      downloadYoutubeBytesWithRanges({
-        url: "https://example.invalid/audio",
-        contentLength: 129 * 1024 * 1024,
-        fetchImpl: fetchImpl as unknown as typeof fetch,
-      }),
-    ).rejects.toThrow(/too large/i);
-    expect(fetchImpl).not.toHaveBeenCalled();
-  });
-
-  it("accepts a complete HTTP 200 response when the server ignores the range header", async () => {
-    const source = Uint8Array.from({ length: 1024 }, (_, index) => index % 251);
-    const fetchImpl = vi.fn(
-      async () => new Response(source, { status: 200 }),
-    ) as unknown as typeof fetch;
-
-    await expect(
-      downloadYoutubeBytesWithRanges({
-        url: "https://example.invalid/audio",
-        contentLength: source.byteLength,
-        fetchImpl,
-      }),
-    ).resolves.toEqual(source);
-  });
-
-  it("retries transient range failures", async () => {
-    const source = Uint8Array.from({ length: 300_000 }, (_, index) => index % 251);
-    const attempts = new Map<string, number>();
-    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
-      const range = new Headers(init?.headers).get("range") ?? "";
-      const attempt = (attempts.get(range) ?? 0) + 1;
-      attempts.set(range, attempt);
-      if (attempt === 1) throw new TypeError("Failed to fetch");
-      const match = /^bytes=(\d+)-(\d+)$/u.exec(range);
-      if (!match) return new Response(null, { status: 400 });
-      const start = Number(match[1]);
-      const end = Number(match[2]);
-      return new Response(source.slice(start, end + 1), { status: 206 });
+      resolveYoutubeDirectAudio(createContext(), { ignoreContextDirect: true }),
+    ).resolves.toEqual({
+      contentLength: 456,
+      mediaSource: "android-vr",
+      mimeType: "audio/webm",
+      url: "https://android-vr.example/audio.webm",
     });
-
-    const downloaded = await downloadYoutubeBytesWithRanges({
-      url: "https://example.invalid/audio",
-      contentLength: source.byteLength,
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-    });
-
-    expect(downloaded).toEqual(source);
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(mocks.resolveYoutubeAudioWithAndroidVr).toHaveBeenCalledOnce();
   });
 });
+
+function createContext(): BrowserYoutubeMediaContext {
+  return {
+    apiKey: "api-key",
+    directAudio: {
+      contentLength: 123,
+      mimeType: "audio/mp4",
+      resolver: "player",
+      url: "https://player.example/audio.m4a",
+    },
+    durationSeconds: 60,
+    sabr: null,
+    title: "Test video",
+    url: "https://www.youtube.com/watch?v=test",
+    videoId: "test",
+    visitorData: null,
+  };
+}

--- a/tests/youtube.android-vr.test.ts
+++ b/tests/youtube.android-vr.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  extractYoutubeAudioFromWatchHtml,
   extractYoutubePlayerBootstrap,
+  resolveYoutubeAudio,
   resolveYoutubeAudioWithAndroidVr,
 } from "../packages/core/src/content/youtube.js";
 
@@ -123,5 +125,75 @@ describe("YouTube Android VR media resolver", () => {
     });
 
     expect(result.url).toBe("https://media.example/aac");
+  });
+
+  it("prefers a direct audio URL embedded in the watch page", async () => {
+    const fetchImpl = vi.fn();
+    const watchHtml = `<script>var ytInitialPlayerResponse = ${JSON.stringify({
+      streamingData: {
+        adaptiveFormats: [
+          {
+            itag: 140,
+            url: "https://media.example/watch-audio",
+            mimeType: 'audio/mp4; codecs="mp4a.40.2"',
+            bitrate: 129_000,
+            contentLength: "321",
+            approxDurationMs: "45000",
+          },
+        ],
+      },
+    })};</script>`;
+
+    expect(extractYoutubeAudioFromWatchHtml(watchHtml)).toMatchObject({
+      url: "https://media.example/watch-audio",
+      filename: "youtube-140.m4a",
+    });
+    await expect(
+      resolveYoutubeAudio({
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        videoId: "abcdefghijk",
+        apiKey: "KEY",
+        watchHtml,
+      }),
+    ).resolves.toMatchObject({
+      url: "https://media.example/watch-audio",
+      resolver: "watch-page",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Android VR when the watch page has no direct media", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            playabilityStatus: { status: "OK" },
+            streamingData: {
+              adaptiveFormats: [
+                {
+                  itag: 251,
+                  url: "https://media.example/fallback",
+                  mimeType: 'audio/webm; codecs="opus"',
+                  bitrate: 128_000,
+                },
+              ],
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+
+    await expect(
+      resolveYoutubeAudio({
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        videoId: "abcdefghijk",
+        apiKey: "KEY",
+        watchHtml: "<html></html>",
+      }),
+    ).resolves.toMatchObject({
+      url: "https://media.example/fallback",
+      resolver: "android-vr",
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## What changed

- Prefer active-player/watch-page YouTube audio, then refresh through Android VR before captured SABR fallback.
- Add daemonless transcription for fetchable direct and embedded media using ranged MediaBunny/WebCodecs decoding and bounded 15-minute PCM chunks.
- Keep browser Whisper warm during active use, dispose it after idle time, and expose resolver/decoder/runtime diagnostics.
- Add Firefox temporary-install smoke coverage plus scheduled live YouTube resolver and daemonless Chrome checks.

## Why

The extension needed a reliable path when the native daemon, `yt-dlp`, or CLI tools are unavailable. Existing browser fallbacks still buffered too much media, missed generic embedded audio/video, and lacked durable cross-browser/live validation.

## User impact

Chrome Browser mode can now summarize captionless YouTube, direct media URLs, and embedded fetchable media without the daemon. Large compliant range-enabled media stays streamed; non-partial responses and decoded PCM remain bounded.

## Validation

- `pnpm check` (433 files passed, 2,284 tests passed; coverage gates met)
- Chrome extension full suite: 69 passed, 4 opt-in skipped
- Firefox `web-ext` temporary-install smoke
- Local ranged browser-slide E2E
- Local synthetic speech -> MediaBunny/WebCodecs -> Whisper -> sidepanel E2E
- Live YouTube resolver tests
- Live captionless YouTube -> daemonless Chrome extension E2E
- Autoreview clean after fixing Android VR fallback ordering and non-partial response bounds
