### PR TITLE
[codex] Optimize diarization media downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.17.3 - Unreleased
 
+### Fixes
+
+- Diarization: extract local video audio once before upload and reuse the compact mono MP3 across ElevenLabs/OpenAI fallbacks instead of sending the full video container.
+- YouTube diarization: download audio only unless slides are also requested; combined slide/diarization runs now fetch separate audio and video streams once and reuse the video for slide extraction.
+
 ## 0.17.2 - 2026-06-11
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -502,8 +502,12 @@ summarize "https://www.youtube.com/watch?v=..." --extract --diarize elevenlabs \
 
 Bare `--diarize` prefers ElevenLabs Scribe v2 (`ELEVENLABS_API_KEY`) and falls back to OpenAI
 `gpt-4o-transcribe-diarize` (`OPENAI_API_KEY`). Speaker changes are emitted as `Speaker <label>: ...`;
-combine with `--timestamps` for `[mm:ss] Speaker <label>: ...`. Local files are transcribed directly;
-YouTube and remote direct media use their normal download path.
+combine with `--timestamps` for `[mm:ss] Speaker <label>: ...`. Before upload, local video is reduced
+to mono 16 kHz MP3 with native or bundled FFmpeg and the same audio file is reused across provider
+fallbacks. Local audio is passed through unless OpenAI's upload limit requires compression. YouTube
+diarization downloads audio only. When combined with `--slides`, one yt-dlp invocation downloads
+separate audio and slide-quality video streams; diarization uploads the audio while slides reuse the
+video. Remote direct media uses its normal audio download path.
 YouTube transcript extraction also prints the current public view count and exposes the resolved
 video ID and observation timestamp in `extracted.sourceMetrics` in JSON output.
 Long OpenAI recordings are split into bounded chunks; timestamps are reassembled and

--- a/docs/media.md
+++ b/docs/media.md
@@ -24,7 +24,8 @@ read_when:
 - `--video-mode transcript` prefers transcript-first media handling even when a page has text.
 - Direct media URLs (mp4/webm/m4a/etc) skip HTML and transcribe.
 - Local audio/video files are routed through the same transcript-first pipeline.
-- `--diarize [auto|elevenlabs|openai]` adds speaker labels to local files and direct media URLs; `--identify-speakers`, anchors, profiles, and remembered mappings use the same naming pass as YouTube. Local files do not require `yt-dlp`.
+- `--diarize [auto|elevenlabs|openai]` adds speaker labels to local files and direct media URLs; `--identify-speakers`, anchors, profiles, and remembered mappings use the same naming pass as YouTube. Local files do not require `yt-dlp`. Local video is converted once to mono 16 kHz MP3 before upload, then reused if diarization falls back between providers.
+- YouTube diarization selects audio-only media. Combined `--slides --diarize` downloads separate video-only and audio-only streams in one yt-dlp run, then shares the video with slide extraction.
 - YouTube still uses the YouTube transcript pipeline (captions → yt-dlp → Android VR direct audio fallback).
 - X/Twitter status URLs with detected video auto-switch to transcript-first (yt-dlp), even in auto mode.
 - X broadcasts (`/i/broadcasts/...`) are treated as media-only and go transcript-first by default.

--- a/docs/transcript-provider-flow.md
+++ b/docs/transcript-provider-flow.md
@@ -57,7 +57,11 @@ Goal: keep provider entrypoints thin; keep provider policy explicit.
   OpenAI chunk/delegate policy.
 - `packages/core/src/transcription/whisper/diarization.ts`
   Explicit speaker-label requests only.
+  Extracts local video audio once before provider attempts.
   ElevenLabs Scribe v2 first in auto mode, then OpenAI `gpt-4o-transcribe-diarize`.
+- YouTube yt-dlp media:
+  Diarization-only downloads audio.
+  Combined slides + diarization downloads separate audio/video streams once and shares the video cache entry with slide extraction.
 - `src/speaker-identification/`
   Optional post-processing for generic diarization labels.
   Timestamp anchors first, exact-transcript remembered mappings second, OpenAI GPT-5.5 context inference last.

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -57,7 +57,7 @@ summarize "https://www.youtube.com/watch?v=..." --extract --diarize openai --tim
 - `auto`: ElevenLabs Scribe v2 first, then OpenAI `gpt-4o-transcribe-diarize`.
 - `elevenlabs`: requires `ELEVENLABS_API_KEY`.
 - `openai`: requires `OPENAI_API_KEY`.
-- YouTube diarization requires `yt-dlp`; local media diarization does not. OpenAI uses `ffmpeg` to split long recordings into bounded chunks, offset their timestamps, and keep chunk-local labels distinct.
+- YouTube diarization requires `yt-dlp` and downloads audio only. With `--slides`, one yt-dlp invocation downloads separate audio-only and video-only streams so diarization uploads audio while slide extraction reuses video without a merge. Local media diarization does not require `yt-dlp`; local video audio is extracted with native or bundled FFmpeg before upload and reused across provider fallbacks. OpenAI uploads are compressed to stay under its size limit when possible, and long recordings are split into bounded chunks with offset timestamps and distinct chunk-local labels.
 
 ## Speaker identification
 

--- a/packages/core/src/content/cache/types.ts
+++ b/packages/core/src/content/cache/types.ts
@@ -1,5 +1,9 @@
 import type { TranscriptSource } from "../link-preview/types.js";
 
+export function buildSharedVideoMediaCacheKey(url: string): string {
+  return `${url}#summarize-slides`;
+}
+
 /** Public shape returned by transcript cache implementations. */
 export interface TranscriptCacheGetResult {
   content: string | null;

--- a/packages/core/src/content/index.ts
+++ b/packages/core/src/content/index.ts
@@ -5,6 +5,7 @@ export type {
   TranscriptCacheGetResult,
   TranscriptCacheSetArgs,
 } from "./cache/types.js";
+export { buildSharedVideoMediaCacheKey } from "./cache/types.js";
 export { NEGATIVE_TTL_MS } from "./transcript/cache.js";
 export {
   createLinkPreviewClient,

--- a/packages/core/src/content/link-preview/content/firecrawl.ts
+++ b/packages/core/src/content/link-preview/content/firecrawl.ts
@@ -48,6 +48,7 @@ export async function buildResultFromFirecrawl({
   mediaTranscriptMode,
   transcriptTimestamps,
   transcriptDiarization,
+  transcriptVideoDownload,
   firecrawlDiagnostics,
   markdownRequested,
   timeoutMs,
@@ -61,6 +62,7 @@ export async function buildResultFromFirecrawl({
   mediaTranscriptMode: FetchLinkContentOptions["mediaTranscript"];
   transcriptTimestamps?: FetchLinkContentOptions["transcriptTimestamps"];
   transcriptDiarization?: FetchLinkContentOptions["transcriptDiarization"];
+  transcriptVideoDownload?: FetchLinkContentOptions["transcriptVideoDownload"];
   firecrawlDiagnostics: FirecrawlDiagnostics;
   markdownRequested: boolean;
   timeoutMs: number;
@@ -85,6 +87,7 @@ export async function buildResultFromFirecrawl({
     mediaTranscriptMode,
     transcriptTimestamps,
     transcriptDiarization,
+    transcriptVideoDownload,
     cacheMode,
   });
   const video = payload.html ? detectPrimaryVideoFromHtml(payload.html, url) : null;

--- a/packages/core/src/content/link-preview/content/html.ts
+++ b/packages/core/src/content/link-preview/content/html.ts
@@ -56,6 +56,7 @@ export async function buildResultFromHtmlDocument({
   mediaTranscriptMode,
   transcriptTimestamps,
   transcriptDiarization,
+  transcriptVideoDownload,
   firecrawlDiagnostics,
   markdownRequested,
   markdownMode,
@@ -71,6 +72,7 @@ export async function buildResultFromHtmlDocument({
   mediaTranscriptMode: FetchLinkContentOptions["mediaTranscript"];
   transcriptTimestamps?: FetchLinkContentOptions["transcriptTimestamps"];
   transcriptDiarization?: FetchLinkContentOptions["transcriptDiarization"];
+  transcriptVideoDownload?: FetchLinkContentOptions["transcriptVideoDownload"];
   firecrawlDiagnostics: FirecrawlDiagnostics;
   markdownRequested: boolean;
   markdownMode: MarkdownMode;
@@ -131,6 +133,7 @@ export async function buildResultFromHtmlDocument({
     mediaTranscriptMode,
     transcriptTimestamps,
     transcriptDiarization,
+    transcriptVideoDownload,
     cacheMode,
   });
   await refreshYoutubeSourceMetrics({

--- a/packages/core/src/content/link-preview/content/index.ts
+++ b/packages/core/src/content/link-preview/content/index.ts
@@ -79,6 +79,7 @@ export async function fetchLinkContent(
   const mediaTranscriptMode = options?.mediaTranscript ?? "auto";
   const transcriptTimestamps = options?.transcriptTimestamps ?? false;
   const transcriptDiarization = options?.transcriptDiarization ?? null;
+  const transcriptVideoDownload = options?.transcriptVideoDownload ?? false;
   const firecrawlMode = resolveFirecrawlMode(options);
   const markdownRequested = (options?.format ?? "text") === "markdown";
   const markdownMode: MarkdownMode = options?.markdownMode ?? "auto";
@@ -103,6 +104,7 @@ export async function fetchLinkContent(
       mediaTranscriptMode,
       transcriptTimestamps,
       transcriptDiarization,
+      transcriptVideoDownload,
       cacheMode,
       fileMtime,
     });
@@ -167,6 +169,7 @@ export async function fetchLinkContent(
       mediaTranscriptMode,
       transcriptTimestamps,
       transcriptDiarization,
+      transcriptVideoDownload,
       cacheMode,
       fileMtime,
     });
@@ -222,6 +225,7 @@ export async function fetchLinkContent(
       mediaTranscriptMode: broadcastTranscriptMode,
       transcriptTimestamps,
       transcriptDiarization,
+      transcriptVideoDownload,
       cacheMode,
       fileMtime,
     });
@@ -276,6 +280,7 @@ export async function fetchLinkContent(
       mediaTranscriptMode,
       transcriptTimestamps,
       transcriptDiarization,
+      transcriptVideoDownload,
       cacheMode,
       fileMtime,
     });
@@ -437,6 +442,7 @@ export async function fetchLinkContent(
             mediaKindHint: media?.kind ?? null,
             transcriptTimestamps,
             transcriptDiarization,
+            transcriptVideoDownload,
             cacheMode,
             fileMtime,
           });
@@ -543,6 +549,7 @@ export async function fetchLinkContent(
       mediaTranscriptMode,
       transcriptTimestamps,
       transcriptDiarization,
+      transcriptVideoDownload,
       firecrawlDiagnostics,
       markdownRequested,
       markdownMode,
@@ -628,6 +635,7 @@ export async function fetchLinkContent(
     mediaTranscriptMode,
     transcriptTimestamps,
     transcriptDiarization,
+    transcriptVideoDownload,
     firecrawlDiagnostics,
     markdownRequested,
     markdownMode,

--- a/packages/core/src/content/link-preview/content/types.ts
+++ b/packages/core/src/content/link-preview/content/types.ts
@@ -31,6 +31,7 @@ export interface FetchLinkContentOptions {
   mediaTranscript?: MediaTranscriptMode;
   transcriptTimestamps?: boolean;
   transcriptDiarization?: DiarizationPreference | null;
+  transcriptVideoDownload?: boolean;
   firecrawl?: FirecrawlMode;
   format?: ContentFormat;
   markdownMode?: MarkdownMode;

--- a/packages/core/src/content/transcript/index.ts
+++ b/packages/core/src/content/transcript/index.ts
@@ -42,6 +42,7 @@ interface ResolveTranscriptOptions {
   mediaKindHint?: ProviderFetchOptions["mediaKindHint"];
   transcriptTimestamps?: ProviderFetchOptions["transcriptTimestamps"];
   transcriptDiarization?: ProviderFetchOptions["transcriptDiarization"];
+  transcriptVideoDownload?: ProviderFetchOptions["transcriptVideoDownload"];
   cacheMode?: CacheMode;
   fileMtime?: number | null;
 }
@@ -64,6 +65,7 @@ export const resolveTranscriptForLink = async (
     mediaKindHint,
     transcriptTimestamps,
     transcriptDiarization,
+    transcriptVideoDownload,
     cacheMode: providedCacheMode,
     fileMtime,
   }: ResolveTranscriptOptions = {},
@@ -172,6 +174,7 @@ export const resolveTranscriptForLink = async (
     mediaKindHint: mediaKindHint ?? null,
     transcriptTimestamps: transcriptTimestamps ?? false,
     transcriptDiarization: transcriptDiarization ?? null,
+    transcriptVideoDownload: transcriptVideoDownload ?? false,
   });
 
   if (shouldReportProgress) {

--- a/packages/core/src/content/transcript/providers/youtube/provider-flow.ts
+++ b/packages/core/src/content/transcript/providers/youtube/provider-flow.ts
@@ -275,6 +275,7 @@ export async function tryYtDlpTranscript(args: {
     openaiApiKey: flow.options.openaiApiKey,
     falApiKey: flow.options.falApiKey,
     diarization: flow.options.transcriptDiarization ?? null,
+    downloadVideo: flow.options.transcriptVideoDownload ?? false,
     mediaCache: flow.options.mediaCache ?? null,
     url: flow.context.url,
     onProgress: flow.options.onProgress ?? null,

--- a/packages/core/src/content/transcript/providers/youtube/yt-dlp.ts
+++ b/packages/core/src/content/transcript/providers/youtube/yt-dlp.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, extname, join } from "node:path";
 import { spawnTracked } from "../../../../processes.js";
 import {
   probeMediaDurationSecondsWithFfprobe,
@@ -11,7 +11,7 @@ import {
   transcribeMediaFileWithWhisper,
 } from "../../../../transcription/whisper.js";
 import { buildMissingTranscriptionProviderMessage } from "../../../../transcription/whisper/provider-setup.js";
-import type { MediaCache } from "../../../cache/types.js";
+import { buildSharedVideoMediaCacheKey, type MediaCache } from "../../../cache/types.js";
 import type { LinkPreviewProgressEvent } from "../../../link-preview/deps.js";
 import { ProgressKind } from "../../../link-preview/deps.js";
 import { resolveLocalDirectMediaSource } from "../../../local-file.js";
@@ -25,6 +25,8 @@ const YT_DLP_TIMEOUT_MS = 300_000;
 const MAX_STDERR_BYTES = 8192;
 const DEFAULT_AUDIO_FORMAT =
   "bestaudio[vcodec=none]/best[height<=360]/best[height<=480]/best[height<=720]/best";
+const DEFAULT_SHARED_VIDEO_FORMAT =
+  "bestvideo[height<=720][vcodec^=avc1][ext=mp4]/bestvideo[height<=720][ext=mp4]/bestvideo[height<=720],bestaudio[vcodec=none]";
 
 type YtDlpTranscriptResult = {
   text: string | null;
@@ -45,6 +47,7 @@ type YtDlpRequest = {
   openaiApiKey?: string | null;
   falApiKey?: string | null;
   diarization?: DiarizationPreference | null;
+  downloadVideo?: boolean;
   url: string;
   onProgress?: ((event: LinkPreviewProgressEvent) => void) | null;
   service?: "youtube" | "podcast" | "generic";
@@ -75,6 +78,7 @@ export const fetchTranscriptWithYtDlp = async ({
   openaiApiKey,
   falApiKey,
   diarization = null,
+  downloadVideo = false,
   url,
   onProgress,
   service = "youtube",
@@ -128,17 +132,29 @@ export const fetchTranscriptWithYtDlp = async ({
   const progress = typeof onProgress === "function" ? onProgress : null;
   const providerHint = startInfo.providerHint;
   const modelId = startInfo.modelId;
-  const cachedMedia = localFileInput ? null : mediaCache ? await mediaCache.get({ url }) : null;
+  const mediaCacheKey = downloadVideo ? buildSharedVideoMediaCacheKey(url) : url;
+  const cachedMedia = localFileInput
+    ? null
+    : mediaCache
+      ? await mediaCache.get({ url: mediaCacheKey })
+      : null;
 
   const outputFile = join(tmpdir(), `summarize-${randomUUID()}.mp3`);
   let filePath = localFileInput?.filePath ?? cachedMedia?.filePath ?? outputFile;
-  let mediaType = localFileInput?.mediaType ?? "audio/mpeg";
+  let mediaType =
+    localFileInput?.mediaType ??
+    cachedMedia?.mediaType ??
+    inferMediaType(
+      cachedMedia?.filename ?? cachedMedia?.filePath ?? "",
+      downloadVideo ? "video" : "audio",
+    ) ??
+    "audio/mpeg";
   let filename =
     localFileInput?.filename ??
     cachedMedia?.filename ??
     (cachedMedia?.filePath ? basename(cachedMedia.filePath) : null) ??
     "audio.mp3";
-  let shouldCleanup = !localFileInput?.filePath && !cachedMedia?.filePath;
+  let cleanupDownloaded: (() => Promise<void>) | null = null;
   try {
     if (localFileInput) {
       notes.push("local file input");
@@ -172,25 +188,26 @@ export const fetchTranscriptWithYtDlp = async ({
         mediaKind,
         totalBytes: null,
       });
-      await downloadAudio(
-        ytDlpPath,
-        url,
-        outputFile,
-        extraArgs,
-        progress
-          ? (downloadedBytes, totalBytes) => {
-              progress({
-                kind: ProgressKind.TranscriptMediaDownloadProgress,
-                url,
-                service,
-                downloadedBytes,
-                totalBytes,
-                mediaKind,
-              });
-            }
-          : null,
-      );
-      const stat = await fs.stat(outputFile);
+      const onDownloadProgress = progress
+        ? (downloadedBytes: number, totalBytes: number | null) => {
+            progress({
+              kind: ProgressKind.TranscriptMediaDownloadProgress,
+              url,
+              service,
+              downloadedBytes,
+              totalBytes,
+              mediaKind,
+            });
+          }
+        : null;
+      const downloaded = downloadVideo
+        ? await downloadSlidesVideoAndAudio(ytDlpPath, url, extraArgs, onDownloadProgress)
+        : await downloadAudio(ytDlpPath, url, outputFile, extraArgs, onDownloadProgress);
+      filePath = downloaded.filePath;
+      mediaType = downloaded.mediaType;
+      filename = downloaded.filename;
+      cleanupDownloaded = downloaded.cleanup;
+      const stat = await fs.stat(filePath);
       progress?.({
         kind: ProgressKind.TranscriptMediaDownloadDone,
         url,
@@ -200,16 +217,27 @@ export const fetchTranscriptWithYtDlp = async ({
         mediaKind,
       });
 
-      if (mediaCache) {
+      if (downloaded.sharedVideo && mediaCache) {
+        const storedVideo = await mediaCache.put({
+          url: mediaCacheKey,
+          filePath: downloaded.sharedVideo.filePath,
+          mediaType: downloaded.sharedVideo.mediaType,
+          filename: downloaded.sharedVideo.filename,
+        });
+        if (storedVideo?.filePath) notes.push("shared slide video cached");
+      } else if (mediaCache) {
         const stored = await mediaCache.put({
-          url,
-          filePath: outputFile,
-          mediaType: "audio/mpeg",
-          filename: "audio.mp3",
+          url: mediaCacheKey,
+          filePath,
+          mediaType,
+          filename,
         });
         if (stored?.filePath) {
           filePath = stored.filePath;
-          shouldCleanup = false;
+          mediaType = stored.mediaType ?? mediaType;
+          filename = stored.filename ?? filename;
+          await cleanupDownloaded?.();
+          cleanupDownloaded = null;
           notes.push("media cached");
         }
       }
@@ -277,9 +305,7 @@ export const fetchTranscriptWithYtDlp = async ({
       notes,
     };
   } finally {
-    if (shouldCleanup) {
-      await fs.unlink(filePath).catch(() => {});
-    }
+    await cleanupDownloaded?.();
   }
 };
 
@@ -363,31 +389,128 @@ async function downloadAudio(
   outputFile: string,
   extraArgs?: string[],
   onProgress?: ((downloadedBytes: number, totalBytes: number | null) => void) | null,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const progressTemplate =
-      "progress:%(progress.downloaded_bytes)s|%(progress.total_bytes)s|%(progress.total_bytes_estimate)s";
-    // Add --enable-file-urls flag for local file:// URLs
-    const isFileUrl = url.startsWith("file://");
-    const args = [
-      "-f",
-      DEFAULT_AUDIO_FORMAT,
-      "-x",
-      "--audio-format",
-      "mp3",
-      "--concurrent-fragments",
-      "4",
-      "--no-playlist",
-      "--retries",
-      "3",
-      "--no-warnings",
-      ...(isFileUrl ? ["--enable-file-urls"] : []),
-      ...(onProgress ? ["--progress", "--newline", "--progress-template", progressTemplate] : []),
-      ...(extraArgs?.length ? extraArgs : []),
-      "-o",
-      outputFile,
+): Promise<{
+  filePath: string;
+  mediaType: string;
+  filename: string;
+  sharedVideo?: undefined;
+  cleanup: () => Promise<void>;
+}> {
+  await runYtDlpDownload({
+    ytDlpPath,
+    url,
+    output: outputFile,
+    format: DEFAULT_AUDIO_FORMAT,
+    extractAudio: true,
+    extraArgs,
+    onProgress,
+  });
+  return {
+    filePath: outputFile,
+    mediaType: "audio/mpeg",
+    filename: "audio.mp3",
+    cleanup: async () => {
+      await fs.unlink(outputFile).catch(() => {});
+    },
+  };
+}
+
+async function downloadSlidesVideoAndAudio(
+  ytDlpPath: string,
+  url: string,
+  extraArgs?: string[],
+  onProgress?: ((downloadedBytes: number, totalBytes: number | null) => void) | null,
+): Promise<{
+  filePath: string;
+  mediaType: string;
+  filename: string;
+  sharedVideo: {
+    filePath: string;
+    mediaType: string;
+    filename: string;
+  };
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await fs.mkdtemp(join(tmpdir(), `summarize-shared-video-${randomUUID()}-`));
+  const outputTemplate = join(dir, "media.%(vcodec)s.%(acodec)s.%(ext)s");
+  try {
+    await runYtDlpDownload({
+      ytDlpPath,
       url,
-    ];
+      output: outputTemplate,
+      format: DEFAULT_SHARED_VIDEO_FORMAT,
+      extractAudio: false,
+      extraArgs,
+      onProgress,
+    });
+    const entries = await fs.readdir(dir);
+    const candidates = (
+      await Promise.all(
+        entries
+          .filter((entry) => !entry.endsWith(".part") && !entry.endsWith(".ytdl"))
+          .map(async (entry) => {
+            const filePath = join(dir, entry);
+            const stat = await fs.stat(filePath).catch(() => null);
+            return stat?.isFile() ? { filePath, size: stat.size } : null;
+          }),
+      )
+    ).filter((entry): entry is { filePath: string; size: number } => entry !== null);
+    const audio = candidates
+      .filter((entry) => basename(entry.filePath).startsWith("media.none."))
+      .sort((a, b) => b.size - a.size)[0];
+    const video = candidates
+      .filter((entry) => !basename(entry.filePath).startsWith("media.none."))
+      .sort((a, b) => b.size - a.size)[0];
+    if (!audio || !video) {
+      throw new Error("yt-dlp completed without both audio and video streams");
+    }
+    const audioFilename = basename(audio.filePath);
+    const videoFilename = basename(video.filePath);
+    return {
+      filePath: audio.filePath,
+      mediaType: inferMediaType(audioFilename, "audio") ?? "audio/webm",
+      filename: audioFilename,
+      sharedVideo: {
+        filePath: video.filePath,
+        mediaType: inferMediaType(videoFilename, "video") ?? "video/mp4",
+        filename: videoFilename,
+      },
+      cleanup: async () => {
+        await fs.rm(dir, { recursive: true, force: true });
+      },
+    };
+  } catch (error) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+async function runYtDlpDownload({
+  ytDlpPath,
+  url,
+  output,
+  format,
+  extractAudio,
+  extraArgs,
+  onProgress,
+}: {
+  ytDlpPath: string;
+  url: string;
+  output: string;
+  format: string;
+  extractAudio: boolean;
+  extraArgs?: string[];
+  onProgress?: ((downloadedBytes: number, totalBytes: number | null) => void) | null;
+}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const args = buildYtDlpDownloadArgs({
+      url,
+      output,
+      format,
+      extractAudio,
+      extraArgs,
+      progress: Boolean(onProgress),
+    });
 
     const { proc, handle } = spawnTracked(ytDlpPath, args, {
       stdio: ["ignore", "pipe", "pipe"],
@@ -478,6 +601,61 @@ async function downloadAudio(
       reject(error);
     });
   });
+}
+
+export function buildYtDlpDownloadArgs({
+  url,
+  output,
+  format,
+  extractAudio,
+  extraArgs,
+  progress,
+}: {
+  url: string;
+  output: string;
+  format: string;
+  extractAudio: boolean;
+  extraArgs?: string[];
+  progress: boolean;
+}): string[] {
+  const progressTemplate =
+    "progress:%(progress.downloaded_bytes)s|%(progress.total_bytes)s|%(progress.total_bytes_estimate)s";
+  return [
+    "-f",
+    format,
+    ...(extractAudio ? ["-x", "--audio-format", "mp3"] : []),
+    "--concurrent-fragments",
+    "4",
+    "--no-playlist",
+    "--retries",
+    "3",
+    "--no-warnings",
+    ...(url.startsWith("file://") ? ["--enable-file-urls"] : []),
+    ...(progress ? ["--progress", "--newline", "--progress-template", progressTemplate] : []),
+    ...(extraArgs?.length ? extraArgs : []),
+    "-o",
+    output,
+    url,
+  ];
+}
+
+function inferMediaType(value: string, kind: "audio" | "video"): string | null {
+  switch (extname(value).toLowerCase()) {
+    case ".mp3":
+      return "audio/mpeg";
+    case ".m4a":
+      return "audio/mp4";
+    case ".mp4":
+    case ".m4v":
+    case ".mov":
+      return kind === "audio" ? "audio/mp4" : "video/mp4";
+    case ".webm":
+      return kind === "audio" ? "audio/webm" : "video/webm";
+    case ".mkv":
+      return "video/x-matroska";
+    default:
+      return null;
+  }
 }
 
 function emitProgressFromLine(

--- a/packages/core/src/content/transcript/providers/youtube/yt-dlp.ts
+++ b/packages/core/src/content/transcript/providers/youtube/yt-dlp.ts
@@ -132,12 +132,18 @@ export const fetchTranscriptWithYtDlp = async ({
   const progress = typeof onProgress === "function" ? onProgress : null;
   const providerHint = startInfo.providerHint;
   const modelId = startInfo.modelId;
-  const mediaCacheKey = downloadVideo ? buildSharedVideoMediaCacheKey(url) : url;
+  const mediaCacheKey = url;
+  const sharedVideoMediaCacheKey = buildSharedVideoMediaCacheKey(url);
   const cachedMedia = localFileInput
     ? null
     : mediaCache
       ? await mediaCache.get({ url: mediaCacheKey })
       : null;
+  const cachedSharedVideo =
+    !localFileInput && downloadVideo && mediaCache
+      ? await mediaCache.get({ url: sharedVideoMediaCacheKey })
+      : null;
+  if (cachedSharedVideo?.filePath) notes.push("shared slide video cache hit");
 
   const outputFile = join(tmpdir(), `summarize-${randomUUID()}.mp3`);
   let filePath = localFileInput?.filePath ?? cachedMedia?.filePath ?? outputFile;
@@ -200,9 +206,10 @@ export const fetchTranscriptWithYtDlp = async ({
             });
           }
         : null;
-      const downloaded = downloadVideo
-        ? await downloadSlidesVideoAndAudio(ytDlpPath, url, extraArgs, onDownloadProgress)
-        : await downloadAudio(ytDlpPath, url, outputFile, extraArgs, onDownloadProgress);
+      const downloaded =
+        downloadVideo && !cachedSharedVideo?.filePath
+          ? await downloadSlidesVideoAndAudio(ytDlpPath, url, extraArgs, onDownloadProgress)
+          : await downloadAudio(ytDlpPath, url, outputFile, extraArgs, onDownloadProgress);
       filePath = downloaded.filePath;
       mediaType = downloaded.mediaType;
       filename = downloaded.filename;
@@ -219,7 +226,7 @@ export const fetchTranscriptWithYtDlp = async ({
 
       if (downloaded.sharedVideo && mediaCache) {
         const storedVideo = await mediaCache.put({
-          url: mediaCacheKey,
+          url: sharedVideoMediaCacheKey,
           filePath: downloaded.sharedVideo.filePath,
           mediaType: downloaded.sharedVideo.mediaType,
           filename: downloaded.sharedVideo.filename,

--- a/packages/core/src/content/transcript/types.ts
+++ b/packages/core/src/content/transcript/types.ts
@@ -28,6 +28,7 @@ export interface ProviderFetchOptions {
   mediaKindHint?: "video" | "audio" | null;
   transcriptTimestamps?: boolean;
   transcriptDiarization?: DiarizationPreference | null;
+  transcriptVideoDownload?: boolean;
   ytDlpPath: string | null;
   transcription?: TranscriptionConfig;
   falApiKey?: string | null;

--- a/packages/core/src/transcription/whisper/diarization.ts
+++ b/packages/core/src/transcription/whisper/diarization.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, extname, join } from "node:path";
 import { MAX_OPENAI_UPLOAD_BYTES } from "./constants.js";
 import { formatDiarizedTranscript } from "./diarization-format.js";
 import {
@@ -31,6 +31,28 @@ import { wrapError } from "./utils.js";
 export const OPENAI_DIARIZATION_CHUNK_SECONDS = 8 * 60;
 const OPENAI_DIARIZATION_CHUNK_CONCURRENCY = 1;
 const OPENAI_DIARIZATION_CHUNK_ATTEMPTS = 3;
+const VIDEO_EXTENSIONS = new Set([
+  ".3gp",
+  ".avi",
+  ".m4v",
+  ".mkv",
+  ".mov",
+  ".mp4",
+  ".mpeg",
+  ".mpg",
+  ".ogv",
+  ".ts",
+  ".webm",
+]);
+
+type PreparedDiarizationMedia = {
+  filePath: string;
+  mediaType: string;
+  filename: string | null;
+  cleanupPath: string | null;
+  note: string | null;
+  optimizedForOpenAi: boolean;
+};
 
 export function resolveDiarizationProviderOrder({
   preference,
@@ -109,45 +131,59 @@ export async function transcribeMediaFileWithDiarization({
   });
   const notes: string[] = [];
   let lastError: Error | null = null;
+  const preparedMedia = await prepareDiarizationMediaFile({
+    filePath,
+    mediaType,
+    filename,
+    providers,
+    totalDurationSeconds: effectiveDurationSeconds,
+  });
+  if (preparedMedia.note) notes.push(preparedMedia.note);
 
-  for (const [index, provider] of providers.entries()) {
-    try {
-      const result =
-        provider === "elevenlabs"
-          ? await transcribeFileWithElevenLabsDiarization({
-              filePath,
-              mediaType,
-              filename,
-              apiKey: elevenlabsApiKey!,
-            })
-          : await transcribeOpenAiMediaFile({
-              filePath,
-              mediaType,
-              filename,
-              apiKey: openaiApiKey!,
-              env,
-              totalDurationSeconds: effectiveDurationSeconds,
-              onProgress,
-            });
-      return { ...result, notes: [...notes, ...result.notes] };
-    } catch (caught) {
-      lastError = wrapError(`${providerLabel(provider)} diarization failed`, caught);
-      const next = providers[index + 1];
-      if (next) {
-        notes.push(
-          `${providerLabel(provider)} diarization failed; falling back to ${providerLabel(next)}: ${lastError.message}`,
-        );
+  try {
+    for (const [index, provider] of providers.entries()) {
+      try {
+        const result =
+          provider === "elevenlabs"
+            ? await transcribeFileWithElevenLabsDiarization({
+                filePath: preparedMedia.filePath,
+                mediaType: preparedMedia.mediaType,
+                filename: preparedMedia.filename,
+                apiKey: elevenlabsApiKey!,
+              })
+            : await transcribeOpenAiMediaFile({
+                filePath: preparedMedia.filePath,
+                mediaType: preparedMedia.mediaType,
+                filename: preparedMedia.filename,
+                apiKey: openaiApiKey!,
+                env,
+                totalDurationSeconds: effectiveDurationSeconds,
+                onProgress,
+                alreadyOptimized: preparedMedia.optimizedForOpenAi,
+                original: { filePath, mediaType, filename },
+              });
+        return { ...result, notes: [...notes, ...result.notes] };
+      } catch (caught) {
+        lastError = wrapError(`${providerLabel(provider)} diarization failed`, caught);
+        const next = providers[index + 1];
+        if (next) {
+          notes.push(
+            `${providerLabel(provider)} diarization failed; falling back to ${providerLabel(next)}: ${lastError.message}`,
+          );
+        }
       }
     }
-  }
 
-  return {
-    text: null,
-    provider: providers.at(-1) ?? null,
-    error: lastError ?? new Error("Speaker diarization failed"),
-    notes,
-    segments: null,
-  };
+    return {
+      text: null,
+      provider: providers.at(-1) ?? null,
+      error: lastError ?? new Error("Speaker diarization failed"),
+      notes,
+      segments: null,
+    };
+  } finally {
+    if (preparedMedia.cleanupPath) await fs.unlink(preparedMedia.cleanupPath).catch(() => {});
+  }
 }
 
 async function transcribeOpenAiMediaFile({
@@ -158,6 +194,8 @@ async function transcribeOpenAiMediaFile({
   env,
   totalDurationSeconds,
   onProgress,
+  alreadyOptimized,
+  original,
 }: {
   filePath: string;
   mediaType: string;
@@ -166,6 +204,12 @@ async function transcribeOpenAiMediaFile({
   env: Record<string, string | undefined>;
   totalDurationSeconds: number | null;
   onProgress?: ((event: WhisperProgressEvent) => void) | null;
+  alreadyOptimized: boolean;
+  original: {
+    filePath: string;
+    mediaType: string;
+    filename: string | null;
+  };
 }): Promise<WhisperTranscriptionResult> {
   const shouldChunk =
     totalDurationSeconds !== null
@@ -186,6 +230,8 @@ async function transcribeOpenAiMediaFile({
     mediaType,
     filename,
     totalDurationSeconds,
+    alreadyOptimized,
+    original,
   });
   try {
     const result = await transcribeFileWithOpenAiDiarization({
@@ -444,16 +490,108 @@ function providerLabel(provider: DiarizationProvider): string {
   return provider === "elevenlabs" ? "ElevenLabs" : "OpenAI";
 }
 
-async function prepareOpenAiDiarizationFile({
+async function prepareDiarizationMediaFile({
   filePath,
   mediaType,
   filename,
+  providers,
   totalDurationSeconds,
 }: {
   filePath: string;
   mediaType: string;
   filename: string | null;
+  providers: DiarizationProvider[];
   totalDurationSeconds: number | null;
+}): Promise<PreparedDiarizationMedia> {
+  if (!isVideoMedia({ filePath, mediaType, filename })) {
+    return {
+      filePath,
+      mediaType,
+      filename,
+      cleanupPath: null,
+      note: null,
+      optimizedForOpenAi: false,
+    };
+  }
+  if (!(await isFfmpegAvailable())) {
+    return {
+      filePath,
+      mediaType,
+      filename,
+      cleanupPath: null,
+      note: "Diarization: local audio extraction unavailable; uploading the original video",
+      optimizedForOpenAi: false,
+    };
+  }
+
+  const optimizeForOpenAi = providers.includes("openai");
+  const bitrateKbps = optimizeForOpenAi
+    ? resolveOpenAiDiarizationBitrateKbps(totalDurationSeconds)
+    : 32;
+  const audioPath = join(tmpdir(), `summarize-diarize-audio-${randomUUID()}.mp3`);
+  let handedOff = false;
+  try {
+    await runFfmpegTranscodeToMp3({
+      inputPath: filePath,
+      outputPath: audioPath,
+      bitrateKbps,
+    });
+    handedOff = true;
+    return {
+      filePath: audioPath,
+      mediaType: "audio/mpeg",
+      filename: "audio.mp3",
+      cleanupPath: audioPath,
+      note: `Diarization: extracted audio from video as mono 16 kHz ${bitrateKbps} kbps MP3`,
+      optimizedForOpenAi: optimizeForOpenAi,
+    };
+  } catch (caught) {
+    return {
+      filePath,
+      mediaType,
+      filename,
+      cleanupPath: null,
+      note: `Diarization: local audio extraction failed; uploading the original video: ${wrapError("ffmpeg", caught).message}`,
+      optimizedForOpenAi: false,
+    };
+  } finally {
+    if (!handedOff) await fs.unlink(audioPath).catch(() => {});
+  }
+}
+
+function isVideoMedia({
+  filePath,
+  mediaType,
+  filename,
+}: {
+  filePath: string;
+  mediaType: string;
+  filename: string | null;
+}): boolean {
+  const normalizedMediaType = mediaType.trim().toLowerCase();
+  if (normalizedMediaType.startsWith("video/")) return true;
+  if (normalizedMediaType.startsWith("audio/")) return false;
+  return VIDEO_EXTENSIONS.has(extname(filename?.trim() || filePath).toLowerCase());
+}
+
+async function prepareOpenAiDiarizationFile({
+  filePath,
+  mediaType,
+  filename,
+  totalDurationSeconds,
+  alreadyOptimized,
+  original,
+}: {
+  filePath: string;
+  mediaType: string;
+  filename: string | null;
+  totalDurationSeconds: number | null;
+  alreadyOptimized: boolean;
+  original: {
+    filePath: string;
+    mediaType: string;
+    filename: string | null;
+  };
 }): Promise<{
   filePath: string;
   mediaType: string;
@@ -464,6 +602,19 @@ async function prepareOpenAiDiarizationFile({
   const stat = await fs.stat(filePath);
   if (stat.size <= MAX_OPENAI_UPLOAD_BYTES) {
     return { filePath, mediaType, filename, cleanupPath: null, note: null };
+  }
+  if (alreadyOptimized) {
+    const originalStat = await fs.stat(original.filePath);
+    if (originalStat.size <= MAX_OPENAI_UPLOAD_BYTES) {
+      return {
+        ...original,
+        cleanupPath: null,
+        note: "OpenAI diarization: extracted audio exceeded the upload limit; using the smaller original video",
+      };
+    }
+    throw new Error(
+      "OpenAI diarization audio remains above the upload limit after local extraction; use ElevenLabs or a shorter recording",
+    );
   }
   if (!(await isFfmpegAvailable())) {
     throw new Error(

--- a/src/run/flows/url/fetch-options.ts
+++ b/src/run/flows/url/fetch-options.ts
@@ -59,6 +59,7 @@ export function resolveUrlFetchOptions({
       : "auto",
     transcriptTimestamps: flags.transcriptTimestamps,
     transcriptDiarization: flags.transcriptDiarization,
+    transcriptVideoDownload: Boolean(flags.slides && flags.transcriptDiarization),
     firecrawl: flags.firecrawlMode,
     format: markdown.markdownRequested ? "markdown" : "text",
     markdownMode: markdown.markdownRequested ? markdown.effectiveMarkdownMode : undefined,

--- a/src/run/flows/url/flow.ts
+++ b/src/run/flows/url/flow.ts
@@ -13,6 +13,7 @@ import {
   formatUSD,
 } from "../../format.js";
 import { writeVerbose } from "../../logging.js";
+import { createRunScopedMediaCache } from "../../run-media-cache.js";
 import { deriveExtractionUi, logExtractionDiagnostics } from "./extract.js";
 import { createUrlExtractionSession } from "./extraction-session.js";
 import { createUrlFlowProgress, writeSlidesBackgroundFailureWarning } from "./flow-progress.js";
@@ -88,6 +89,11 @@ export async function runUrlFlow({
     io.envForRun,
   );
 
+  const sharedMediaScope =
+    isYoutubeUrl && flags.slides && flags.transcriptDiarization
+      ? await createRunScopedMediaCache(ctx.mediaCache)
+      : null;
+  const mediaCtx = sharedMediaScope ? { ...ctx, mediaCache: sharedMediaScope.cache } : ctx;
   writeVerbose(io.stderr, flags.verbose, "extract start", flags.verboseColor, io.envForRun);
   const {
     handleSigint,
@@ -103,8 +109,8 @@ export async function runUrlFlow({
     styleDim,
     styleLabel,
     websiteProgress,
-  } = createUrlFlowProgress({ ctx, theme });
-  const flowCtx = progressHooks === hooks ? ctx : { ...ctx, hooks: progressHooks };
+  } = createUrlFlowProgress({ ctx: mediaCtx, theme });
+  const flowCtx = progressHooks === hooks ? mediaCtx : { ...mediaCtx, hooks: progressHooks };
   const activeHooks = flowCtx.hooks;
 
   const extractionSession = createUrlExtractionSession({
@@ -339,5 +345,6 @@ export async function runUrlFlow({
     }
     activeHooks.clearProgressIfCurrent(pauseProgressLine);
     stopProgress();
+    await sharedMediaScope?.cleanup();
   }
 }

--- a/src/run/run-media-cache.ts
+++ b/src/run/run-media-cache.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { extname, join } from "node:path";
+import type { MediaCache, MediaCacheEntry } from "../content/index.js";
+
+export async function createRunScopedMediaCache(
+  backing: MediaCache | null,
+): Promise<{ cache: MediaCache; cleanup: () => Promise<void> }> {
+  const dir = await fs.mkdtemp(join(tmpdir(), "summarize-run-media-"));
+  const entries = new Map<string, MediaCacheEntry>();
+
+  const cache: MediaCache = {
+    get: async ({ url }) => {
+      const local = entries.get(url);
+      if (local) {
+        try {
+          await fs.access(local.filePath);
+          local.lastAccessAtMs = Date.now();
+          return local;
+        } catch {
+          entries.delete(url);
+        }
+      }
+      return (await backing?.get({ url })) ?? null;
+    },
+    put: async ({ url, filePath, mediaType = null, filename = null }) => {
+      const persisted = await backing?.put({ url, filePath, mediaType, filename });
+      if (persisted) return persisted;
+
+      const suffix = extname(filename?.trim() || filePath) || ".bin";
+      const destination = join(dir, `${randomUUID()}${suffix}`);
+      try {
+        await fs.rename(filePath, destination);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EXDEV") throw error;
+        await fs.copyFile(filePath, destination);
+        await fs.rm(filePath, { force: true });
+      }
+      const stat = await fs.stat(destination);
+      const now = Date.now();
+      const entry: MediaCacheEntry = {
+        url,
+        filePath: destination,
+        sizeBytes: stat.size,
+        sha256: null,
+        mediaType,
+        filename,
+        createdAtMs: now,
+        lastAccessAtMs: now,
+        expiresAtMs: null,
+      };
+      entries.set(url, entry);
+      return entry;
+    },
+  };
+
+  return {
+    cache,
+    cleanup: async () => {
+      entries.clear();
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}

--- a/src/slides/download.ts
+++ b/src/slides/download.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { buildSharedVideoMediaCacheKey } from "@steipete/summarize-core/content";
 import { runProcess, runProcessCapture } from "./process.js";
 
 const YT_DLP_TIMEOUT_MS = 300_000;
@@ -12,7 +13,7 @@ export function buildYtDlpCookiesArgs(cookiesFromBrowser?: string | null): strin
 }
 
 export function buildSlidesMediaCacheKey(url: string): string {
-  return `${url}#summarize-slides`;
+  return buildSharedVideoMediaCacheKey(url);
 }
 
 export function formatBytes(bytes: number): string {

--- a/tests/cli.diarize.media.e2e.test.ts
+++ b/tests/cli.diarize.media.e2e.test.ts
@@ -1,9 +1,19 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Writable } from "node:stream";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
+
+vi.mock("../packages/core/src/transcription/whisper/ffmpeg.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../packages/core/src/transcription/whisper/ffmpeg.js")>();
+  return {
+    ...actual,
+    probeMediaDurationSecondsWithFfprobe: vi.fn(async () => 2),
+  };
+});
 
 function collectStream() {
   let text = "";
@@ -29,7 +39,19 @@ describe("CLI media diarization integration", () => {
     async ({ extension, timestamps, identifySpeakers }) => {
       const root = mkdtempSync(join(tmpdir(), `summarize-diarize-e2e-${extension}-`));
       const mediaPath = join(root, `interview.${extension}`);
-      writeFileSync(mediaPath, Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]));
+      if (extension === "mp4") {
+        copyFileSync(
+          fileURLToPath(
+            new URL(
+              "../apps/chrome-extension/tests/fixtures/ffmpeg-wasm-sample.mp4",
+              import.meta.url,
+            ),
+          ),
+          mediaPath,
+        );
+      } else {
+        writeFileSync(mediaPath, Buffer.from([0x49, 0x44, 0x33]));
+      }
       const stdout = collectStream();
       const stderr = collectStream();
       const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -39,6 +61,12 @@ describe("CLI media diarization integration", () => {
         expect(form.get("model")).toBe("gpt-4o-transcribe-diarize");
         expect(form.get("response_format")).toBe("diarized_json");
         expect(form.get("chunking_strategy")).toBe("auto");
+        const file = form.get("file") as File;
+        expect(file.name).toBe(extension === "mp4" ? "audio.mp3" : "interview.mp3");
+        expect(file.type).toBe("audio/mpeg");
+        if (extension === "mp4") {
+          expect(file.size).toBeLessThan(readFileSync(mediaPath).byteLength);
+        }
         return new Response(
           JSON.stringify({
             segments: [

--- a/tests/ffmpeg-wasm.test.ts
+++ b/tests/ffmpeg-wasm.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveBundledFfmpegCommand } from "../packages/core/src/ffmpeg.js";
+import { runFfmpegTranscodeToMp3 } from "../packages/core/src/transcription/whisper/ffmpeg.js";
 import { runProcess, runProcessCapture } from "../src/slides/process.js";
 
 const fixture = resolve(
@@ -68,5 +69,19 @@ describe("bundled ffmpeg wasm", () => {
       errorLabel: "ffmpeg-wasm",
     });
     expect((await stat(outputPath)).size).toBeGreaterThan(0);
+  }, 60_000);
+
+  it("extracts diarization audio without a native ffmpeg command", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "summarize-ffmpeg-wasm-audio-"));
+    const outputPath = join(outputDir, "audio.mp3");
+    vi.stubEnv("PATH", outputDir);
+    await runFfmpegTranscodeToMp3({
+      inputPath: fixture,
+      outputPath,
+      bitrateKbps: 24,
+    });
+    const output = await stat(outputPath);
+    expect(output.size).toBeGreaterThan(0);
+    expect(output.size).toBeLessThan((await stat(fixture)).size);
   }, 60_000);
 });

--- a/tests/run-media-cache.test.ts
+++ b/tests/run-media-cache.test.ts
@@ -1,0 +1,34 @@
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createRunScopedMediaCache } from "../src/run/run-media-cache.js";
+
+describe("run-scoped media cache", () => {
+  it("keeps shared downloads alive for the run and removes them on cleanup", async () => {
+    const root = await mkdtemp(join(tmpdir(), "summarize-run-media-test-"));
+    const source = join(root, "video.mp4");
+    await writeFile(source, new Uint8Array([1, 2, 3]));
+    const scope = await createRunScopedMediaCache(null);
+
+    try {
+      const stored = await scope.cache.put({
+        url: "https://example.com/video#summarize-slides",
+        filePath: source,
+        mediaType: "video/mp4",
+        filename: "video.mp4",
+      });
+      expect(stored?.filePath).not.toBe(source);
+      await expect(access(source)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(await scope.cache.get({ url: "https://example.com/video#summarize-slides" })).toEqual(
+        stored,
+      );
+
+      await scope.cleanup();
+      await expect(access(stored!.filePath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await scope.cleanup();
+    }
+  });
+});

--- a/tests/run.url-fetch-options.test.ts
+++ b/tests/run.url-fetch-options.test.ts
@@ -14,6 +14,7 @@ const baseFlags = {
   youtubeMode: "auto" as const,
   videoMode: "auto" as const,
   transcriptTimestamps: false,
+  transcriptDiarization: null,
   firecrawlMode: "off" as const,
   slides: null,
 };
@@ -80,5 +81,27 @@ describe("url fetch options", () => {
 
     expect(defaultResult.options.throwOnAssetLikeHtmlError).toBe(false);
     expect(cliResult.options.throwOnAssetLikeHtmlError).toBe(true);
+  });
+
+  it("requests shared video only when slides and diarization are combined", () => {
+    const diarizationOnly = resolveUrlFetchOptions({
+      targetUrl: "https://www.youtube.com/watch?v=abc123def45",
+      flags: { ...baseFlags, transcriptDiarization: "openai" },
+      markdown,
+      cacheMode: "default",
+    });
+    const slidesAndDiarization = resolveUrlFetchOptions({
+      targetUrl: "https://www.youtube.com/watch?v=abc123def45",
+      flags: {
+        ...baseFlags,
+        slides: { enabled: true },
+        transcriptDiarization: "openai",
+      },
+      markdown,
+      cacheMode: "default",
+    });
+
+    expect(diarizationOnly.options.transcriptVideoDownload).toBe(false);
+    expect(slidesAndDiarization.options.transcriptVideoDownload).toBe(true);
   });
 });

--- a/tests/transcript.yt-dlp.shared-video.test.ts
+++ b/tests/transcript.yt-dlp.shared-video.test.ts
@@ -1,0 +1,97 @@
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildSharedVideoMediaCacheKey } from "../packages/core/src/content/cache/types.js";
+import { fetchTranscriptWithYtDlp } from "../packages/core/src/content/transcript/providers/youtube/yt-dlp.js";
+import { createRunScopedMediaCache } from "../src/run/run-media-cache.js";
+
+vi.mock("../packages/core/src/transcription/whisper/ffmpeg.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../packages/core/src/transcription/whisper/ffmpeg.js")>();
+  return {
+    ...actual,
+    probeMediaDurationSecondsWithFfprobe: vi.fn(async () => 1),
+  };
+});
+
+describe("yt-dlp shared slide video", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("downloads separate video and audio streams, uploads audio, and caches video", async () => {
+    const root = await mkdtemp(join(tmpdir(), "summarize-ytdlp-shared-test-"));
+    const ytDlpPath = join(root, "yt-dlp");
+    const argsPath = join(root, "args.txt");
+    await writeFile(
+      ytDlpPath,
+      `#!/bin/sh
+printf '%s\\n' "$@" > ${JSON.stringify(argsPath)}
+output=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = '-o' ]; then
+    shift
+    output="$1"
+  fi
+  shift
+done
+audio=$(printf '%s' "$output" | sed 's/%(vcodec)s/none/; s/%(acodec)s/opus/; s/%(ext)s/webm/')
+video=$(printf '%s' "$output" | sed 's/%(vcodec)s/avc1/; s/%(acodec)s/none/; s/%(ext)s/mp4/')
+printf 'audio' > "$audio"
+printf 'video-data' > "$video"
+`,
+    );
+    await chmod(ytDlpPath, 0o755);
+    const scope = await createRunScopedMediaCache(null);
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const form = init?.body as FormData;
+      const file = form.get("file") as File;
+      expect(file.name).toBe("media.none.opus.webm");
+      expect(file.type).toBe("audio/webm");
+      expect(file.size).toBe(5);
+      return new Response(
+        JSON.stringify({
+          segments: [{ start: 0, end: 1, speaker: "A", text: "Shared." }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP", "1");
+    vi.stubEnv("SUMMARIZE_ONNX_PARAKEET_CMD", "");
+    vi.stubEnv("SUMMARIZE_ONNX_CANARY_CMD", "");
+    const url = "https://www.youtube.com/watch?v=jNQXAC9IVRw";
+
+    try {
+      const result = await fetchTranscriptWithYtDlp({
+        ytDlpPath,
+        openaiApiKey: "OPENAI",
+        diarization: "openai",
+        downloadVideo: true,
+        mediaCache: scope.cache,
+        url,
+      });
+
+      expect(result.text).toBe("Speaker A: Shared.");
+      expect(result.notes).toContain("shared slide video cached");
+      const cachedVideo = await scope.cache.get({
+        url: buildSharedVideoMediaCacheKey(url),
+      });
+      expect(cachedVideo?.filename).toBe("media.avc1.none.mp4");
+      expect(cachedVideo?.mediaType).toBe("video/mp4");
+      expect(await readFile(cachedVideo!.filePath, "utf8")).toBe("video-data");
+
+      const args = (await readFile(argsPath, "utf8")).split("\n");
+      expect(args).toContain(
+        "bestvideo[height<=720][vcodec^=avc1][ext=mp4]/bestvideo[height<=720][ext=mp4]/bestvideo[height<=720],bestaudio[vcodec=none]",
+      );
+      expect(args).not.toContain("-x");
+      expect(args).not.toContain("--audio-format");
+    } finally {
+      await scope.cleanup();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/transcript.yt-dlp.test.ts
+++ b/tests/transcript.yt-dlp.test.ts
@@ -27,8 +27,19 @@ vi.mock("node:fs", async () => {
   };
 });
 vi.mock("../packages/core/src/transcription/whisper/fal-client.js", () => falMock);
+vi.mock("../packages/core/src/transcription/whisper/ffmpeg.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../packages/core/src/transcription/whisper/ffmpeg.js")>();
+  return {
+    ...actual,
+    probeMediaDurationSecondsWithFfprobe: vi.fn(async () => 2),
+  };
+});
 
-import { fetchTranscriptWithYtDlp } from "../packages/core/src/content/transcript/providers/youtube/yt-dlp.js";
+import {
+  buildYtDlpDownloadArgs,
+  fetchTranscriptWithYtDlp,
+} from "../packages/core/src/content/transcript/providers/youtube/yt-dlp.js";
 
 const mockSpawnSuccess = () => {
   spawnMock.mockImplementation(() => {
@@ -249,6 +260,70 @@ describe("yt-dlp transcript helper", () => {
 
     const args = spawnMock.mock.calls[0]?.[1] ?? [];
     expect(args).toContain("--no-playlist");
+  });
+
+  it("uses audio-only extraction unless a shared slide video is requested", () => {
+    const audioArgs = buildYtDlpDownloadArgs({
+      url: "https://youtu.be/dQw4w9WgXcQ",
+      output: "/tmp/audio.mp3",
+      format: "bestaudio",
+      extractAudio: true,
+      progress: false,
+    });
+    const sharedArgs = buildYtDlpDownloadArgs({
+      url: "https://youtu.be/dQw4w9WgXcQ",
+      output: "/tmp/media.%(vcodec)s.%(acodec)s.%(ext)s",
+      format: "bestvideo,bestaudio",
+      extractAudio: false,
+      progress: false,
+    });
+
+    expect(audioArgs).toEqual(
+      expect.arrayContaining(["-f", "bestaudio", "-x", "--audio-format", "mp3"]),
+    );
+    expect(sharedArgs).toEqual(expect.arrayContaining(["-f", "bestvideo,bestaudio"]));
+    expect(sharedArgs).not.toContain("-x");
+    expect(sharedArgs).not.toContain("--audio-format");
+  });
+
+  it("reuses cached slide video for diarization without another yt-dlp download", async () => {
+    const mediaCache = {
+      get: vi.fn(async () => ({
+        url: "https://youtu.be/dQw4w9WgXcQ#summarize-slides",
+        filePath: "/tmp/cached-video.mp4",
+        sizeBytes: 1024,
+        sha256: null,
+        mediaType: "video/mp4",
+        filename: "video.mp4",
+        createdAtMs: 1,
+        lastAccessAtMs: 1,
+        expiresAtMs: null,
+      })),
+      put: vi.fn(),
+    };
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          segments: [{ start: 0, end: 1, speaker: "A", text: "Cached." }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await fetchTranscriptWithYtDlp({
+      ytDlpPath: "/usr/bin/yt-dlp",
+      openaiApiKey: "OPENAI",
+      diarization: "openai",
+      downloadVideo: true,
+      mediaCache,
+      url: "https://youtu.be/dQw4w9WgXcQ",
+    });
+
+    expect(result.text).toBe("Speaker A: Cached.");
+    expect(mediaCache.get).toHaveBeenCalledWith({
+      url: "https://youtu.be/dQw4w9WgXcQ#summarize-slides",
+    });
+    expect(spawnMock.mock.calls.some(([command]) => command === "/usr/bin/yt-dlp")).toBe(false);
   });
 
   it("emits download progress events from yt-dlp output", async () => {

--- a/tests/transcript.yt-dlp.test.ts
+++ b/tests/transcript.yt-dlp.test.ts
@@ -286,19 +286,23 @@ describe("yt-dlp transcript helper", () => {
     expect(sharedArgs).not.toContain("--audio-format");
   });
 
-  it("reuses cached slide video for diarization without another yt-dlp download", async () => {
+  it("downloads audio when the shared slide cache contains video only", async () => {
     const mediaCache = {
-      get: vi.fn(async () => ({
-        url: "https://youtu.be/dQw4w9WgXcQ#summarize-slides",
-        filePath: "/tmp/cached-video.mp4",
-        sizeBytes: 1024,
-        sha256: null,
-        mediaType: "video/mp4",
-        filename: "video.mp4",
-        createdAtMs: 1,
-        lastAccessAtMs: 1,
-        expiresAtMs: null,
-      })),
+      get: vi.fn(async ({ url }: { url: string }) =>
+        url.endsWith("#summarize-slides")
+          ? {
+              url,
+              filePath: "/tmp/cached-video.mp4",
+              sizeBytes: 1024,
+              sha256: null,
+              mediaType: "video/mp4",
+              filename: "video.mp4",
+              createdAtMs: 1,
+              lastAccessAtMs: 1,
+              expiresAtMs: null,
+            }
+          : null,
+      ),
       put: vi.fn(),
     };
     (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
@@ -320,10 +324,26 @@ describe("yt-dlp transcript helper", () => {
     });
 
     expect(result.text).toBe("Speaker A: Cached.");
+    expect(result.notes).toContain("shared slide video cache hit");
+    expect(mediaCache.get).toHaveBeenCalledWith({
+      url: "https://youtu.be/dQw4w9WgXcQ",
+    });
     expect(mediaCache.get).toHaveBeenCalledWith({
       url: "https://youtu.be/dQw4w9WgXcQ#summarize-slides",
     });
-    expect(spawnMock.mock.calls.some(([command]) => command === "/usr/bin/yt-dlp")).toBe(false);
+    const args = spawnMock.mock.calls.find(([command]) => command === "/usr/bin/yt-dlp")?.[1] ?? [];
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "-f",
+        expect.stringContaining("bestaudio"),
+        "-x",
+        "--audio-format",
+        "mp3",
+      ]),
+    );
+    expect(args).not.toContain(
+      "bestvideo[height<=720][vcodec^=avc1][ext=mp4]/bestvideo[height<=720][ext=mp4]/bestvideo[height<=720],bestaudio[vcodec=none]",
+    );
   });
 
   it("emits download progress events from yt-dlp output", async () => {

--- a/tests/transcription.diarization.test.ts
+++ b/tests/transcription.diarization.test.ts
@@ -64,6 +64,15 @@ describe("transcription diarization", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    ffmpegMocks.isFfmpegAvailable.mockReset();
+    ffmpegMocks.isFfmpegAvailable.mockResolvedValue(true);
+    ffmpegMocks.probeMediaDurationSecondsWithFfprobe.mockReset();
+    ffmpegMocks.probeMediaDurationSecondsWithFfprobe.mockResolvedValue(null);
+    ffmpegMocks.runFfmpegSegment.mockReset();
+    ffmpegMocks.runFfmpegTranscodeToMp3.mockReset();
+    ffmpegMocks.runFfmpegTranscodeToMp3.mockImplementation(async ({ outputPath }) => {
+      await writeFile(outputPath, new Uint8Array([4, 5, 6]));
+    });
   });
 
   it("prefers ElevenLabs and falls back to OpenAI in auto mode", () => {
@@ -279,6 +288,192 @@ describe("transcription diarization", () => {
       });
       expect(result.provider).toBe("openai");
       expect(result.text).toBe("Speaker A: Hello.");
+    } finally {
+      vi.unstubAllGlobals();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("extracts video audio once and reuses it across diarization fallbacks", async () => {
+    const root = await mkdtemp(join(tmpdir(), "summarize-video-diarize-"));
+    const filePath = join(root, "interview.mp4");
+    await writeFile(filePath, new Uint8Array([1, 2, 3, 4, 5, 6]));
+    const uploads: Array<{ name: string; size: number; type: string }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const form = init?.body as FormData;
+      const file = form.get("file") as File;
+      uploads.push({ name: file.name, size: file.size, type: file.type });
+      if (input.toString().includes("elevenlabs")) {
+        return new Response("temporary failure", { status: 500 });
+      }
+      return new Response(
+        JSON.stringify({
+          segments: [{ start: 0, end: 1, speaker: "A", text: "Hello." }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    let preparedPath: string | null = null;
+    ffmpegMocks.runFfmpegTranscodeToMp3.mockImplementationOnce(
+      async ({ outputPath, bitrateKbps }) => {
+        expect(bitrateKbps).toBe(24);
+        preparedPath = outputPath;
+        await writeFile(outputPath, new Uint8Array([4, 5, 6]));
+      },
+    );
+
+    try {
+      vi.stubGlobal("fetch", fetchMock);
+      const result = await transcribeMediaFileWithDiarization({
+        filePath,
+        mediaType: "video/mp4",
+        filename: "interview.mp4",
+        preference: "auto",
+        elevenlabsApiKey: "ELEVEN",
+        openaiApiKey: "OPENAI",
+        env: {},
+        totalDurationSeconds: 60,
+      });
+      expect(result.provider).toBe("openai");
+      expect(result.notes).toContain(
+        "Diarization: extracted audio from video as mono 16 kHz 24 kbps MP3",
+      );
+      expect(ffmpegMocks.runFfmpegTranscodeToMp3).toHaveBeenCalledTimes(1);
+      expect(uploads).toEqual([
+        { name: "audio.mp3", size: 3, type: "audio/mpeg" },
+        { name: "audio.mp3", size: 3, type: "audio/mpeg" },
+      ]);
+      expect(preparedPath).not.toBeNull();
+      await expect(access(preparedPath!)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      vi.unstubAllGlobals();
+      if (preparedPath) await rm(preparedPath, { force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses a higher bitrate for ElevenLabs-only video diarization", async () => {
+    const root = await mkdtemp(join(tmpdir(), "summarize-elevenlabs-video-diarize-"));
+    const filePath = join(root, "interview.mp4");
+    await writeFile(filePath, new Uint8Array([1, 2, 3]));
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const form = init?.body as FormData;
+      const file = form.get("file") as File;
+      expect(file.name).toBe("audio.mp3");
+      expect(file.type).toBe("audio/mpeg");
+      return new Response(
+        JSON.stringify({
+          words: [{ text: "Hello", start: 0, end: 1, speaker_id: "speaker_1" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    try {
+      vi.stubGlobal("fetch", fetchMock);
+      const result = await transcribeMediaFileWithDiarization({
+        filePath,
+        mediaType: "video/mp4",
+        filename: "interview.mp4",
+        preference: "elevenlabs",
+        elevenlabsApiKey: "ELEVEN",
+        openaiApiKey: null,
+        env: {},
+        totalDurationSeconds: 60,
+      });
+      expect(result.provider).toBe("elevenlabs");
+      expect(ffmpegMocks.runFfmpegTranscodeToMp3).toHaveBeenCalledWith({
+        inputPath: filePath,
+        outputPath: expect.stringMatching(/summarize-diarize-audio-.*\.mp3$/),
+        bitrateKbps: 32,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves the original video when local audio extraction is unavailable", async () => {
+    const root = await mkdtemp(join(tmpdir(), "summarize-video-diarize-no-ffmpeg-"));
+    const filePath = join(root, "interview.mp4");
+    await writeFile(filePath, new Uint8Array([1, 2, 3]));
+    ffmpegMocks.isFfmpegAvailable.mockResolvedValueOnce(false);
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const form = init?.body as FormData;
+      const file = form.get("file") as File;
+      expect(file.name).toBe("interview.mp4");
+      expect(file.type).toBe("video/mp4");
+      return new Response(
+        JSON.stringify({
+          words: [{ text: "Hello", start: 0, end: 1, speaker_id: "speaker_1" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    try {
+      vi.stubGlobal("fetch", fetchMock);
+      const result = await transcribeMediaFileWithDiarization({
+        filePath,
+        mediaType: "video/mp4",
+        filename: "interview.mp4",
+        preference: "elevenlabs",
+        elevenlabsApiKey: "ELEVEN",
+        openaiApiKey: null,
+        env: {},
+        totalDurationSeconds: 60,
+      });
+      expect(result.provider).toBe("elevenlabs");
+      expect(result.notes).toContain(
+        "Diarization: local audio extraction unavailable; uploading the original video",
+      );
+      expect(ffmpegMocks.runFfmpegTranscodeToMp3).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses a smaller original video when extracted audio exceeds OpenAI's limit", async () => {
+    const root = await mkdtemp(join(tmpdir(), "summarize-video-diarize-smaller-original-"));
+    const filePath = join(root, "interview.mp4");
+    await writeFile(filePath, new Uint8Array([1, 2, 3]));
+    ffmpegMocks.runFfmpegTranscodeToMp3.mockImplementationOnce(async ({ outputPath }) => {
+      const handle = await open(outputPath, "w");
+      await handle.truncate(MAX_OPENAI_UPLOAD_BYTES + 1);
+      await handle.close();
+    });
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const form = init?.body as FormData;
+      const file = form.get("file") as File;
+      expect(file.name).toBe("interview.mp4");
+      expect(file.type).toBe("video/mp4");
+      expect(file.size).toBe(3);
+      return new Response(
+        JSON.stringify({
+          segments: [{ start: 0, end: 1, speaker: "A", text: "Hello." }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    try {
+      vi.stubGlobal("fetch", fetchMock);
+      const result = await transcribeMediaFileWithDiarization({
+        filePath,
+        mediaType: "video/mp4",
+        filename: "interview.mp4",
+        preference: "openai",
+        elevenlabsApiKey: null,
+        openaiApiKey: "OPENAI",
+        env: {},
+        totalDurationSeconds: 60,
+      });
+      expect(result.provider).toBe("openai");
+      expect(result.notes).toContain(
+        "OpenAI diarization: extracted audio exceeded the upload limit; using the smaller original video",
+      );
+      expect(ffmpegMocks.runFfmpegTranscodeToMp3).toHaveBeenCalledTimes(1);
     } finally {
       vi.unstubAllGlobals();
       await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- extract local video audio once before diarization and reuse it across provider fallback
- use audio-only YouTube downloads for diarization; combined slides + diarization downloads separate audio/video streams in one yt-dlp invocation
- add run-scoped media reuse while keeping slide-only video cache entries separate from transcript audio
- preserve upstream long-recording OpenAI chunking and bundled FFmpeg fallback behavior

## Validation

- `pnpm -s check` (438 test files passed; 2336 tests passed)
- `pnpm -C apps/chrome-extension build`
- `pnpm -C apps/chrome-extension test:chrome` (68 passed; 5 environment-gated skips)
- live yt-dlp dual-stream download against `jNQXAC9IVRw`
- autoreview clean after fixing the slide-video/audio cache collision