### PR TITLE
build: update browser Transformers runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - YouTube metadata: harden view-count freshness, fallbacks, embedded transcript cache identity, and timeout enforcement while reading response bodies.
+- Chrome extension: update Transformers.js to 4.2 and resolve its bundled ONNX runtime assets through the installed dependency graph.
 
 ### Docs
 

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -18,7 +18,7 @@
     "test:firefox:lint": "env -u NO_COLOR pnpm build:firefox && env -u NO_COLOR web-ext lint --source-dir .output/firefox-mv3 --self-hosted --boring"
   },
   "dependencies": {
-    "@huggingface/transformers": "3.8.1",
+    "@huggingface/transformers": "4.2.0",
     "@mozilla/readability": "0.6.0",
     "@steipete/summarize-core": "workspace:*",
     "googlevideo": "4.0.4",

--- a/apps/chrome-extension/scripts/transformers-runtime-assets.ts
+++ b/apps/chrome-extension/scripts/transformers-runtime-assets.ts
@@ -1,0 +1,24 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+export type TransformersRuntimeAsset = {
+  fileName: string;
+  sourcePath: string;
+};
+
+export function resolveTransformersRuntimeAssets(): TransformersRuntimeAsset[] {
+  const transformersEntry = require.resolve("@huggingface/transformers");
+  const dependencyRequire = createRequire(transformersEntry);
+
+  return [
+    {
+      fileName: "ort-wasm-simd-threaded.asyncify.mjs",
+      sourcePath: dependencyRequire.resolve("onnxruntime-web/ort-wasm-simd-threaded.asyncify.mjs"),
+    },
+    {
+      fileName: "ort-wasm-simd-threaded.asyncify.wasm",
+      sourcePath: dependencyRequire.resolve("onnxruntime-web/ort-wasm-simd-threaded.asyncify.wasm"),
+    },
+  ];
+}

--- a/apps/chrome-extension/src/entrypoints/offscreen/whisper.ts
+++ b/apps/chrome-extension/src/entrypoints/offscreen/whisper.ts
@@ -9,10 +9,6 @@ const WHISPER_MODEL = "onnx-community/whisper-tiny";
 const WEBGPU_MODEL_LOAD_TIMEOUT_MS = 30_000;
 const WASM_MODEL_LOAD_TIMEOUT_MS = 90_000;
 const WHISPER_IDLE_DISPOSE_MS = 5 * 60 * 1000;
-const ORT_WASM_URL = new URL(
-  "../../../node_modules/@huggingface/transformers/dist/ort-wasm-simd-threaded.jsep.wasm",
-  import.meta.url,
-).href;
 type WhisperDevice = "webgpu" | "wasm";
 type WhisperPipelineFactory = (
   device: WhisperDevice,
@@ -101,8 +97,8 @@ async function getTranscriber(onStatus: (status: string) => void): Promise<{
     env.useBrowserCache = true;
     if (env.backends.onnx.wasm) {
       env.backends.onnx.wasm.wasmPaths = {
-        mjs: chrome.runtime.getURL("assets/ort-wasm-simd-threaded.jsep.mjs"),
-        wasm: ORT_WASM_URL,
+        mjs: chrome.runtime.getURL("assets/ort-wasm-simd-threaded.asyncify.mjs"),
+        wasm: chrome.runtime.getURL("assets/ort-wasm-simd-threaded.asyncify.wasm"),
       };
       env.backends.onnx.wasm.proxy = false;
     }

--- a/apps/chrome-extension/tests/browser-media-local.live.spec.ts
+++ b/apps/chrome-extension/tests/browser-media-local.live.spec.ts
@@ -49,9 +49,8 @@ test("transcribes embedded browser media through MediaBunny and local Whisper", 
   const media = fs.readFileSync(mediaPath);
   const html = `<!doctype html>
 <html>
-  <head><meta charset="utf-8"><title>Browser Media Speech</title></head>
+  <head><meta charset="utf-8"><title></title></head>
   <body>
-    <h1>Browser Media Speech</h1>
     <audio controls preload="auto" src="/speech.m4a"></audio>
   </body>
 </html>`;
@@ -116,8 +115,6 @@ test("transcribes embedded browser media through MediaBunny and local Whisper", 
     await expect
       .poll(async () => await getPanelModel(panel), { timeout: 8 * 60 * 1000 })
       .toBe("Browser");
-    const summary = (await getPanelSummaryMarkdown(panel)).toLowerCase();
-    expect(summary).toMatch(/purple|telescope|orange piano/u);
 
     const background = await getBackground(harness);
     const readDiagnostic = async () =>
@@ -135,15 +132,25 @@ test("transcribes embedded browser media through MediaBunny and local Whisper", 
               return null;
             }
           })
-          .find((entry) => entry?.event === "extract:browser-media:transcript");
+          .find(
+            (entry) =>
+              entry?.event === "extract:browser-media:transcript" ||
+              entry?.event === "extract:browser-media:local-transcript-failed",
+          );
       });
     await expect.poll(readDiagnostic, { timeout: 5_000 }).not.toBeUndefined();
     const diagnostic = await readDiagnostic();
+    if (diagnostic?.event === "extract:browser-media:local-transcript-failed") {
+      throw new Error(`Local browser media transcription failed: ${String(diagnostic.error)}`);
+    }
     expect(diagnostic).toMatchObject({
       decoder: "mediabunny-webcodecs",
       mediaInput: "url-range",
       mediaSource: "embedded",
     });
+
+    const summary = (await getPanelSummaryMarkdown(panel)).toLowerCase();
+    expect(summary).toMatch(/purple|telescope|orange piano/u);
   } finally {
     await closeExtension(harness.context, harness.userDataDir);
     await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/apps/chrome-extension/wxt.config.ts
+++ b/apps/chrome-extension/wxt.config.ts
@@ -1,6 +1,7 @@
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { defineConfig } from "wxt";
+import { resolveTransformersRuntimeAssets } from "./scripts/transformers-runtime-assets";
 
 const targetBrowser = process.env.BROWSER === "firefox" ? "firefox" : "chrome";
 
@@ -43,17 +44,13 @@ export default defineConfig({
             {
               name: "bundle-transformers-onnx-runtime",
               generateBundle() {
-                const filename = "ort-wasm-simd-threaded.jsep.mjs";
-                this.emitFile({
-                  type: "asset",
-                  fileName: `assets/${filename}`,
-                  source: readFileSync(
-                    new URL(
-                      `./node_modules/@huggingface/transformers/dist/${filename}`,
-                      import.meta.url,
-                    ),
-                  ),
-                });
+                for (const asset of resolveTransformersRuntimeAssets()) {
+                  this.emitFile({
+                    type: "asset",
+                    fileName: `assets/${asset.fileName}`,
+                    source: readFileSync(asset.sourcePath),
+                  });
+                }
               },
             },
           ]
@@ -62,13 +59,14 @@ export default defineConfig({
       rollupOptions: {
         output: {
           assetFileNames: (asset) =>
-            asset.names.some((name) => name === "ort-wasm-simd-threaded.jsep.wasm")
+            asset.names.some((name) => name === "ort-wasm-simd-threaded.asyncify.wasm")
               ? "assets/[name][extname]"
               : "assets/[name]-[hash][extname]",
         },
       },
     },
     resolve: {
+      conditions: ["onnxruntime-web-use-extern-wasm"],
       alias: {
         react: "preact/compat",
         "react-dom": "preact/compat",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
   apps/chrome-extension:
     dependencies:
       '@huggingface/transformers':
-        specifier: 3.8.1
-        version: 3.8.1
+        specifier: 4.2.0
+        version: 4.2.0
       '@mozilla/readability':
         specifier: 0.6.0
         version: 0.6.0
@@ -723,8 +723,11 @@ packages:
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
     engines: {node: '>=18'}
 
-  '@huggingface/transformers@3.8.1':
-    resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -898,10 +901,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1918,10 +1917,6 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
-
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
 
   chrome-launcher@1.2.0:
     resolution: {integrity: sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q==}
@@ -2975,10 +2970,6 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
-
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -3056,18 +3047,18 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  onnxruntime-common@1.21.0:
-    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
 
-  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
-    resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
 
-  onnxruntime-node@1.21.0:
-    resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
     os: [win32, darwin, linux]
 
-  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
-    resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
@@ -3590,10 +3581,6 @@ packages:
     resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
     engines: {node: '>=20'}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
-    engines: {node: '>=18'}
-
   thread-stream@3.2.0:
     resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
 
@@ -3959,10 +3946,6 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -4538,11 +4521,14 @@ snapshots:
 
   '@huggingface/jinja@0.5.9': {}
 
-  '@huggingface/transformers@3.8.1':
+  '@huggingface/tokenizers@0.1.3': {}
+
+  '@huggingface/transformers@4.2.0':
     dependencies:
       '@huggingface/jinja': 0.5.9
-      onnxruntime-node: 1.21.0
-      onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
       sharp: 0.34.5
 
   '@humanfs/core@0.19.2':
@@ -4656,10 +4642,6 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
-
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5467,8 +5449,6 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
-
-  chownr@3.0.0: {}
 
   chrome-launcher@1.2.0:
     dependencies:
@@ -6492,10 +6472,6 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  minizlib@3.1.0:
-    dependencies:
-      minipass: 7.1.3
-
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
@@ -6573,22 +6549,22 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  onnxruntime-common@1.21.0: {}
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
 
-  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4: {}
+  onnxruntime-common@1.24.3: {}
 
-  onnxruntime-node@1.21.0:
+  onnxruntime-node@1.24.3:
     dependencies:
+      adm-zip: 0.5.17
       global-agent: 3.0.0
-      onnxruntime-common: 1.21.0
-      tar: 7.5.16
+      onnxruntime-common: 1.24.3
 
-  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     dependencies:
       flatbuffers: 25.9.23
       guid-typescript: 1.0.9
       long: 5.3.2
-      onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
       platform: 1.3.6
       protobufjs: 7.6.2
 
@@ -7217,14 +7193,6 @@ snapshots:
       has-flag: 5.0.1
       supports-color: 10.2.2
 
-  tar@7.5.16:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
   thread-stream@3.2.0:
     dependencies:
       real-require: 0.2.0
@@ -7645,8 +7613,6 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   y18n@5.0.8: {}
-
-  yallist@5.0.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/tests/chrome.transformers-runtime-assets.test.ts
+++ b/tests/chrome.transformers-runtime-assets.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveTransformersRuntimeAssets } from "../apps/chrome-extension/scripts/transformers-runtime-assets";
+
+describe("Chrome Transformers.js runtime assets", () => {
+  it("resolves the JavaScript factory and WASM binary from the installed dependency graph", () => {
+    const assets = resolveTransformersRuntimeAssets();
+
+    expect(assets.map((asset) => asset.fileName)).toEqual([
+      "ort-wasm-simd-threaded.asyncify.mjs",
+      "ort-wasm-simd-threaded.asyncify.wasm",
+    ]);
+    for (const asset of assets) {
+      expect(basename(asset.sourcePath)).toBe(asset.fileName);
+      const minimumBytes = asset.fileName.endsWith(".wasm") ? 1_000_000 : 10_000;
+      expect(readFileSync(asset.sourcePath).byteLength).toBeGreaterThan(minimumBytes);
+    }
+  });
+});


### PR DESCRIPTION
## Context

Dependency-freshness backstop after #264. Audited all direct and development dependencies against stable upstream releases with a June 5, 2026 cutoff.

Only one bounded, age-qualified update was both available and appropriate:

- `@huggingface/transformers` 3.8.1 -> 4.2.0, stable since April 23, 2026.
- Resolve ONNX Runtime assets through the installed dependency graph and use the external-WASM export's required `asyncify` factory/binary.
- Harden the live browser-media test so visible fixture text cannot bypass local media transcription and failures expose the offscreen diagnostic.

Deferred releases younger than seven days: `esbuild` 0.28.1, `happy-dom` 20.10.2, `osc-progress` 0.3.1, and `sanitize-html` 2.17.5. Kept `@types/node` on Node 24 because the repository and CI target Node 24; the age-qualified update is a separate Node 25 major. Existing prerelease adoption was not expanded except for the transitive ONNX Runtime version selected by the stable Transformers.js release.

## Proof

- `pnpm -s check`: 467 test files, 2,351 passed, 28 skipped.
- `pnpm -s build`: pass.
- Built CLI: `0.17.3 (cc3f9d33)`; live `--extract --format text https://example.com` pass.
- Chrome extension: build pass; 69 Playwright tests passed, 4 expected live skips.
- Live Chrome transcription: synthesized AAC speech -> MediaBunny URL-range decode -> local Whisper -> expected transcript, pass.
- Firefox extension smoke: pass.
- Firefox `web-ext lint`: 0 errors; existing compatibility warnings only.
- Runtime artifact: one asyncify factory and one WASM binary, 24 MB total Chrome output.
- Autoreview: clean, no accepted/actionable findings.
- Public Model Identifier Gate: PASS. No model identifier added by the diff; the unchanged `onnx-community/whisper-tiny` and identifiers embedded by Transformers.js resolve to public Hugging Face model pages.

No release or version bump.
