### PR TITLE
fix(cli): present delegated video summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- CLI video summaries: restore terminal and JSON output when direct video understanding delegates URL handling to the asset summarizer.
 - Development CLI: build the core workspace before `pnpm summarize` and `pnpm s` so newly added core exports never depend on stale generated files.
 - Slides: ignore invalid zero-index slide markers without hanging while extracting slide references.
 - Summary length: use `long` as the built-in default across the CLI, daemon, and Chrome extension; explicit and configured lengths remain unchanged.

--- a/src/application/execute-summarize.ts
+++ b/src/application/execute-summarize.ts
@@ -628,6 +628,7 @@ export async function executeSummarize(
           summaryDetails = {
             kind: "delegated-asset",
             summaryEmitted: urlResult.summary.summaryEmitted,
+            summary: urlResult.summary,
           };
           normalizedSummary = urlResult.summary.summary;
           if (!urlResult.summary.summaryEmitted) {

--- a/src/application/url-result.ts
+++ b/src/application/url-result.ts
@@ -1,4 +1,5 @@
 import type { UrlSummaryResolution } from "../engine/web-summary.js";
+import type { AssetSummaryResult } from "../run/flows/asset/types.js";
 
 export type UrlSummaryPresentationResolution =
   | {
@@ -32,6 +33,7 @@ export type SummarizeExecutionDetails =
   | {
       kind: "delegated-asset";
       summaryEmitted: boolean;
+      summary: AssetSummaryResult;
     };
 
 export type SummarizeExtractionDetails = {

--- a/src/run/cli-summarize-execution.ts
+++ b/src/run/cli-summarize-execution.ts
@@ -25,6 +25,24 @@ function toPresentAssetSummaryArgs(input: AssetExecutionInput): PresentAssetSumm
   };
 }
 
+function toDelegatedAssetSummaryArgs(
+  result: Extract<SummarizeResult, { kind: "summary" }>,
+): PresentAssetSummaryArgs {
+  if (result.details.kind !== "delegated-asset") {
+    throw new Error("CLI delegated asset presentation requires delegated asset details");
+  }
+  const { extracted } = result.details.summary;
+  return {
+    sourceKind: "asset-url",
+    sourceLabel: extracted.source,
+    attachment: {
+      kind: extracted.mediaType.startsWith("image/") ? "image" : "file",
+      mediaType: extracted.mediaType,
+      filename: extracted.filename,
+    },
+  };
+}
+
 export function createCliSummarizeExecutor(options: {
   request: SummarizeRequest;
   runtime: SummarizeRuntime;
@@ -60,6 +78,14 @@ export function createCliSummarizeExecutor(options: {
     }
     if (result.kind === "asset-media") {
       await presentMediaFileResult(options.presentationContext, result.details);
+      return;
+    }
+    if (result.kind === "summary" && result.details.kind === "delegated-asset") {
+      await presentAssetSummary(
+        options.presentationContext,
+        toDelegatedAssetSummaryArgs(result),
+        result.details.summary,
+      );
       return;
     }
     await presentCliSummarizeResult({

--- a/src/run/cli-summarize-output.ts
+++ b/src/run/cli-summarize-output.ts
@@ -39,7 +39,9 @@ export async function presentCliSummarizeResult(options: {
   ) {
     throw new Error("CLI URL presentation requires a URL result");
   }
-  if (result.details.kind === "delegated-asset") return;
+  if (result.details.kind === "delegated-asset") {
+    throw new Error("CLI delegated asset presentation requires an asset context");
+  }
   if (result.input.kind !== "url") {
     throw new Error("CLI URL presentation requires a URL result");
   }

--- a/src/run/flows/url/video-only.ts
+++ b/src/run/flows/url/video-only.ts
@@ -95,14 +95,12 @@ export async function handleVideoOnlyExtractedContent({
   });
   assertAssetMediaTypeSupported({ attachment: loadedVideo.attachment, sizeLabel: null });
 
-  let chosenModel: string | null = null;
   if (flags.progressEnabled) spinner.setText(renderStatus("Summarizing video"));
   const summary = await hooks.summarizeAsset({
     sourceKind: "asset-url",
     sourceLabel: loadedVideo.sourceLabel,
     attachment: loadedVideo.attachment,
     onModelChosen: (modelId) => {
-      chosenModel = modelId;
       hooks.onModelChosen?.(modelId);
       if (flags.progressEnabled) {
         const meta = `${styleDim("(")}${styleDim("model: ")}${accent(modelId)}${styleDim(")")}`;
@@ -111,11 +109,18 @@ export async function handleVideoOnlyExtractedContent({
     },
   });
   const slideCount = directVideoSlides ? directVideoSlides.slides.length : null;
-  hooks.writeViaFooter([
-    ...extractionUi.footerParts,
-    ...(chosenModel ? [`model ${chosenModel}`] : []),
-    ...(slideCount != null ? [`slides ${slideCount}`] : []),
-  ]);
   updateSummaryProgress();
-  return { handled: true, extracted, slides: directVideoSlides, summary };
+  return {
+    handled: true,
+    extracted,
+    slides: directVideoSlides,
+    summary: {
+      ...summary,
+      footerParts: [
+        ...extractionUi.footerParts,
+        ...summary.footerParts,
+        ...(slideCount != null ? [`slides ${slideCount}`] : []),
+      ],
+    },
+  };
 }

--- a/tests/application.execute-summarize.test.ts
+++ b/tests/application.execute-summarize.test.ts
@@ -211,6 +211,18 @@ describe("executeSummarize", () => {
       summary: "Video summary.",
       usedModel: "google/gemini-2.5-pro",
       summaryFromCache: false,
+      details: {
+        kind: "delegated-asset",
+        summaryEmitted: false,
+        summary: {
+          summary: "Video summary.",
+          extracted: {
+            source: "https://cdn.example.com/video.mp4",
+            mediaType: "video/mp4",
+            filename: "video.mp4",
+          },
+        },
+      },
     });
     expect(events.map((event) => event.type)).toEqual([
       "run-started",

--- a/tests/run.cli-summarize-execution.test.ts
+++ b/tests/run.cli-summarize-execution.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   SummarizeRequest,
   SummarizeResult,
@@ -79,10 +79,15 @@ function createExecutor(result: SummarizeResult) {
 }
 
 describe("CLI summarize execution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("executes the planned request and presents URL results", async () => {
     const result = {
       kind: "summary",
       input: { kind: "url" },
+      details: { kind: "visible-page" },
     } as SummarizeResult;
     const fixture = createExecutor(result);
 
@@ -131,6 +136,62 @@ describe("CLI summarize execution", () => {
       },
       details,
     );
+  });
+
+  it("presents delegated URL video summaries through the asset presenter", async () => {
+    const summary = {
+      kind: "summary",
+      outcome: "model",
+      summary: "Video summary",
+      summaryEmitted: false,
+      summaryFromCache: false,
+      prompt: "Prompt",
+      extracted: {
+        kind: "asset",
+        source: "https://cdn.example.com/video.mp4",
+        mediaType: "video/mp4",
+        filename: "video.mp4",
+      },
+      footerParts: [],
+      llm: {
+        provider: "google",
+        model: "google/gemini-2.5-pro",
+        maxCompletionTokens: 256,
+        strategy: "single",
+      },
+    } as const;
+    const result = {
+      kind: "summary",
+      input: {
+        kind: "url",
+        url: "https://example.com/video",
+        title: null,
+        maxCharacters: null,
+      },
+      details: {
+        kind: "delegated-asset",
+        summaryEmitted: false,
+        summary,
+      },
+    } as SummarizeResult;
+    const fixture = createExecutor(result);
+
+    await fixture.execute();
+
+    expect(mocks.presentAssetSummary).toHaveBeenCalledWith(
+      fixture.presentationContext,
+      {
+        sourceKind: "asset-url",
+        sourceLabel: "https://cdn.example.com/video.mp4",
+        attachment: {
+          kind: "file",
+          mediaType: "video/mp4",
+          filename: "video.mp4",
+        },
+      },
+      summary,
+    );
+    expect(mocks.presentCliSummarizeResult).not.toHaveBeenCalled();
   });
 
   it("presents asset extraction from application metrics", async () => {

--- a/tests/run.url-video-only.test.ts
+++ b/tests/run.url-video-only.test.ts
@@ -312,7 +312,11 @@ describe("handleVideoOnlyExtractedContent", () => {
       handled: true,
       extracted: baseExtracted,
       slides: { sourceId: "vid123", slides: [{ index: 1 }, { index: 2 }] },
-      summary: { summary: "Video summary.", llm: { model: "google/gemini-2.5-pro" } },
+      summary: {
+        summary: "Video summary.",
+        footerParts: ["html", "video url", "slides 2"],
+        llm: { model: "google/gemini-2.5-pro" },
+      },
     });
     expect(onExtracted).toHaveBeenCalledWith(baseExtracted);
     expect(mocks.loadRemoteAsset).toHaveBeenCalledWith({
@@ -332,12 +336,7 @@ describe("handleVideoOnlyExtractedContent", () => {
       }),
     );
     expect(onModelChosen).toHaveBeenCalledWith("google/gemini-2.5-pro");
-    expect(writeViaFooter).toHaveBeenCalledWith([
-      "html",
-      "video url",
-      "model google/gemini-2.5-pro",
-      "slides 2",
-    ]);
+    expect(writeViaFooter).not.toHaveBeenCalled();
     expect(updateSummaryProgress).toHaveBeenCalledTimes(1);
     expect(spinner.setText).toHaveBeenCalledWith("Downloading video");
     expect(spinner.setText).toHaveBeenCalledWith("Summarizing video");


### PR DESCRIPTION
## Summary

- preserve byte-free delegated asset results across the application boundary
- route direct video URL summaries through the existing asset presenter for terminal and JSON output
- keep URL extraction and slide metadata in a single footer

## Verification

- `pnpm -s vitest run tests/run.cli-summarize-execution.test.ts tests/application.execute-summarize.test.ts tests/run.url-video-only.test.ts`
- `pnpm -s check`
- autoreview: clean, no accepted/actionable findings