### PR TITLE
fix(core): block translated private IPv4 targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - CLI video summaries: restore terminal and JSON output when direct video understanding delegates URL handling to the asset summarizer.
 - Development CLI: build the core workspace before `pnpm summarize` and `pnpm s` so newly added core exports never depend on stale generated files.
+- Network safety: block private IPv4 targets embedded in the IPv4-translatable IPv6 prefix.
 - Slides: ignore invalid zero-index slide markers without hanging while extracting slide references.
 - Summary length: use `long` as the built-in default across the CLI, daemon, and Chrome extension; explicit and configured lengths remain unchanged.
 

--- a/packages/core/src/content/network-safety.ts
+++ b/packages/core/src/content/network-safety.ts
@@ -68,8 +68,10 @@ function isBlockedIpv6(address: string): boolean {
   const allZero = parts.every((part) => part === 0);
   const loopback = parts.slice(0, 7).every((part) => part === 0) && eighth === 1;
   const mappedIpv4 = parts.slice(0, 5).every((part) => part === 0) && sixth === 0xffff;
+  const translatedIpv4 =
+    parts.slice(0, 4).every((part) => part === 0) && parts[4] === 0xffff && parts[5] === 0;
   const compatibleIpv4 = parts.slice(0, 6).every((part) => part === 0) && !allZero && !loopback;
-  if (mappedIpv4 || compatibleIpv4) {
+  if (mappedIpv4 || translatedIpv4 || compatibleIpv4) {
     return isBlockedIpv4(embeddedIpv4(parts));
   }
   const wellKnownNat64 =

--- a/tests/daemon.url-fetch-guard.test.ts
+++ b/tests/daemon.url-fetch-guard.test.ts
@@ -46,6 +46,9 @@ describe("daemon URL fetch guard", () => {
     await expect(assertDaemonUrlFetchAllowed("https://[::1]/", { lookup })).rejects.toThrow(
       /blocked local network address/,
     );
+    await expect(
+      assertDaemonUrlFetchAllowed("https://[::ffff:0:c0a8:101]/", { lookup }),
+    ).rejects.toThrow(/blocked local network address/);
     expect(lookup).not.toHaveBeenCalled();
   });
 

--- a/tests/hover.security.test.ts
+++ b/tests/hover.security.test.ts
@@ -25,6 +25,7 @@ describe("hover summary security boundaries", () => {
     expect(isHoverSummarizeUrlAllowed("http://100.64.0.1/internal")).toBe(false);
     expect(isHoverSummarizeUrlAllowed("http://224.0.0.1/multicast")).toBe(false);
     expect(isHoverSummarizeUrlAllowed("http://[::ffff:127.0.0.1]/admin")).toBe(false);
+    expect(isHoverSummarizeUrlAllowed("http://[::ffff:0:c0a8:101]/admin")).toBe(false);
     expect(isHoverSummarizeUrlAllowed("http://localhost:8787/health")).toBe(false);
     expect(isHoverSummarizeUrlAllowed("http://panel.localhost/admin")).toBe(false);
     expect(isHoverSummarizeUrlAllowed("http://printer.local/status")).toBe(false);

--- a/tests/network-safety.test.ts
+++ b/tests/network-safety.test.ts
@@ -18,6 +18,8 @@ describe("network safety policy", () => {
       "203.0.113.1",
       "::1",
       "::ffff:127.0.0.1",
+      "::ffff:0:192.168.1.1",
+      "::ffff:0:a9fe:a9fe",
       "::7f00:1",
       "64:ff9b::a9fe:a9fe",
       "64:ff9b:1::808:808",
@@ -34,7 +36,13 @@ describe("network safety policy", () => {
   });
 
   it("allows public IPv4, IPv6, and NAT64 addresses", () => {
-    for (const address of ["192.0.8.1", "8.8.8.8", "64:ff9b::808:808", "[2606:4700:4700::1111]"]) {
+    for (const address of [
+      "192.0.8.1",
+      "8.8.8.8",
+      "::ffff:0:8.8.8.8",
+      "64:ff9b::808:808",
+      "[2606:4700:4700::1111]",
+    ]) {
       expect(isBlockedNetworkAddress(address), address).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary

- classify IPv4-translatable IPv6 addresses separately from IPv4-mapped addresses
- apply the existing IPv4 block policy to their embedded final 32 bits
- cover core policy, daemon URL literals, hover URLs, and public translated addresses

## Verification

- `pnpm -s build && pnpm -s vitest run tests/network-safety.test.ts tests/daemon.url-fetch-guard.test.ts tests/hover.security.test.ts`
- `pnpm -s check`
- autoreview: clean, no accepted/actionable findings