### PR TITLE
fix(extension): reject stale YouTube transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - CLI video summaries: restore terminal and JSON output when direct video understanding delegates URL handling to the asset summarizer.
+- Chrome extension: reject YouTube caption and transcript-panel results when the tab navigates to another video during extraction.
 - Development CLI: build the core workspace before `pnpm summarize` and `pnpm s` so newly added core exports never depend on stale generated files.
 - Network safety: block private IPv4 targets embedded in the IPv4-translatable IPv6 prefix.
 - Slides: ignore invalid zero-index slide markers without hanging while extracting slide references.

--- a/apps/chrome-extension/src/entrypoints/background/youtube-transcript.ts
+++ b/apps/chrome-extension/src/entrypoints/background/youtube-transcript.ts
@@ -38,7 +38,7 @@ export async function extractYouTubeTranscriptInTab(
         const [result] = await chrome.scripting.executeScript({
           target: { tabId },
           world: "MAIN",
-          args: [url],
+          args: [url, source.url],
           func: fetchYouTubeCaptionText,
         });
         return result?.result ?? null;
@@ -47,6 +47,7 @@ export async function extractYouTubeTranscriptInTab(
         const [result] = await chrome.scripting.executeScript({
           target: { tabId },
           world: "MAIN",
+          args: [source.url],
           func: readYouTubeTranscriptPanel,
         });
         return result?.result ?? null;

--- a/apps/chrome-extension/src/lib/youtube-page-transcript.ts
+++ b/apps/chrome-extension/src/lib/youtube-page-transcript.ts
@@ -167,14 +167,34 @@ export function readYouTubePageCaptionSource(): BrowserYouTubeCaptionSource {
 }
 
 // Keep this function self-contained: Chrome serializes it for MAIN-world injection.
-export async function fetchYouTubeCaptionText(url: string): Promise<string | null> {
+export async function fetchYouTubeCaptionText(
+  url: string,
+  expectedPageUrl: string | null = null,
+): Promise<string | null> {
+  const pageIdentity = (value: string) => {
+    try {
+      const pageUrl = new URL(value);
+      const videoId =
+        pageUrl.searchParams.get("v") ??
+        pageUrl.pathname.match(/^\/shorts\/([^/?#]+)/)?.[1] ??
+        null;
+      return videoId ? `youtube:${videoId}` : pageUrl.href;
+    } catch {
+      return value;
+    }
+  };
+  const expectedIdentity = expectedPageUrl ? pageIdentity(expectedPageUrl) : null;
+  const isExpectedPage = () =>
+    expectedIdentity == null || pageIdentity(location.href) === expectedIdentity;
+  if (!isExpectedPage()) return null;
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 5000);
   try {
     const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) return null;
+    if (!response.ok || !isExpectedPage()) return null;
     const raw = await response.text();
-    return raw.trim() ? raw : null;
+    return isExpectedPage() && raw.trim() ? raw : null;
   } catch {
     return null;
   } finally {
@@ -183,7 +203,24 @@ export async function fetchYouTubeCaptionText(url: string): Promise<string | nul
 }
 
 // Keep this function self-contained: Chrome serializes it for MAIN-world injection.
-export async function readYouTubeTranscriptPanel(): Promise<BrowserYouTubeTranscriptPanel | null> {
+export async function readYouTubeTranscriptPanel(
+  expectedPageUrl: string | null = null,
+): Promise<BrowserYouTubeTranscriptPanel | null> {
+  const pageIdentity = (value: string) => {
+    try {
+      const pageUrl = new URL(value);
+      const videoId =
+        pageUrl.searchParams.get("v") ??
+        pageUrl.pathname.match(/^\/shorts\/([^/?#]+)/)?.[1] ??
+        null;
+      return videoId ? `youtube:${videoId}` : pageUrl.href;
+    } catch {
+      return value;
+    }
+  };
+  const expectedIdentity = expectedPageUrl ? pageIdentity(expectedPageUrl) : null;
+  const isExpectedPage = () =>
+    expectedIdentity == null || pageIdentity(location.href) === expectedIdentity;
   const normalize = (text: string) =>
     text
       .replace(/\s+/g, " ")
@@ -215,13 +252,16 @@ export async function readYouTubeTranscriptPanel(): Promise<BrowserYouTubeTransc
     Array.from(document.querySelectorAll("button, tp-yt-paper-button, ytd-button-renderer"));
   const scrollBefore = { x: globalThis.scrollX ?? 0, y: globalThis.scrollY ?? 0 };
   try {
+    if (!isExpectedPage()) return null;
     document.querySelector("ytd-watch-metadata")?.scrollIntoView({ block: "center" });
     await delay(120);
+    if (!isExpectedPage()) return null;
     const expand = buttons().find((element) =>
       /\bmore\b/i.test(normalize(element.textContent ?? "")),
     ) as HTMLElement | undefined;
     expand?.click();
     await delay(250);
+    if (!isExpectedPage()) return null;
     const transcriptButton = (document.querySelector(
       "ytd-video-description-transcript-section-renderer button",
     ) ??
@@ -232,12 +272,15 @@ export async function readYouTubeTranscriptPanel(): Promise<BrowserYouTubeTransc
     transcriptButton.click();
     for (let attempt = 0; attempt < 20; attempt += 1) {
       await delay(200);
+      if (!isExpectedPage()) return null;
       const lines = parsePanel();
       if (lines.length > 0) return { url: location.href, lines };
     }
     return null;
   } finally {
-    globalThis.scrollTo?.(scrollBefore.x, scrollBefore.y);
+    if (isExpectedPage()) {
+      globalThis.scrollTo?.(scrollBefore.x, scrollBefore.y);
+    }
   }
 }
 
@@ -322,7 +365,7 @@ export async function extractYouTubePageTranscript(
   return resolveYouTubePageTranscript({
     source,
     limit,
-    loadCaptionText: fetchYouTubeCaptionText,
-    loadPanel: allowPanelFallback ? readYouTubeTranscriptPanel : null,
+    loadCaptionText: (url) => fetchYouTubeCaptionText(url, source.url),
+    loadPanel: allowPanelFallback ? () => readYouTubeTranscriptPanel(source.url) : null,
   });
 }

--- a/tests/chrome.youtube-transcript.test.ts
+++ b/tests/chrome.youtube-transcript.test.ts
@@ -247,6 +247,99 @@ describe("chrome youtube transcript extraction", () => {
     expect(scrollTo).toHaveBeenCalledWith(5, 8);
   });
 
+  it("rejects caption and panel work after the tab navigates to another video", async () => {
+    (globalThis as { ytInitialPlayerResponse?: unknown }).ytInitialPlayerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            {
+              baseUrl: "https://example.com/caption?lang=en",
+              languageCode: "en",
+              name: { simpleText: "English" },
+            },
+          ],
+        },
+      },
+      videoDetails: { lengthSeconds: "42", videoId: "test" },
+    };
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          events: [{ tStartMs: 1000, segs: [{ utf8: "Stale caption" }] }],
+        }),
+    }));
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchImpl,
+    });
+    const button = { click: vi.fn(), textContent: "Show transcript" };
+    installDocumentStub({
+      querySelector: vi.fn((selector: string) =>
+        selector.includes("transcript-section") ? button : null,
+      ) as unknown as Document["querySelector"],
+      querySelectorAll: vi.fn(() => [button]) as unknown as Document["querySelectorAll"],
+    });
+    let injectionCount = 0;
+    Object.defineProperty(globalThis, "chrome", {
+      configurable: true,
+      value: {
+        scripting: {
+          executeScript: vi.fn(async (options: ExecuteScriptOptions) => {
+            injectionCount += 1;
+            if (injectionCount === 2) {
+              (globalThis.location as { href: string }).href =
+                "https://www.youtube.com/watch?v=next";
+            }
+            const serialized = Function(`return (${options.func.toString()})`)() as (
+              ...args: unknown[]
+            ) => unknown;
+            return [{ result: await serialized(...(options.args ?? [])) }];
+          }),
+        },
+      },
+    });
+
+    const result = await extractYouTubeTranscriptInTab(7, 10_000);
+
+    expect(result).toEqual({ ok: false, error: "No YouTube caption transcript found." });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(button.click).not.toHaveBeenCalled();
+  });
+
+  it("rejects a caption response when navigation occurs while reading its body", async () => {
+    (globalThis as { ytInitialPlayerResponse?: unknown }).ytInitialPlayerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [
+            {
+              baseUrl: "https://example.com/caption?lang=en",
+              languageCode: "en",
+              name: { simpleText: "English" },
+            },
+          ],
+        },
+      },
+      videoDetails: { videoId: "test" },
+    };
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn(async () => ({
+        ok: true,
+        text: async () => {
+          (globalThis.location as { href: string }).href = "https://www.youtube.com/watch?v=next";
+          return JSON.stringify({
+            events: [{ tStartMs: 1000, segs: [{ utf8: "Stale caption" }] }],
+          });
+        },
+      })),
+    });
+
+    const result = await extractYouTubePageTranscript(10_000, false);
+
+    expect(result).toEqual({ ok: false, error: "No YouTube caption transcript found." });
+  });
+
   it("reports wrapper failures", async () => {
     Object.defineProperty(globalThis, "chrome", {
       configurable: true,


### PR DESCRIPTION
## Summary

- pass discovered YouTube page identity into injected caption and transcript-panel work
- reject results when SPA navigation changes the active video before or during asynchronous reads
- avoid clicking or restoring scroll state on the newly navigated page

## Verification

- `pnpm -s vitest run tests/chrome.youtube-transcript.test.ts`
- `pnpm -C apps/chrome-extension build`
- `pnpm -C apps/chrome-extension test:chrome` (69 passed, 4 skipped)
- `pnpm -s check`
- autoreview: clean, no accepted/actionable findings