### PR TITLE
fix(core): ignore WebVTT metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Network safety: block private IPv4 targets embedded in the IPv4-translatable IPv6 prefix.
 - Slides: ignore invalid zero-index slide markers without hanging while extracting slide references.
 - Summary length: use `long` as the built-in default across the CLI, daemon, and Chrome extension; explicit and configured lengths remain unchanged.
+- YouTube captions: ignore WebVTT header metadata, cue identifiers, comments, styles, and regions when building transcripts.
 
 ## 0.18.0 - 2026-06-12
 

--- a/packages/core/src/content/youtube-captions.ts
+++ b/packages/core/src/content/youtube-captions.ts
@@ -236,34 +236,36 @@ function parseXml(raw: string): YoutubeCaptionTranscript | null {
 function parseVtt(raw: string): YoutubeCaptionTranscript | null {
   const lines: YoutubeCaptionLine[] = [];
   let hasTiming = false;
-  let startMs: number | null = null;
-  let endMs: number | null = null;
-  let textLines: string[] = [];
-  const flush = () => {
-    const text = normalizeYoutubeCaptionText(textLines.join(" "));
-    if (text) lines.push({ startMs, endMs, text });
-    startMs = null;
-    endMs = null;
-    textLines = [];
-  };
-  for (const line of raw.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed) {
-      flush();
+  const blocks = raw.replace(/\r\n?/g, "\n").split(/\n[ \t]*\n/);
+  for (const block of blocks) {
+    const blockLines = block
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const firstLine = blockLines[0] ?? "";
+    if (
+      !firstLine ||
+      /^WEBVTT(?:[ \t].*)?$/i.test(firstLine) ||
+      /^(NOTE|STYLE|REGION)(?:[ \t]|$)/i.test(firstLine)
+    ) {
       continue;
     }
-    const timing = /^(\S+)\s+-->\s+(\S+)/.exec(trimmed);
-    if (timing) {
-      hasTiming = true;
-      flush();
-      startMs = timing[1] ? parseTimestampStringToMs(timing[1]) : null;
-      endMs = timing[2] ? parseTimestampStringToMs(timing[2]) : null;
-      continue;
-    }
-    if (trimmed === "WEBVTT" || /^\d+$/.test(trimmed)) continue;
-    textLines.push(trimmed);
+
+    const timingIndex = blockLines
+      .slice(0, 2)
+      .findIndex((line) => /^(\S+)\s+-->\s+(\S+)/.test(line));
+    if (timingIndex < 0) continue;
+    const timing = /^(\S+)\s+-->\s+(\S+)/.exec(blockLines[timingIndex] ?? "");
+    if (!timing) continue;
+    hasTiming = true;
+    const text = normalizeYoutubeCaptionText(blockLines.slice(timingIndex + 1).join(" "));
+    if (!text) continue;
+    lines.push({
+      startMs: timing[1] ? parseTimestampStringToMs(timing[1]) : null,
+      endMs: timing[2] ? parseTimestampStringToMs(timing[2]) : null,
+      text,
+    });
   }
-  flush();
   return hasTiming ? transcriptFromLines(lines) : null;
 }
 

--- a/tests/core.youtube-captions.test.ts
+++ b/tests/core.youtube-captions.test.ts
@@ -82,6 +82,43 @@ describe("YouTube caption codec", () => {
     });
   });
 
+  it("ignores WebVTT header metadata, cue identifiers, and metadata blocks", () => {
+    const transcript = parseYoutubeCaptionPayload(
+      [
+        "WEBVTT - YouTube captions",
+        "Kind: captions",
+        "Language: en",
+        "",
+        "NOTE generated metadata",
+        "00:00:00.000 --> 00:00:01.000",
+        "This comment is not a cue.",
+        "",
+        "STYLE",
+        "::cue { color: lime; }",
+        "",
+        "REGION",
+        "id:sidebar",
+        "width:40%",
+        "",
+        "cue-17",
+        "00:00:02.000 --> 00:00:04.000 align:start position:0%",
+        "Actual caption",
+        "second line",
+      ].join("\n"),
+    );
+
+    expect(transcript).toMatchObject({
+      text: "Actual caption second line",
+      segments: [
+        {
+          startMs: 2_000,
+          endMs: 4_000,
+          text: "Actual caption second line",
+        },
+      ],
+    });
+  });
+
   it("tries canonical JSON3, base, and VTT variants until one parses", async () => {
     const loadText = vi.fn(async (url: string) =>
       url.includes("fmt=vtt")


### PR DESCRIPTION
## Summary

- parse WebVTT as blocks instead of accepting arbitrary non-timing lines
- ignore header metadata plus NOTE, STYLE, and REGION blocks
- support cue identifiers and timing settings without leaking them into transcript text

## Verification

- `pnpm -s build && pnpm -s vitest run tests/core.youtube-captions.test.ts tests/chrome.youtube-transcript.test.ts`
- `pnpm -s check`
- autoreview: clean, no accepted/actionable findings