### PR TITLE
fix: sync and package fish completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Shell completions: sync and package Fish completions for both CLI aliases and subcommands, with candidate values matched to accepted CLI choices (#277, thanks @vincent-peng).
 - CLI video summaries: restore terminal and JSON output when direct video understanding delegates URL handling to the asset summarizer.
 - Chrome extension: reject YouTube caption and transcript-panel results when the tab navigates to another video during extraction.
 - Development CLI: build the core workspace before `pnpm summarize` and `pnpm s` so newly added core exports never depend on stale generated files.

--- a/completions/summarize.fish
+++ b/completions/summarize.fish
@@ -3,6 +3,11 @@
 set -g __summarize_commands help slides status refresh-free daemon transcriber
 set -g __summarize_themes aurora ember moss mono
 
+function __summarize_needs_subcommand
+    set -l tokens (commandline -opc)
+    test (count $tokens) -lt 2
+end
+
 function __summarize_no_subcommand
     set -l tokens (commandline -opc)
     if test (count $tokens) -lt 2
@@ -18,21 +23,30 @@ function __summarize_command_is
     test "$tokens[2]" = "$argv[1]"
 end
 
-function __summarize_needs_daemon_command
-    set -l daemon_commands install restart status uninstall run
+function __summarize_needs_child_command
+    set -l parent "$argv[1]"
+    set -e argv[1]
     set -l tokens (commandline -opc)
     test (count $tokens) -ge 2
-    and test "$tokens[2]" = daemon
+    and test "$tokens[2]" = "$parent"
     or return 1
     if test (count $tokens) -eq 2
         return 0
     end
     test (count $tokens) -eq 3
-    and not contains -- $tokens[3] $daemon_commands
+    and not contains -- $tokens[3] $argv
+end
+
+function __summarize_nested_command_is
+    set -l tokens (commandline -opc)
+    test (count $tokens) -ge 3
+    or return 1
+    test "$tokens[2]" = "$argv[1]"
+    and test "$tokens[3]" = "$argv[2]"
 end
 
 for cmd in summarize summarizer
-    complete -c $cmd -n '__summarize_no_subcommand' -xa "$__summarize_commands" -d 'Subcommand'
+    complete -c $cmd -n '__summarize_needs_subcommand' -xa "$__summarize_commands" -d 'Subcommand'
 
     # YouTube and media options
     complete -c $cmd -n '__summarize_no_subcommand' -l youtube -d 'YouTube transcript source' -xa 'auto web no-auto yt-dlp apify'
@@ -59,7 +73,7 @@ for cmd in summarize summarizer
     # Content options
     complete -c $cmd -n '__summarize_no_subcommand' -l firecrawl -d 'Firecrawl usage' -xa 'off auto always'
     complete -c $cmd -n '__summarize_no_subcommand' -l format -d 'Content format' -xa 'md markdown text plain'
-    complete -c $cmd -n '__summarize_no_subcommand' -l preprocess -d 'Preprocess inputs' -xa 'off auto always on'
+    complete -c $cmd -n '__summarize_no_subcommand' -l preprocess -d 'Preprocess inputs' -xa 'off auto always'
     complete -c $cmd -n '__summarize_no_subcommand' -l markdown-mode -d 'Markdown conversion mode' -xa 'off auto llm readability'
 
     # Summary options
@@ -103,7 +117,7 @@ for cmd in summarize summarizer
     complete -c $cmd -s h -l help -d 'Display help'
 
     # help topics
-    complete -c $cmd -n '__summarize_command_is help' -xa "$__summarize_commands" -d 'Help topic'
+    complete -c $cmd -n '__summarize_needs_child_command help help slides status refresh-free daemon transcriber' -xa "$__summarize_commands" -d 'Help topic'
 
     # slides subcommand
     complete -c $cmd -n '__summarize_command_is slides' -l slides-ocr -d 'Run OCR on extracted slides'
@@ -136,13 +150,13 @@ for cmd in summarize summarizer
     complete -c $cmd -n '__summarize_command_is refresh-free' -l verbose -d 'Print detailed progress'
 
     # daemon subcommand
-    complete -c $cmd -n '__summarize_needs_daemon_command' -xa 'install restart status uninstall run' -d 'Daemon command'
-    complete -c $cmd -n '__summarize_command_is daemon' -l dev -d 'Install dev-mode daemon'
-    complete -c $cmd -n '__summarize_command_is daemon' -l port -d 'Daemon port' -x
-    complete -c $cmd -n '__summarize_command_is daemon' -l token -d 'Daemon auth token' -x
+    complete -c $cmd -n '__summarize_needs_child_command daemon install restart status uninstall run' -xa 'install restart status uninstall run' -d 'Daemon command'
+    complete -c $cmd -n '__summarize_nested_command_is daemon install' -l dev -d 'Install dev-mode daemon'
+    complete -c $cmd -n '__summarize_nested_command_is daemon install; or __summarize_nested_command_is daemon run' -l port -d 'Daemon port' -x
+    complete -c $cmd -n '__summarize_nested_command_is daemon install; or __summarize_nested_command_is daemon run' -l token -d 'Daemon auth token' -x
 
     # transcriber subcommand
-    complete -c $cmd -n '__summarize_command_is transcriber' -xa 'setup' -d 'Transcriber command'
-    complete -c $cmd -n '__summarize_command_is transcriber' -l model -d 'ONNX transcription model' -xa 'parakeet canary'
-    complete -c $cmd -n '__summarize_command_is transcriber' -l theme -d 'CLI theme' -xa "$__summarize_themes"
+    complete -c $cmd -n '__summarize_needs_child_command transcriber setup' -xa 'setup' -d 'Transcriber command'
+    complete -c $cmd -n '__summarize_nested_command_is transcriber setup' -l model -d 'ONNX transcription model' -xa 'parakeet canary'
+    complete -c $cmd -n '__summarize_nested_command_is transcriber setup' -l theme -d 'CLI theme' -xa "$__summarize_themes"
 end

--- a/completions/summarize.fish
+++ b/completions/summarize.fish
@@ -5,27 +5,30 @@ set -g __summarize_themes aurora ember moss mono
 
 function __summarize_no_subcommand
     set -l tokens (commandline -opc)
-    for token in $tokens[2..-1]
-        contains -- $token $__summarize_commands
-        and return 1
+    if test (count $tokens) -lt 2
+        return 0
     end
-    return 0
+    not contains -- $tokens[2] $__summarize_commands
 end
 
-function __summarize_seen_command
-    set -l wanted $argv[1]
+function __summarize_command_is
     set -l tokens (commandline -opc)
-    contains -- $wanted $tokens[2..-1]
+    test (count $tokens) -ge 2
+    or return 1
+    test "$tokens[2]" = "$argv[1]"
 end
 
-function __summarize_no_daemon_subcommand
+function __summarize_needs_daemon_command
     set -l daemon_commands install restart status uninstall run
     set -l tokens (commandline -opc)
-    for token in $tokens[2..-1]
-        contains -- $token $daemon_commands
-        and return 1
+    test (count $tokens) -ge 2
+    and test "$tokens[2]" = daemon
+    or return 1
+    if test (count $tokens) -eq 2
+        return 0
     end
-    return 0
+    test (count $tokens) -eq 3
+    and not contains -- $tokens[3] $daemon_commands
 end
 
 for cmd in summarize summarizer
@@ -100,46 +103,46 @@ for cmd in summarize summarizer
     complete -c $cmd -s h -l help -d 'Display help'
 
     # help topics
-    complete -c $cmd -n '__summarize_seen_command help' -xa "$__summarize_commands" -d 'Help topic'
+    complete -c $cmd -n '__summarize_command_is help' -xa "$__summarize_commands" -d 'Help topic'
 
     # slides subcommand
-    complete -c $cmd -n '__summarize_seen_command slides' -l slides-ocr -d 'Run OCR on extracted slides'
-    complete -c $cmd -n '__summarize_seen_command slides' -l slides-dir -d 'Base output dir for slides' -rF
-    complete -c $cmd -n '__summarize_seen_command slides' -s o -l output -d 'Alias for --slides-dir' -rF
-    complete -c $cmd -n '__summarize_seen_command slides' -l slides-scene-threshold -d 'Scene detection threshold (0.1-1.0)' -x
-    complete -c $cmd -n '__summarize_seen_command slides' -l slides-max -d 'Maximum slides to extract' -x
-    complete -c $cmd -n '__summarize_seen_command slides' -l slides-min-duration -d 'Minimum seconds between slides' -x
-    complete -c $cmd -n '__summarize_seen_command slides' -l render -d 'Inline render mode' -xa 'auto kitty iterm none'
-    complete -c $cmd -n '__summarize_seen_command slides' -l theme -d 'CLI theme' -xa "$__summarize_themes"
-    complete -c $cmd -n '__summarize_seen_command slides' -l timeout -d 'Timeout for video extraction' -x
-    complete -c $cmd -n '__summarize_seen_command slides' -l no-cache -d 'Bypass slide cache'
-    complete -c $cmd -n '__summarize_seen_command slides' -l json -d 'Output JSON payload'
-    complete -c $cmd -n '__summarize_seen_command slides' -l verbose -d 'Print detailed progress to stderr'
-    complete -c $cmd -n '__summarize_seen_command slides' -l debug -d 'Alias for --verbose'
-    complete -c $cmd -n '__summarize_seen_command slides' -s V -l version -d 'Print version and exit'
+    complete -c $cmd -n '__summarize_command_is slides' -l slides-ocr -d 'Run OCR on extracted slides'
+    complete -c $cmd -n '__summarize_command_is slides' -l slides-dir -d 'Base output dir for slides' -rF
+    complete -c $cmd -n '__summarize_command_is slides' -s o -l output -d 'Alias for --slides-dir' -rF
+    complete -c $cmd -n '__summarize_command_is slides' -l slides-scene-threshold -d 'Scene detection threshold (0.1-1.0)' -x
+    complete -c $cmd -n '__summarize_command_is slides' -l slides-max -d 'Maximum slides to extract' -x
+    complete -c $cmd -n '__summarize_command_is slides' -l slides-min-duration -d 'Minimum seconds between slides' -x
+    complete -c $cmd -n '__summarize_command_is slides' -l render -d 'Inline render mode' -xa 'auto kitty iterm none'
+    complete -c $cmd -n '__summarize_command_is slides' -l theme -d 'CLI theme' -xa "$__summarize_themes"
+    complete -c $cmd -n '__summarize_command_is slides' -l timeout -d 'Timeout for video extraction' -x
+    complete -c $cmd -n '__summarize_command_is slides' -l no-cache -d 'Bypass slide cache'
+    complete -c $cmd -n '__summarize_command_is slides' -l json -d 'Output JSON payload'
+    complete -c $cmd -n '__summarize_command_is slides' -l verbose -d 'Print detailed progress to stderr'
+    complete -c $cmd -n '__summarize_command_is slides' -l debug -d 'Alias for --verbose'
+    complete -c $cmd -n '__summarize_command_is slides' -s V -l version -d 'Print version and exit'
 
     # status subcommand
-    complete -c $cmd -n '__summarize_seen_command status' -l json -d 'Output structured JSON'
-    complete -c $cmd -n '__summarize_seen_command status' -l probe -d 'Probe model-list endpoints'
-    complete -c $cmd -n '__summarize_seen_command status' -l verbose -d 'Include detailed status'
-    complete -c $cmd -n '__summarize_seen_command status' -l no-color -d 'Disable ANSI colors'
+    complete -c $cmd -n '__summarize_command_is status' -l json -d 'Output structured JSON'
+    complete -c $cmd -n '__summarize_command_is status' -l probe -d 'Probe model-list endpoints'
+    complete -c $cmd -n '__summarize_command_is status' -l verbose -d 'Include detailed status'
+    complete -c $cmd -n '__summarize_command_is status' -l no-color -d 'Disable ANSI colors'
 
     # refresh-free subcommand
-    complete -c $cmd -n '__summarize_seen_command refresh-free' -l runs -d 'Smoke-test runs per model' -x
-    complete -c $cmd -n '__summarize_seen_command refresh-free' -l smart -d 'Smart benchmark runs' -x
-    complete -c $cmd -n '__summarize_seen_command refresh-free' -l min-params -d 'Minimum parameter size' -x
-    complete -c $cmd -n '__summarize_seen_command refresh-free' -l max-age-days -d 'Maximum model age in days' -x
-    complete -c $cmd -n '__summarize_seen_command refresh-free' -l set-default -d 'Set free preset as default'
-    complete -c $cmd -n '__summarize_seen_command refresh-free' -l verbose -d 'Print detailed progress'
+    complete -c $cmd -n '__summarize_command_is refresh-free' -l runs -d 'Smoke-test runs per model' -x
+    complete -c $cmd -n '__summarize_command_is refresh-free' -l smart -d 'Smart benchmark runs' -x
+    complete -c $cmd -n '__summarize_command_is refresh-free' -l min-params -d 'Minimum parameter size' -x
+    complete -c $cmd -n '__summarize_command_is refresh-free' -l max-age-days -d 'Maximum model age in days' -x
+    complete -c $cmd -n '__summarize_command_is refresh-free' -l set-default -d 'Set free preset as default'
+    complete -c $cmd -n '__summarize_command_is refresh-free' -l verbose -d 'Print detailed progress'
 
     # daemon subcommand
-    complete -c $cmd -n '__summarize_seen_command daemon; and __summarize_no_daemon_subcommand' -xa 'install restart status uninstall run' -d 'Daemon command'
-    complete -c $cmd -n '__summarize_seen_command daemon' -l dev -d 'Install dev-mode daemon'
-    complete -c $cmd -n '__summarize_seen_command daemon' -l port -d 'Daemon port' -x
-    complete -c $cmd -n '__summarize_seen_command daemon' -l token -d 'Daemon auth token' -x
+    complete -c $cmd -n '__summarize_needs_daemon_command' -xa 'install restart status uninstall run' -d 'Daemon command'
+    complete -c $cmd -n '__summarize_command_is daemon' -l dev -d 'Install dev-mode daemon'
+    complete -c $cmd -n '__summarize_command_is daemon' -l port -d 'Daemon port' -x
+    complete -c $cmd -n '__summarize_command_is daemon' -l token -d 'Daemon auth token' -x
 
     # transcriber subcommand
-    complete -c $cmd -n '__summarize_seen_command transcriber' -xa 'setup' -d 'Transcriber command'
-    complete -c $cmd -n '__summarize_seen_command transcriber' -l model -d 'ONNX transcription model' -xa 'parakeet canary'
-    complete -c $cmd -n '__summarize_seen_command transcriber' -l theme -d 'CLI theme' -xa "$__summarize_themes"
+    complete -c $cmd -n '__summarize_command_is transcriber' -xa 'setup' -d 'Transcriber command'
+    complete -c $cmd -n '__summarize_command_is transcriber' -l model -d 'ONNX transcription model' -xa 'parakeet canary'
+    complete -c $cmd -n '__summarize_command_is transcriber' -l theme -d 'CLI theme' -xa "$__summarize_themes"
 end

--- a/completions/summarize.fish
+++ b/completions/summarize.fish
@@ -1,58 +1,145 @@
-# Completions for summarize (steipete/summarize)
+# Fish completions for summarize (steipete/summarize)
 
-# YouTube options
-complete -c summarize -l youtube -d 'YouTube transcript source' -xa 'auto web no-auto yt-dlp apify'
-complete -c summarize -l transcriber -d 'Audio transcription backend' -xa 'auto whisper parakeet canary'
-complete -c summarize -l video-mode -d 'Video handling mode' -xa 'auto transcript understand'
+set -g __summarize_commands help slides status refresh-free daemon transcriber
+set -g __summarize_themes aurora ember moss mono
 
-# Slides options
-complete -c summarize -l slides -d 'Extract slides for video URLs'
-complete -c summarize -l slides-debug -d 'Show slide image paths'
-complete -c summarize -l slides-ocr -d 'Run OCR on extracted slides'
-complete -c summarize -l slides-dir -d 'Base output dir for slides' -rF
-complete -c summarize -l slides-scene-threshold -d 'Scene detection threshold (0.1-1.0)' -x
-complete -c summarize -l slides-max -d 'Maximum slides to extract' -x
-complete -c summarize -l slides-min-duration -d 'Minimum seconds between slides' -x
-complete -c summarize -l timestamps -d 'Include timestamps in transcripts'
+function __summarize_no_subcommand
+    set -l tokens (commandline -opc)
+    for token in $tokens[2..-1]
+        contains -- $token $__summarize_commands
+        and return 1
+    end
+    return 0
+end
 
-# Content options
-complete -c summarize -l firecrawl -d 'Firecrawl usage' -xa 'off auto always'
-complete -c summarize -l format -d 'Content format' -xa 'md text'
-complete -c summarize -l preprocess -d 'Preprocess inputs' -xa 'off auto always'
-complete -c summarize -l markdown-mode -d 'Markdown conversion mode' -xa 'off auto llm readability'
+function __summarize_seen_command
+    set -l wanted $argv[1]
+    set -l tokens (commandline -opc)
+    contains -- $wanted $tokens[2..-1]
+end
 
-# Summary options
-complete -c summarize -l length -d 'Summary length' -xa 'short s medium m long l xl xxl'
-complete -c summarize -l max-extract-characters -d 'Max characters in --extract' -x
-complete -c summarize -l language -l lang -d 'Output language' -xa 'auto en de english german'
-complete -c summarize -l max-output-tokens -d 'Hard cap for LLM output tokens' -x
-complete -c summarize -l force-summary -d 'Force LLM summary even for short content'
-complete -c summarize -l timeout -d 'Timeout for fetching/LLM (e.g. 30s, 2m)' -x
-complete -c summarize -l retries -d 'LLM retry attempts on timeout' -x
+function __summarize_no_daemon_subcommand
+    set -l daemon_commands install restart status uninstall run
+    set -l tokens (commandline -opc)
+    for token in $tokens[2..-1]
+        contains -- $token $daemon_commands
+        and return 1
+    end
+    return 0
+end
 
-# Model options
-complete -c summarize -l model -d 'LLM model id' -x
-complete -c summarize -l cli -d 'Use CLI provider' -xa 'claude gemini codex agent'
-complete -c summarize -l prompt -d 'Override summary prompt' -x
-complete -c summarize -l prompt-file -d 'Read prompt from file' -rF
+for cmd in summarize summarizer
+    complete -c $cmd -n '__summarize_no_subcommand' -xa "$__summarize_commands" -d 'Subcommand'
 
-# Cache options
-complete -c summarize -l no-cache -d 'Bypass summary cache'
-complete -c summarize -l no-media-cache -d 'Disable media download cache'
-complete -c summarize -l cache-stats -d 'Print cache stats and exit'
-complete -c summarize -l clear-cache -d 'Delete cache database and exit'
+    # YouTube and media options
+    complete -c $cmd -n '__summarize_no_subcommand' -l youtube -d 'YouTube transcript source' -xa 'auto web no-auto yt-dlp apify'
+    complete -c $cmd -n '__summarize_no_subcommand' -l transcriber -d 'Audio transcription backend' -xa 'auto whisper parakeet canary'
+    complete -c $cmd -n '__summarize_no_subcommand' -l diarize -d 'Add speaker labels' -xa 'auto elevenlabs openai'
+    complete -c $cmd -n '__summarize_no_subcommand' -l identify-speakers -d 'Resolve diarization labels to real names'
+    complete -c $cmd -n '__summarize_no_subcommand' -l no-identify-speakers -d 'Keep generic diarization labels'
+    complete -c $cmd -n '__summarize_no_subcommand' -l speaker-profile -d 'Speaker profile name' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l speaker-at -d 'Timestamp speaker anchor' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l remember-speakers -d 'Persist resolved speaker mappings'
+    complete -c $cmd -n '__summarize_no_subcommand' -l video-mode -d 'Video handling mode' -xa 'auto transcript understand'
+    complete -c $cmd -n '__summarize_no_subcommand' -l embedded-video -d 'Embedded YouTube handling' -xa 'auto off prefer both'
 
-# Output options
-complete -c summarize -l extract -d 'Print extracted content (no LLM)'
-complete -c summarize -l json -d 'Output structured JSON'
-complete -c summarize -l stream -d 'Stream LLM output' -xa 'auto on off'
-complete -c summarize -l plain -d 'Keep raw text/markdown (no ANSI)'
-complete -c summarize -l no-color -d 'Disable ANSI colors'
-complete -c summarize -l theme -d 'CLI theme' -xa 'aurora ember moss mono'
+    # Slides options
+    complete -c $cmd -n '__summarize_no_subcommand' -l slides -d 'Extract slides for video URLs' -xa 'true false yes no on off 1 0'
+    complete -c $cmd -n '__summarize_no_subcommand' -l slides-debug -d 'Show slide image paths'
+    complete -c $cmd -n '__summarize_no_subcommand' -l slides-ocr -d 'Run OCR on extracted slides'
+    complete -c $cmd -n '__summarize_no_subcommand' -l slides-dir -d 'Base output dir for slides' -rF
+    complete -c $cmd -n '__summarize_no_subcommand' -l slides-scene-threshold -d 'Scene detection threshold (0.1-1.0)' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l slides-max -d 'Maximum slides to extract' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l slides-min-duration -d 'Minimum seconds between slides' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l timestamps -d 'Include timestamps in transcripts'
 
-# Debug/info
-complete -c summarize -l verbose -d 'Print detailed progress to stderr'
-complete -c summarize -l debug -d 'Alias for --verbose'
-complete -c summarize -l metrics -d 'Metrics output' -xa 'off on detailed'
-complete -c summarize -s V -l version -d 'Print version and exit'
-complete -c summarize -s h -l help -d 'Display help'
+    # Content options
+    complete -c $cmd -n '__summarize_no_subcommand' -l firecrawl -d 'Firecrawl usage' -xa 'off auto always'
+    complete -c $cmd -n '__summarize_no_subcommand' -l format -d 'Content format' -xa 'md markdown text plain'
+    complete -c $cmd -n '__summarize_no_subcommand' -l preprocess -d 'Preprocess inputs' -xa 'off auto always on'
+    complete -c $cmd -n '__summarize_no_subcommand' -l markdown-mode -d 'Markdown conversion mode' -xa 'off auto llm readability'
+
+    # Summary options
+    complete -c $cmd -n '__summarize_no_subcommand' -l length -d 'Summary length' -xa 'short s medium m long l xl xxl'
+    complete -c $cmd -n '__summarize_no_subcommand' -l max-extract-characters -d 'Max characters in --extract' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l language -l lang -d 'Output language' -xa 'auto en de english german'
+    complete -c $cmd -n '__summarize_no_subcommand' -l max-output-tokens -d 'Hard cap for LLM output tokens' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l force-summary -d 'Force LLM summary even for short content'
+    complete -c $cmd -n '__summarize_no_subcommand' -l timeout -d 'Timeout for fetching/LLM' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l retries -d 'LLM retry attempts on timeout' -x
+
+    # Model options
+    complete -c $cmd -n '__summarize_no_subcommand' -l model -d 'LLM model id' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l cli -d 'Use CLI provider' -xa 'claude gemini codex agent openclaw opencode copilot agy pi'
+    complete -c $cmd -n '__summarize_no_subcommand' -l fast -d 'Use OpenAI fast service tier'
+    complete -c $cmd -n '__summarize_no_subcommand' -l service-tier -d 'OpenAI service tier' -xa 'default fast priority flex'
+    complete -c $cmd -n '__summarize_no_subcommand' -l thinking -d 'OpenAI reasoning effort' -xa 'none low medium high xhigh off min mid'
+    complete -c $cmd -n '__summarize_no_subcommand' -l prompt -d 'Override summary prompt' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l prompt-file -d 'Read prompt from file' -rF
+
+    # Cache options
+    complete -c $cmd -n '__summarize_no_subcommand' -l no-cache -d 'Bypass summary cache'
+    complete -c $cmd -n '__summarize_no_subcommand' -l no-media-cache -d 'Disable media download cache'
+    complete -c $cmd -n '__summarize_no_subcommand' -l cache-stats -d 'Print cache stats and exit'
+    complete -c $cmd -n '__summarize_no_subcommand' -l clear-cache -d 'Delete cache database and exit'
+
+    # Output options
+    complete -c $cmd -n '__summarize_no_subcommand' -l extract -d 'Print extracted content'
+    complete -c $cmd -n '__summarize_no_subcommand' -l json -d 'Output structured JSON'
+    complete -c $cmd -n '__summarize_no_subcommand' -l stream -d 'Stream LLM output' -xa 'auto on off'
+    complete -c $cmd -n '__summarize_no_subcommand' -l width -d 'Override terminal width' -x
+    complete -c $cmd -n '__summarize_no_subcommand' -l plain -d 'Keep raw text/markdown'
+    complete -c $cmd -n '__summarize_no_subcommand' -l no-color -d 'Disable ANSI colors'
+    complete -c $cmd -n '__summarize_no_subcommand' -l theme -d 'CLI theme' -xa "$__summarize_themes"
+
+    # Debug/info
+    complete -c $cmd -n '__summarize_no_subcommand' -l verbose -d 'Print detailed progress to stderr'
+    complete -c $cmd -n '__summarize_no_subcommand' -l debug -d 'Alias for --verbose'
+    complete -c $cmd -n '__summarize_no_subcommand' -l metrics -d 'Metrics output' -xa 'off on detailed'
+    complete -c $cmd -n '__summarize_no_subcommand' -s V -l version -d 'Print version and exit'
+    complete -c $cmd -s h -l help -d 'Display help'
+
+    # help topics
+    complete -c $cmd -n '__summarize_seen_command help' -xa "$__summarize_commands" -d 'Help topic'
+
+    # slides subcommand
+    complete -c $cmd -n '__summarize_seen_command slides' -l slides-ocr -d 'Run OCR on extracted slides'
+    complete -c $cmd -n '__summarize_seen_command slides' -l slides-dir -d 'Base output dir for slides' -rF
+    complete -c $cmd -n '__summarize_seen_command slides' -s o -l output -d 'Alias for --slides-dir' -rF
+    complete -c $cmd -n '__summarize_seen_command slides' -l slides-scene-threshold -d 'Scene detection threshold (0.1-1.0)' -x
+    complete -c $cmd -n '__summarize_seen_command slides' -l slides-max -d 'Maximum slides to extract' -x
+    complete -c $cmd -n '__summarize_seen_command slides' -l slides-min-duration -d 'Minimum seconds between slides' -x
+    complete -c $cmd -n '__summarize_seen_command slides' -l render -d 'Inline render mode' -xa 'auto kitty iterm none'
+    complete -c $cmd -n '__summarize_seen_command slides' -l theme -d 'CLI theme' -xa "$__summarize_themes"
+    complete -c $cmd -n '__summarize_seen_command slides' -l timeout -d 'Timeout for video extraction' -x
+    complete -c $cmd -n '__summarize_seen_command slides' -l no-cache -d 'Bypass slide cache'
+    complete -c $cmd -n '__summarize_seen_command slides' -l json -d 'Output JSON payload'
+    complete -c $cmd -n '__summarize_seen_command slides' -l verbose -d 'Print detailed progress to stderr'
+    complete -c $cmd -n '__summarize_seen_command slides' -l debug -d 'Alias for --verbose'
+    complete -c $cmd -n '__summarize_seen_command slides' -s V -l version -d 'Print version and exit'
+
+    # status subcommand
+    complete -c $cmd -n '__summarize_seen_command status' -l json -d 'Output structured JSON'
+    complete -c $cmd -n '__summarize_seen_command status' -l probe -d 'Probe model-list endpoints'
+    complete -c $cmd -n '__summarize_seen_command status' -l verbose -d 'Include detailed status'
+    complete -c $cmd -n '__summarize_seen_command status' -l no-color -d 'Disable ANSI colors'
+
+    # refresh-free subcommand
+    complete -c $cmd -n '__summarize_seen_command refresh-free' -l runs -d 'Smoke-test runs per model' -x
+    complete -c $cmd -n '__summarize_seen_command refresh-free' -l smart -d 'Smart benchmark runs' -x
+    complete -c $cmd -n '__summarize_seen_command refresh-free' -l min-params -d 'Minimum parameter size' -x
+    complete -c $cmd -n '__summarize_seen_command refresh-free' -l max-age-days -d 'Maximum model age in days' -x
+    complete -c $cmd -n '__summarize_seen_command refresh-free' -l set-default -d 'Set free preset as default'
+    complete -c $cmd -n '__summarize_seen_command refresh-free' -l verbose -d 'Print detailed progress'
+
+    # daemon subcommand
+    complete -c $cmd -n '__summarize_seen_command daemon; and __summarize_no_daemon_subcommand' -xa 'install restart status uninstall run' -d 'Daemon command'
+    complete -c $cmd -n '__summarize_seen_command daemon' -l dev -d 'Install dev-mode daemon'
+    complete -c $cmd -n '__summarize_seen_command daemon' -l port -d 'Daemon port' -x
+    complete -c $cmd -n '__summarize_seen_command daemon' -l token -d 'Daemon auth token' -x
+
+    # transcriber subcommand
+    complete -c $cmd -n '__summarize_seen_command transcriber' -xa 'setup' -d 'Transcriber command'
+    complete -c $cmd -n '__summarize_seen_command transcriber' -l model -d 'ONNX transcription model' -xa 'parakeet canary'
+    complete -c $cmd -n '__summarize_seen_command transcriber' -l theme -d 'CLI theme' -xa "$__summarize_themes"
+end

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "summarizer": "./dist/cli.js"
   },
   "files": [
+    "completions",
     "dist",
     "docs",
     "CHANGELOG.md",

--- a/tests/package-bin.test.ts
+++ b/tests/package-bin.test.ts
@@ -5,7 +5,34 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
 import { describe, expect, it } from "vitest";
+import {
+  parseExtractFormat,
+  parseFirecrawlMode,
+  parseMarkdownMode,
+  parseStreamMode,
+  parseYoutubeMode,
+} from "../src/flags.js";
 import { buildProgram, buildSlidesProgram } from "../src/run/help.js";
+
+const completedChoiceValues = (fish: string, condition: string, longOption: string): string[] => {
+  const line = fish
+    .split("\n")
+    .find(
+      (candidate) =>
+        candidate.includes(`-n '${condition}'`) &&
+        new RegExp(`(?:^|\\s)-l\\s+${longOption}(?:\\s|$)`).test(candidate),
+    );
+  expect(line, `missing Fish completion for --${longOption}`).toBeDefined();
+
+  const literal = line?.match(/(?:^|\s)-xa\s+'([^']*)'/)?.[1];
+  if (literal) return literal.trim().split(/\s+/);
+
+  const variable = line?.match(/(?:^|\s)-xa\s+"\$([a-z0-9_]+)"/i)?.[1];
+  expect(variable, `missing Fish candidates for --${longOption}`).toBeDefined();
+  const declaration = fish.match(new RegExp(`^set\\s+-g\\s+${variable}\\s+(.+)$`, "m"))?.[1];
+  expect(declaration, `missing Fish candidate variable ${variable}`).toBeDefined();
+  return declaration?.trim().split(/\s+/) ?? [];
+};
 
 describe("package bin wrappers", () => {
   it("writes an executable dist wrapper that runs the ESM CLI entrypoint", async () => {
@@ -118,6 +145,30 @@ describe("package bin wrappers", () => {
     expect(completedLongOptions("__summarize_command_is slides")).toEqual(
       expect.arrayContaining(visibleLongOptions(buildSlidesProgram())),
     );
+
+    for (const [condition, program] of [
+      ["__summarize_no_subcommand", buildProgram()],
+      ["__summarize_command_is slides", buildSlidesProgram()],
+    ] as const) {
+      for (const option of program.options) {
+        if (!option.long || !option.argChoices) continue;
+        expect(completedChoiceValues(fish, condition, option.long.slice(2)).sort()).toEqual(
+          [...option.argChoices].sort(),
+        );
+      }
+    }
+
+    for (const [longOption, parse] of [
+      ["youtube", parseYoutubeMode],
+      ["firecrawl", parseFirecrawlMode],
+      ["format", parseExtractFormat],
+      ["markdown-mode", parseMarkdownMode],
+      ["stream", parseStreamMode],
+    ] as const) {
+      for (const value of completedChoiceValues(fish, "__summarize_no_subcommand", longOption)) {
+        expect(() => parse(value), `invalid Fish candidate --${longOption} ${value}`).not.toThrow();
+      }
+    }
   });
 
   it("routes fish subcommands from the first CLI argument", async () => {
@@ -125,5 +176,14 @@ describe("package bin wrappers", () => {
 
     expect(fish).toContain('test "$tokens[2]" = "$argv[1]"');
     expect(fish).not.toContain("$tokens[2..-1]");
+    expect(fish).toContain(
+      "complete -c $cmd -n '__summarize_needs_subcommand' -xa \"$__summarize_commands\"",
+    );
+    expect(fish).toContain(
+      "complete -c $cmd -n '__summarize_nested_command_is daemon install' -l dev",
+    );
+    expect(fish).toContain(
+      "complete -c $cmd -n '__summarize_nested_command_is transcriber setup' -l model",
+    );
   });
 });

--- a/tests/package-bin.test.ts
+++ b/tests/package-bin.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
 import { describe, expect, it } from "vitest";
+import { buildProgram, buildSlidesProgram } from "../src/run/help.js";
 
 describe("package bin wrappers", () => {
   it("writes an executable dist wrapper that runs the ESM CLI entrypoint", async () => {
@@ -82,5 +83,32 @@ describe("package bin wrappers", () => {
 
     expect(pkg.bin?.summarize).toBe("./dist/cli.js");
     expect(pkg.bin?.summarizer).toBe("./dist/cli.js");
+  });
+
+  it("ships fish completions in the npm package", async () => {
+    const pkg = JSON.parse(await readFile("package.json", "utf8")) as {
+      files?: string[];
+    };
+
+    expect(pkg.files).toContain("completions");
+  });
+
+  it("keeps fish completions aligned with visible CLI options", async () => {
+    const fish = await readFile("completions/summarize.fish", "utf8");
+    const completedLongOptions = Array.from(
+      new Set(Array.from(fish.matchAll(/(?:^|\s)-l\s+([a-z0-9-]+)/g)).map((match) => match[1])),
+    );
+    const visibleLongOptions = (program: ReturnType<typeof buildProgram>) =>
+      program.options
+        .filter((option) => !option.hidden)
+        .flatMap((option) => option.flags.match(/--[a-z0-9-]+/g) ?? [])
+        .map((flag) => flag.slice(2));
+
+    expect(completedLongOptions).toEqual(
+      expect.arrayContaining(visibleLongOptions(buildProgram())),
+    );
+    expect(completedLongOptions).toEqual(
+      expect.arrayContaining(visibleLongOptions(buildSlidesProgram())),
+    );
   });
 });

--- a/tests/package-bin.test.ts
+++ b/tests/package-bin.test.ts
@@ -95,20 +95,35 @@ describe("package bin wrappers", () => {
 
   it("keeps fish completions aligned with visible CLI options", async () => {
     const fish = await readFile("completions/summarize.fish", "utf8");
-    const completedLongOptions = Array.from(
-      new Set(Array.from(fish.matchAll(/(?:^|\s)-l\s+([a-z0-9-]+)/g)).map((match) => match[1])),
-    );
+    const completedLongOptions = (condition: string) =>
+      Array.from(
+        new Set(
+          fish
+            .split("\n")
+            .filter((line) => line.includes(`-n '${condition}'`))
+            .flatMap((line) =>
+              Array.from(line.matchAll(/(?:^|\s)-l\s+([a-z0-9-]+)/g), (match) => match[1]),
+            ),
+        ),
+      );
     const visibleLongOptions = (program: ReturnType<typeof buildProgram>) =>
       program.options
         .filter((option) => !option.hidden)
         .flatMap((option) => option.flags.match(/--[a-z0-9-]+/g) ?? [])
         .map((flag) => flag.slice(2));
 
-    expect(completedLongOptions).toEqual(
+    expect(completedLongOptions("__summarize_no_subcommand")).toEqual(
       expect.arrayContaining(visibleLongOptions(buildProgram())),
     );
-    expect(completedLongOptions).toEqual(
+    expect(completedLongOptions("__summarize_command_is slides")).toEqual(
       expect.arrayContaining(visibleLongOptions(buildSlidesProgram())),
     );
+  });
+
+  it("routes fish subcommands from the first CLI argument", async () => {
+    const fish = await readFile("completions/summarize.fish", "utf8");
+
+    expect(fish).toContain('test "$tokens[2]" = "$argv[1]"');
+    expect(fish).not.toContain("$tokens[2..-1]");
   });
 });


### PR DESCRIPTION
## Summary
- sync fish completions with the current CLI flags, CLI providers, and subcommands
- add completions for the `summarizer` bin alias alongside `summarize`
- include the completions directory in the npm package files
- add regression coverage so visible Commander options and packaged completions do not drift silently

## Details
The existing fish completion file had fallen behind the current CLI surface. In particular it missed newer media/diarization flags, OpenAI service controls, `--width`, current `--cli` providers, and the command tree for `slides`, `status`, `refresh-free`, `daemon`, and `transcriber`.

The package manifest also excluded `completions`, so the file was not present in the npm tarball even though it lived in the repository.

## Verification
- `fish -n completions/summarize.fish`
- fish completion smoke checks for `summarize --di`, `summarize --cli `, `summarize slides --re`, `summarize daemon `, and `summarizer --cli `
- `pnpm format:check completions/summarize.fish package.json tests/package-bin.test.ts`
- `pnpm exec vitest run tests/cli.help.test.ts tests/cli.flags.test.ts tests/package-bin.test.ts`
- `npm pack --dry-run --ignore-scripts --json` includes `completions/summarize.fish`