### PR TITLE
fix: correct browser user scripts permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Browser extension: declare User Scripts permissions per browser, route Chrome users to the required extension toggle, remove an invalid manifest permission, and align documented browser minimums.
 - CLI video summaries: restore terminal and JSON output when direct video understanding delegates URL handling to the asset summarizer.
 - Chrome extension: reject YouTube caption and transcript-panel results when the tab navigates to another video during extraction.
 - Development CLI: build the core workspace before `pnpm summarize` and `pnpm s` so newly added core exports never depend on stale generated files.

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -4,8 +4,8 @@ Browser extension for Chrome and Firefox that streams AI-powered summaries direc
 
 **Supported browsers**:
 
-- Chrome (Side Panel) - Auto-opens on toolbar icon click
-- Firefox 131+ (Sidebar) - Toggle with toolbar icon or `Ctrl+Shift+U`
+- Chrome 120+ (Side Panel) - Auto-opens on toolbar icon click
+- Firefox 140+ (Sidebar) - Toggle with toolbar icon or `Ctrl+Shift+U`
 
 Docs + setup: `https://summarize.sh`
 

--- a/apps/chrome-extension/src/automation/userscripts.ts
+++ b/apps/chrome-extension/src/automation/userscripts.ts
@@ -50,7 +50,7 @@ export function buildUserScriptsGuidance(status: UserScriptsStatus): string {
   if (chromeVersion >= 120) {
     return [
       permissionHint,
-      `Chrome ${chromeVersion} detected. The userScripts API requires Chrome 120+ with experimental features enabled. Update Chrome and retry.`,
+      `Chrome ${chromeVersion} detected. Enable Developer mode in chrome://extensions, then reload the extension and try again.`,
     ]
       .filter(Boolean)
       .join(" ");

--- a/apps/chrome-extension/src/entrypoints/options/index.html
+++ b/apps/chrome-extension/src/entrypoints/options/index.html
@@ -136,7 +136,7 @@
                 Enable automation permissions
               </button>
               <span class="subtitle permissionHint">
-                Opens Chrome permission prompt for optional <code>userScripts</code>.
+                Enables the browser's <code>userScripts</code> permission required by automation.
               </span>
             </div>
             <div id="userScriptsNotice" class="notice" hidden></div>

--- a/apps/chrome-extension/src/entrypoints/options/support.ts
+++ b/apps/chrome-extension/src/entrypoints/options/support.ts
@@ -79,11 +79,14 @@ export function createAutomationPermissionsController(options: {
     const status = await getUserScriptsStatus();
     const hasPermission = status.permissionGranted;
     const apiAvailable = status.apiAvailable;
+    const needsChromeToggle = status.chromeVersion !== null && hasPermission && !apiAvailable;
 
     automationPermissionsBtn.disabled = !chrome.permissions || (hasPermission && apiAvailable);
-    automationPermissionsBtn.textContent = hasPermission
-      ? "Automation permissions granted"
-      : "Enable automation permissions";
+    automationPermissionsBtn.textContent = needsChromeToggle
+      ? "Open Chrome User Scripts settings"
+      : hasPermission
+        ? "Automation permissions granted"
+        : "Enable automation permissions";
 
     if (!getAutomationEnabled()) {
       userScriptsNoticeEl.hidden = true;
@@ -103,6 +106,13 @@ export function createAutomationPermissionsController(options: {
   const requestPermissions = async () => {
     if (!chrome.permissions) return;
     try {
+      const status = await getUserScriptsStatus();
+      if (status.chromeVersion !== null && status.permissionGranted && !status.apiAvailable) {
+        await chrome.tabs.create({
+          url: `chrome://extensions/?id=${chrome.runtime.id}`,
+        });
+        return;
+      }
       const ok = await chrome.permissions.request({
         permissions: ["userScripts"],
       });

--- a/apps/chrome-extension/tests/extension.spec.ts
+++ b/apps/chrome-extension/tests/extension.spec.ts
@@ -84,6 +84,20 @@ test("manifest excludes Meta sites from always-on content scripts", () => {
   }
 });
 
+test("Chromium manifest grants User Scripts as a required permission", () => {
+  const manifestPath = path.resolve(__dirname, "..", ".output", "chrome-mv3", "manifest.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+    minimum_chrome_version?: string;
+    permissions?: string[];
+    optional_permissions?: string[];
+  };
+
+  expect(manifest.minimum_chrome_version).toBe("120");
+  expect(manifest.permissions).toContain("userScripts");
+  expect(manifest.permissions).not.toContain("windows");
+  expect(manifest.optional_permissions).not.toContain("userScripts");
+});
+
 test("sidepanel shows a ready state instead of going blank when switching tabs manually", async ({
   browserName: _browserName,
 }, testInfo) => {

--- a/apps/chrome-extension/wxt.config.ts
+++ b/apps/chrome-extension/wxt.config.ts
@@ -96,10 +96,10 @@ export default defineConfig({
         "webNavigation",
         ...(browser === "firefox" ? [] : ["webRequest" as const]),
         "scripting",
-        "windows",
+        ...(browser === "firefox" ? [] : ["userScripts" as const]),
         ...(browser === "firefox" ? [] : ["debugger" as const]),
       ],
-      optional_permissions: ["userScripts"],
+      optional_permissions: browser === "firefox" ? ["userScripts"] : [],
       host_permissions: ["<all_urls>", "http://127.0.0.1:8787/*"],
       background: {
         type: "module",
@@ -132,6 +132,7 @@ export default defineConfig({
             },
           }
         : {
+            minimum_chrome_version: "120",
             // Chrome uses side_panel API
             side_panel: {
               default_path: "sidepanel/index.html",
@@ -147,10 +148,13 @@ export default defineConfig({
             browser_specific_settings: {
               gecko: {
                 id: "summarize-test@steipete.com",
-                strict_min_version: "131.0",
+                strict_min_version: "140.0",
                 data_collection_permissions: {
                   required: ["none"],
                 },
+              },
+              gecko_android: {
+                strict_min_version: "142.0",
               },
             },
           }

--- a/tests/extension.firefox.manifest.test.ts
+++ b/tests/extension.firefox.manifest.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import extensionConfig from "../apps/chrome-extension/wxt.config.js";
 
 describe("firefox extension manifest", () => {
-  it("uses sidebar_action and omits sidePanel permission", () => {
+  it("uses Firefox-compatible permissions and metadata", () => {
     const manifestFactory = (extensionConfig as { manifest?: unknown }).manifest;
     if (typeof manifestFactory !== "function") {
       throw new Error("Missing manifest factory in WXT config");
@@ -14,8 +14,34 @@ describe("firefox extension manifest", () => {
 
     const permissions = Array.isArray(manifest.permissions) ? manifest.permissions : [];
     expect(permissions).not.toContain("sidePanel");
+    expect(permissions).not.toContain("userScripts");
+    expect(permissions).not.toContain("windows");
+    expect(manifest.optional_permissions).toEqual(["userScripts"]);
 
     const commands = manifest.commands as Record<string, unknown> | undefined;
     expect(commands?._execute_sidebar_action).toBeTruthy();
+
+    const browserSettings = manifest.browser_specific_settings as
+      | {
+          gecko?: { strict_min_version?: string };
+          gecko_android?: { strict_min_version?: string };
+        }
+      | undefined;
+    expect(browserSettings?.gecko?.strict_min_version).toBe("140.0");
+    expect(browserSettings?.gecko_android?.strict_min_version).toBe("142.0");
+  });
+
+  it("uses Chrome-compatible User Scripts permissions", () => {
+    const manifestFactory = (extensionConfig as { manifest?: unknown }).manifest;
+    if (typeof manifestFactory !== "function") {
+      throw new Error("Missing manifest factory in WXT config");
+    }
+
+    const manifest = manifestFactory({ browser: "chrome" }) as Record<string, unknown>;
+    const permissions = Array.isArray(manifest.permissions) ? manifest.permissions : [];
+    expect(permissions).toContain("userScripts");
+    expect(permissions).not.toContain("windows");
+    expect(manifest.optional_permissions).toEqual([]);
+    expect(manifest.minimum_chrome_version).toBe("120");
   });
 });

--- a/tests/options.support.test.ts
+++ b/tests/options.support.test.ts
@@ -242,6 +242,48 @@ describe("options support", () => {
     expect(flashStatus).toHaveBeenCalledWith("Permission request denied");
   });
 
+  it("opens Chrome extension settings when the required permission needs its browser toggle", async () => {
+    const automationPermissionsBtn = {
+      disabled: false,
+      textContent: "",
+    } as HTMLButtonElement;
+    const userScriptsNoticeEl = createFakeElement();
+    const createTab = vi.fn(async () => undefined);
+    const request = vi.fn(async () => true);
+    vi.stubGlobal("chrome", {
+      permissions: { request },
+      runtime: { id: "extension-id" },
+      tabs: { create: createTab },
+    });
+    vi.mocked(getUserScriptsStatus)
+      .mockResolvedValueOnce({
+        apiAvailable: false,
+        permissionGranted: true,
+        chromeVersion: 138,
+      })
+      .mockResolvedValueOnce({
+        apiAvailable: false,
+        permissionGranted: true,
+        chromeVersion: 138,
+      });
+
+    const controller = createAutomationPermissionsController({
+      automationPermissionsBtn,
+      userScriptsNoticeEl,
+      getAutomationEnabled: () => true,
+      flashStatus: vi.fn(),
+    });
+    await controller.updateUi();
+    expect(automationPermissionsBtn.disabled).toBe(false);
+    expect(automationPermissionsBtn.textContent).toBe("Open Chrome User Scripts settings");
+
+    await controller.requestPermissions();
+    expect(createTab).toHaveBeenCalledWith({
+      url: "chrome://extensions/?id=extension-id",
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("ignores permission requests when permissions api is missing or throws", async () => {
     const automationPermissionsBtn = {
       disabled: false,


### PR DESCRIPTION
## Summary

- declare `userScripts` as required in Chromium and optional-only in Firefox
- route Chromium users to the browser's User Scripts toggle instead of granting an ineffective optional permission
- remove the invalid `windows` named permission
- align supported browser metadata with Chrome 120, Firefox desktop 140, and Firefox Android 142
- add manifest and options-controller regressions

## Reproduction

The shipped Chromium manifest listed `userScripts` only in `optional_permissions`. Clicking the Options permission button changed `permissions.contains()` to true, but `chrome.userScripts` remained undefined after reopening the extension page, so automation could not run while the UI reported permission granted.

## Verification

- `pnpm -s check`
- `pnpm -C apps/chrome-extension test:chrome` (70 passed, 4 documented live skips)
- `pnpm -C apps/chrome-extension test:firefox`
- `pnpm -C apps/chrome-extension exec web-ext lint --source-dir .output/firefox-mv3 --self-hosted --boring`
- loaded Chromium runtime check: required permission true; gated API produces the new settings action
- autoreview: clean, no accepted/actionable findings
