### PR TITLE
fix: close terminal daemon event streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Daemon: close live summarize and slide SSE connections immediately after terminal events instead of retaining them until session cleanup.
 - Browser extension: declare User Scripts permissions per browser, route Chrome users to the required extension toggle, remove an invalid manifest permission, and align documented browser minimums.
 - CLI video summaries: restore terminal and JSON output when direct video understanding delegates URL handling to the asset summarizer.
 - Chrome extension: reject YouTube caption and transcript-panel results when the tab navigates to another video during extraction.

--- a/src/daemon/server-session.ts
+++ b/src/daemon/server-session.ts
@@ -55,7 +55,10 @@ export function pushToSession(
   if (session.summaryEvents.done) return;
   pushBufferedSseEvent(session.summaryEvents, event);
   onSessionEvent?.(event, session.id);
-  if (event.event === "done" || event.event === "error") session.summaryEvents.done = true;
+  if (event.event === "done" || event.event === "error") {
+    session.summaryEvents.done = true;
+    closeBufferedSseChannel(session.summaryEvents);
+  }
 }
 
 export function pushSlidesToSession(
@@ -65,7 +68,10 @@ export function pushSlidesToSession(
 ) {
   pushBufferedSseEvent(session.slideEvents, event);
   onSessionEvent?.(event, session.id);
-  if (event.event === "done" || event.event === "error") session.slideEvents.done = true;
+  if (event.event === "done") {
+    session.slideEvents.done = true;
+    closeBufferedSseChannel(session.slideEvents);
+  }
   if (event.event === "status") session.slidesLastStatus = event.data.text;
 }
 

--- a/tests/daemon.server-session.test.ts
+++ b/tests/daemon.server-session.test.ts
@@ -33,12 +33,16 @@ describe("daemon server sessions", () => {
     ]);
     expect(session.summaryEvents.done).toBe(true);
     expect(client.write).toHaveBeenCalledTimes(2);
+    expect(client.end).toHaveBeenCalledOnce();
+    expect(session.summaryEvents.clients.size).toBe(0);
     expect(onEvent).toHaveBeenCalledTimes(2);
   });
 
   it("keeps slide terminal sequencing separate from summary policy", () => {
     const session = createSession(() => "summary-1");
+    const client = createClient();
     const onEvent = vi.fn();
+    session.slideEvents.clients.add(client);
 
     emitSlidesStatus(session, "  extracting  ", onEvent);
     emitSlidesDone(session, { ok: false, error: "failed" }, onEvent);
@@ -49,6 +53,9 @@ describe("daemon server sessions", () => {
       "done",
     ]);
     expect(session.slideEvents.done).toBe(true);
+    expect(client.write).toHaveBeenCalledTimes(3);
+    expect(client.end).toHaveBeenCalledOnce();
+    expect(session.slideEvents.clients.size).toBe(0);
     expect(session.slidesLastStatus).toBe("extracting");
     expect(onEvent).toHaveBeenCalledTimes(3);
   });


### PR DESCRIPTION
## Summary

- close attached summarize SSE clients after `done` or `error`
- preserve slide failure ordering and close slide streams after final `done`
- add regression assertions for response termination and client cleanup

## Verification

- `pnpm -s vitest run tests/daemon.server-session.test.ts tests/daemon.server-summarize-events.test.ts tests/daemon.server-refresh-route.test.ts`
- `pnpm -s check`
- foreground daemon: successful `done` and failing `error` streams both exited normally
- autoreview: clean, no actionable findings
