### PR TITLE
fix: print cli errors once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- CLI errors: print Commander validation failures and missing-input help once instead of duplicating them across stdout/stderr.
 - Shell completions: sync and package Fish completions for both CLI aliases and subcommands, with candidate values matched to accepted CLI choices (#277, thanks @vincent-peng).
 - Daemon: close live summarize and slide SSE connections immediately after terminal events instead of retaining them until session cleanup.
 - Browser extension: declare User Scripts permissions per browser, route Chrome users to the required extension toggle, remove an invalid manifest permission, and align documented browser minimums.

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { CommanderError } from "commander";
 import { runCli } from "./run.js";
 
 export type CliMainArgs = {
@@ -134,6 +135,17 @@ export async function runCliMain({
     const mergedEnv = env === process.env ? { ...(await loadDotenvFromCwd()), ...env } : env;
     await runCli(argv, { env: mergedEnv, fetch, stdout, stderr });
   } catch (error: unknown) {
+    if (error instanceof CommanderError) {
+      setExitCode(error.exitCode);
+      return;
+    }
+
+    const exitCode = (error as { exitCode?: unknown } | null)?.exitCode;
+    if ((error as { silent?: unknown } | null)?.silent === true && typeof exitCode === "number") {
+      setExitCode(exitCode);
+      return;
+    }
+
     const isTty = Boolean((stderr as unknown as { isTTY?: boolean }).isTTY);
     if (isTty) stderr.write("\n");
 
@@ -149,11 +161,6 @@ export async function runCliMain({
 
     const message =
       error instanceof Error ? error.message : error ? String(error) : "Unknown error";
-    const exitCode = (error as { exitCode?: unknown } | null)?.exitCode;
-    if ((error as { silent?: unknown } | null)?.silent === true && typeof exitCode === "number") {
-      setExitCode(exitCode);
-      return;
-    }
     stderr.write(`${stripAnsi(message)}\n`);
     setExitCode(typeof exitCode === "number" ? exitCode : 1);
   }

--- a/src/run/run-input.ts
+++ b/src/run/run-input.ts
@@ -34,7 +34,7 @@ export function resolveRunInput({
   if (!rawInput) {
     const help = buildConciseHelp();
     stdout.write(`${help}\n`);
-    throw new Error(help);
+    throw Object.assign(new Error(help), { exitCode: 1, silent: true });
   }
 
   const inputTarget = resolveInputTarget(rawInput);

--- a/tests/cli-main.integration.test.ts
+++ b/tests/cli-main.integration.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Writable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { runCliMain } from "../src/cli-main.js";
+
+function collectStream() {
+  let text = "";
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      text += chunk.toString();
+      callback();
+    },
+  });
+  return { stream, getText: () => text };
+}
+
+async function run(argv: string[]) {
+  const stdout = collectStream();
+  const stderr = collectStream();
+  let exitCode: number | null = null;
+
+  await runCliMain({
+    argv,
+    env: { HOME: mkdtempSync(join(tmpdir(), "summarize-cli-main-")) },
+    fetch: globalThis.fetch.bind(globalThis),
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+    exit: () => {},
+    setExitCode: (code) => {
+      exitCode = code;
+    },
+  });
+
+  return { stdout: stdout.getText(), stderr: stderr.getText(), exitCode };
+}
+
+describe("cli main integration", () => {
+  it.each([
+    [["--definitely-invalid"], "error: unknown option '--definitely-invalid'"],
+    [["slides", "--definitely-invalid"], "error: unknown option '--definitely-invalid'"],
+    [
+      ["--preprocess", "on", "https://example.com"],
+      "error: option '--preprocess <mode>' argument 'on' is invalid",
+    ],
+  ])("prints Commander errors once for %j", async (argv, expected) => {
+    const result = await run(argv);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(
+      result.stderr.match(new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")),
+    ).toHaveLength(1);
+  });
+
+  it.each([[[]], [["--verbose"]], [["--debug"]]])(
+    "prints missing-input help only to stdout for %j",
+    async (argv) => {
+      const result = await run(argv);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain("Usage: summarize <input> [flags]");
+      expect(result.stderr).toBe("");
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- avoid reprinting Commander diagnostics already written to stderr
- make missing-input help a silent exit after its stdout rendering
- cover main, slides, invalid choice, verbose, and debug entrypoint paths

## Verification

- `pnpm -s vitest run tests/cli-main.integration.test.ts tests/cli-main.test.ts tests/cli.errors.test.ts`
- `pnpm -s check`
- rebuilt CLI runtime smoke for duplicated error/help cases
- autoreview: clean, no actionable findings
