### PR TITLE
fix: render slides in extract mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Slides: render extracted slide labels or debug paths for `--slides --extract` even when a direct video has no transcript.
 - CLI errors: print Commander validation failures and missing-input help once instead of duplicating them across stdout/stderr.
 - Shell completions: sync and package Fish completions for both CLI aliases and subcommands, with candidate values matched to accepted CLI choices (#277, thanks @vincent-peng).
 - Daemon: close live summarize and slide SSE connections immediately after terminal events instead of retaining them until session cleanup.

--- a/src/run/cli-summarize-output.ts
+++ b/src/run/cli-summarize-output.ts
@@ -48,6 +48,18 @@ export async function presentCliSummarizeResult(options: {
 
   const extractionUi = deriveExtractionUi(result.extracted);
   const transcriptionCostLabel = buildTranscriptionCostLabel(ctx, result);
+  const extractionSlidesReady =
+    result.kind === "extraction" &&
+    Boolean(result.slides?.slides.length) &&
+    Boolean(result.slides?.slides.every((slide) => slide.imagePath.trim().length > 0));
+  const slidesOutputEnabled =
+    Boolean(ctx.flags.slides) &&
+    !ctx.flags.json &&
+    (result.kind === "extraction"
+      ? extractionSlidesReady
+      : result.details.kind === "url-summary" &&
+        result.details.resolution.kind === "summary" &&
+        !result.details.resolution.summaryEmitted);
   const slidesOutput =
     options.slidesOutput === undefined
       ? createSlidesTerminalOutput({
@@ -59,13 +71,7 @@ export async function presentCliSummarizeResult(options: {
           },
           extracted: result.extracted,
           slides: result.slides,
-          enabled:
-            result.kind === "summary" &&
-            result.details.kind === "url-summary" &&
-            result.details.resolution.kind === "summary" &&
-            !result.details.resolution.summaryEmitted &&
-            Boolean(ctx.flags.slides) &&
-            !ctx.flags.json,
+          enabled: slidesOutputEnabled,
           outputMode: "delta",
           clearProgressForStdout: ctx.hooks.clearProgressForStdout,
           restoreProgressAfterStdout: ctx.hooks.restoreProgressAfterStdout ?? null,

--- a/tests/run.cli-summarize-output.test.ts
+++ b/tests/run.cli-summarize-output.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SummarizeResult } from "../src/application/summarize-contracts.js";
+import type { SlidesTerminalOutput } from "../src/run/flows/url/slides-output.js";
+import type { UrlFlowContext } from "../src/run/flows/url/types.js";
+
+const mocks = vi.hoisted(() => ({
+  createSlidesTerminalOutput: vi.fn(),
+  deriveExtractionUi: vi.fn(() => ({
+    contentSizeLabel: "0 B",
+    viaSourceLabel: "",
+    footerParts: [],
+    finishSourceLabel: null,
+  })),
+  outputExtractedUrl: vi.fn(),
+  presentExtractedUrlSummary: vi.fn(),
+}));
+
+vi.mock("../src/run/flows/url/slides-output.js", () => ({
+  createSlidesTerminalOutput: mocks.createSlidesTerminalOutput,
+}));
+vi.mock("../src/run/flows/url/extract.js", () => ({
+  deriveExtractionUi: mocks.deriveExtractionUi,
+}));
+vi.mock("../src/run/flows/url/summary.js", () => ({
+  outputExtractedUrl: mocks.outputExtractedUrl,
+  presentExtractedUrlSummary: mocks.presentExtractedUrlSummary,
+}));
+
+import { presentCliSummarizeResult } from "../src/run/cli-summarize-output.js";
+
+describe("CLI summarize output", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates slide output for extract-only results with extracted slides", async () => {
+    const slidesOutput = { renderFromText: vi.fn() } as unknown as SlidesTerminalOutput;
+    mocks.createSlidesTerminalOutput.mockReturnValue(slidesOutput);
+    const ctx = {
+      io: {},
+      flags: {
+        json: false,
+        plain: true,
+        lengthArg: { kind: "preset", preset: "long" },
+        slides: { enabled: true },
+        slidesDebug: true,
+      },
+      hooks: {
+        clearProgressForStdout: vi.fn(),
+        restoreProgressAfterStdout: null,
+      },
+      model: { openaiWhisperUsdPerMinute: null },
+    } as unknown as UrlFlowContext;
+    const result = {
+      kind: "extraction",
+      input: {
+        kind: "url",
+        url: "file:///tmp/video.mp4",
+        title: null,
+        maxCharacters: null,
+      },
+      extracted: {
+        content: "",
+        transcriptSource: null,
+        transcriptionProvider: null,
+        mediaDurationSeconds: null,
+      },
+      slides: {
+        slides: [{ index: 1, timestamp: 0, imagePath: "/tmp/slide.png" }],
+      },
+      details: {
+        kind: "url-extraction",
+        prompt: "prompt",
+        effectiveMarkdownMode: "off",
+      },
+    } as unknown as SummarizeResult;
+
+    await presentCliSummarizeResult({ ctx, result });
+
+    expect(mocks.createSlidesTerminalOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slides: result.slides,
+        enabled: true,
+      }),
+    );
+    expect(mocks.outputExtractedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slides: result.slides,
+        slidesOutput,
+      }),
+    );
+  });
+
+  it("does not render a planned extraction timeline before slide paths are finalized", async () => {
+    mocks.createSlidesTerminalOutput.mockReturnValue(null);
+    const ctx = {
+      io: {},
+      flags: {
+        json: false,
+        plain: false,
+        lengthArg: { kind: "preset", preset: "long" },
+        slides: { enabled: true },
+        slidesDebug: false,
+      },
+      hooks: {
+        clearProgressForStdout: vi.fn(),
+        restoreProgressAfterStdout: null,
+      },
+      model: { openaiWhisperUsdPerMinute: null },
+    } as unknown as UrlFlowContext;
+    const result = {
+      kind: "extraction",
+      input: {
+        kind: "url",
+        url: "https://example.com/video.mp4",
+        title: null,
+        maxCharacters: null,
+      },
+      extracted: {
+        content: "Transcript",
+        transcriptSource: null,
+        transcriptionProvider: null,
+        mediaDurationSeconds: 60,
+      },
+      slides: {
+        slides: [{ index: 1, timestamp: 0, imagePath: "" }],
+      },
+      details: {
+        kind: "url-extraction",
+        prompt: "prompt",
+        effectiveMarkdownMode: "off",
+      },
+    } as unknown as SummarizeResult;
+
+    await presentCliSummarizeResult({ ctx, result });
+
+    expect(mocks.createSlidesTerminalOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(mocks.outputExtractedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ slidesOutput: null }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- render finalized slide output for `--slides --extract`
- keep planned timelines with empty image paths from entering the post-run renderer
- cover finalized and planned extraction results

## Reproduction

`summarize <local.mp4> --slides --extract --plain --metrics off` extracted slide files and exited successfully while writing no output. `--slides-debug` was also empty.

## Verification

- focused slide/output suite: 19 tests passed
- rebuilt CLI: two slide labels emitted; `--slides-debug` emitted both image paths
- `pnpm -s check`: 522 files passed, 29 skipped; 2,752 tests passed, 43 skipped
- structured autoreview clean after fixing its planned-timeline deadlock finding
