### PR TITLE
test: fix live credential skips

### DIFF
--- a/tests/live/anthropic-pdf.live.test.ts
+++ b/tests/live/anthropic-pdf.live.test.ts
@@ -17,10 +17,9 @@ function shouldSoftSkipLiveError(message: string): boolean {
 
   it(
     "summarizes PDF attachments",
-    async () => {
+    async ({ skip }) => {
       if (!anthropicApiKey) {
-        it.skip("requires ANTHROPIC_API_KEY", () => {});
-        return;
+        skip("requires ANTHROPIC_API_KEY");
       }
 
       try {

--- a/tests/live/free-preset.live.test.ts
+++ b/tests/live/free-preset.live.test.ts
@@ -36,11 +36,10 @@ const silentStderr = new Writable({
 
   it(
     "refresh-free + --model free returns JSON with llm!=null",
-    async () => {
+    async ({ skip }) => {
       const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY?.trim() ?? "";
       if (!OPENROUTER_API_KEY) {
-        it.skip("requires OPENROUTER_API_KEY", () => {});
-        return;
+        skip("requires OPENROUTER_API_KEY");
       }
 
       const home = await fs.mkdtemp(path.join(os.tmpdir(), "summarize-live-free-"));
@@ -97,11 +96,10 @@ const silentStderr = new Writable({
 
   it(
     "--model free streams when stdout is a TTY",
-    async () => {
+    async ({ skip }) => {
       const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY?.trim() ?? "";
       if (!OPENROUTER_API_KEY) {
-        it.skip("requires OPENROUTER_API_KEY", () => {});
-        return;
+        skip("requires OPENROUTER_API_KEY");
       }
 
       const home = await fs.mkdtemp(path.join(os.tmpdir(), "summarize-live-free-stream-"));

--- a/tests/live/google-preview-fallback.live.test.ts
+++ b/tests/live/google-preview-fallback.live.test.ts
@@ -8,15 +8,14 @@ const LIVE = process.env.SUMMARIZE_LIVE_TEST === "1";
 
   it(
     "returns non-empty text for google/gemini-3-flash-preview",
-    async () => {
+    async ({ skip }) => {
       const googleApiKey =
         process.env.GEMINI_API_KEY ??
         process.env.GOOGLE_GENERATIVE_AI_API_KEY ??
         process.env.GOOGLE_API_KEY ??
         null;
       if (!googleApiKey) {
-        it.skip("requires GEMINI_API_KEY", () => {});
-        return;
+        skip("requires GEMINI_API_KEY");
       }
 
       const result = await generateTextWithModelId({

--- a/tests/live/models-live.test.ts
+++ b/tests/live/models-live.test.ts
@@ -25,10 +25,9 @@ function shouldSoftSkipLiveError(message: string): boolean {
 
   it(
     "OpenAI (gpt-5.2) returns text",
-    async () => {
+    async ({ skip }) => {
       if (!apiKeys.openaiApiKey) {
-        it.skip("requires OPENAI_API_KEY", () => {});
-        return;
+        skip("requires OPENAI_API_KEY");
       }
       try {
         const result = await generateTextWithModelId({
@@ -51,10 +50,9 @@ function shouldSoftSkipLiveError(message: string): boolean {
 
   it(
     "OpenAI (gpt-5.2) streams text (temperature ignored)",
-    async () => {
+    async ({ skip }) => {
       if (!apiKeys.openaiApiKey) {
-        it.skip("requires OPENAI_API_KEY", () => {});
-        return;
+        skip("requires OPENAI_API_KEY");
       }
       try {
         const result = await streamTextWithModelId({
@@ -83,10 +81,9 @@ function shouldSoftSkipLiveError(message: string): boolean {
 
   it(
     "OpenAI (gpt-5-mini) streams text",
-    async () => {
+    async ({ skip }) => {
       if (!apiKeys.openaiApiKey) {
-        it.skip("requires OPENAI_API_KEY", () => {});
-        return;
+        skip("requires OPENAI_API_KEY");
       }
       try {
         const result = await streamTextWithModelId({
@@ -115,10 +112,9 @@ function shouldSoftSkipLiveError(message: string): boolean {
 
   it(
     "Anthropic (opus 4.5) returns text",
-    async () => {
+    async ({ skip }) => {
       if (!apiKeys.anthropicApiKey) {
-        it.skip("requires ANTHROPIC_API_KEY", () => {});
-        return;
+        skip("requires ANTHROPIC_API_KEY");
       }
       try {
         const result = await generateTextWithModelId({
@@ -141,10 +137,9 @@ function shouldSoftSkipLiveError(message: string): boolean {
 
   it(
     "Anthropic (sonnet 4.5) returns text",
-    async () => {
+    async ({ skip }) => {
       if (!apiKeys.anthropicApiKey) {
-        it.skip("requires ANTHROPIC_API_KEY", () => {});
-        return;
+        skip("requires ANTHROPIC_API_KEY");
       }
       try {
         const result = await generateTextWithModelId({
@@ -167,10 +162,9 @@ function shouldSoftSkipLiveError(message: string): boolean {
 
   it(
     "xAI (grok 4.1 fast) returns text",
-    async () => {
+    async ({ skip }) => {
       if (!apiKeys.xaiApiKey) {
-        it.skip("requires XAI_API_KEY", () => {});
-        return;
+        skip("requires XAI_API_KEY");
       }
       try {
         const result = await generateTextWithModelId({
@@ -193,10 +187,9 @@ function shouldSoftSkipLiveError(message: string): boolean {
 
   it(
     "Google (Gemini 3 Flash) returns text",
-    async () => {
+    async ({ skip }) => {
       if (!apiKeys.googleApiKey) {
-        it.skip("requires GEMINI_API_KEY", () => {});
-        return;
+        skip("requires GEMINI_API_KEY");
       }
       try {
         const result = await generateTextWithModelId({

--- a/tests/live/openai-pdf.live.test.ts
+++ b/tests/live/openai-pdf.live.test.ts
@@ -17,10 +17,9 @@ function shouldSoftSkipLiveError(message: string): boolean {
 
   it(
     "summarizes PDF attachments",
-    async () => {
+    async ({ skip }) => {
       if (!openaiApiKey) {
-        it.skip("requires OPENAI_API_KEY", () => {});
-        return;
+        skip("requires OPENAI_API_KEY");
       }
 
       try {

--- a/tests/live/openrouter-fallback.live.test.ts
+++ b/tests/live/openrouter-fallback.live.test.ts
@@ -17,11 +17,10 @@ function shouldSoftSkipLiveError(message: string): boolean {
 
   it(
     "maps native model to OpenRouter id and returns text",
-    async () => {
+    async ({ skip }) => {
       const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY?.trim() ?? "";
       if (!OPENROUTER_API_KEY) {
-        it.skip("requires OPENROUTER_API_KEY", () => {});
-        return;
+        skip("requires OPENROUTER_API_KEY");
       }
 
       const config: SummarizeConfig = {

--- a/tests/live/podcast-hosts.live.test.ts
+++ b/tests/live/podcast-hosts.live.test.ts
@@ -96,11 +96,10 @@ const silentStderr = new Writable({
 
   it(
     "amazon music episode prefers description-sized content (requires Firecrawl)",
-    async () => {
+    async ({ skip }) => {
       const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY?.trim() ?? "";
       if (!FIRECRAWL_API_KEY) {
-        it.skip("requires FIRECRAWL_API_KEY", () => {});
-        return;
+        skip("requires FIRECRAWL_API_KEY");
       }
 
       const out = collectStream();

--- a/tests/live/zai.live.test.ts
+++ b/tests/live/zai.live.test.ts
@@ -33,10 +33,9 @@ const silentStderr = new Writable({
 
   it(
     "zai/glm-4.7 returns text",
-    async () => {
+    async ({ skip }) => {
       if (!ZAI_KEY) {
-        it.skip("requires Z_AI_API_KEY (or ZAI_API_KEY)", () => {});
-        return;
+        skip("requires Z_AI_API_KEY (or ZAI_API_KEY)");
       }
       try {
         const out = collectStdout();


### PR DESCRIPTION
## Summary

- use Vitest test-context skips for missing live credentials
- cover all 15 invalid nested `it.skip()` branches across eight live-test files

## Reproduction

With live tests enabled and `FIRECRAWL_API_KEY` absent, the podcast-host suite failed with `Calling the test function inside another test function is not allowed`.

## Verification

- credential-absent live batch: 8 files passed, 3 public podcast tests passed, 15 tests skipped with explicit reasons
- no nested `it.skip()` remains under `tests/live`
- `pnpm -s check`: 522 files passed, 29 skipped; 2,752 tests passed, 43 skipped
- structured autoreview clean
