### PR TITLE
test: fix youtube slides debug diagnostics

### DIFF
--- a/apps/chrome-extension/tests/sidepanel.youtube-e2e.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.youtube-e2e.spec.ts
@@ -35,6 +35,7 @@ import {
   getPanelSlideDescriptions,
   getPanelSlidesSummaryComplete,
   getPanelSlidesSummaryMarkdown,
+  getPanelSlidesSummaryModel,
   getPanelSlidesTimeline,
   getPanelSummaryMarkdown,
   getPanelTranscriptTimedText,


### PR DESCRIPTION
## Summary

- import the existing slide-summary model test hook used by debug diagnostics

## Reproduction

Running the real daemon YouTube slides E2E with `SUMMARIZE_DEBUG_SLIDES=1` threw `ReferenceError: getPanelSlidesSummaryModel is not defined`.

## Verification

- debug-enabled E2E now prints the slide summary model and continues
- extension lint passed
- `pnpm -s check`: 522 files passed, 29 skipped; 2,752 tests passed, 43 skipped
- structured autoreview clean
