### PR TITLE
fix: cap remote asset extraction output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- CLI extraction: honor `--max-extract-characters` for remote text and document assets, not only web-page extraction.
 - Slides: render extracted slide labels or debug paths for `--slides --extract` even when a direct video has no transcript.
 - CLI errors: print Commander validation failures and missing-input help once instead of duplicating them across stdout/stderr.
 - Shell completions: sync and package Fish completions for both CLI aliases and subcommands, with candidate values matched to accepted CLI choices (#277, thanks @vincent-peng).

--- a/src/application/execute-summarize.ts
+++ b/src/application/execute-summarize.ts
@@ -379,6 +379,10 @@ export async function executeSummarize(
         throw new Error("Resolved asset execution requires prepared asset resources");
       }
       if (request.extractOnly) {
+        const maxCharacters =
+          request.input.kind === "url" || request.input.kind === "input-url"
+            ? request.input.maxCharacters
+            : null;
         const extractedAsset = await extractAssetContent({
           ctx: {
             env: assetSummaryContext.env,
@@ -388,6 +392,7 @@ export async function executeSummarize(
             preprocessMode: assetSummaryContext.preprocessMode,
           },
           attachment: input.attachment,
+          ...(typeof maxCharacters === "number" ? { maxCharacters } : {}),
         });
         const report = assetSummaryContext.shouldComputeReport
           ? await assetSummaryContext.buildReport()

--- a/src/run/flows/asset/extract.ts
+++ b/src/run/flows/asset/extract.ts
@@ -1,3 +1,4 @@
+import { applyContentBudget } from "@steipete/summarize-core/content";
 import type { ExecFileFn } from "../../../markitdown.js";
 import { convertToMarkdownWithMarkitdown } from "../../../markitdown.js";
 import { formatBytes } from "../../../tty/format.js";
@@ -35,9 +36,11 @@ const baseDiagnostics: ExtractDiagnosticsForFinishLine = {
 export async function extractAssetContent({
   ctx,
   attachment,
+  maxCharacters,
 }: {
   ctx: AssetExtractContext;
   attachment: AssetAttachment;
+  maxCharacters?: number | null;
 }): Promise<AssetExtractResult> {
   const textContent = getTextContentFromAttachment(attachment);
   if (textContent) {
@@ -47,7 +50,10 @@ export async function extractAssetContent({
       );
     }
     return {
-      content: textContent.content,
+      content:
+        typeof maxCharacters === "number"
+          ? applyContentBudget(textContent.content, maxCharacters).content
+          : textContent.content,
       diagnostics: baseDiagnostics,
     };
   }
@@ -106,7 +112,10 @@ export async function extractAssetContent({
   }
 
   return {
-    content: markdown,
+    content:
+      typeof maxCharacters === "number"
+        ? applyContentBudget(markdown, maxCharacters).content
+        : markdown,
     diagnostics: {
       ...baseDiagnostics,
       markdown: { used: true, provider: null, notes: usedOcr ? "markitdown+ocr" : "markitdown" },

--- a/tests/cli.extract.asset-url.test.ts
+++ b/tests/cli.extract.asset-url.test.ts
@@ -110,6 +110,53 @@ describe("cli --extract (asset url)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("caps extracted text assets with --max-extract-characters", async () => {
+    const body = `First sentence. ${"word ".repeat(100)}`;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url === "https://example.com/file.txt") {
+        return new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+
+    let stdoutText = "";
+    const stdout = new Writable({
+      write(chunk, _encoding, callback) {
+        stdoutText += chunk.toString();
+        callback();
+      },
+    });
+
+    await runCli(
+      [
+        "--extract",
+        "--max-extract-characters",
+        "80",
+        "--timeout",
+        "2s",
+        "https://example.com/file.txt",
+      ],
+      {
+        env: {},
+        fetch: fetchMock as unknown as typeof fetch,
+        stdout,
+        stderr: new Writable({
+          write(_chunk, _encoding, cb) {
+            cb();
+          },
+        }),
+      },
+    );
+
+    expect(stdoutText.trim().length).toBeLessThanOrEqual(80);
+    expect(stdoutText.trim()).not.toBe(body.trim());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("routes extensionless text downloads through asset JSON output", async () => {
     const body = "a,b\n1,2\n";
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary

- forward URL extraction character budgets into remote asset extraction
- apply the shared content budget to text assets and MarkItDown document output
- add a CLI regression for remote text assets
- document the user-visible fix

## Verification

- focused asset/application/CLI tests (28 passed)
- rebuilt CLI live HTTPS probe: 300-character cap produced 163 plain characters and 164 JSON content characters
- `pnpm -s check` (522 files passed, 2,753 tests passed)
- autoreview clean
