### PR TITLE
docs: correct custom length minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ summarize "https://example.com" --length 20k
   - Prefer `--length` unless you need a hard cap.
 - Short content: when extracted content is shorter than the requested length, the CLI returns the content as-is.
   - Override with `--force-summary` to always run the LLM.
-- Minimums: `--length` numeric values must be >= 50 chars; `--max-output-tokens` must be >= 16.
+- Minimums: `--length` numeric values must be >= 10 chars; `--max-output-tokens` must be >= 16.
 - Preset targets (source of truth: `packages/core/src/prompts/summary-lengths.ts`):
   - short: target ~900 chars (range 600-1,200)
   - medium: target ~1,800 chars (range 1,200-2,500)


### PR DESCRIPTION
## Summary

- correct the documented numeric `--length` minimum from 50 to 10 characters
- align README guidance with `parseLengthArg` and its tests

## Verification

- `pnpm exec vitest run tests/cli.flags.test.ts`
- `pnpm -s check`
- `pnpm exec oxfmt --check README.md`
- `git diff --check`
- autoreview: no actionable findings
