### PR TITLE
fix: avoid concurrent dev CLI build races

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:lib": "tsgo -p tsconfig.build.json",
     "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:coverage",
     "clean": "rimraf dist packages/core/dist",
-    "dev:cli": "pnpm -C packages/core build && tsx src/cli.ts",
+    "dev:cli": "tsx --tsconfig tsconfig.dev.json src/cli.ts",
     "docs:build": "node scripts/build-docs-site.mjs",
     "docs:list": "tsx scripts/docs-list.ts",
     "docs:serve": "bash scripts/docs-serve.sh",

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -13,6 +13,11 @@ const corePackage = JSON.parse(readFileSync(resolve("packages/core/package.json"
   engines: Record<string, string>;
 };
 const releaseScript = readFileSync(resolve("scripts/release.sh"), "utf8");
+const devTsconfig = JSON5.parse(readFileSync(resolve("tsconfig.dev.json"), "utf8")) as {
+  compilerOptions?: {
+    paths?: Record<string, string[]>;
+  };
+};
 const oxfmtConfig = JSON5.parse(readFileSync(resolve(".oxfmtrc.jsonc"), "utf8")) as {
   ignorePatterns?: string[];
 };
@@ -43,10 +48,14 @@ describe("package scripts", () => {
     );
   });
 
-  it("builds core before source CLI aliases", () => {
-    expect(rootPackage.scripts["dev:cli"]).toBe("pnpm -C packages/core build && tsx src/cli.ts");
+  it("runs source CLI aliases against core source without rebuilding shared output", () => {
+    expect(rootPackage.scripts["dev:cli"]).toBe("tsx --tsconfig tsconfig.dev.json src/cli.ts");
     expect(rootPackage.scripts.s).toBe("pnpm dev:cli");
     expect(rootPackage.scripts.summarize).toBe("pnpm dev:cli");
+    expect(devTsconfig.compilerOptions?.paths).toEqual({
+      "@steipete/summarize-core": ["packages/core/src/index.ts"],
+      "@steipete/summarize-core/*": ["packages/core/src/*"],
+    });
   });
 
   it("typechecks both workspace layers from the root script", () => {

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@steipete/summarize-core": ["packages/core/src/index.ts"],
+      "@steipete/summarize-core/*": ["packages/core/src/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- run the development CLI directly against core TypeScript sources
- stop rebuilding and deleting shared core output before every source CLI invocation
- retain the existing clean core build for production and release paths

## Reproduction

Eight concurrent core builds caused one process to fail while copying shared FFmpeg assets:

`ENOENT: no such file or directory, unlink packages/core/dist/ffmpeg-wasm/node/ffprobe_g`

## Verification

- core import resolves to `packages/core/src/index.ts`
- eight concurrent `pnpm -s summarize --version` invocations pass
- core dist timestamps remain unchanged by development CLI runs
- real local-file summary passes through the development CLI
- `pnpm -s build`
- `pnpm exec vitest run tests/package-scripts.test.ts`
- `pnpm -s check`
- autoreview: no actionable findings
