### PR TITLE
fix: report calibrated slide threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - CLI extraction: honor `--max-extract-characters` for remote text and document assets, not only web-page extraction.
+- Slides: report the calibrated scene threshold in JSON and `slides.json` when interval fallback supplies frames after zero scene detections.
 - Slides: render extracted slide labels or debug paths for `--slides --extract` even when a direct video has no transcript.
 - CLI errors: print Commander validation failures and missing-input help once instead of duplicating them across stdout/stderr.
 - Shell completions: sync and package Fish completions for both CLI aliases and subcommands, with candidate values matched to accepted CLI choices (#277, thanks @vincent-peng).

--- a/src/slides/frame-extraction.ts
+++ b/src/slides/frame-extraction.ts
@@ -118,7 +118,7 @@ export async function detectSlideTimestamps({
   const autoTune: SlideAutoTune = autoTuneThreshold
     ? {
         enabled: true,
-        chosenThreshold: timestamps.length > 0 ? effectiveThreshold : baseThreshold,
+        chosenThreshold: effectiveThreshold,
         confidence: calibration.confidence,
         strategy: "hash",
       }

--- a/tests/slides.scene-detection.test.ts
+++ b/tests/slides.scene-detection.test.ts
@@ -3,14 +3,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   runProcess: vi.fn(),
   runProcessCapture: vi.fn(),
+  runProcessCaptureBuffer: vi.fn(),
 }));
 
 vi.mock("../src/slides/process.js", () => ({
   runProcess: mocks.runProcess,
   runProcessCapture: mocks.runProcessCapture,
-  runProcessCaptureBuffer: vi.fn(),
+  runProcessCaptureBuffer: mocks.runProcessCaptureBuffer,
+  runWithConcurrency: async <T>(tasks: Array<() => Promise<T>>) =>
+    Promise.all(tasks.map((task) => task())),
 }));
 
+import { detectSlideTimestamps } from "../src/slides/frame-extraction.js";
 import {
   adjustTimestampWithinSegment,
   applyMaxSlidesFilter,
@@ -160,6 +164,44 @@ describe("slides scene detection", () => {
       [2, 2],
     ]);
     expect(mocks.runProcess).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the calibrated threshold when interval fallback replaces zero scene detections", async () => {
+    mocks.runProcessCapture.mockResolvedValue(
+      JSON.stringify({
+        streams: [{ codec_type: "video", width: 1280, height: 720, duration: "10" }],
+      }),
+    );
+    const darkThenLight = Buffer.concat([Buffer.alloc(512, 0), Buffer.alloc(512, 255)]);
+    const lightThenDark = Buffer.concat([Buffer.alloc(512, 255), Buffer.alloc(512, 0)]);
+    mocks.runProcessCaptureBuffer
+      .mockResolvedValueOnce(darkThenLight)
+      .mockResolvedValueOnce(lightThenDark)
+      .mockResolvedValueOnce(darkThenLight);
+    mocks.runProcess.mockResolvedValue(undefined);
+    const warnings: string[] = [];
+
+    const result = await detectSlideTimestamps({
+      ffmpegPath: "ffmpeg",
+      ffprobePath: "ffprobe",
+      inputPath: "/tmp/video.mp4",
+      sceneThreshold: 0.3,
+      autoTuneThreshold: true,
+      env: {},
+      timeoutMs: 1000,
+      warnings,
+      workers: 1,
+      sampleCount: 3,
+    });
+
+    expect(result.timestamps).toEqual([]);
+    expect(result.autoTune).toEqual({
+      enabled: true,
+      chosenThreshold: 0.05,
+      confidence: 1,
+      strategy: "hash",
+    });
+    expect(warnings).toEqual(["Auto-tuned scene threshold from 0.3 to 0.05"]);
   });
 
   it("parses ffprobe output and falls back to format duration", async () => {


### PR DESCRIPTION
## Summary

- keep slide auto-tune metadata at the threshold actually used for detection
- prevent JSON and persisted `slides.json` from contradicting the auto-tune warning
- cover the zero-scene-detection plus interval-fallback path

## Reproduction

Standalone slide extraction for the MDN flower video returned:

- warning: auto-tuned from 0.3 to 0.05
- `autoTune.chosenThreshold`: 0.3

## Verification

- `pnpm exec vitest run tests/slides.scene-detection.test.ts`
- `pnpm -s build`
- live standalone slides extraction against the MDN flower video now reports and persists 0.05
- `pnpm -s check`
- autoreview: no actionable findings
