### PR TITLE
fix: honor explicit slide thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - CLI extraction: honor `--max-extract-characters` for remote text and document assets, not only web-page extraction.
+- Slides: honor explicit and configured scene thresholds without silently replacing them through auto-tuning.
 - Slides: report the calibrated scene threshold in JSON and `slides.json` when interval fallback supplies frames after zero scene detections.
 - Slides: render extracted slide labels or debug paths for `--slides --extract` even when a direct video has no transcript.
 - CLI errors: print Commander validation failures and missing-input help once instead of duplicating them across stdout/stderr.

--- a/src/slides/settings.ts
+++ b/src/slides/settings.ts
@@ -99,7 +99,7 @@ export function resolveSlideSettings(input: SlideSettingsInput): SlideSettings |
     ocr: Boolean(ocrFlag ?? false),
     outputDir,
     sceneThreshold,
-    autoTuneThreshold: true,
+    autoTuneThreshold: !input.slidesSceneThresholdExplicit,
     maxSlides,
     minDurationSeconds,
   };

--- a/tests/cli.slides-mode.test.ts
+++ b/tests/cli.slides-mode.test.ts
@@ -75,6 +75,7 @@ vi.mock("../src/run/slides-render.js", async () => {
 describe("cli slides mode", () => {
   afterEach(() => {
     renderMocks.renderSlidesInline.mockClear();
+    mocks.extractSlidesForSource.mockClear();
   });
 
   it("prints slide paths in text mode", async () => {
@@ -104,6 +105,24 @@ describe("cli slides mode", () => {
     const parsed = JSON.parse(stdout.getText());
     expect(parsed.ok).toBe(true);
     expect(parsed.slides?.slides?.length).toBe(1);
+  });
+
+  it("keeps an explicit scene threshold instead of auto-tuning it", async () => {
+    const stdout = collectStream({ isTTY: false });
+    const stderr = collectStream({ isTTY: false });
+    await runCli(
+      ["slides", "https://example.com/video.mp4", "--json", "--slides-scene-threshold", "0.2"],
+      {
+        env: { HOME: "/tmp" },
+        fetch: globalThis.fetch.bind(globalThis),
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+      },
+    );
+
+    const call = mocks.extractSlidesForSource.mock.calls[0]?.[0];
+    expect(call?.settings.sceneThreshold).toBe(0.2);
+    expect(call?.settings.autoTuneThreshold).toBe(false);
   });
 
   it("fails to render inline when stdout is not a TTY", async () => {

--- a/tests/runner-slides.test.ts
+++ b/tests/runner-slides.test.ts
@@ -13,6 +13,18 @@ describe("resolveRunnerSlidesSettings", () => {
     expect(settings?.enabled).toBe(true);
   });
 
+  it("disables auto-tuning when the scene threshold is explicit", () => {
+    const settings = resolveRunnerSlidesSettings({
+      normalizedArgv: ["--slides", "--slides-scene-threshold", "0.2"],
+      programOpts: { slides: true, slidesSceneThreshold: "0.2" },
+      config: null,
+      inputTarget: { kind: "file", filePath: "/tmp/video.webm" },
+    });
+
+    expect(settings?.sceneThreshold).toBe(0.2);
+    expect(settings?.autoTuneThreshold).toBe(false);
+  });
+
   it("rejects slides for stdin", () => {
     expect(() =>
       resolveRunnerSlidesSettings({

--- a/tests/slides.settings.test.ts
+++ b/tests/slides.settings.test.ts
@@ -43,6 +43,18 @@ describe("resolveSlideSettings", () => {
     });
   });
 
+  it("disables auto-tuning for an explicit scene threshold", () => {
+    const settings = resolveSlideSettings({
+      slides: true,
+      slidesSceneThreshold: "0.2",
+      slidesSceneThresholdExplicit: true,
+      cwd: "/tmp",
+    });
+
+    expect(settings?.sceneThreshold).toBe(0.2);
+    expect(settings?.autoTuneThreshold).toBe(false);
+  });
+
   it("rejects invalid scene threshold", () => {
     expect(() =>
       resolveSlideSettings({ slides: true, slidesSceneThreshold: "2", cwd: "/tmp" }),


### PR DESCRIPTION
## Summary

- disable scene-threshold calibration when the CLI or config supplies a threshold
- preserve default auto-tuning when no threshold is explicit
- cover direct settings, main runner, and standalone slides command wiring

## Reproduction

`--slides-scene-threshold 0.2` previously returned `autoTuneThreshold: true`, detected at 0.05, and warned that the explicit value was auto-tuned away.

## Verification

- `pnpm exec vitest run tests/slides.settings.test.ts tests/runner-slides.test.ts tests/cli.slides-mode.test.ts`
- `pnpm -s build`
- live standalone extraction reports auto-tune disabled and chosen threshold 0.2
- `pnpm -s check`
- autoreview: no actionable findings
