### PR TITLE
fix: wait for first-open cache locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - CLI extraction: honor `--max-extract-characters` for remote text and document assets, not only web-page extraction.
+- Cache: wait for concurrent first-open SQLite locks before enabling WAL instead of failing CLI startup with `database is locked`.
 - Slides: honor explicit and configured scene thresholds without silently replacing them through auto-tuning.
 - Slides: report the calibrated scene threshold in JSON and `slides.json` when interval fallback supplies frames after zero scene detections.
 - Slides: render extracted slide labels or debug paths for `--slides --extract` even when a direct video has no transcript.

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -193,9 +193,9 @@ export async function createCacheStore({
 }): Promise<CacheStore> {
   ensureDir(dirname(path));
   const db = await openSqlite(path);
+  db.exec("PRAGMA busy_timeout=5000");
   db.exec("PRAGMA journal_mode=WAL");
   db.exec("PRAGMA synchronous=NORMAL");
-  db.exec("PRAGMA busy_timeout=5000");
   db.exec("PRAGMA auto_vacuum=INCREMENTAL");
   db.exec(`
     CREATE TABLE IF NOT EXISTS cache_entries (

--- a/tests/cache.store.test.ts
+++ b/tests/cache.store.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -5,6 +6,56 @@ import { describe, expect, it } from "vitest";
 import { buildTranscriptCacheKey, createCacheStore } from "../src/cache.js";
 
 describe("cache store", () => {
+  it("waits for a first-open database lock before enabling WAL", async () => {
+    const root = mkdtempSync(join(tmpdir(), "summarize-cache-"));
+    const path = join(root, "cache.sqlite");
+    const holder = spawn(
+      process.execPath,
+      [
+        "--no-warnings",
+        "--input-type=module",
+        "--eval",
+        `
+          import { DatabaseSync } from "node:sqlite";
+          const db = new DatabaseSync(process.argv[1]);
+          db.exec("CREATE TABLE holder (id INTEGER)");
+          db.exec("BEGIN EXCLUSIVE");
+          process.stdout.write("locked\\n");
+          setTimeout(() => {
+            db.exec("COMMIT");
+            db.close();
+          }, 300);
+        `,
+        path,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const holderExit = new Promise<void>((resolve, reject) => {
+      holder.on("error", reject);
+      holder.on("close", (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`lock holder exited with code ${String(code)}`));
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      let output = "";
+      holder.on("error", reject);
+      holder.stdout.on("data", (chunk) => {
+        output += chunk.toString();
+        if (output.includes("locked")) resolve();
+      });
+      holder.on("close", (code) => {
+        if (!output.includes("locked")) {
+          reject(new Error(`lock holder exited before acquiring the lock (${String(code)})`));
+        }
+      });
+    });
+
+    const store = await createCacheStore({ path, maxBytes: 1024 * 1024 });
+    store.close();
+    await holderExit;
+  });
+
   it("round-trips text entries", async () => {
     const root = mkdtempSync(join(tmpdir(), "summarize-cache-"));
     const path = join(root, "cache.sqlite");


### PR DESCRIPTION
## Summary

- install SQLite's busy timeout before negotiating WAL mode
- let concurrent first-open CLI processes wait for cache initialization locks
- add a deterministic external exclusive-lock regression

## Reproduction

A 12-process fresh-home stress run failed in round 2 with `database is locked`. The focused regression also failed at `PRAGMA journal_mode=WAL` before the fix.

## Verification

- deterministic lock-holder regression passes
- 30 rounds of 12 concurrent fresh-home CLI processes pass
- `pnpm -s build`
- `pnpm exec vitest run tests/cache.store.test.ts`
- `pnpm -s check`
- autoreview: no actionable findings after fixing one accepted test-listener race
