### PR TITLE
fix: restore daemon chat history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Chrome extension: restore persisted chat history after the daemon agent-route refactor.
 - CLI extraction: honor `--max-extract-characters` for remote text and document assets, not only web-page extraction.
 - Cache: wait for concurrent first-open SQLite locks before enabling WAL instead of failing CLI startup with `database is locked`.
 - Slides: honor explicit and configured scene thresholds without silently replacing them through auto-tuning.

--- a/src/daemon/agent-cache.ts
+++ b/src/daemon/agent-cache.ts
@@ -1,0 +1,118 @@
+import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
+import {
+  buildLanguageKey,
+  buildLengthKey,
+  buildSummaryCacheKey,
+  hashJson,
+  normalizeContentForHash,
+  type CacheState,
+} from "../cache.js";
+import { resolveOutputLanguageSetting, resolveSummaryLength } from "../run/run-settings.js";
+import { buildAgentPromptHash } from "./agent.js";
+
+export type AgentCacheInput = {
+  pageUrl: string;
+  cacheContent: string;
+  model: string | null;
+  length: unknown;
+  language: unknown;
+  automationEnabled: boolean;
+};
+
+type ChatHistoryMessage = Extract<Message, { role: "user" | "assistant" | "toolResult" }>;
+
+export function buildAgentCacheKey({
+  pageUrl,
+  cacheContent,
+  model,
+  length,
+  language,
+  automationEnabled,
+}: AgentCacheInput): string {
+  const contentHash = hashJson({
+    pageUrl: pageUrl.trim(),
+    content: normalizeContentForHash(cacheContent),
+  });
+  const promptHash = buildAgentPromptHash(automationEnabled);
+  const { lengthArg } = resolveSummaryLength(length, "xl");
+  const outputLanguage = resolveOutputLanguageSetting({
+    raw: language,
+    fallback: { kind: "auto" },
+  });
+  const modelKey = typeof model === "string" && model.trim() ? model.trim() : "auto";
+  return buildSummaryCacheKey({
+    contentHash,
+    promptHash,
+    model: modelKey,
+    lengthKey: buildLengthKey(lengthArg),
+    languageKey: buildLanguageKey(outputLanguage),
+  });
+}
+
+function filterChatHistoryMessages(raw: unknown): ChatHistoryMessage[] {
+  if (!Array.isArray(raw)) return [];
+  const now = Date.now();
+  return raw.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const message = item as Message;
+    if (message.role !== "user" && message.role !== "assistant" && message.role !== "toolResult") {
+      return [];
+    }
+    return [
+      {
+        ...message,
+        timestamp: typeof message.timestamp === "number" ? message.timestamp : now,
+      } as ChatHistoryMessage,
+    ];
+  });
+}
+
+function resolveCacheStore(cacheState: CacheState) {
+  return cacheState.mode === "default" ? cacheState.store : null;
+}
+
+export function readAgentHistory({
+  cacheState,
+  cacheInput,
+}: {
+  cacheState: CacheState;
+  cacheInput: AgentCacheInput;
+}): Message[] | null {
+  const cacheStore = resolveCacheStore(cacheState);
+  if (!cacheStore) return null;
+  const cached = cacheStore.getJson<unknown>("chat", buildAgentCacheKey(cacheInput));
+  if (!cached) return null;
+  const rawMessages = Array.isArray(cached)
+    ? cached
+    : typeof cached === "object" &&
+        cached &&
+        Array.isArray((cached as { messages?: unknown }).messages)
+      ? (cached as { messages: unknown[] }).messages
+      : null;
+  return rawMessages ? filterChatHistoryMessages(rawMessages) : null;
+}
+
+export function writeAgentHistory({
+  cacheState,
+  cacheInput,
+  messages,
+  assistant,
+}: {
+  cacheState: CacheState;
+  cacheInput: AgentCacheInput;
+  messages: unknown;
+  assistant: AssistantMessage;
+}): void {
+  const cacheStore = resolveCacheStore(cacheState);
+  if (!cacheStore) return;
+  const history = filterChatHistoryMessages([
+    ...(Array.isArray(messages) ? messages : []),
+    assistant,
+  ]);
+  cacheStore.setJson(
+    "chat",
+    buildAgentCacheKey(cacheInput),
+    { messages: history },
+    cacheState.ttlMs,
+  );
+}

--- a/src/daemon/server-agent-route.ts
+++ b/src/daemon/server-agent-route.ts
@@ -1,7 +1,9 @@
 import type http from "node:http";
-import type { Message } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
 import { encodeSseEvent, type SseEvent } from "@steipete/summarize-core/runtime";
+import type { CacheState } from "../cache.js";
 import { runWithProcessContext } from "../processes.js";
+import { type AgentCacheInput, readAgentHistory, writeAgentHistory } from "./agent-cache.js";
 import { completeAgentResponse, streamAgentResponse } from "./agent.js";
 import { json, readJsonBody, wantsJsonResponse } from "./server-http.js";
 
@@ -11,6 +13,7 @@ export async function handleAgentRoute({
   url,
   cors,
   env,
+  cacheState,
   createRunId,
 }: {
   req: http.IncomingMessage;
@@ -18,9 +21,12 @@ export async function handleAgentRoute({
   url: URL;
   cors: Record<string, string>;
   env: Record<string, string | undefined>;
+  cacheState: CacheState;
   createRunId: () => string;
 }) {
-  if (!(req.method === "POST" && url.pathname === "/v1/agent")) {
+  const isAgentRequest = req.method === "POST" && url.pathname === "/v1/agent";
+  const isHistoryRequest = req.method === "POST" && url.pathname === "/v1/agent/history";
+  if (!isAgentRequest && !isHistoryRequest) {
     return false;
   }
 
@@ -41,8 +47,14 @@ export async function handleAgentRoute({
   const pageUrl = typeof obj.url === "string" ? obj.url.trim() : "";
   const pageTitle = typeof obj.title === "string" ? obj.title.trim() : null;
   const pageContent = typeof obj.pageContent === "string" ? obj.pageContent : "";
+  const cacheContent =
+    typeof obj.cacheContent === "string" && obj.cacheContent.trim().length > 0
+      ? obj.cacheContent
+      : pageContent;
   const messages = obj.messages;
   const modelOverride = typeof obj.model === "string" ? obj.model.trim() : null;
+  const lengthRaw = obj.length;
+  const languageRaw = obj.language;
   const tools = Array.isArray(obj.tools)
     ? obj.tools.filter((tool): tool is string => typeof tool === "string")
     : [];
@@ -50,6 +62,19 @@ export async function handleAgentRoute({
 
   if (!pageUrl) {
     json(res, 400, { ok: false, error: "missing url" }, cors);
+    return true;
+  }
+
+  const cacheInput: AgentCacheInput = {
+    pageUrl,
+    cacheContent,
+    model: modelOverride,
+    length: lengthRaw,
+    language: languageRaw,
+    automationEnabled,
+  };
+  if (isHistoryRequest) {
+    json(res, 200, { ok: true, messages: readAgentHistory({ cacheState, cacheInput }) }, cors);
     return true;
   }
 
@@ -71,6 +96,7 @@ export async function handleAgentRoute({
           automationEnabled,
         }),
       );
+      writeAgentHistory({ cacheState, cacheInput, messages, assistant });
       json(res, 200, { ok: true, assistant }, cors);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -98,6 +124,7 @@ export async function handleAgentRoute({
     res.write(encodeSseEvent(event));
   };
 
+  let finalAssistant: AssistantMessage | null = null;
   try {
     await runWithProcessContext({ runId, source: "agent" }, async () =>
       streamAgentResponse({
@@ -110,10 +137,16 @@ export async function handleAgentRoute({
         tools,
         automationEnabled,
         onChunk: (text) => writeEvent({ event: "chunk", data: { text } }),
-        onAssistant: (assistant) => writeEvent({ event: "assistant", data: assistant }),
+        onAssistant: (assistant) => {
+          finalAssistant = assistant;
+          writeEvent({ event: "assistant", data: assistant });
+        },
         signal: controller.signal,
       }),
     );
+    if (finalAssistant) {
+      writeAgentHistory({ cacheState, cacheInput, messages, assistant: finalAssistant });
+    }
     writeEvent({ event: "done", data: {} });
     res.end();
   } catch (error) {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -173,7 +173,17 @@ export async function runDaemonServer({
         return;
       }
 
-      if (await handleAgentRoute({ req, res, url, cors, env, createRunId: randomUUID })) {
+      if (
+        await handleAgentRoute({
+          req,
+          res,
+          url,
+          cors,
+          env,
+          cacheState,
+          createRunId: randomUUID,
+        })
+      ) {
         return;
       }
 

--- a/tests/daemon.agent-history.test.ts
+++ b/tests/daemon.agent-history.test.ts
@@ -1,0 +1,192 @@
+import { mkdtempSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runDaemonServer } from "../src/daemon/server.js";
+import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+
+const mocks = vi.hoisted(() => ({
+  completeSimple: vi.fn(),
+  getModel: vi.fn(),
+  streamSimple: vi.fn(),
+}));
+
+vi.mock("@earendil-works/pi-ai", () => ({
+  completeSimple: mocks.completeSimple,
+  getModel: mocks.getModel,
+  streamSimple: mocks.streamSimple,
+}));
+
+const findFreePort = async (): Promise<number> =>
+  await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to resolve port")));
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+
+const model = {
+  id: "gpt-5.2",
+  name: "gpt-5.2",
+  provider: "openai",
+  api: "openai-responses" as const,
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: false,
+  input: ["text"] as const,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 8192,
+  maxTokens: 2048,
+};
+
+beforeEach(() => {
+  const assistant = makeAssistantMessage({ text: "Cached reply" });
+  mocks.completeSimple.mockReset();
+  mocks.getModel.mockReset();
+  mocks.streamSimple.mockReset();
+  mocks.getModel.mockReturnValue(model);
+  mocks.completeSimple.mockResolvedValue(assistant);
+  mocks.streamSimple.mockReturnValue(makeTextDeltaStream(["Cached ", "reply"], assistant));
+});
+
+describe("daemon agent history", () => {
+  it("persists JSON and SSE responses and isolates cache keys", async () => {
+    const home = mkdtempSync(join(tmpdir(), "summarize-daemon-agent-history-"));
+    const port = await findFreePort();
+    const token = "test-agent-history-token";
+    const abortController = new AbortController();
+    let resolveReady: (() => void) | null = null;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const serverPromise = runDaemonServer({
+      env: { HOME: home, OPENAI_API_KEY: "test-key" },
+      fetchImpl: fetch,
+      config: {
+        version: 2,
+        token,
+        tokens: [token],
+        port,
+        env: {},
+        installedAt: new Date().toISOString(),
+      },
+      port,
+      signal: abortController.signal,
+      onListening: () => resolveReady?.(),
+    });
+    await ready;
+
+    const request = async (pathname: string, body: Record<string, unknown>, accept?: string) => {
+      const response = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+          ...(accept ? { accept } : {}),
+        },
+        body: JSON.stringify(body),
+      });
+      return response;
+    };
+    const cacheFields = {
+      url: "https://example.com/article",
+      pageContent: "Rendered page context",
+      cacheContent: "Stable extracted article",
+      model: "openai/gpt-5.2",
+      length: "short",
+      language: "en",
+      automationEnabled: false,
+    };
+
+    try {
+      const miss = await request("/v1/agent/history", cacheFields);
+      expect(miss.status).toBe(200);
+      expect(await miss.json()).toEqual({ ok: true, messages: null });
+
+      const jsonResponse = await request(
+        "/v1/agent",
+        {
+          ...cacheFields,
+          automationEnabled: true,
+          messages: [
+            { role: "user", content: "JSON question" },
+            {
+              role: "toolResult",
+              toolCallId: "call-1",
+              toolName: "repl",
+              content: [{ type: "text", text: "Tool output" }],
+              isError: false,
+            },
+          ],
+        },
+        "application/json",
+      );
+      expect(jsonResponse.status).toBe(200);
+      expect(await jsonResponse.json()).toMatchObject({
+        ok: true,
+        assistant: { role: "assistant" },
+      });
+
+      const jsonHistory = await request("/v1/agent/history", {
+        ...cacheFields,
+        automationEnabled: true,
+      });
+      expect(jsonHistory.status).toBe(200);
+      expect(await jsonHistory.json()).toMatchObject({
+        ok: true,
+        messages: [
+          { role: "user", content: "JSON question", timestamp: expect.any(Number) },
+          {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "repl",
+            timestamp: expect.any(Number),
+          },
+          { role: "assistant", timestamp: expect.any(Number) },
+        ],
+      });
+
+      const isolatedHistory = await request("/v1/agent/history", {
+        ...cacheFields,
+        cacheContent: "Different extracted article",
+        automationEnabled: true,
+      });
+      expect(await isolatedHistory.json()).toEqual({ ok: true, messages: null });
+
+      const otherPageHistory = await request("/v1/agent/history", {
+        ...cacheFields,
+        url: "https://example.com/other",
+        automationEnabled: true,
+      });
+      expect(await otherPageHistory.json()).toEqual({ ok: true, messages: null });
+
+      const streamFields = { ...cacheFields, cacheContent: "Streamed extracted article" };
+      const streamResponse = await request("/v1/agent", {
+        ...streamFields,
+        messages: [{ role: "user", content: "SSE question" }],
+      });
+      expect(streamResponse.status).toBe(200);
+      const streamBody = await streamResponse.text();
+      expect(streamBody).toContain("event: assistant");
+      expect(streamBody).toContain("event: done");
+
+      const streamHistory = await request("/v1/agent/history", streamFields);
+      expect(await streamHistory.json()).toMatchObject({
+        ok: true,
+        messages: [
+          { role: "user", content: "SSE question", timestamp: expect.any(Number) },
+          { role: "assistant", timestamp: expect.any(Number) },
+        ],
+      });
+    } finally {
+      abortController.abort();
+      await serverPromise;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- restore the documented `POST /v1/agent/history` daemon route
- persist successful JSON and SSE agent responses in the chat cache
- retain user, assistant, and tool-result messages
- scope history keys by URL, content, model, length, language, and automation prompt

## Regression

The slides refactor removed daemon chat persistence and the history route while the Chrome extension and docs continued to call and advertise it. Live authenticated requests returned 404.

## Verification

- `pnpm -s check` (523 files passed, 29 skipped; 2,759 tests passed, 43 skipped)
- `pnpm -s build`
- focused daemon agent/cache suite
- compiled foreground daemon: SSE response persisted user/toolResult/assistant history; identical content on another URL returned no history
- autoreview clean after fixing tool-result retention and cross-page cache isolation
