### PR TITLE
fix: cancel disconnected CLI agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Daemon chat: cancel CLI-backed agent processes when their HTTP client disconnects.
 - Chrome extension: restore persisted chat history after the daemon agent-route refactor.
 - CLI extraction: honor `--max-extract-characters` for remote text and document assets, not only web-page extraction.
 - Cache: wait for concurrent first-open SQLite locks before enabling WAL instead of failing CLI startup with `database is locked`.

--- a/src/daemon/agent.ts
+++ b/src/daemon/agent.ts
@@ -325,6 +325,7 @@ export async function streamAgentResponse({
         timeoutMs: 120_000,
         env,
         config: resolved.cliConfig,
+        signal,
       }),
     );
     onChunk(result.text);
@@ -383,6 +384,7 @@ export async function completeAgentResponse({
   modelOverride,
   tools,
   automationEnabled,
+  signal,
 }: {
   env: Record<string, string | undefined>;
   pageUrl: string;
@@ -392,6 +394,7 @@ export async function completeAgentResponse({
   modelOverride: string | null;
   tools: string[];
   automationEnabled: boolean;
+  signal?: AbortSignal;
 }): Promise<AssistantMessage> {
   const normalizedMessages = normalizeMessages(messages);
   const toolList = resolveToolList(automationEnabled, tools, TOOL_DEFINITIONS);
@@ -420,6 +423,7 @@ export async function completeAgentResponse({
         timeoutMs: 120_000,
         env,
         config: resolved.cliConfig,
+        signal,
       }),
     );
     return { role: "assistant", content: result.text } as unknown as AssistantMessage;
@@ -439,6 +443,7 @@ export async function completeAgentResponse({
       maxTokens: maxOutputTokens,
       ...resolveProviderPayloadOptions(provider),
       apiKey,
+      signal,
     },
   );
 

--- a/src/daemon/server-agent-route.ts
+++ b/src/daemon/server-agent-route.ts
@@ -81,6 +81,10 @@ export async function handleAgentRoute({
   const normalizedModelOverride =
     modelOverride && modelOverride.toLowerCase() !== "auto" ? modelOverride : null;
   const runId = `agent-${createRunId()}`;
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  req.once("aborted", abort);
+  res.once("close", abort);
   const wantsJson = wantsJsonResponse(req, url);
   if (wantsJson) {
     try {
@@ -94,11 +98,13 @@ export async function handleAgentRoute({
           modelOverride: normalizedModelOverride,
           tools,
           automationEnabled,
+          signal: controller.signal,
         }),
       );
       writeAgentHistory({ cacheState, cacheInput, messages, assistant });
       json(res, 200, { ok: true, assistant }, cors);
     } catch (error) {
+      if (controller.signal.aborted) return true;
       const message = error instanceof Error ? error.message : String(error);
       console.error("[summarize-daemon] agent failed", error);
       json(res, 500, { ok: false, error: message }, cors);
@@ -113,11 +119,6 @@ export async function handleAgentRoute({
     "x-accel-buffering": "no",
     ...cors,
   });
-
-  const controller = new AbortController();
-  const abort = () => controller.abort();
-  req.on("close", abort);
-  res.on("close", abort);
 
   const writeEvent = (event: SseEvent) => {
     if (res.writableEnded) return;

--- a/src/llm/cli-exec.ts
+++ b/src/llm/cli-exec.ts
@@ -67,6 +67,12 @@ function getExecCommand(error: CliExecError, cmd: string, args: string[]): strin
     : [cmd, ...args].join(" ");
 }
 
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("This operation was aborted", "AbortError");
+}
+
 export async function execCliWithInput({
   execFileImpl,
   cmd,
@@ -75,6 +81,7 @@ export async function execCliWithInput({
   timeoutMs,
   env,
   cwd,
+  signal,
 }: {
   execFileImpl: ExecFileFn;
   cmd: string;
@@ -83,9 +90,11 @@ export async function execCliWithInput({
   timeoutMs: number;
   env: Record<string, string | undefined>;
   cwd?: string;
+  signal?: AbortSignal;
 }): Promise<{ stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
     let interruptedSignal: NodeJS.Signals | null = null;
+    let aborted = false;
     let child: ReturnType<ExecFileFn> | null = null;
     const forwardSignal = (signal: NodeJS.Signals) => {
       if (interruptedSignal) return;
@@ -98,14 +107,30 @@ export async function execCliWithInput({
     };
     const handleSigint = () => forwardSignal("SIGINT");
     const handleSigterm = () => forwardSignal("SIGTERM");
+    const handleAbort = () => {
+      if (aborted) return;
+      aborted = true;
+      try {
+        child?.kill("SIGTERM");
+      } catch {
+        // Process may have already exited between cancellation and forwarding.
+      }
+    };
     const cleanupSignalHandlers = () => {
       process.removeListener("SIGINT", handleSigint);
       process.removeListener("SIGTERM", handleSigterm);
+      signal?.removeEventListener("abort", handleAbort);
     };
+
+    if (signal?.aborted) {
+      reject(abortReason(signal));
+      return;
+    }
 
     // Run before progress UI exit handlers so active CLI backends don't survive Ctrl+C.
     process.prependOnceListener("SIGINT", handleSigint);
     process.prependOnceListener("SIGTERM", handleSigterm);
+    signal?.addEventListener("abort", handleAbort, { once: true });
 
     child = execFileImpl(
       cmd,
@@ -119,6 +144,10 @@ export async function execCliWithInput({
       (error, stdout, stderr) => {
         cleanupSignalHandlers();
         const stderrText = toUtf8String(stderr);
+        if (aborted && signal) {
+          reject(abortReason(signal));
+          return;
+        }
         if (interruptedSignal) {
           reject(new CliInterruptedError(interruptedSignal));
           return;
@@ -145,6 +174,14 @@ export async function execCliWithInput({
         resolve({ stdout: toUtf8String(stdout), stderr: stderrText });
       },
     );
+
+    if (aborted) {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // Process may have exited synchronously in an injected exec implementation.
+      }
+    }
 
     if (child.stdin) {
       child.stdin.write(input);

--- a/src/llm/cli.ts
+++ b/src/llm/cli.ts
@@ -57,6 +57,7 @@ type RunCliModelOptions = {
   cwd?: string;
   extraArgs?: string[];
   systemPrompt?: string | null;
+  signal?: AbortSignal;
 };
 
 type CliRunResult = {
@@ -203,6 +204,7 @@ export async function runCliModel({
   cwd,
   extraArgs,
   systemPrompt,
+  signal,
 }: RunCliModelOptions): Promise<CliRunResult> {
   const execFileFn = execFileImpl ?? execFile;
   const binary = resolveCliBinary(provider, config, env);
@@ -253,6 +255,7 @@ export async function runCliModel({
       timeoutMs,
       env: effectiveEnv,
       cwd,
+      signal,
     });
     const parsed = JSON.parse(stdout);
     const payloads = parsed?.result?.payloads;
@@ -286,6 +289,7 @@ export async function runCliModel({
         timeoutMs,
         env: effectiveEnv,
         cwd: isolatedCwd ?? cwd,
+        signal,
       });
       return parseOpenCodeOutputFromJsonl(stdout);
     } finally {
@@ -335,6 +339,7 @@ export async function runCliModel({
         timeoutMs,
         env: isolatedCodexHome ? { ...effectiveEnv, CODEX_HOME: isolatedCodexHome } : effectiveEnv,
         cwd: isolatedCwd ?? cwd,
+        signal,
       });
       const { usage, costUsd } = parseCodexUsageFromJsonl(stdout);
       let fileText = "";
@@ -385,6 +390,7 @@ export async function runCliModel({
       timeoutMs,
       env: effectiveEnv,
       cwd,
+      signal,
     });
     const text = stdout.trim();
     if (!text) throw new Error("CLI returned empty output");
@@ -417,6 +423,7 @@ export async function runCliModel({
         timeoutMs,
         env: effectiveEnv,
         cwd: isolatedCwd ?? cwd,
+        signal,
       });
       const text = stdout.trim();
       if (!text) throw new Error("CLI returned empty output");
@@ -464,6 +471,7 @@ export async function runCliModel({
         timeoutMs,
         env: effectiveEnv,
         cwd: isolatedCwd ?? cwd,
+        signal,
       });
       return parsePiOutputFromJsonl(stdout);
     } finally {
@@ -496,6 +504,7 @@ export async function runCliModel({
     timeoutMs,
     env: effectiveEnv,
     cwd,
+    signal,
   });
   return parseJsonProviderOutput({ provider, stdout });
 }

--- a/tests/daemon.agent-disconnect.test.ts
+++ b/tests/daemon.agent-disconnect.test.ts
@@ -1,0 +1,115 @@
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runDaemonServer } from "../src/daemon/server.js";
+
+const findFreePort = async (): Promise<number> =>
+  await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to resolve port")));
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+
+async function waitForMarker(markerPath: string, expected: string): Promise<void> {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    if (existsSync(markerPath) && readFileSync(markerPath, "utf8").trim() === expected) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for ${expected} marker`);
+}
+
+describe("daemon agent disconnect", () => {
+  it("cancels CLI-backed SSE and JSON agent processes", async () => {
+    const home = mkdtempSync(join(tmpdir(), "summarize-daemon-agent-disconnect-"));
+    const markerPath = join(home, "marker.txt");
+    const cliPath = join(home, "fake-openclaw.cjs");
+    writeFileSync(
+      cliPath,
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const marker = process.env.CANCEL_MARKER;
+fs.writeFileSync(marker, "started");
+process.on("SIGTERM", () => {
+  fs.writeFileSync(marker, "interrupted");
+  process.exit(0);
+});
+setTimeout(() => {
+  fs.writeFileSync(marker, "completed");
+  process.stdout.write('{"result":{"payloads":[{"text":"late"}]}}\\n');
+}, 10000);
+`,
+      { mode: 0o700 },
+    );
+    chmodSync(cliPath, 0o700);
+
+    const port = await findFreePort();
+    const token = "test-agent-disconnect-token";
+    const daemonController = new AbortController();
+    let resolveReady: (() => void) | null = null;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const serverPromise = runDaemonServer({
+      env: {
+        HOME: home,
+        OPENCLAW_PATH: cliPath,
+        CANCEL_MARKER: markerPath,
+      },
+      fetchImpl: fetch,
+      config: {
+        version: 2,
+        token,
+        tokens: [token],
+        port,
+        env: {},
+        installedAt: new Date().toISOString(),
+      },
+      port,
+      signal: daemonController.signal,
+      onListening: () => resolveReady?.(),
+    });
+    await ready;
+
+    const disconnect = async (accept?: string) => {
+      rmSync(markerPath, { force: true });
+      const requestController = new AbortController();
+      const responsePromise = fetch(`http://127.0.0.1:${port}/v1/agent`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+          ...(accept ? { accept } : {}),
+        },
+        body: JSON.stringify({
+          url: "https://example.com/disconnect",
+          pageContent: "Disconnect context",
+          messages: [{ role: "user", content: "Wait" }],
+          model: "cli/openclaw/main",
+        }),
+        signal: requestController.signal,
+      }).then((response) => response.text());
+      await waitForMarker(markerPath, "started");
+      requestController.abort();
+      await expect(responsePromise).rejects.toMatchObject({ name: "AbortError" });
+      await waitForMarker(markerPath, "interrupted");
+    };
+
+    try {
+      await disconnect();
+      await disconnect("application/json");
+    } finally {
+      daemonController.abort();
+      await serverPromise;
+    }
+  });
+});

--- a/tests/llm.cli-exec-signals.test.ts
+++ b/tests/llm.cli-exec-signals.test.ts
@@ -3,6 +3,58 @@ import { CliInterruptedError, execCliWithInput } from "../src/llm/cli-exec.js";
 import type { ExecFileFn } from "../src/markitdown.js";
 
 describe("execCliWithInput signals", () => {
+  it("terminates the active child when the request aborts", async () => {
+    const kill = vi.fn();
+    let callback: Parameters<ExecFileFn>[3] | undefined;
+    const controller = new AbortController();
+
+    const execFileImpl: ExecFileFn = ((_cmd, _args, _options, cb) => {
+      callback = cb;
+      return {
+        kill,
+        stdin: {
+          write: vi.fn(),
+          end: vi.fn(),
+        },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    const promise = execCliWithInput({
+      execFileImpl,
+      cmd: "slow-cli",
+      args: [],
+      input: "prompt",
+      timeoutMs: 10_000,
+      env: {},
+      signal: controller.signal,
+    });
+
+    controller.abort();
+    callback?.(Object.assign(new Error("terminated"), { signal: "SIGTERM", killed: true }), "", "");
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("does not start a child for an already-aborted request", async () => {
+    const execFileImpl = vi.fn() as unknown as ExecFileFn;
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      execCliWithInput({
+        execFileImpl,
+        cmd: "slow-cli",
+        args: [],
+        input: "prompt",
+        timeoutMs: 10_000,
+        env: {},
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(execFileImpl).not.toHaveBeenCalled();
+  });
+
   it("forwards SIGINT to the active child and rejects as an interrupt", async () => {
     const beforeSigint = process.listenerCount("SIGINT");
     const beforeSigterm = process.listenerCount("SIGTERM");


### PR DESCRIPTION
## Summary

- propagate daemon agent request cancellation into native and CLI model calls
- add AbortSignal support to all CLI provider executions
- terminate active CLI children when SSE or JSON clients disconnect
- avoid spawning CLI children for already-aborted requests

## Regression

Disconnecting `/v1/agent` stopped the HTTP stream but CLI-backed agent processes continued running to completion because the route AbortSignal ended at `streamAgentResponse`.

## Verification

- `pnpm -s check` (524 files passed, 29 skipped; 2,762 tests passed, 43 skipped)
- `pnpm -s build`
- 64-test CLI provider suite
- real HTTP integration covering SSE and JSON disconnects with a spawned deterministic OpenClaw process
- compiled foreground daemon immediately interrupted the child after curl disconnected
- autoreview clean
