### PR TITLE
fix: serialize concurrent media cache writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Media cache: serialize index updates across concurrent daemon and CLI processes to prevent failed writes, lost entries, and orphaned files.
 - Daemon chat: cancel CLI-backed agent processes when their HTTP client disconnects.
 - Chrome extension: restore persisted chat history after the daemon agent-route refactor.
 - CLI extraction: honor `--max-extract-characters` for remote text and document assets, not only web-page extraction.

--- a/src/media-cache.ts
+++ b/src/media-cache.ts
@@ -1,6 +1,7 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { createReadStream, promises as fs } from "node:fs";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import type { MediaCache, MediaCacheEntry } from "./content/index.js";
 
 export type MediaCacheVerifyMode = "none" | "size" | "hash";
@@ -36,6 +37,9 @@ export const DEFAULT_MEDIA_CACHE_VERIFY: MediaCacheVerifyMode = "size";
 
 const INDEX_VERSION = 1;
 const INDEX_FILENAME = "index.json";
+const INDEX_LOCK_RETRY_MS = 25;
+const INDEX_LOCK_HEARTBEAT_MS = 30_000;
+const INDEX_LOCK_STALE_MS = 5 * 60_000;
 
 const ensureDir = async (path: string) => {
   await fs.mkdir(path, { recursive: true });
@@ -116,10 +120,66 @@ const readIndex = async (indexPath: string): Promise<MediaCacheIndex> => {
   return { version: INDEX_VERSION, entries: {} };
 };
 
+function isNodeErrorWithCode(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
+async function readLockInfo(lockPath: string) {
+  return fs.lstat(lockPath).catch((error: unknown) => {
+    if (isNodeErrorWithCode(error, "ENOENT")) return null;
+    throw error;
+  });
+}
+
+async function acquireIndexLock(indexPath: string): Promise<() => Promise<void>> {
+  const lockPath = `${indexPath}.lock`;
+
+  while (true) {
+    try {
+      const handle = await fs.open(lockPath, "wx", 0o600);
+      const identity = await handle.stat();
+      try {
+        await handle.writeFile(`${process.pid}\n`, "utf8");
+      } catch (error) {
+        await handle.close().catch(() => {});
+        await fs.unlink(lockPath).catch(() => {});
+        throw error;
+      }
+      const heartbeat = setInterval(() => {
+        const now = new Date();
+        void handle.utimes(now, now).catch(() => {});
+      }, INDEX_LOCK_HEARTBEAT_MS);
+      heartbeat.unref();
+      return async () => {
+        clearInterval(heartbeat);
+        await handle.close();
+        const current = await readLockInfo(lockPath);
+        if (current && current.dev === identity.dev && current.ino === identity.ino) {
+          await fs.unlink(lockPath);
+        }
+      };
+    } catch (error) {
+      if (!isNodeErrorWithCode(error, "EEXIST")) throw error;
+      const info = await readLockInfo(lockPath);
+      if (info?.isFile() && Date.now() - info.mtimeMs > INDEX_LOCK_STALE_MS) {
+        await fs.unlink(lockPath).catch((unlinkError: unknown) => {
+          if (!isNodeErrorWithCode(unlinkError, "ENOENT")) throw unlinkError;
+        });
+        continue;
+      }
+      await delay(INDEX_LOCK_RETRY_MS);
+    }
+  }
+}
+
 const writeIndex = async (indexPath: string, index: MediaCacheIndex) => {
-  const tmpPath = `${indexPath}.tmp-${process.pid}-${Date.now()}`;
-  await fs.writeFile(tmpPath, JSON.stringify(index));
-  await fs.rename(tmpPath, indexPath);
+  const tmpPath = `${indexPath}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    await fs.writeFile(tmpPath, JSON.stringify(index));
+    await fs.rename(tmpPath, indexPath);
+  } finally {
+    await fs.rm(tmpPath, { force: true });
+  }
 };
 
 const removeEntry = async (
@@ -179,6 +239,15 @@ export async function createMediaCache({
   const indexPath = join(cacheDir, INDEX_FILENAME);
   await ensureDir(cacheDir);
 
+  const withIndexLock = async <T>(fn: () => Promise<T>): Promise<T> => {
+    const release = await acquireIndexLock(indexPath);
+    try {
+      return await fn();
+    } finally {
+      await release();
+    }
+  };
+
   const pruneExpired = async (index: MediaCacheIndex, now: number) => {
     const entries = Object.entries(index.entries);
     for (const [key, entry] of entries) {
@@ -224,47 +293,49 @@ export async function createMediaCache({
 
   const get = async ({ url }: { url: string }): Promise<MediaCacheEntry | null> => {
     if (!shouldCacheUrl(url)) return null;
-    const now = Date.now();
-    const index = await readIndex(indexPath);
-    await pruneExpired(index, now);
-    const key = hashKey(url);
-    const entry = index.entries[key];
-    if (!entry) return null;
+    return await withIndexLock(async () => {
+      const now = Date.now();
+      const index = await readIndex(indexPath);
+      await pruneExpired(index, now);
+      const key = hashKey(url);
+      const entry = index.entries[key];
+      if (!entry) return null;
 
-    const filePath = join(cacheDir, entry.fileName);
-    let stat: { size: number } | null = null;
-    try {
-      stat = await fs.stat(filePath);
-    } catch {
-      await removeEntry(cacheDir, index, key, entry);
+      const filePath = join(cacheDir, entry.fileName);
+      let stat: { size: number } | null = null;
+      try {
+        stat = await fs.stat(filePath);
+      } catch {
+        await removeEntry(cacheDir, index, key, entry);
+        await writeIndex(indexPath, index);
+        return null;
+      }
+
+      if (verify === "size" && typeof entry.sizeBytes === "number") {
+        if (stat.size !== entry.sizeBytes) {
+          await removeEntry(cacheDir, index, key, entry);
+          await writeIndex(indexPath, index);
+          return null;
+        }
+      }
+      if (verify === "hash") {
+        const hash = await hashFile(filePath);
+        if (entry.sha256 && entry.sha256 !== hash) {
+          await removeEntry(cacheDir, index, key, entry);
+          await writeIndex(indexPath, index);
+          return null;
+        }
+        entry.sha256 = hash;
+      }
+
+      if (typeof entry.sizeBytes !== "number" || entry.sizeBytes !== stat.size) {
+        entry.sizeBytes = stat.size;
+      }
+      entry.lastAccessAtMs = now;
+      index.entries[key] = entry;
       await writeIndex(indexPath, index);
-      return null;
-    }
-
-    if (verify === "size" && typeof entry.sizeBytes === "number") {
-      if (stat.size !== entry.sizeBytes) {
-        await removeEntry(cacheDir, index, key, entry);
-        await writeIndex(indexPath, index);
-        return null;
-      }
-    }
-    if (verify === "hash") {
-      const hash = await hashFile(filePath);
-      if (entry.sha256 && entry.sha256 !== hash) {
-        await removeEntry(cacheDir, index, key, entry);
-        await writeIndex(indexPath, index);
-        return null;
-      }
-      entry.sha256 = hash;
-    }
-
-    if (typeof entry.sizeBytes !== "number" || entry.sizeBytes !== stat.size) {
-      entry.sizeBytes = stat.size;
-    }
-    entry.lastAccessAtMs = now;
-    index.entries[key] = entry;
-    await writeIndex(indexPath, index);
-    return normalizeEntry(cacheDir, entry);
+      return normalizeEntry(cacheDir, entry);
+    });
   };
 
   const put = async ({
@@ -279,38 +350,44 @@ export async function createMediaCache({
     filename?: string | null;
   }): Promise<MediaCacheEntry | null> => {
     if (!shouldCacheUrl(url)) return null;
-    const now = Date.now();
-    const index = await readIndex(indexPath);
-    await pruneExpired(index, now);
-    const key = hashKey(url);
-    const ext = resolveExtension(filename, mediaType);
-    const fileName = `${key}${ext}`;
-    const destPath = join(cacheDir, fileName);
-
     const sourceStat = await fs.stat(filePath);
     if (Number.isFinite(maxBytes) && maxBytes > 0 && sourceStat.size > maxBytes) {
       return null;
     }
-    await moveFile(filePath, destPath);
-    const stat = sourceStat;
-    const sha256 = verify === "hash" ? await hashFile(destPath) : null;
-    const expiresAtMs = ttlMs > 0 ? now + ttlMs : null;
-    const entry: MediaCacheIndexEntry = {
-      url,
-      fileName,
-      sizeBytes: stat.size,
-      sha256,
-      mediaType,
-      filename,
-      createdAtMs: now,
-      lastAccessAtMs: now,
-      expiresAtMs,
-    };
-    index.entries[key] = entry;
-    await enforceMaxBytes(index);
-    const finalEntry = index.entries[key];
-    await writeIndex(indexPath, index);
-    return finalEntry ? normalizeEntry(cacheDir, finalEntry) : null;
+
+    const key = hashKey(url);
+    const ext = resolveExtension(filename, mediaType);
+    const fileName = `${key}${ext}`;
+    const stagingPath = join(cacheDir, `.${key}.incoming-${process.pid}-${randomUUID()}`);
+    await moveFile(filePath, stagingPath);
+    try {
+      const sha256 = verify === "hash" ? await hashFile(stagingPath) : null;
+      return await withIndexLock(async () => {
+        const now = Date.now();
+        const index = await readIndex(indexPath);
+        await pruneExpired(index, now);
+        await moveFile(stagingPath, join(cacheDir, fileName));
+        const expiresAtMs = ttlMs > 0 ? now + ttlMs : null;
+        const entry: MediaCacheIndexEntry = {
+          url,
+          fileName,
+          sizeBytes: sourceStat.size,
+          sha256,
+          mediaType,
+          filename,
+          createdAtMs: now,
+          lastAccessAtMs: now,
+          expiresAtMs,
+        };
+        index.entries[key] = entry;
+        await enforceMaxBytes(index);
+        const finalEntry = index.entries[key];
+        await writeIndex(indexPath, index);
+        return finalEntry ? normalizeEntry(cacheDir, finalEntry) : null;
+      });
+    } finally {
+      await fs.rm(stagingPath, { force: true });
+    }
   };
 
   return { get, put };

--- a/tests/media-cache.test.ts
+++ b/tests/media-cache.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -9,6 +9,78 @@ const makeTempDir = async (prefix: string) => {
 };
 
 describe("media cache", () => {
+  it("serializes concurrent writes across independent cache instances", async () => {
+    const cacheDir = await makeTempDir("summarize-media-cache-");
+    try {
+      const caches = await Promise.all(
+        Array.from({ length: 3 }, () =>
+          createMediaCache({
+            path: cacheDir,
+            maxBytes: 10 * 1024 * 1024,
+            ttlMs: 60_000,
+            verify: "size",
+          }),
+        ),
+      );
+      const count = 30;
+      await Promise.all(
+        Array.from({ length: count }, async (_, index) => {
+          const tempFile = join(cacheDir, `source-${index}.bin`);
+          await writeFile(tempFile, new Uint8Array([index]));
+          await caches[index % caches.length]?.put({
+            url: `https://example.com/concurrent-${index}.mp4`,
+            filePath: tempFile,
+            mediaType: "video/mp4",
+            filename: `${index}.mp4`,
+          });
+        }),
+      );
+
+      const index = JSON.parse(await readFile(join(cacheDir, "index.json"), "utf8")) as {
+        entries: Record<string, unknown>;
+      };
+      expect(Object.keys(index.entries)).toHaveLength(count);
+      const entries = await Promise.all(
+        Array.from({ length: count }, (_, entryIndex) =>
+          caches[0]?.get({ url: `https://example.com/concurrent-${entryIndex}.mp4` }),
+        ),
+      );
+      expect(entries.every(Boolean)).toBe(true);
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  it("recovers a stale index lock", async () => {
+    const cacheDir = await makeTempDir("summarize-media-cache-");
+    try {
+      const cache = await createMediaCache({
+        path: cacheDir,
+        maxBytes: 10 * 1024 * 1024,
+        ttlMs: 60_000,
+        verify: "size",
+      });
+      const lockPath = join(cacheDir, "index.json.lock");
+      await writeFile(lockPath, "stale");
+      const staleDate = new Date(Date.now() - 10 * 60_000);
+      await utimes(lockPath, staleDate, staleDate);
+      const tempFile = join(cacheDir, "stale-lock.bin");
+      await writeFile(tempFile, new Uint8Array([1, 2, 3]));
+
+      const stored = await cache.put({
+        url: "https://example.com/stale-lock.mp4",
+        filePath: tempFile,
+        mediaType: "video/mp4",
+        filename: "stale-lock.mp4",
+      });
+
+      expect(stored).not.toBeNull();
+      await expect(stat(lockPath)).rejects.toBeDefined();
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true });
+    }
+  });
+
   it("stores and reuses cached media", async () => {
     const cacheDir = await makeTempDir("summarize-media-cache-");
     try {


### PR DESCRIPTION
## Summary

- serialize media-cache index read/modify/write operations across processes
- stage slow media copy/hash work before the index lock
- recover stale locks and avoid colliding atomic-write temp paths

## Reproduction

- 30 concurrent puts in one process collided on the timestamp-based index temp path
- 20 concurrent processes left 6 index entries for 20 cached files

## Verification

- `pnpm -s check` (524 files, 2,764 tests)
- `pnpm -s build`
- focused media-cache/run-cache/shared-video tests
- built 30-operation same-process contention: 30 entries, 30 files
- built 20-process contention: 20 entries, 20 files
- autoreview clean after fixing large-file lock timeout finding
