### PR TITLE
fix: persist media cache expiry pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Media cache: persist TTL pruning to the index after an expired-entry miss.
 - Media cache: serialize index updates across concurrent daemon and CLI processes to prevent failed writes, lost entries, and orphaned files.
 - Daemon chat: cancel CLI-backed agent processes when their HTTP client disconnects.
 - Chrome extension: restore persisted chat history after the daemon agent-route refactor.

--- a/src/media-cache.ts
+++ b/src/media-cache.ts
@@ -249,12 +249,15 @@ export async function createMediaCache({
   };
 
   const pruneExpired = async (index: MediaCacheIndex, now: number) => {
+    let pruned = false;
     const entries = Object.entries(index.entries);
     for (const [key, entry] of entries) {
       if (entry.expiresAtMs != null && entry.expiresAtMs <= now) {
         await removeEntry(cacheDir, index, key, entry);
+        pruned = true;
       }
     }
+    return pruned;
   };
 
   const computeSizeBytes = async (entry: MediaCacheIndexEntry): Promise<number | null> => {
@@ -296,10 +299,13 @@ export async function createMediaCache({
     return await withIndexLock(async () => {
       const now = Date.now();
       const index = await readIndex(indexPath);
-      await pruneExpired(index, now);
+      const pruned = await pruneExpired(index, now);
       const key = hashKey(url);
       const entry = index.entries[key];
-      if (!entry) return null;
+      if (!entry) {
+        if (pruned) await writeIndex(indexPath, index);
+        return null;
+      }
 
       const filePath = join(cacheDir, entry.fileName);
       let stat: { size: number } | null = null;

--- a/tests/media-cache.test.ts
+++ b/tests/media-cache.test.ts
@@ -234,6 +234,10 @@ describe("media cache", () => {
       const cached = await cache.get({ url: "https://example.com/expired" });
       expect(cached).toBeNull();
       await expect(stat(stored.filePath)).rejects.toBeDefined();
+      const pruned = JSON.parse(await readFile(indexPath, "utf8")) as {
+        entries?: Record<string, unknown>;
+      };
+      expect(pruned.entries).toEqual({});
     } finally {
       await rm(cacheDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- persist media-cache TTL pruning when the requested key is absent
- verify expired entries are removed from both disk and `index.json`

## Reproduction

Expiring two entries and requesting an unrelated cache miss removed both media files but left both entries in the persisted index.

## Verification

- `pnpm -s check` (524 files, 2,764 tests)
- `pnpm -s build`
- focused media-cache/run-cache/shared-video tests
- built expiry reproduction reports zero persisted entries
- autoreview clean
