### PR TITLE
fix: expand daemon log home paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Daemon logging: expand `~` in configured log file paths instead of creating a literal working-directory path.
 - Media cache: persist TTL pruning to the index after an expired-entry miss.
 - Media cache: serialize index updates across concurrent daemon and CLI processes to prevent failed writes, lost entries, and orphaned files.
 - Daemon chat: cancel CLI-backed agent processes when their HTTP client disconnects.

--- a/src/logging/daemon.ts
+++ b/src/logging/daemon.ts
@@ -42,6 +42,12 @@ const LOG_LEVEL_MAP: Record<DaemonLogLevel, number> = {
   error: 5,
 };
 
+function resolveLogFilePath(raw: string, home: string): string {
+  if (raw === "~") return home;
+  if (raw.startsWith("~/")) return path.resolve(path.join(home, raw.slice(2)));
+  return raw;
+}
+
 function safeJsonStringify(value: unknown): string {
   const seen = new WeakSet<object>();
   return JSON.stringify(value, (_key, val) => {
@@ -88,9 +94,10 @@ export function resolveDaemonLoggingConfig({
   if (!logging || logging.enabled !== true) return null;
 
   const { logDir } = resolveDaemonLogPaths(env);
+  const home = env.HOME?.trim() || env.USERPROFILE?.trim() || "";
   const file =
     typeof logging.file === "string" && logging.file.trim()
-      ? logging.file.trim()
+      ? resolveLogFilePath(logging.file.trim(), home)
       : path.join(logDir, "daemon.jsonl");
   const maxMb =
     typeof logging.maxMb === "number" && logging.maxMb > 0 ? logging.maxMb : DEFAULT_LOG_MAX_MB;

--- a/tests/daemon.logging.e2e.test.ts
+++ b/tests/daemon.logging.e2e.test.ts
@@ -61,7 +61,7 @@ describe("daemon logging", () => {
             enabled: true,
             level: "debug",
             format: "json",
-            file: logPath,
+            file: "~/.summarize/logs/daemon.jsonl",
             maxMb: 1,
             maxFiles: 1,
           },


### PR DESCRIPTION
## Summary

- expand leading home-directory shorthand in configured daemon log paths
- exercise the documented path through the daemon logging end-to-end test
- document the user-visible fix

## Proof

- focused daemon logging/config tests: 7 passed
- full check: 524 files, 2,764 tests passed
- production build and built-output path smoke
- autoreview: clean, no accepted/actionable findings
