### PR TITLE
fix: preserve repeated streaming deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Streaming: preserve repeated model deltas when a chunk exactly matches the accumulated summary.
 - Daemon logging: expand `~` in configured log file paths instead of creating a literal working-directory path.
 - Media cache: persist TTL pruning to the index after an expired-entry miss.
 - Media cache: serialize index updates across concurrent daemon and CLI processes to prevent failed writes, lost entries, and orphaned files.

--- a/src/engine/model-executor.ts
+++ b/src/engine/model-executor.ts
@@ -397,6 +397,22 @@ export function createModelExecutor(deps: ModelExecutorDeps) {
           }
         }
 
+        const finalText = (await streamResult.finalText)?.trim() ?? "";
+        if (finalText.length > streamed.length && finalText.startsWith(streamed)) {
+          const prevStreamed = streamed;
+          const firstChunk = !streamHandlerStarted;
+          streamed = finalText;
+          if (streamHandler) {
+            streamHandlerStarted = true;
+            streamOutputEmitted =
+              (await streamHandler.onChunk({
+                streamed,
+                prevStreamed: firstChunk ? "" : prevStreamed,
+                appended: firstChunk ? streamed : streamed.slice(prevStreamed.length),
+              })) || streamOutputEmitted;
+          }
+        }
+
         streamedRaw = streamed;
         const trimmed = streamed.trim();
         streamed = trimmed;

--- a/src/llm/generate-text-stream.ts
+++ b/src/llm/generate-text-stream.ts
@@ -1,7 +1,11 @@
 import { streamSimple } from "@earendil-works/pi-ai";
-import type { Context } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
 import { createUnsupportedFunctionalityError } from "./errors.js";
-import { resolveEffectiveTemperature, streamUsageWithTimeout } from "./generate-text-shared.js";
+import {
+  resolveEffectiveTemperature,
+  streamUsageWithTimeout,
+  withTimeoutFallback,
+} from "./generate-text-shared.js";
 import type { LlmApiKeys } from "./generate-text-types.js";
 import { parseGatewayStyleModelId } from "./model-id.js";
 import type { LlmProvider } from "./model-id.js";
@@ -25,6 +29,7 @@ import {
   resolveXaiModel,
 } from "./providers/models.js";
 import { completeOpenAiText, streamOpenAiText } from "./providers/openai.js";
+import { extractText } from "./providers/shared.js";
 import type { OpenAiClientConfig } from "./providers/types.js";
 import type { LlmTokenUsage } from "./types.js";
 
@@ -51,8 +56,50 @@ export type StreamTextResult = {
   canonicalModelId: string;
   provider: LlmProvider;
   usage: Promise<LlmTokenUsage | null>;
+  finalText: Promise<string | null>;
   lastError: () => unknown;
 };
+
+function resolveStreamCompletion(
+  stream: { result: () => Promise<AssistantMessage> },
+  timeoutMs: number,
+): Pick<StreamTextResult, "usage" | "finalText"> {
+  const result = stream.result();
+  return {
+    usage: streamUsageWithTimeout({ result, timeoutMs }),
+    finalText: withTimeoutFallback({
+      promise: result.then((message) => extractText(message) || null).catch(() => null),
+      timeoutMs,
+      fallback: null,
+    }),
+  };
+}
+
+function captureFinalText(textStream: AsyncIterable<string>): {
+  textStream: AsyncIterable<string>;
+  finalText: Promise<string | null>;
+} {
+  let resolveFinalText: (value: string | null) => void = () => {};
+  const finalText = new Promise<string | null>((resolve) => {
+    resolveFinalText = resolve;
+  });
+  return {
+    textStream: {
+      async *[Symbol.asyncIterator]() {
+        let collected = "";
+        try {
+          for await (const chunk of textStream) {
+            collected += chunk;
+            yield chunk;
+          }
+        } finally {
+          resolveFinalText(collected.trim() || null);
+        }
+      },
+    },
+    finalText,
+  };
+}
 
 function createTimedTextStream({
   textStream,
@@ -260,7 +307,7 @@ export async function streamTextWithContext({
         }),
         canonicalModelId: parsed.canonical,
         provider: parsed.provider,
-        usage: streamUsageWithTimeout({ result: stream.result(), timeoutMs }),
+        ...resolveStreamCompletion(stream, timeoutMs),
         lastError: () => lastError,
       };
     }
@@ -298,7 +345,7 @@ export async function streamTextWithContext({
         }),
         canonicalModelId: parsed.canonical,
         provider: parsed.provider,
-        usage: streamUsageWithTimeout({ result: stream.result(), timeoutMs }),
+        ...resolveStreamCompletion(stream, timeoutMs),
         lastError: () => lastError,
       };
     }
@@ -337,7 +384,7 @@ export async function streamTextWithContext({
         }),
         canonicalModelId: parsed.canonical,
         provider: parsed.provider,
-        usage: streamUsageWithTimeout({ result: stream.result(), timeoutMs }),
+        ...resolveStreamCompletion(stream, timeoutMs),
         lastError: () => lastError,
       };
     }
@@ -385,9 +432,10 @@ export async function streamTextWithContext({
             setLastError,
           });
           if (streamResult) {
+            const captured = captureFinalText(streamResult.textStream);
             return {
               textStream: createTimedTextStream({
-                textStream: streamResult.textStream,
+                textStream: captured.textStream,
                 timeoutMs,
                 controller,
                 setLastError,
@@ -397,6 +445,7 @@ export async function streamTextWithContext({
                 : parsed.canonical,
               provider: parsed.provider,
               usage: streamResult.usage,
+              finalText: captured.finalText,
               lastError: () => lastError,
             };
           }
@@ -426,6 +475,7 @@ export async function streamTextWithContext({
             : parsed.canonical,
           provider: parsed.provider,
           usage: Promise.resolve(result.usage),
+          finalText: Promise.resolve(result.text.trim() || null),
           lastError: () => lastError,
         };
       }
@@ -459,7 +509,7 @@ export async function streamTextWithContext({
         }),
         canonicalModelId: parsed.canonical,
         provider: parsed.provider,
-        usage: streamUsageWithTimeout({ result: stream.result(), timeoutMs }),
+        ...resolveStreamCompletion(stream, timeoutMs),
         lastError: () => lastError,
       };
     }

--- a/src/llm/generate-text.ts
+++ b/src/llm/generate-text.ts
@@ -437,6 +437,7 @@ export async function streamTextWithModelId({
   canonicalModelId: string;
   provider: LlmProvider;
   usage: Promise<LlmTokenUsage | null>;
+  finalText: Promise<string | null>;
   lastError: () => unknown;
 }> {
   const context = promptToContext(prompt);

--- a/tests/cli.stream-merge.test.ts
+++ b/tests/cli.stream-merge.test.ts
@@ -57,13 +57,18 @@ function writeLiteLlmCache(root: string) {
 
 async function runStreamedSummary(
   chunks: string[],
-  options?: { perfTrace?: boolean; stdoutIsTty?: boolean; writeLiteLlmCatalog?: boolean },
+  options?: {
+    finalText?: string;
+    perfTrace?: boolean;
+    stdoutIsTty?: boolean;
+    writeLiteLlmCatalog?: boolean;
+  },
 ): Promise<{ stderr: string; stdout: string; stdoutChunks: string[] }> {
   mocks.streamSimple.mockReset().mockImplementation(() =>
     makeTextDeltaStream(
       chunks,
       makeAssistantMessage({
-        text: chunks.at(-1) ?? "",
+        text: options?.finalText ?? chunks.at(-1) ?? "",
         usage: { input: 100, output: 50, totalTokens: 150 },
       }),
     ),
@@ -140,6 +145,13 @@ describe("cli stream chunk merge", () => {
   it("keeps delta chunks unchanged", async () => {
     const { stdout: out } = await runStreamedSummary(["Hello ", "world", "!"]);
     expect(out).toBe("Hello world!\n");
+  }, 20_000);
+
+  it("preserves identical consecutive delta chunks", async () => {
+    const { stdout: out } = await runStreamedSummary(["repeat", "repeat"], {
+      finalText: "repeatrepeat",
+    });
+    expect(out).toBe("repeatrepeat\n");
   }, 20_000);
 
   it("writes the first plain stdout chunk before a newline arrives", async () => {

--- a/tests/engine.model-executor.test.ts
+++ b/tests/engine.model-executor.test.ts
@@ -212,6 +212,7 @@ describe("model executor streaming", () => {
     mocks.streamTextWithModelId.mockResolvedValue({
       textStream: textStream(),
       usage: Promise.resolve(null),
+      finalText: Promise.resolve(null),
       provider: "openai",
       canonicalModelId: "openai/gpt-5.4",
       lastError: () => null,
@@ -249,6 +250,7 @@ describe("model executor streaming", () => {
     mocks.streamTextWithModelId.mockResolvedValue({
       textStream: textStream(),
       usage: Promise.resolve(null),
+      finalText: Promise.resolve(null),
       provider: "openai",
       canonicalModelId: "openai/gpt-5.4",
       lastError: () => null,
@@ -271,6 +273,75 @@ describe("model executor streaming", () => {
     expect(result).toMatchObject({ summary: "Final value", summaryEmitted: false });
   });
 
+  it("restores a repeated delta suffix from the authoritative final text", async () => {
+    async function* textStream() {
+      yield "repeat";
+      yield "repeat";
+    }
+    mocks.streamTextWithModelId.mockResolvedValue({
+      textStream: textStream(),
+      usage: Promise.resolve(null),
+      finalText: Promise.resolve("repeatrepeat"),
+      provider: "openai",
+      canonicalModelId: "openai/gpt-5.4",
+      lastError: () => null,
+    });
+
+    const engine = createTestModelExecutor(undefined, true);
+    const result = await engine.runSummaryAttempt({
+      attempt: {
+        transport: "native",
+        userModelId: "openai/gpt-5.4",
+        llmModelId: "openai/gpt-5.4",
+        openrouterProviders: null,
+        forceOpenRouter: false,
+        requiredEnv: "OPENAI_API_KEY",
+      },
+      prompt: { userText: "Summarize this." },
+      allowStreaming: true,
+    });
+
+    expect(result).toMatchObject({ summary: "repeatrepeat", summaryEmitted: false });
+  });
+
+  it("emits authoritative final text when the stream has no deltas", async () => {
+    async function* textStream() {}
+    mocks.streamTextWithModelId.mockResolvedValue({
+      textStream: textStream(),
+      usage: Promise.resolve(null),
+      finalText: Promise.resolve("Recovered summary"),
+      provider: "openai",
+      canonicalModelId: "openai/gpt-5.4",
+      lastError: () => null,
+    });
+    const onChunk = vi.fn(() => true);
+    const onDone = vi.fn(() => false);
+    const onReset = vi.fn();
+
+    const engine = createTestModelExecutor(undefined, true);
+    const result = await engine.runSummaryAttempt({
+      attempt: {
+        transport: "native",
+        userModelId: "openai/gpt-5.4",
+        llmModelId: "openai/gpt-5.4",
+        openrouterProviders: null,
+        forceOpenRouter: false,
+        requiredEnv: "OPENAI_API_KEY",
+      },
+      prompt: { userText: "Summarize this." },
+      allowStreaming: true,
+      streamHandler: { onChunk, onDone, onReset },
+    });
+
+    expect(result).toMatchObject({ summary: "Recovered summary", summaryEmitted: true });
+    expect(onChunk).toHaveBeenCalledWith({
+      streamed: "Recovered summary",
+      prevStreamed: "",
+      appended: "Recovered summary",
+    });
+    expect(onDone).toHaveBeenCalledWith("Recovered summary");
+  });
+
   it("emits a complete fallback after an invisible stream prefix", async () => {
     async function* textStream() {
       yield "\n";
@@ -279,6 +350,7 @@ describe("model executor streaming", () => {
     mocks.streamTextWithModelId.mockResolvedValue({
       textStream: textStream(),
       usage: Promise.resolve(null),
+      finalText: Promise.resolve(null),
       provider: "openai",
       canonicalModelId: "openai/gpt-5.4",
       lastError: () => null,
@@ -328,6 +400,7 @@ describe("model executor streaming", () => {
     mocks.streamTextWithModelId.mockResolvedValue({
       textStream: textStream(),
       usage: Promise.resolve(null),
+      finalText: Promise.resolve(null),
       provider: "openai",
       canonicalModelId: "openai/gpt-5.4",
       lastError: () => null,
@@ -361,6 +434,7 @@ describe("model executor streaming", () => {
     mocks.streamTextWithModelId.mockResolvedValue({
       textStream: textStream(),
       usage: Promise.resolve(null),
+      finalText: Promise.resolve(null),
       provider: "openai",
       canonicalModelId: "openai/gpt-5.4",
       lastError: () => null,
@@ -394,6 +468,7 @@ describe("model executor streaming", () => {
     mocks.streamTextWithModelId.mockResolvedValue({
       textStream: textStream(),
       usage: Promise.resolve(null),
+      finalText: Promise.resolve(null),
       provider: "openai",
       canonicalModelId: "openai/gpt-5.4",
       lastError: () => null,
@@ -433,6 +508,7 @@ describe("model executor streaming", () => {
     mocks.streamTextWithModelId.mockResolvedValue({
       textStream: textStream(),
       usage: Promise.resolve(null),
+      finalText: Promise.resolve(null),
       provider: "openai",
       canonicalModelId: "openai/gpt-5.4",
       lastError: () => null,

--- a/tests/llm.generate-text.test.ts
+++ b/tests/llm.generate-text.test.ts
@@ -1234,6 +1234,7 @@ describe("llm generate/stream", () => {
 
     expect(chunks).toEqual(["He", "llo"]);
     expect(result.canonicalModelId).toBe("openai/gpt-5.5");
+    await expect(result.finalText).resolves.toBe("Hello");
     await expect(result.usage).resolves.toEqual({
       promptTokens: 3,
       completionTokens: 4,


### PR DESCRIPTION
## Summary

- preserve real repeated streaming deltas when heuristic snapshot merging drops them
- reconcile append-only missing output from the provider's authoritative final message
- cover Pi-backed and direct OpenAI SSE streaming transports

## Reproduction

Two identical delta chunks such as `repeat`, `repeat` were interpreted as a duplicate cumulative snapshot. The CLI emitted only `repeat` even when the provider's final result was `repeatrepeat`. A two-chunk 2 MiB probe lost exactly the second 1 MiB.

## Verification

- focused streaming/provider suite: 7 files, 70 tests
- full `pnpm -s check`: 524 files, 2,767 tests; branch coverage 85.01%
- `pnpm -s build`
- exact two-identical-1-MiB-delta probe
- autoreview clean, no actionable findings
