### PR TITLE
fix: allow ONNX for local media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Local media: accept configured Parakeet and Canary ONNX transcribers instead of rejecting them during provider preflight.
 - Streaming: preserve repeated model deltas when a chunk exactly matches the accumulated summary.
 - Daemon logging: expand `~` in configured log file paths instead of creating a literal working-directory path.
 - Media cache: persist TTL pruning to the index after an expired-entry miss.

--- a/packages/core/src/content/index.ts
+++ b/packages/core/src/content/index.ts
@@ -68,6 +68,10 @@ export {
 } from "./link-preview/types.js";
 export { formatTimestampMs, parseTimestampStringToMs } from "./transcript/timestamps.js";
 export {
+  resolveTranscriptionAvailability,
+  type TranscriptionAvailability,
+} from "./transcript/providers/transcription-start.js";
+export {
   buildYoutubeCaptionTrackUrls,
   formatYoutubeCaptionLines,
   normalizeYoutubeCaptionText,

--- a/src/run/flows/asset/media.ts
+++ b/src/run/flows/asset/media.ts
@@ -7,7 +7,11 @@
 import { statSync } from "node:fs";
 import { isAbsolute, resolve as resolvePath } from "node:path";
 import { pathToFileURL } from "node:url";
-import { createLinkPreviewClient, type ExtractedLinkContent } from "../../../content/index.js";
+import {
+  createLinkPreviewClient,
+  resolveTranscriptionAvailability,
+  type ExtractedLinkContent,
+} from "../../../content/index.js";
 import { createFirecrawlScraper } from "../../../firecrawl.js";
 import {
   identifySpeakersInExtractedContent,
@@ -104,11 +108,6 @@ export async function executeMediaFile(
   // Check for yt-dlp: either via env var or on PATH
   const ytDlpPath = ctx.env.YT_DLP_PATH || ((await isBinaryAvailable("yt-dlp")) ? "yt-dlp" : null);
 
-  // Check for whisper.cpp: either via env var or by checking if whisper-cli is on PATH
-  const hasLocalWhisper = ctx.env.SUMMARIZE_WHISPER_CPP_BINARY
-    ? true
-    : await isBinaryAvailable("whisper-cli");
-
   if (ctx.transcriptDiarization === "elevenlabs" && !elevenlabsKey) {
     throw new Error("Speaker diarization with ElevenLabs requires ELEVENLABS_API_KEY");
   }
@@ -119,38 +118,45 @@ export async function executeMediaFile(
     throw new Error("Speaker diarization requires ELEVENLABS_API_KEY or OPENAI_API_KEY");
   }
 
+  const transcription = {
+    env: ctx.envForRun,
+    falApiKey: falKey,
+    groqApiKey: groqKey,
+    assemblyaiApiKey: assemblyaiKey ?? ctx.apiStatus.assemblyaiApiKey,
+    elevenlabsApiKey: elevenlabsKey,
+    geminiApiKey: geminiKey,
+    openaiApiKey: openaiKey,
+  };
+  const availability = await resolveTranscriptionAvailability({ transcription });
   const hasAnyTranscriptionProvider =
-    groqKey ||
-    assemblyaiKey ||
-    geminiKey ||
-    openaiKey ||
-    falKey ||
-    hasLocalWhisper ||
-    Boolean(ctx.transcriptDiarization && elevenlabsKey);
+    ctx.transcriptDiarization !== null || availability.hasAnyProvider;
 
   if (!hasAnyTranscriptionProvider) {
     throw new Error(`Media file transcription requires one of the following:
 
-1. Groq Whisper (fast, free tier):
+1. Local ONNX (Parakeet or Canary):
+   Run summarize transcriber setup
+
+2. Groq Whisper (fast, free tier):
    Set GROQ_API_KEY=gsk_...
 
-2. Gemini audio transcription:
+3. Gemini audio transcription:
    Set GEMINI_API_KEY=...
 
-3. AssemblyAI transcription:
+4. AssemblyAI transcription:
    Set ASSEMBLYAI_API_KEY=...
 
-4. OpenAI Whisper:
+5. OpenAI Whisper:
    Set OPENAI_API_KEY=sk-...
 
-5. FAL Whisper:
+6. FAL Whisper:
    Set FAL_KEY=...
 
-6. Local whisper.cpp (recommended, free):
+7. Local whisper.cpp:
    brew install whisper-cpp
    Ensure whisper-cli is on your PATH (or set SUMMARIZE_WHISPER_CPP_BINARY)
 
-See: https://github.com/openai/whisper for setup details`);
+See: summarize transcriber help`);
   }
 
   const isHttpUrl = (value: string): boolean => {
@@ -233,15 +239,7 @@ See: https://github.com/openai/whisper for setup details`);
     env: ctx.envForRun,
     apifyApiToken: ctx.apiStatus.apifyToken,
     ytDlpPath: ytDlpPath,
-    transcription: {
-      env: ctx.envForRun,
-      falApiKey: falKey,
-      groqApiKey: groqKey,
-      assemblyaiApiKey: assemblyaiKey ?? ctx.apiStatus.assemblyaiApiKey,
-      elevenlabsApiKey: elevenlabsKey,
-      geminiApiKey: geminiKey,
-      openaiApiKey: openaiKey,
-    },
+    transcription,
     scrapeWithFirecrawl: firecrawlScraper,
     convertHtmlToMarkdown: null, // Not needed for media
     readTweetWithBird: readTweetWithBirdClient,

--- a/tests/cli.asset.audio-file.test.ts
+++ b/tests/cli.asset.audio-file.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Writable } from "node:stream";
@@ -42,6 +42,61 @@ vi.mock("@earendil-works/pi-ai", () => ({
 }));
 
 describe("cli asset inputs (media files)", () => {
+  it.each(["parakeet", "canary"] as const)(
+    "transcribes a local WAV with configured ONNX %s",
+    async (model) => {
+      const root = mkdtempSync(join(tmpdir(), `summarize-audio-onnx-${model}-`));
+      const cacheDir = join(root, "onnx");
+      const modelDir = join(cacheDir, model);
+      mkdirSync(modelDir, { recursive: true });
+      writeFileSync(join(modelDir, "model.onnx"), "fixture");
+      writeFileSync(join(modelDir, "vocab.txt"), "fixture");
+      const wavPath = join(root, "test-audio.wav");
+      writeFileSync(wavPath, "RIFF fixture WAVE");
+
+      const stdout = collectStream();
+      const stderr = collectStream();
+      const commandEnv =
+        model === "parakeet" ? "SUMMARIZE_ONNX_PARAKEET_CMD" : "SUMMARIZE_ONNX_CANARY_CMD";
+      const env = {
+        HOME: root,
+        SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP: "1",
+        SUMMARIZE_ONNX_CACHE_DIR: cacheDir,
+        [commandEnv]: JSON.stringify([
+          process.execPath,
+          "-e",
+          `process.stdout.write("Local ${model} transcript")`,
+          "{input}",
+        ]),
+      };
+
+      await runCli(
+        [
+          "--extract",
+          "--plain",
+          "--metrics",
+          "off",
+          "--no-cache",
+          "--no-media-cache",
+          "--transcriber",
+          model,
+          wavPath,
+        ],
+        {
+          env,
+          fetch: vi.fn(async () => {
+            throw new Error("unexpected fetch");
+          }) as unknown as typeof fetch,
+          stdout: stdout.stream,
+          stderr: stderr.stream,
+        },
+      );
+
+      expect(stdout.getText()).toContain(`Local ${model} transcript`);
+      expect(stderr.getText()).toBe("");
+    },
+  );
+
   it("detects missing transcription provider and provides setup guidance", async () => {
     mocks.streamSimple.mockClear();
 
@@ -66,6 +121,7 @@ describe("cli asset inputs (media files)", () => {
     await expect(run()).rejects.toThrow(/Media file transcription requires/);
     await expect(run()).rejects.toThrow(/OpenAI Whisper/);
     await expect(run()).rejects.toThrow(/FAL Whisper/);
+    await expect(run()).rejects.toThrow(/Local ONNX/);
     await expect(run()).rejects.toThrow(/whisper\.cpp/);
     expect(mocks.streamSimple).toHaveBeenCalledTimes(0);
   });
@@ -96,8 +152,10 @@ describe("cli asset inputs (media files)", () => {
       await run();
     } catch (err) {
       const errMsg = String(err);
-      expect(errMsg).toMatch(/OPENAI_API_KEY|FAL_KEY|SUMMARIZE_WHISPER_CPP_BINARY/);
-      expect(errMsg).toMatch(/github\.com\/openai\/whisper/);
+      expect(errMsg).toMatch(
+        /summarize transcriber setup|OPENAI_API_KEY|FAL_KEY|SUMMARIZE_WHISPER_CPP_BINARY/,
+      );
+      expect(errMsg).toMatch(/summarize transcriber help/);
     }
     expect(mocks.streamSimple).toHaveBeenCalledTimes(0);
   });

--- a/tests/cli.asset.media-file-options.test.ts
+++ b/tests/cli.asset.media-file-options.test.ts
@@ -8,11 +8,16 @@ import type { ExtractedLinkContent } from "../src/content/index.js";
 import { executeMediaFile } from "../src/run/flows/asset/media.js";
 import type { AssetSummaryContext } from "../src/run/flows/asset/types.js";
 
-const createLinkPreviewClient = vi.hoisted(() => vi.fn());
+const contentMocks = vi.hoisted(() => ({
+  createLinkPreviewClient: vi.fn(),
+  resolveTranscriptionAvailability: vi.fn(async () => ({ hasAnyProvider: true })),
+}));
 
 vi.mock("../src/content/index.js", () => ({
-  createLinkPreviewClient,
+  ...contentMocks,
 }));
+
+const { createLinkPreviewClient } = contentMocks;
 
 function makeContext(overrides: Partial<AssetSummaryContext>): AssetSummaryContext {
   const stderr = new Writable({

--- a/tests/cli.asset.media-file-size.test.ts
+++ b/tests/cli.asset.media-file-size.test.ts
@@ -12,6 +12,7 @@ const createLinkPreviewClient = vi.fn();
 
 vi.mock("../src/content/index.js", () => ({
   createLinkPreviewClient,
+  resolveTranscriptionAvailability: vi.fn(async () => ({ hasAnyProvider: true })),
 }));
 
 function makeContext(): AssetSummaryContext {

--- a/tests/cli.asset.media-path-cache.test.ts
+++ b/tests/cli.asset.media-path-cache.test.ts
@@ -10,6 +10,7 @@ const fetchLinkContent = vi.hoisted(() => vi.fn());
 
 vi.mock("../src/content/index.js", () => ({
   createLinkPreviewClient,
+  resolveTranscriptionAvailability: vi.fn(async () => ({ hasAnyProvider: true })),
 }));
 
 import { runCli } from "../src/run.js";

--- a/tests/cli.video-mode.transcript-options.test.ts
+++ b/tests/cli.video-mode.transcript-options.test.ts
@@ -65,6 +65,7 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("../src/content/index.js", () => ({
   createLinkPreviewClient: mocks.createLinkPreviewClient,
+  resolveTranscriptionAvailability: vi.fn(async () => ({ hasAnyProvider: true })),
 }));
 
 import { runCli } from "../src/run.js";


### PR DESCRIPTION
## Summary

- allow configured Parakeet and Canary ONNX transcribers through local media preflight
- use the canonical transcription availability resolver instead of a stale provider checklist
- add real local WAV regressions for both ONNX models
- update missing-provider guidance and changelog

## Reproduction

A local WAV with `--transcriber parakeet` and a valid `SUMMARIZE_ONNX_PARAKEET_CMD` exited before transcription:

```text
Media file transcription requires one of the following:
...
```

The downstream transcription flow already supported ONNX. The local-file preflight, added before ONNX support, only checked cloud keys and whisper.cpp.

## Proof

- focused: 7 files, 38 tests
- production CLI: local Parakeet and Canary WAV extraction both exit 0 with the expected transcript
- `pnpm -s build`
- `pnpm -s check`: 524 files, 2,769 tests, 85.07% branch coverage
- structured autoreview: clean, confidence 0.86
