### PR TITLE
fix: terminate tracked processes on CLI signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- CLI cancellation: terminate tracked transcriber, downloader, and media-tool process trees on SIGINT or SIGTERM.
 - Local media: accept configured Parakeet and Canary ONNX transcribers instead of rejecting them during provider preflight.
 - Streaming: preserve repeated model deltas when a chunk exactly matches the accumulated summary.
 - Daemon logging: expand `~` in configured log file paths instead of creating a literal working-directory path.

--- a/packages/core/src/processes.ts
+++ b/packages/core/src/processes.ts
@@ -5,7 +5,7 @@ import type {
   ExecFileOptions,
   SpawnOptions,
 } from "node:child_process";
-import { execFile, spawn } from "node:child_process";
+import { execFile, spawn, spawnSync } from "node:child_process";
 
 export type ProcessContext = {
   runId?: string | null;
@@ -56,6 +56,7 @@ export type SpawnTrackedOptions = SpawnOptions & {
 
 const processContext = new AsyncLocalStorage<ProcessContext>();
 let processObserver: ProcessObserver | null = null;
+const activeTrackedProcesses = new Map<ChildProcess, { processGroup: boolean }>();
 
 export function setProcessObserver(next: ProcessObserver | null): void {
   processObserver = next;
@@ -77,6 +78,47 @@ function registerProcess(info: ProcessRegistration): ProcessHandle | null {
     runId: info.runId ?? ctx.runId ?? null,
     source: info.source ?? ctx.source ?? null,
   });
+}
+
+function registerActiveProcess(proc: ChildProcess, processGroup: boolean): void {
+  activeTrackedProcesses.set(proc, { processGroup });
+  const cleanup = () => {
+    activeTrackedProcesses.delete(proc);
+  };
+  proc.on("error", cleanup);
+  proc.on("close", cleanup);
+}
+
+export function terminateTrackedProcesses(signal: NodeJS.Signals): void {
+  for (const [proc, metadata] of activeTrackedProcesses) {
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      activeTrackedProcesses.delete(proc);
+      continue;
+    }
+
+    if (process.platform === "win32" && proc.pid) {
+      const result = spawnSync("taskkill", ["/PID", String(proc.pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      if (result.status === 0) continue;
+    }
+
+    if (metadata.processGroup && proc.pid) {
+      try {
+        process.kill(-proc.pid, signal);
+        continue;
+      } catch {
+        // The group may have exited between the state check and signal.
+      }
+    }
+
+    try {
+      proc.kill(signal);
+    } catch {
+      // Process already exited.
+    }
+  }
 }
 
 type LineListener = (line: string) => void;
@@ -104,8 +146,9 @@ function attachLineReader(stream: NodeJS.ReadableStream | null | undefined, onLi
 export function trackChildProcess(
   proc: ChildProcess,
   info: ProcessRegistration,
-  options?: { captureOutput?: boolean },
+  options?: { captureOutput?: boolean; processGroup?: boolean },
 ): ProcessHandle | null {
+  registerActiveProcess(proc, options?.processGroup === true);
   const handle = registerProcess(info);
   if (!handle) return null;
   handle.setPid(proc.pid ?? null);
@@ -143,7 +186,12 @@ export function spawnTracked(
   options: SpawnTrackedOptions = {},
 ): { proc: ChildProcess; handle: ProcessHandle | null } {
   const { label, kind, runId, source, captureOutput, ...spawnOptions } = options;
-  const proc = spawn(command, args, spawnOptions);
+  const processGroup = process.platform !== "win32" && spawnOptions.detached !== false;
+  const effectiveSpawnOptions =
+    processGroup && spawnOptions.detached === undefined
+      ? { ...spawnOptions, detached: true }
+      : spawnOptions;
+  const proc = spawn(command, args, effectiveSpawnOptions);
   const handle = trackChildProcess(
     proc,
     {
@@ -153,10 +201,10 @@ export function spawnTracked(
       kind,
       runId,
       source,
-      cwd: spawnOptions.cwd ? String(spawnOptions.cwd) : null,
-      env: spawnOptions.env ?? null,
+      cwd: effectiveSpawnOptions.cwd ? String(effectiveSpawnOptions.cwd) : null,
+      env: effectiveSpawnOptions.env ?? null,
     },
-    { captureOutput },
+    { captureOutput, processGroup },
   );
   return { proc, handle };
 }

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { CommanderError } from "commander";
+import { terminateTrackedProcesses } from "./processes.js";
 import { runCli } from "./run.js";
 
 export type CliMainArgs = {
@@ -22,6 +23,24 @@ export function handlePipeErrors(stream: NodeJS.WritableStream, exit: (code: num
     }
     throw error;
   });
+}
+
+export function installCliSignalHandlers(exit: (code: number) => void): () => void {
+  let handled = false;
+  const handleSignal = (signal: "SIGINT" | "SIGTERM", exitCode: number) => {
+    if (handled) return;
+    handled = true;
+    terminateTrackedProcesses(signal);
+    queueMicrotask(() => exit(exitCode));
+  };
+  const handleSigint = () => handleSignal("SIGINT", 130);
+  const handleSigterm = () => handleSignal("SIGTERM", 143);
+  process.once("SIGINT", handleSigint);
+  process.once("SIGTERM", handleSigterm);
+  return () => {
+    process.removeListener("SIGINT", handleSigint);
+    process.removeListener("SIGTERM", handleSigterm);
+  };
 }
 
 function parseDotenv(text: string): Record<string, string> {
@@ -124,6 +143,7 @@ export async function runCliMain({
 }: CliMainArgs): Promise<void> {
   handlePipeErrors(stdout, exit);
   handlePipeErrors(stderr, exit);
+  const cleanupSignalHandlers = installCliSignalHandlers(exit);
 
   const verbose =
     argv.includes("--verbose") ||
@@ -163,5 +183,7 @@ export async function runCliMain({
       error instanceof Error ? error.message : error ? String(error) : "Unknown error";
     stderr.write(`${stripAnsi(message)}\n`);
     setExitCode(typeof exitCode === "number" ? exitCode : 1);
+  } finally {
+    cleanupSignalHandlers();
   }
 }

--- a/tests/cli-main.test.ts
+++ b/tests/cli-main.test.ts
@@ -6,9 +6,13 @@ import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 
 const runCliMock = vi.fn(async () => {});
+const terminateTrackedProcessesMock = vi.fn();
 
 vi.mock("../src/run.js", () => ({
   runCli: runCliMock,
+}));
+vi.mock("../src/processes.js", () => ({
+  terminateTrackedProcesses: terminateTrackedProcessesMock,
 }));
 
 describe("cli main wiring", async () => {
@@ -80,6 +84,56 @@ describe("cli main wiring", async () => {
 
     expect(exitCode).toBe(130);
     expect(stderrText).toBe("");
+  });
+
+  it.each([
+    ["SIGINT", 130],
+    ["SIGTERM", 143],
+  ] as const)("terminates tracked children and exits on %s", async (signal, expectedExitCode) => {
+    let finishRun: (() => void) | null = null;
+    runCliMock.mockReset().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRun = resolve;
+        }),
+    );
+    terminateTrackedProcessesMock.mockReset();
+    const exit = vi.fn();
+    const beforeSigint = process.listenerCount("SIGINT");
+    const beforeSigterm = process.listenerCount("SIGTERM");
+
+    const run = runCliMain({
+      argv: [],
+      env: {},
+      fetch: globalThis.fetch.bind(globalThis),
+      stdout: new Writable({
+        write(_c, _e, cb) {
+          cb();
+        },
+      }),
+      stderr: new Writable({
+        write(_c, _e, cb) {
+          cb();
+        },
+      }),
+      exit,
+      setExitCode: () => {},
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    const laterSignalCleanup = vi.fn();
+    process.once(signal, laterSignalCleanup);
+
+    process.emit(signal);
+
+    expect(terminateTrackedProcessesMock).toHaveBeenCalledWith(signal);
+    expect(laterSignalCleanup).toHaveBeenCalledOnce();
+    expect(exit).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(exit).toHaveBeenCalledWith(expectedExitCode);
+    finishRun?.();
+    await run;
+    expect(process.listenerCount("SIGINT")).toBe(beforeSigint);
+    expect(process.listenerCount("SIGTERM")).toBe(beforeSigterm);
   });
 
   it("strips ANSI control sequences from non-verbose errors", async () => {

--- a/tests/processes.test.ts
+++ b/tests/processes.test.ts
@@ -6,6 +6,7 @@ import {
   runWithProcessContext,
   setProcessObserver,
   spawnTracked,
+  terminateTrackedProcesses,
 } from "../packages/core/src/processes.js";
 
 const createObserver = (capture: {
@@ -26,6 +27,7 @@ const createObserver = (capture: {
 });
 
 afterEach(() => {
+  terminateTrackedProcesses("SIGKILL");
   setProcessObserver(null);
 });
 
@@ -149,5 +151,47 @@ describe("process tracking", () => {
     await once(proc, "close");
 
     expect(capture.outputs.length).toBe(0);
+  });
+
+  it("terminates active tracked processes", async () => {
+    const { proc } = spawnTracked(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const closed = once(proc, "close");
+
+    terminateTrackedProcesses("SIGTERM");
+
+    const [, signal] = await closed;
+    expect(signal).toBe("SIGTERM");
+  });
+
+  it.runIf(process.platform !== "win32")("terminates tracked process groups", async () => {
+    const parentScript = [
+      'const { spawn } = require("node:child_process");',
+      "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+      "process.stdout.write(String(child.pid));",
+      "setInterval(() => {}, 1000);",
+    ].join("\n");
+    const { proc } = spawnTracked(process.execPath, ["-e", parentScript], {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const [chunk] = await once(proc.stdout!, "data");
+    const childPid = Number(String(chunk));
+    const closed = once(proc, "close");
+
+    terminateTrackedProcesses("SIGTERM");
+    await closed;
+
+    let childAlive = true;
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      try {
+        process.kill(childPid, 0);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      } catch {
+        childAlive = false;
+        break;
+      }
+    }
+    expect(childAlive).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- track active external subprocesses independently of the daemon process observer
- isolate spawned tools into POSIX process groups and terminate Windows trees with `taskkill`
- forward CLI SIGINT/SIGTERM to tracked process trees before exiting 130/143
- defer exit until existing progress cleanup listeners have run

## Reproduction

During local ONNX transcription, sending SIGINT to the CLI terminated the parent but left the transcriber child alive:

```text
CLI: signal SIGINT
ONNX child: alive, no interrupt received
```

The same lifetime gap applied to other tools launched through `spawnTracked`.

## Proof

- production local ONNX SIGINT: CLI exit 130, child received SIGINT, no survivor or completion marker
- production local ONNX SIGTERM: CLI exit 143, child received SIGTERM, no survivor or completion marker
- focused process/signal regressions include direct child, grandchild process group, exit ordering, and listener cleanup
- `pnpm -s build`
- `pnpm -s check`: 524 files, 2,773 tests, 85.04% branch coverage
- first autoreview finding fixed: deferred exit preserves spinner/OSC cleanup
- second autoreview: clean, confidence 0.74
