### PR TITLE
fix: make Chrome Browser runtime daemonless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.18.2 - Unreleased
 
+### Fixes
+
+- Chrome extension: keep Browser runtime fully daemonless even with saved tokens, fail clearly when local extraction or transcription is unavailable, and hide daemon-backed chat and automation without an authenticated daemon.
+
 ## 0.18.1 - 2026-06-13
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ YouTube slide screenshots (from the browser):
 
 ### Beginner quickstart (extension)
 
-1. Install the CLI (choose one):
-   - **npm** (cross‑platform): `npm i -g @steipete/summarize`
+1. Install the extension (Chrome Web Store link above) and open the Side Panel.
+2. Keep the default **Browser** runtime for daemonless local extraction, extractive page/media summaries, browser transcription, and slides.
+3. Optional: install the CLI and pair the daemon for AI summaries, chat, automation, hover summaries, OCR, and broader native media support:
+   - **npm** (cross-platform): `npm i -g @steipete/summarize`
    - **Homebrew** (Homebrew/core): `brew install summarize`
-2. Install the extension (Chrome Web Store link above) and open the Side Panel.
-3. The panel shows a token + install command. Run it in Terminal:
    - `summarize daemon install --token <TOKEN>`
 
 Why a daemon/service?
 
-- Browser mode works without the daemon for page summaries, ranged video slides through MediaBunny/WebCodecs, and fetchable YouTube/direct/embedded media transcription with browser-cached Whisper.
-- The optional daemon on `127.0.0.1` is faster and adds native ffmpeg, configurable transcription providers, OCR, and broader media support.
+- Browser mode works without the daemon for local extractive page/media summaries, ranged video slides through MediaBunny/WebCodecs, and fetchable YouTube/direct/embedded media transcription with browser-cached Whisper.
+- The optional daemon on `127.0.0.1` adds AI summaries, chat, automation, hover summaries, native ffmpeg, configurable transcription providers, OCR, and broader media support.
 - The service autostarts (launchd/systemd/Scheduled Task) so the Side Panel is always ready.
 
 If you only want the **CLI**, you can skip the daemon install entirely.
@@ -153,7 +153,7 @@ If native `ffmpeg`/`ffprobe` are unavailable, Summarize uses the bundled WebAsse
 ### CLI vs extension
 
 - **CLI only:** just install via npm/Homebrew and run `summarize ...` (no daemon needed).
-- **Chrome extension:** Browser mode works without the CLI or daemon; install the daemon for faster and broader media support.
+- **Chrome extension:** Browser mode works without the CLI or daemon for extractive summaries; install the daemon for AI summaries and daemon-backed tools.
 - **Firefox extension:** install the CLI and daemon for media extraction.
 
 ### Quickstart

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -59,12 +59,12 @@ Step-by-step:
 
 ## Optional Daemon (Pairing)
 
-Chrome Browser mode works without a CLI install or daemon. It can summarize pages, use MediaBunny with native WebCodecs for fetchable video slides up to 128 MB, and transcribe captionless YouTube videos with local multilingual Whisper. YouTube audio prefers a same-origin Android VR direct-media URL, with the active tab's captured SABR session as fallback. Chrome's native audio decoder is preferred; MediaBunny handles supported streams that WebAudio rejects. The Whisper model downloads on first use and is cached by Chrome; offline model bundling is not currently provided. Install the daemon for faster extraction, native tools, configurable transcription providers, OCR, and Firefox media support.
+Chrome Browser mode works without a CLI install or daemon. It provides local extractive page/media summaries, uses MediaBunny with native WebCodecs for fetchable video slides up to 128 MB, and transcribes captionless YouTube videos with local multilingual Whisper. YouTube audio prefers a same-origin Android VR direct-media URL, with the active tab's captured SABR session as fallback. Chrome's native audio decoder is preferred; MediaBunny handles supported streams that WebAudio rejects. The Whisper model downloads on first use and is cached by Chrome; offline model bundling is not currently provided. Install the daemon for AI summaries, chat, automation, hover summaries, native tools, configurable transcription providers, OCR, broader media support, and Firefox media support.
 
 1. Install `summarize` (choose one):
    - `npm i -g @steipete/summarize` (requires Node.js 24+)
    - `brew install summarize` (macOS, Linux)
-2. Open the Side Panel (Chrome) or Sidebar (Firefox). You'll see a **Setup** screen with a token and an install command.
+2. Switch Runtime to **Daemon**, then copy the pairing token and install command from the extension.
 3. Open Terminal:
    - macOS: Applications → Utilities → Terminal
    - Windows: Start menu → Terminal (or PowerShell) — **right-click → Run as administrator**
@@ -72,7 +72,7 @@ Chrome Browser mode works without a CLI install or daemon. It can summarize page
 4. Paste the command from the Setup screen and press Enter.
    - Installed binary: `summarize daemon install --token <TOKEN>`
    - Repo/dev checkout: `pnpm summarize daemon install --token <TOKEN> --dev`
-5. Back in your browser, the Setup screen should disappear once the daemon is running.
+5. Back in your browser, the Daemon runtime setup screen should disappear once the daemon is running.
 6. Verify / troubleshoot:
    - `summarize daemon status`
    - `summarize daemon restart`

--- a/apps/chrome-extension/src/entrypoints/background/extractors/types.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extractors/types.ts
@@ -9,6 +9,7 @@ export type ExtractorContext = {
   maxChars: number;
   minTextChars: number;
   token: string;
+  allowDaemon?: boolean;
   noCache?: boolean;
   includeDiagnostics?: boolean;
   signal?: AbortSignal;

--- a/apps/chrome-extension/src/entrypoints/background/extractors/url-daemon.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extractors/url-daemon.ts
@@ -23,7 +23,7 @@ type UrlDaemonExtractResponse = {
 
 export const urlDaemonExtractor: Extractor = {
   name: "url-daemon",
-  match: () => true,
+  match: (ctx) => ctx.allowDaemon !== false && Boolean(ctx.token.trim()),
   async extract(ctx: ExtractorContext): Promise<ExtractorResult | null> {
     const res = await ctx.fetchImpl("http://127.0.0.1:8787/v1/summarize", {
       method: "POST",

--- a/apps/chrome-extension/src/entrypoints/background/panel-content-preparation.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-content-preparation.ts
@@ -17,6 +17,7 @@ export type PreparedPanelContent = {
   payload: ExtractResponse & { ok: true };
   title: string | null;
   transcriptTimedText: string | null;
+  localTranscriptError: string | null;
   source: CachedExtract["source"];
   diagnostics: CachedExtract["diagnostics"];
   prefersUrlMode: boolean;
@@ -189,6 +190,7 @@ export async function preparePanelContent({
         maxChars: settings.maxChars,
         minTextChars: 1,
         token: settings.token,
+        allowDaemon: !useBrowserSummary,
         noCache: refresh,
         includeDiagnostics: settings.extendedLogging,
         signal,
@@ -241,6 +243,7 @@ export async function preparePanelContent({
       payload: { ...payload, title },
       title,
       transcriptTimedText,
+      localTranscriptError: null,
       source,
       diagnostics,
       prefersUrlMode,
@@ -300,9 +303,14 @@ export async function ensurePreparedPanelTranscript({
         : "extract:browser-media:local-transcript-failed",
       { error: localTranscript.error },
     );
-    return content;
+    return { ...content, localTranscriptError: localTranscript.error };
   }
-  if (!urlsMatch(localTranscript.url, tabUrl)) return content;
+  if (!urlsMatch(localTranscript.url, tabUrl)) {
+    return {
+      ...content,
+      localTranscriptError: "The page changed before browser transcription completed.",
+    };
+  }
   logPanel(
     localTranscriptKind === "youtube"
       ? "extract:url-direct:local-transcript"
@@ -331,6 +339,7 @@ export async function ensurePreparedPanelTranscript({
       media: { hasVideo: true, hasAudio: true, hasCaptions: false },
     },
     transcriptTimedText: localTranscript.transcriptTimedText,
+    localTranscriptError: null,
   };
 }
 

--- a/apps/chrome-extension/src/entrypoints/background/panel-state.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-state.ts
@@ -85,10 +85,9 @@ export async function resolvePanelState({
   const settings = await loadSettings();
   const tab = await getActiveTab(session.windowId);
   const token = settings.token.trim();
-  const [health, authed] = await Promise.all([
-    daemonHealth(),
-    token ? daemonPing(token) : Promise.resolve({ ok: false }),
-  ]);
+  const [health, authed] = token
+    ? await Promise.all([daemonHealth(), daemonPing(token)])
+    : [{ ok: false }, { ok: false }];
   const daemonReady = health.ok && authed.ok;
   const pendingUrl = session.daemonRecovery.getPendingUrl();
   const currentUrlMatches = Boolean(pendingUrl && tab?.url && urlsMatch(tab.url, pendingUrl));

--- a/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
@@ -1,4 +1,8 @@
-import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
+import {
+  isDirectMediaUrl,
+  isYouTubeVideoUrl,
+  shouldPreferUrlMode,
+} from "@steipete/summarize-core/content/url";
 import { planMediaExtraction } from "../../lib/media-extraction-plan";
 import type { RunStart } from "../../lib/panel-contracts";
 import type { Settings } from "../../lib/settings";
@@ -131,7 +135,7 @@ export async function summarizeActiveTab({
   const settings = await loadSettings();
   const isManual = reason === "manual" || reason === "refresh" || reason === "length-change";
   if (!isManual && !settings.autoSummarize) return;
-  const useBrowserSummary = settings.slideRuntime === "browser" && !settings.token.trim();
+  const useBrowserSummary = settings.slideRuntime === "browser";
   if (!useBrowserSummary && !settings.token.trim()) {
     await emitState(session, "Setup required (missing token)");
     return;
@@ -260,6 +264,31 @@ export async function summarizeActiveTab({
   if (useBrowserSummary) {
     await ensureLocalBrowserTranscript();
     if (isSuperseded()) return;
+    const browserExtractionPlan = planMediaExtraction({
+      url: resolvedPayload.url,
+      requestedInputMode,
+    });
+    const requiresMediaTranscript =
+      browserExtractionPlan.isYouTubeVideo ||
+      isDirectMediaUrl(resolvedPayload.url) ||
+      Boolean(resolvedPayload.media?.hasVideo || resolvedPayload.media?.hasAudio);
+    const localTranscriptError = preparedContent.localTranscriptError
+      ?.trim()
+      .replace(/[.!?]+$/, "");
+    const browserError =
+      localTranscriptError && requiresMediaTranscript
+        ? `Could not transcribe this media in Browser mode: ${localTranscriptError}. Switch Runtime to Daemon for broader media support.`
+        : resolvedPayload.text.trim().length === 0
+          ? browserExtractionPlan.localTranscriptKind
+            ? "No transcript text was available in Browser mode. Switch Runtime to Daemon for broader media support."
+            : "No readable text was available in Browser mode. Reload the page or switch Runtime to Daemon for URL extraction."
+          : null;
+    if (browserError) {
+      send({ type: "run:error", message: browserError });
+      sendStatus(`Error: ${browserError}`);
+      clearCurrentRun();
+      return;
+    }
   }
   const effectiveInputMode =
     opts?.inputMode ??
@@ -389,16 +418,6 @@ export async function summarizeActiveTab({
     session.daemonStatus.markReady();
   } catch (err) {
     if (isSuperseded()) return;
-    if (settings.slideRuntime === "browser") {
-      if (isDaemonUnreachableError(err)) {
-        session.daemonRecovery.recordFailure(resolvedPayload.url);
-      }
-      await ensureLocalBrowserTranscript();
-      if (isSuperseded()) return;
-      cacheResolvedPayload();
-      sendBrowserSummarySnapshot();
-      return;
-    }
     const message = friendlyFetchError(err, "Daemon request failed");
     send({ type: "run:error", message });
     sendStatus(`Error: ${message}`);

--- a/apps/chrome-extension/src/entrypoints/options/index.html
+++ b/apps/chrome-extension/src/entrypoints/options/index.html
@@ -125,11 +125,15 @@
             </div>
             <div class="combo">
               <div id="chatToggle"></div>
-              <span class="subtitle">Enable Chat mode in the side panel (default on).</span>
+              <span class="subtitle">
+                Enable daemon-backed Chat mode in the side panel (default on).
+              </span>
             </div>
             <div class="combo">
               <div id="automationToggle"></div>
-              <span class="subtitle">Enable website automation tools in the side panel.</span>
+              <span class="subtitle">
+                Enable daemon-backed website automation tools in the side panel.
+              </span>
             </div>
             <div class="combo">
               <button id="automationPermissions" type="button" class="miniButton">
@@ -155,35 +159,36 @@
             <header class="advancedHead">
               <h2>Runtime</h2>
               <div class="hint">
-                Browser mode is the default. Switch to daemon mode only when you want the local
-                helper for heavier slide extraction.
+                Browser mode runs locally with extractive summaries. Daemon mode adds AI summaries
+                and daemon-backed tools.
               </div>
             </header>
             <div class="advancedFields">
               <div class="subgroup">
                 <div class="subgroupHead">
-                  <span class="subgroupTitle">Slide extraction backend</span>
+                  <span class="subgroupTitle">Summary and slide runtime</span>
                 </div>
                 <div class="subgroupBody">
                   <div
                     id="slideRuntimeMode"
                     class="runtimeModeGrid"
                     role="radiogroup"
-                    aria-label="Slide extraction backend"
+                    aria-label="Summary and slide runtime"
                   >
                     <label class="runtimeModeCard">
                       <input type="radio" name="slideRuntimeMode" value="browser" />
                       <div class="runtimeModeTitle">Browser</div>
                       <div class="runtimeModeText">
-                        Runs inside Chrome. Uses browser transcript and frame capture without
-                        requiring the Summarize daemon.
+                        Runs inside Chrome. Local extraction, extractive summaries, browser
+                        transcription, and frame capture; no Summarize daemon required.
                       </div>
                     </label>
                     <label class="runtimeModeCard">
                       <input type="radio" name="slideRuntimeMode" value="daemon" />
                       <div class="runtimeModeTitle">Daemon</div>
                       <div class="runtimeModeText">
-                        Sends slide extraction to the local daemon for long or expensive videos.
+                        Uses the local daemon for AI summaries, chat, automation, hover summaries,
+                        OCR, and broader native media support.
                       </div>
                     </label>
                   </div>
@@ -228,7 +233,8 @@
               </div>
             </label>
             <div class="hint">
-              Used only for daemon mode and daemon-backed tools. Browser mode works without it.
+              Used only for Daemon runtime and daemon-backed tools. Browser summaries work without
+              it.
             </div>
           </section>
         </div>

--- a/apps/chrome-extension/src/entrypoints/sidepanel/automation-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/automation-runtime.ts
@@ -3,6 +3,7 @@ import { executeToolCall, getAutomationToolNames } from "../../automation/tools"
 import { runChatAgentLoop } from "./chat-agent-loop";
 import type { ChatController } from "./chat-controller";
 import { buildEmptyUsage } from "./chat-history-store";
+import { isPanelAutomationAvailable } from "./panel-capabilities";
 import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
 import type { ChatMessage, PanelState } from "./types";
 
@@ -182,7 +183,7 @@ export function createAutomationRuntime({
 
   const runAgentLoop = async () => {
     await runChatAgentLoop({
-      automationEnabled: panelState.panelSession.automationEnabled,
+      automationEnabled: isPanelAutomationAvailable(panelState),
       chatController,
       chatSession: getChatSession(),
       confirmToolCall,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime.ts
@@ -10,6 +10,7 @@ import { createChatSession } from "./chat-session";
 import type { ChatHistoryLimits } from "./chat-state";
 import { createChatStreamRuntime } from "./chat-stream-runtime";
 import { createChatUiRuntime } from "./chat-ui-runtime";
+import { isPanelChatAvailable } from "./panel-capabilities";
 import type { PanelStateAction } from "./panel-state-store";
 import { parseTimestampHref } from "./timestamp-links";
 import type { ChatMessage, PanelState } from "./types";
@@ -139,7 +140,7 @@ export function createSidepanelChatRuntime({
     chatContainerEl,
     chatDockContainerEl: chatDockEl,
     renderEl,
-    getChatEnabled: () => panelState.panelSession.chatEnabled,
+    getChatEnabled: () => isPanelChatAvailable(panelState),
     getActiveTabId,
     getSummaryMarkdown: () => panelState.summaryMarkdown,
     clearMetrics: clearChatMetrics,
@@ -168,7 +169,7 @@ export function createSidepanelChatRuntime({
   });
 
   const chatStreamRuntime = createChatStreamRuntime({
-    chatEnabled: () => panelState.panelSession.chatEnabled,
+    chatEnabled: () => isPanelChatAvailable(panelState),
     isChatStreaming: () => panelState.chat.streaming,
     setChatStreaming: (value) => {
       dispatchPanelState({ type: "chat-streaming", value });

--- a/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
@@ -7,6 +7,7 @@ import { bootstrapSidepanel } from "./bootstrap-runtime";
 import { createSidepanelDom } from "./dom";
 import { createSidepanelInteractionRuntime } from "./interaction-runtime";
 import { createMetricsController } from "./metrics-controller";
+import { isPanelChatAvailable } from "./panel-capabilities";
 import { createPanelMessagingRuntime } from "./panel-messaging";
 import { createPanelStateStore } from "./panel-state-store";
 import { createSidepanelPresentationRuntime } from "./presentation-runtime";
@@ -211,7 +212,7 @@ registerSidepanelRuntimeTestHooks({
 });
 
 const interactionRuntime = createSidepanelInteractionRuntime({
-  chatEnabled: () => getPanelSession().chatEnabled,
+  chatEnabled: () => isPanelChatAvailable(panelState),
   getRawChatInput: () => chatInputEl.value,
   clearChatInput: () => {
     chatInputEl.value = "";

--- a/apps/chrome-extension/src/entrypoints/sidepanel/panel-capabilities.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/panel-capabilities.ts
@@ -1,0 +1,9 @@
+import type { PanelState } from "./types";
+
+export function isPanelChatAvailable(panelState: PanelState): boolean {
+  return panelState.panelSession.chatEnabled && panelState.panelSession.daemonFeaturesAvailable;
+}
+
+export function isPanelAutomationAvailable(panelState: PanelState): boolean {
+  return panelState.panelSession.automationEnabled && isPanelChatAvailable(panelState);
+}

--- a/apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store.ts
@@ -100,6 +100,7 @@ export function createInitialPanelState(): PanelState {
       autoSummarize: false,
       chatEnabled: defaultSettings.chatEnabled,
       automationEnabled: defaultSettings.automationEnabled,
+      daemonFeaturesAvailable: false,
       settingsHydrated: false,
       pendingSettingsSnapshot: null,
       lastPanelOpen: false,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/test-hooks-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/test-hooks-runtime.ts
@@ -1,5 +1,6 @@
 import type { BgToPanel, UiState } from "../../lib/panel-contracts";
 import type { SidepanelDom } from "./dom";
+import { isPanelChatAvailable } from "./panel-capabilities";
 import type { PanelStateAction } from "./panel-state-store";
 import type { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import { selectRetainedSlideSummaryMarkdown } from "./retained-slide-summary";
@@ -62,7 +63,7 @@ export function registerSidepanelRuntimeTestHooks({
     getSlidesSummaryMarkdown: () => panelState.slidesSummary.markdown,
     getSlidesSummaryComplete: () => panelState.slidesSummary.complete,
     getSlidesSummaryModel: () => panelState.slidesSummary.model,
-    getChatEnabled: () => panelState.panelSession.chatEnabled,
+    getChatEnabled: () => isPanelChatAvailable(panelState),
     getSettingsHydrated: () => panelState.panelSession.settingsHydrated,
     setTranscriptTimedText: (value) => {
       setSlidesTranscriptTimedText(value);

--- a/apps/chrome-extension/src/entrypoints/sidepanel/types.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/types.ts
@@ -86,6 +86,7 @@ export type PanelState = {
     autoSummarize: boolean;
     chatEnabled: boolean;
     automationEnabled: boolean;
+    daemonFeaturesAvailable: boolean;
     settingsHydrated: boolean;
     pendingSettingsSnapshot: Partial<Settings> | null;
     lastPanelOpen: boolean;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
@@ -1,5 +1,6 @@
 import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import type { PanelCachePayload } from "./panel-cache";
+import { isPanelChatAvailable } from "./panel-capabilities";
 import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
 import {
   resolvePanelNavigationDecision,
@@ -152,7 +153,7 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
     const currentSource = opts.panelState.currentSource;
     const inputModeOverride = opts.panelState.slidesSession.inputModeOverride;
     const mediaAvailable = opts.panelState.slidesSession.mediaAvailable;
-    const chatEnabledValue = opts.panelState.panelSession.chatEnabled;
+    const chatEnabledValue = state.settings.chatEnabled;
     const slidesLayoutValue = opts.panelState.slidesSession.slidesLayout;
 
     const ignoreTransientTabState = shouldIgnoreTransientPanelTabState({
@@ -257,6 +258,7 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
       value: {
         chatEnabled: state.settings.chatEnabled,
         automationEnabled: state.settings.automationEnabled,
+        daemonFeaturesAvailable: state.daemon.ok && state.daemon.authed,
       },
     });
     const nextSlidesOcrEnabled = Boolean(state.settings.slidesOcrEnabled);
@@ -313,7 +315,7 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
     }
     opts.applyChatEnabled();
     if (
-      opts.panelState.panelSession.chatEnabled &&
+      isPanelChatAvailable(opts.panelState) &&
       opts.panelState.navigation.activeTabId &&
       !shouldPreferUrlMode(nextTabUrl ?? "") &&
       opts.panelState.chat.messages.length === 0

--- a/apps/chrome-extension/tests/sidepanel.chat-errors.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.chat-errors.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { mockDaemonSummarize } from "./helpers/daemon-fixtures";
 import {
   activateTabByUrl,
   assertNoErrors,
@@ -30,6 +31,7 @@ test("sidepanel shows an error when agent request fails", async ({
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
 
   try {
+    await mockDaemonSummarize(harness);
     await seedSettings(harness, { token: "test-token", autoSummarize: false, chatEnabled: true });
     const contentPage = await harness.context.newPage();
     await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
@@ -99,22 +101,39 @@ test("sidepanel hides inline error when message is empty", async ({
       ).__summarizeTestHooks = {};
     });
     await waitForPanelPort(page);
-
+    await waitForSettingsHydratedHook(page);
     await page.evaluate(() => {
-      const hooks = (
-        window as typeof globalThis & {
-          __summarizeTestHooks?: {
-            showInlineError?: (message: string) => void;
-            isInlineErrorVisible?: () => boolean;
-            getInlineErrorMessage?: () => string;
-          };
-        }
-      ).__summarizeTestHooks;
-      hooks?.showInlineError?.("Boom");
+      const global = window as typeof globalThis & {
+        __summarizePanelPort?: { disconnect?: () => void };
+      };
+      global.__summarizePanelPort?.disconnect?.();
+      global.__summarizePanelPort = undefined;
     });
-    await expect(page.locator("#inlineError")).toBeVisible();
 
-    await page.evaluate(() => {
+    const shown = await page.evaluate(
+      (state) => {
+        const hooks = (
+          window as typeof globalThis & {
+            __summarizeTestHooks?: {
+              applyUiState?: (state: unknown) => void;
+              showInlineError?: (message: string) => void;
+              isInlineErrorVisible?: () => boolean;
+              getInlineErrorMessage?: () => string;
+            };
+          }
+        ).__summarizeTestHooks;
+        hooks?.applyUiState?.(state);
+        hooks?.showInlineError?.("Boom");
+        return {
+          visible: hooks?.isInlineErrorVisible?.() ?? false,
+          message: hooks?.getInlineErrorMessage?.() ?? "",
+        };
+      },
+      buildUiState({ daemon: { ok: false, authed: false } }),
+    );
+    expect(shown).toEqual({ visible: true, message: "Boom" });
+
+    const hidden = await page.evaluate(() => {
       const hooks = (
         window as typeof globalThis & {
           __summarizeTestHooks?: {
@@ -125,10 +144,13 @@ test("sidepanel hides inline error when message is empty", async ({
         }
       ).__summarizeTestHooks;
       hooks?.showInlineError?.("   ");
+      return {
+        visible: hooks?.isInlineErrorVisible?.() ?? false,
+        message: hooks?.getInlineErrorMessage?.() ?? "",
+      };
     });
 
-    await expect(page.locator("#inlineError")).toBeHidden();
-    await expect(page.locator("#inlineErrorMessage")).toHaveText("");
+    expect(hidden).toEqual({ visible: false, message: "" });
     assertNoErrors(harness);
   } finally {
     await closeExtension(harness.context, harness.userDataDir);
@@ -141,6 +163,7 @@ test("sidepanel shows daemon upgrade hint when /v1/agent is missing", async ({
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
 
   try {
+    await mockDaemonSummarize(harness);
     await seedSettings(harness, { token: "test-token", autoSummarize: false, chatEnabled: true });
     const contentPage = await harness.context.newPage();
     await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
@@ -201,7 +224,15 @@ test("sidepanel shows automation notice when permission event fires", async ({
   try {
     const page = await openExtensionPage(harness, "sidepanel.html", "#title");
     await waitForPanelPort(page);
+    await waitForSettingsHydratedHook(page);
     await page.evaluate(() => {
+      const global = window as typeof globalThis & {
+        __summarizePanelPort?: { disconnect?: () => void };
+      };
+      global.__summarizePanelPort?.disconnect?.();
+      global.__summarizePanelPort = undefined;
+    });
+    const notice = await page.evaluate(() => {
       window.dispatchEvent(
         new CustomEvent("summarize:automation-permissions", {
           detail: {
@@ -211,10 +242,15 @@ test("sidepanel shows automation notice when permission event fires", async ({
           },
         }),
       );
+      const noticeEl = document.getElementById("automationNotice");
+      return {
+        visible: !noticeEl?.classList.contains("hidden"),
+        message: document.getElementById("automationNoticeMessage")?.textContent ?? "",
+      };
     });
 
-    await expect(page.locator("#automationNotice")).toBeVisible();
-    await expect(page.locator("#automationNoticeMessage")).toContainText("Enable User Scripts");
+    expect(notice.visible).toBe(true);
+    expect(notice.message).toContain("Enable User Scripts");
     assertNoErrors(harness);
   } finally {
     await closeExtension(harness.context, harness.userDataDir);

--- a/apps/chrome-extension/tests/sidepanel.chat.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.chat.spec.ts
@@ -34,6 +34,7 @@ test("sidepanel chat queue sends next message after stream completes", async ({
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
 
   try {
+    await mockDaemonSummarize(harness);
     await seedSettings(harness, { token: "test-token", autoSummarize: false, chatEnabled: true });
     const contentPage = await harness.context.newPage();
     await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
@@ -101,6 +102,7 @@ test("sidepanel chat sends mixed OCR and transcript slide text to the bot", asyn
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
 
   try {
+    await mockDaemonSummarize(harness);
     await seedSettings(harness, {
       token: "test-token",
       autoSummarize: false,
@@ -198,6 +200,7 @@ test("sidepanel chat queue drains messages after stream completes", async ({
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
 
   try {
+    await mockDaemonSummarize(harness);
     await seedSettings(harness, { token: "test-token", autoSummarize: false, chatEnabled: true });
     const contentPage = await harness.context.newPage();
     await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
@@ -284,6 +287,7 @@ test("sidepanel clears chat on user navigation", async ({
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
 
   try {
+    await mockDaemonSummarize(harness);
     await seedSettings(harness, { token: "test-token", autoSummarize: false, chatEnabled: true });
     const contentPage = await harness.context.newPage();
     await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });

--- a/apps/chrome-extension/tests/sidepanel.core.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.core.spec.ts
@@ -69,6 +69,7 @@ test("sidepanel updates chat visibility when settings change", async ({
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
 
   try {
+    await mockDaemonSummarize(harness);
     await seedSettings(harness, { chatEnabled: true });
     const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
       (window as typeof globalThis & { IntersectionObserver?: unknown }).IntersectionObserver =
@@ -76,10 +77,52 @@ test("sidepanel updates chat visibility when settings change", async ({
     });
     await waitForPanelPort(page);
     await waitForSettingsHydratedHook(page);
+    await sendBgMessage(harness, {
+      type: "ui:state",
+      state: buildUiState({
+        daemon: { ok: true, authed: true },
+        settings: { chatEnabled: true, tokenPresent: true },
+      }),
+    });
     await waitForChatEnabled(page, true);
     await expect(page.locator("#chatDock")).toBeVisible();
 
     await updateSettings(page, { chatEnabled: false });
+    await waitForChatEnabled(page, false);
+    await expect(page.locator("#chatDock")).toBeHidden();
+    await expect(page.locator("#chatContainer")).toBeHidden();
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
+test("sidepanel hides daemon-backed chat when browser mode has no daemon", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, {
+      token: "",
+      chatEnabled: true,
+      slideRuntime: "browser",
+    });
+    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+    await waitForPanelPort(page);
+    await waitForSettingsHydratedHook(page);
+    await sendBgMessage(harness, {
+      type: "ui:state",
+      state: buildUiState({
+        daemon: { ok: false, authed: false },
+        settings: {
+          chatEnabled: true,
+          slideRuntime: "browser",
+          tokenPresent: false,
+        },
+      }),
+    });
+
     await waitForChatEnabled(page, false);
     await expect(page.locator("#chatDock")).toBeHidden();
     await expect(page.locator("#chatContainer")).toBeHidden();

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -13,7 +13,8 @@ Goal: Chrome **Side Panel** (“real sidebar”) summarizes **what you see** on 
 Quickstart:
 
 - Build/load extension: `apps/chrome-extension/README.md`
-- Chrome Browser mode works immediately without a daemon for page summaries, fetchable video slides, and fetchable YouTube/direct/embedded media transcription.
+- Chrome Browser mode works immediately without a daemon for local extractive page/media summaries, fetchable video slides, and fetchable YouTube/direct/embedded media transcription.
+- AI summaries, chat, automation, hover summaries, OCR, process/log tools, and broader native media support require the daemon.
 - Optional: install summarize for daemon-backed media support:
   - `npm i -g @steipete/summarize`
   - `brew install summarize` (macOS, Linux)
@@ -162,7 +163,7 @@ See `docs/media.md` for detection and transcript rules.
   - Typography: font family (dropdown + custom), font size (slider).
 - Advanced overrides (Options → Advanced tab).
   - Leave blank to use daemon config/defaults; set a value to override.
-  - Chat (advanced): enable/disable the side panel chat input (default on; summary is the first message).
+  - Chat (advanced): enable/disable the daemon-backed side panel chat input (default on; hidden when no authenticated daemon is available).
   - Summary timestamps (advanced): include `[mm:ss]` links in summaries for media when available (default on).
   - Slides parallel (advanced): show summary first and extract slides in parallel (default on).
   - Slides OCR text (advanced): allow OCR text as a slide text source (default off).

--- a/tests/chrome.extractor-router.test.ts
+++ b/tests/chrome.extractor-router.test.ts
@@ -221,4 +221,35 @@ describe("chrome/extractor-router", () => {
       ),
     ).toBe(true);
   });
+
+  it("does not call daemon URL extraction when daemon fallback is disabled", async () => {
+    const extractFromTab = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        ok: true as const,
+        url: "https://example.com/article",
+        title: "Page Title",
+        text: "",
+        truncated: false,
+        media: null,
+      },
+    }));
+    const { ctx, fetchImpl, logs } = createContext({
+      allowDaemon: false,
+      extractFromTab,
+    });
+
+    const result = await routeExtract(ctx);
+
+    expect(result).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(
+      logs.some(
+        (entry) =>
+          entry.event === "extractor.try" &&
+          entry.detail?.extractor === "url-daemon" &&
+          entry.detail?.matched === false,
+      ),
+    ).toBe(true);
+  });
 });

--- a/tests/chrome.panel-content-preparation.test.ts
+++ b/tests/chrome.panel-content-preparation.test.ts
@@ -96,6 +96,7 @@ describe("chrome panel content preparation", () => {
         },
         title: "Tab title",
         transcriptTimedText: null,
+        localTranscriptError: null,
         source: "url",
         diagnostics: { strategy: "daemon" },
         prefersUrlMode: false,
@@ -105,6 +106,7 @@ describe("chrome panel content preparation", () => {
       expect.objectContaining({
         url: articleUrl,
         noCache: false,
+        allowDaemon: true,
         signal: harness.args.signal,
       }),
     );
@@ -284,6 +286,7 @@ describe("chrome panel content preparation", () => {
       },
       title: "Video",
       transcriptTimedText: null,
+      localTranscriptError: null,
       source: "page",
       diagnostics: null,
       prefersUrlMode: true,
@@ -339,6 +342,7 @@ describe("chrome panel content preparation", () => {
       },
       title: "Media",
       transcriptTimedText: null,
+      localTranscriptError: null,
       source: "page",
       diagnostics: null,
       prefersUrlMode: false,
@@ -366,7 +370,10 @@ describe("chrome panel content preparation", () => {
       })),
     });
 
-    expect(result).toBe(content);
+    expect(result).toEqual({
+      ...content,
+      localTranscriptError: "The page changed before browser transcription completed.",
+    });
   });
 
   it("keeps prepared content and logs a local transcription failure", async () => {
@@ -381,6 +388,7 @@ describe("chrome panel content preparation", () => {
       },
       title: "Video",
       transcriptTimedText: null,
+      localTranscriptError: null,
       source: "page",
       diagnostics: null,
       prefersUrlMode: true,
@@ -403,9 +411,22 @@ describe("chrome panel content preparation", () => {
       transcribeMediaLocally: vi.fn(),
     });
 
-    expect(result).toBe(content);
+    expect(result).toEqual({
+      ...content,
+      localTranscriptError: "decoder unavailable",
+    });
     expect(logPanel).toHaveBeenCalledWith("extract:url-direct:local-transcript-failed", {
       error: "decoder unavailable",
     });
+  });
+
+  it("disables daemon URL fallback for browser summaries", async () => {
+    const harness = createHarness({ useBrowserSummary: true });
+
+    await preparePanelContent(harness.args);
+
+    expect(harness.routeExtractImpl).toHaveBeenCalledWith(
+      expect.objectContaining({ allowDaemon: false }),
+    );
   });
 });

--- a/tests/chrome.panel-state.test.ts
+++ b/tests/chrome.panel-state.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolvePanelState } from "../apps/chrome-extension/src/entrypoints/background/panel-state.js";
+import { defaultSettings } from "../apps/chrome-extension/src/lib/settings.js";
+
+function createSession() {
+  return {
+    windowId: 1,
+    runController: null,
+    agentController: null,
+    inflightUrl: null,
+    daemonRecovery: {
+      getPendingUrl: () => null,
+      maybeRecover: vi.fn(() => false),
+      updateStatus: vi.fn(),
+    },
+    daemonStatus: {
+      resolve: vi.fn((state) => state),
+    },
+  };
+}
+
+describe("chrome panel state", () => {
+  it("does not probe localhost when no daemon token is configured", async () => {
+    const daemonHealth = vi.fn(async () => ({ ok: true }));
+    const daemonPing = vi.fn(async () => ({ ok: true }));
+
+    const result = await resolvePanelState({
+      session: createSession(),
+      status: "",
+      loadSettings: vi.fn(async () => ({ ...defaultSettings, token: "" })),
+      getActiveTab: vi.fn(async () => null),
+      daemonHealth,
+      daemonPing,
+      panelSessionStore: {
+        isPanelOpen: () => true,
+        getCachedExtract: () => null,
+      },
+      urlsMatch: (left, right) => left === right,
+      canSummarizeUrl: () => false,
+    });
+
+    expect(daemonHealth).not.toHaveBeenCalled();
+    expect(daemonPing).not.toHaveBeenCalled();
+    expect(result.state.daemon).toMatchObject({ ok: false, authed: false });
+  });
+});

--- a/tests/chrome.panel-summarize.test.ts
+++ b/tests/chrome.panel-summarize.test.ts
@@ -407,7 +407,7 @@ describe("chrome panel summarize", () => {
     });
   });
 
-  it("keeps daemon summaries when browser runtime has a daemon token", async () => {
+  it("keeps browser summaries local when browser runtime has a daemon token", async () => {
     const harness = createHarness();
     const url = "https://example.com/article";
 
@@ -439,33 +439,31 @@ describe("chrome panel summarize", () => {
       })),
     });
 
-    expect(harness.fetchImpl).toHaveBeenCalledOnce();
-    expect(harness.sent).toEqual([
-      {
-        type: "run:start",
-        run: {
-          id: "summary",
-          url,
-          title: "Browser Article",
-          model: defaultSettings.model,
-          reason: "manual",
-          slides: false,
-        },
+    expect(harness.fetchImpl).not.toHaveBeenCalled();
+    expect(harness.sent[0]).toMatchObject({
+      type: "run:snapshot",
+      run: {
+        url,
+        title: "Browser Article",
+        model: "Browser",
+        reason: "manual",
+        slides: false,
       },
-    ]);
+    });
   });
 
-  it("falls back to a browser summary snapshot when the configured daemon is unreachable", async () => {
+  it("does not probe an unreachable daemon in browser runtime", async () => {
     const harness = createHarness();
     const url = "https://example.com/article";
     const sendStatus = vi.fn();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("Failed to fetch");
+    });
 
     await harness.summarize({
       reason: "manual",
       sendStatus,
-      fetchImpl: vi.fn(async () => {
-        throw new Error("Failed to fetch");
-      }) as unknown as typeof fetch,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
       isDaemonUnreachableError: () => true,
       loadSettings: vi.fn(async () => ({
         ...defaultSettings,
@@ -499,22 +497,24 @@ describe("chrome panel summarize", () => {
       run: { url, model: "Browser", slides: false },
       markdown: expect.stringContaining("First sentence\\."),
     });
-    expect(harness.session.daemonRecovery.recordFailure).toHaveBeenCalledWith(url);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(harness.session.daemonRecovery.recordFailure).not.toHaveBeenCalled();
     expect(sendStatus).toHaveBeenLastCalledWith("");
   });
 
-  it("falls back to a browser summary snapshot when a saved daemon token is stale", async () => {
+  it("does not probe a stale daemon token in browser runtime", async () => {
     const harness = createHarness();
     const url = "https://example.com/article";
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: async () => ({ ok: false, error: "Unauthorized" }),
+    }));
 
     await harness.summarize({
       reason: "manual",
-      fetchImpl: vi.fn(async () => ({
-        ok: false,
-        status: 401,
-        statusText: "Unauthorized",
-        json: async () => ({ ok: false, error: "Unauthorized" }),
-      })) as unknown as typeof fetch,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
       isDaemonUnreachableError: () => false,
       loadSettings: vi.fn(async () => ({
         ...defaultSettings,
@@ -548,6 +548,126 @@ describe("chrome panel summarize", () => {
       run: { url, model: "Browser", slides: false },
       markdown: expect.stringContaining("First sentence\\."),
     });
+    expect(fetchImpl).not.toHaveBeenCalled();
     expect(harness.session.daemonRecovery.recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("reports browser media transcription failures instead of summarizing descriptions", async () => {
+    const harness = createHarness();
+
+    await harness.summarize({
+      reason: "manual",
+      loadSettings: vi.fn(async () => ({
+        ...defaultSettings,
+        token: "",
+        autoSummarize: true,
+        slidesEnabled: false,
+        slideRuntime: "browser",
+      })),
+      extractFromTab: vi.fn(async () => ({
+        ok: true,
+        data: {
+          ok: true,
+          url: youtubeUrl,
+          title: "YouTube",
+          text: "Video description without captions.",
+          truncated: false,
+          media: { hasVideo: true, hasAudio: true, hasCaptions: false },
+        },
+      })),
+      transcribeYouTubeLocally: vi.fn(async () => ({
+        ok: false as const,
+        error: "decoder unavailable",
+      })),
+    });
+
+    expect(harness.fetchImpl).not.toHaveBeenCalled();
+    expect(harness.sent).toEqual([
+      {
+        type: "run:error",
+        message:
+          "Could not transcribe this media in Browser mode: decoder unavailable. Switch Runtime to Daemon for broader media support.",
+      },
+    ]);
+    expect(harness.session.lastSummarizedUrl).toBeNull();
+  });
+
+  it("summarizes usable text-first preferred URLs when no local media is available", async () => {
+    const harness = createHarness();
+    const url = "https://x.com/example/status/1234567890123456789";
+
+    await harness.summarize({
+      reason: "manual",
+      loadSettings: vi.fn(async () => ({
+        ...defaultSettings,
+        token: "",
+        autoSummarize: true,
+        slidesEnabled: false,
+        slideRuntime: "browser",
+      })),
+      getActiveTab: vi.fn(async () => ({
+        id: 7,
+        windowId: 1,
+        url,
+        title: "Post",
+      })),
+      extractFromTab: vi.fn(async () => ({
+        ok: true,
+        data: {
+          ok: true,
+          url,
+          title: "Post",
+          text: "Useful post text without fetchable media.",
+          truncated: false,
+          media: null,
+        },
+      })),
+      transcribeMediaLocally: vi.fn(async () => ({
+        ok: false as const,
+        error: "No fetchable media source.",
+      })),
+    });
+
+    expect(harness.fetchImpl).not.toHaveBeenCalled();
+    expect(harness.sent[0]).toMatchObject({
+      type: "run:snapshot",
+      run: { url, model: "Browser", slides: false },
+      markdown: expect.stringContaining("Useful post text without fetchable media\\."),
+    });
+  });
+
+  it("reports empty browser page extraction instead of caching a fake summary", async () => {
+    const harness = createHarness();
+    const url = "https://example.com/empty";
+
+    await harness.summarize({
+      reason: "manual",
+      loadSettings: vi.fn(async () => ({
+        ...defaultSettings,
+        token: "",
+        autoSummarize: true,
+        slidesEnabled: false,
+        slideRuntime: "browser",
+      })),
+      getActiveTab: vi.fn(async () => ({
+        id: 7,
+        windowId: 1,
+        url,
+        title: "Empty",
+      })),
+      extractFromTab: vi.fn(async () => ({
+        ok: false,
+        error: "blocked",
+      })),
+    });
+
+    expect(harness.sent).toEqual([
+      {
+        type: "run:error",
+        message:
+          "No readable text was available in Browser mode. Reload the page or switch Runtime to Daemon for URL extraction.",
+      },
+    ]);
+    expect(harness.session.lastSummarizedUrl).toBeNull();
   });
 });

--- a/tests/sidepanel.automation-runtime.test.ts
+++ b/tests/sidepanel.automation-runtime.test.ts
@@ -27,9 +27,12 @@ vi.mock("../apps/chrome-extension/src/automation/tools", () => ({
   getAutomationToolNames: vi.fn(() => ["navigate", "debugger"]),
 }));
 
-function createHarness(options: { activeTabId?: number | null } = {}) {
+function createHarness(
+  options: { activeTabId?: number | null; daemonFeaturesAvailable?: boolean } = {},
+) {
   const panelState = createInitialPanelState();
   panelState.panelSession.automationEnabled = true;
+  panelState.panelSession.daemonFeaturesAvailable = options.daemonFeaturesAvailable ?? true;
   panelState.summaryMarkdown = "Summary";
   const automationNoticeActionBtn = document.createElement("button");
   const automationNoticeEl = document.createElement("div");
@@ -233,5 +236,13 @@ describe("automation runtime", () => {
     await expect(options.hasDebuggerPermission()).resolves.toBe(true);
     await options.executeToolCall({ name: "navigate" });
     expect(automationMocks.executeToolCall).toHaveBeenCalledOnce();
+  });
+
+  it("disables automation tools when daemon features are unavailable", async () => {
+    const harness = createHarness({ daemonFeaturesAvailable: false });
+
+    await harness.runtime.runAgentLoop();
+
+    expect(capturedAgentLoopOptions).toMatchObject({ automationEnabled: false });
   });
 });

--- a/tests/sidepanel.chat-runtime.test.ts
+++ b/tests/sidepanel.chat-runtime.test.ts
@@ -41,6 +41,7 @@ function createHarness(options: { chatEnabled?: boolean } = {}) {
   const store = createPanelStateStore(createInitialPanelState());
   store.state.panelSession.chatEnabled = options.chatEnabled ?? true;
   store.state.panelSession.automationEnabled = true;
+  store.state.panelSession.daemonFeaturesAvailable = true;
   store.state.navigation.activeTabId = 7;
   store.state.navigation.activeTabUrl = "https://example.com/current";
   store.state.summaryMarkdown = "Current summary";


### PR DESCRIPTION
## Summary

- Keep Chrome Browser runtime local even when a daemon token is saved.
- Prevent Browser extraction from silently falling through to daemon URL extraction, and report local media or empty extraction failures clearly.
- Hide daemon-backed chat and automation when no authenticated daemon is available, with matching documentation and regression coverage.

## Root cause

Browser summary selection depended on the absence of a saved token, so Browser runtime could still invoke the daemon. Extraction fallback and side-panel capability state also treated daemon-backed behavior as generally available.

## Validation

- pnpm -s check
- pnpm -C apps/chrome-extension test:chrome
- Focused extension unit suite: 43 passed
- Chrome extension suite: 71 passed, 4 expected live skips
- Structured autoreview: clean