### PR TITLE
[security] fix(core): cap remote transcript response sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.18.2 - Unreleased
 
+### Fixes
+
+- Remote transcripts: cap RSS and embedded caption response bodies at 5 MiB and cancel oversized streams. Thanks @Hinotoi-agent.
+
 ## 0.18.1 - 2026-06-13
 
 ### Fixes

--- a/packages/core/src/content/transcript/providers/generic-embedded.ts
+++ b/packages/core/src/content/transcript/providers/generic-embedded.ts
@@ -7,6 +7,7 @@ import {
   vttToPlainText,
   vttToSegments,
 } from "../parse.js";
+import { readTranscriptTextWithLimit } from "./response-size-limit.js";
 
 export type EmbeddedTrack = {
   url: string;
@@ -77,7 +78,7 @@ export async function fetchCaptionTrack(
       notes.push(`Embedded captions fetch failed (${res.status})`);
       return null;
     }
-    const body = await res.text();
+    const body = await readTranscriptTextWithLimit(res);
     const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
     const type = track.type?.toLowerCase() ?? "";
 

--- a/packages/core/src/content/transcript/providers/podcast/rss-transcript.ts
+++ b/packages/core/src/content/transcript/providers/podcast/rss-transcript.ts
@@ -6,6 +6,7 @@ import {
   vttToPlainText,
   vttToSegments,
 } from "../../parse.js";
+import { readTranscriptTextWithLimit } from "../response-size-limit.js";
 import { TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
 import {
   decodeXmlEntities,
@@ -65,7 +66,7 @@ export async function tryFetchTranscriptFromFeedXml({
       const contentType =
         res.headers.get("content-type")?.toLowerCase().split(";")[0]?.trim() ?? null;
       const effectiveType = preferred.type?.toLowerCase().split(";")[0]?.trim() ?? contentType;
-      const body = await res.text();
+      const body = await readTranscriptTextWithLimit(res);
       const parsed = parseTranscriptBody({
         body,
         transcriptUrl,

--- a/packages/core/src/content/transcript/providers/response-size-limit.ts
+++ b/packages/core/src/content/transcript/providers/response-size-limit.ts
@@ -1,0 +1,47 @@
+export const MAX_REMOTE_TRANSCRIPT_BYTES = 5 * 1024 * 1024;
+
+export async function readTranscriptTextWithLimit(
+  res: Response,
+  maxBytes = MAX_REMOTE_TRANSCRIPT_BYTES,
+): Promise<string> {
+  const contentLength = res.headers.get("content-length");
+  if (contentLength) {
+    const parsed = Number(contentLength);
+    if (Number.isFinite(parsed) && parsed > maxBytes) {
+      await res.body?.cancel().catch(() => {});
+      throw new Error(`transcript too large (${parsed} bytes). Limit is ${maxBytes} bytes.`);
+    }
+  }
+
+  if (!res.body) {
+    const arrayBuffer = await res.arrayBuffer();
+    if (arrayBuffer.byteLength > maxBytes) {
+      throw new Error(
+        `transcript too large (${arrayBuffer.byteLength} bytes). Limit is ${maxBytes} bytes.`,
+      );
+    }
+    return new TextDecoder().decode(arrayBuffer);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let received = 0;
+  let text = "";
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > maxBytes) {
+        await reader.cancel().catch(() => {});
+        throw new Error(`transcript too large (${received} bytes). Limit is ${maxBytes} bytes.`);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/tests/security.embedded-caption-size-limit.test.ts
+++ b/tests/security.embedded-caption-size-limit.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { fetchCaptionTrack } from "../packages/core/src/content/transcript/providers/generic-embedded.js";
+import { MAX_REMOTE_TRANSCRIPT_BYTES } from "../packages/core/src/content/transcript/providers/response-size-limit.js";
+
+function repeatedTranscriptStream(
+  totalBytes: number,
+  chunkBytes = 64 * 1024,
+  onCancel?: () => void,
+) {
+  let sent = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const size = Math.min(chunkBytes, totalBytes - sent);
+      sent += size;
+      controller.enqueue(new Uint8Array(size).fill("A".charCodeAt(0)));
+    },
+    cancel() {
+      onCancel?.();
+    },
+  });
+}
+
+async function fetchTrack(fetchImpl: typeof fetch) {
+  const notes: string[] = [];
+  const result = await fetchCaptionTrack(
+    fetchImpl,
+    {
+      url: "https://example.com/captions.vtt",
+      type: "text/vtt",
+      language: "en",
+    },
+    notes,
+    true,
+  );
+  return { notes, result };
+}
+
+describe("embedded caption track size limits", () => {
+  it("rejects oversized caption responses from Content-Length before reading the body", async () => {
+    let bodyRead = false;
+    const fetchImpl = async () => {
+      const response = new Response(null, {
+        status: 200,
+        headers: {
+          "content-type": "text/vtt",
+          "content-length": String(MAX_REMOTE_TRANSCRIPT_BYTES + 1),
+        },
+      });
+      response.arrayBuffer = async () => {
+        bodyRead = true;
+        throw new Error("body should not be read after oversized Content-Length");
+      };
+      return response;
+    };
+
+    const { notes, result } = await fetchTrack(fetchImpl as unknown as typeof fetch);
+
+    expect(result).toBeNull();
+    expect(bodyRead).toBe(false);
+    expect(notes.join("\n")).toMatch(/transcript too large/i);
+  });
+
+  it("rejects streamed caption responses once they exceed the byte cap", async () => {
+    const fetchImpl = async () =>
+      new Response(repeatedTranscriptStream(MAX_REMOTE_TRANSCRIPT_BYTES + 1), {
+        status: 200,
+        headers: { "content-type": "text/vtt" },
+      });
+
+    const { notes, result } = await fetchTrack(fetchImpl as unknown as typeof fetch);
+
+    expect(result).toBeNull();
+    expect(notes.join("\n")).toMatch(/transcript too large/i);
+  });
+
+  it("still accepts small embedded caption responses", async () => {
+    const fetchImpl = async () =>
+      new Response("WEBVTT\n\n00:00.000 --> 00:01.000\nsmall caption", {
+        status: 200,
+        headers: {
+          "content-type": "text/vtt",
+          "content-length": "49",
+        },
+      });
+
+    const { notes, result } = await fetchTrack(fetchImpl as unknown as typeof fetch);
+
+    expect(notes).toEqual([]);
+    expect(result?.text).toBe("small caption");
+    expect(result?.segments?.[0]?.text).toBe("small caption");
+  });
+});

--- a/tests/security.rss-transcript-size-limit.test.ts
+++ b/tests/security.rss-transcript-size-limit.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { tryFetchTranscriptFromFeedXml } from "../packages/core/src/content/transcript/providers/podcast/rss-transcript.js";
+import { MAX_REMOTE_TRANSCRIPT_BYTES } from "../packages/core/src/content/transcript/providers/response-size-limit.js";
+
+const MAX_RSS_TRANSCRIPT_BYTES = MAX_REMOTE_TRANSCRIPT_BYTES;
+
+function feedWithTranscript(url: string) {
+  return `<?xml version="1.0"?>
+    <rss xmlns:podcast="https://podcastindex.org/namespace/1.0">
+      <channel>
+        <item>
+          <title>attacker episode</title>
+          <podcast:transcript url="${url}" type="text/plain" />
+        </item>
+      </channel>
+    </rss>`;
+}
+
+function repeatedTranscriptStream(
+  totalBytes: number,
+  chunkBytes = 64 * 1024,
+  onCancel?: () => void,
+) {
+  let sent = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const size = Math.min(chunkBytes, totalBytes - sent);
+      sent += size;
+      controller.enqueue(new Uint8Array(size).fill("A".charCodeAt(0)));
+    },
+    cancel() {
+      onCancel?.();
+    },
+  });
+}
+
+async function fetchTranscript(fetchImpl: typeof fetch) {
+  const notes: string[] = [];
+  const result = await tryFetchTranscriptFromFeedXml({
+    fetchImpl,
+    feedXml: feedWithTranscript("http://93.184.216.34/huge.txt"),
+    episodeTitle: "attacker episode",
+    notes,
+    lookup: async () => [{ address: "93.184.216.34", family: 4 }],
+  });
+  return { notes, result };
+}
+
+describe("RSS <podcast:transcript> size limits", () => {
+  it("rejects oversized transcript responses from Content-Length before reading the body", async () => {
+    let bodyRead = false;
+    const fetchImpl = async () => {
+      const response = new Response(null, {
+        status: 200,
+        headers: {
+          "content-type": "text/plain",
+          "content-length": String(MAX_RSS_TRANSCRIPT_BYTES + 1),
+        },
+      });
+      response.arrayBuffer = async () => {
+        bodyRead = true;
+        throw new Error("body should not be read after oversized Content-Length");
+      };
+      return response;
+    };
+
+    const { notes, result } = await fetchTranscript(fetchImpl as unknown as typeof fetch);
+
+    expect(result).toBeNull();
+    expect(bodyRead).toBe(false);
+    expect(notes.join("\n")).toMatch(/transcript too large/i);
+  });
+
+  it("rejects streamed transcript responses once they exceed the byte cap", async () => {
+    const fetchImpl = async () =>
+      new Response(repeatedTranscriptStream(MAX_RSS_TRANSCRIPT_BYTES + 1), {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+
+    const { notes, result } = await fetchTranscript(fetchImpl as unknown as typeof fetch);
+
+    expect(result).toBeNull();
+    expect(notes.join("\n")).toMatch(/transcript too large/i);
+  });
+
+  it("still accepts small RSS transcript responses", async () => {
+    const fetchImpl = async () =>
+      new Response("small public transcript", {
+        status: 200,
+        headers: {
+          "content-type": "text/plain",
+          "content-length": "23",
+        },
+      });
+
+    const { notes, result } = await fetchTranscript(fetchImpl as unknown as typeof fetch);
+
+    expect(result?.text).toBe("small public transcript");
+    expect(notes).toContain("Used RSS <podcast:transcript> (skipped Whisper)");
+  });
+});

--- a/tests/security.transcript-response-size-limit.test.ts
+++ b/tests/security.transcript-response-size-limit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { readTranscriptTextWithLimit } from "../packages/core/src/content/transcript/providers/response-size-limit.js";
+
+describe("transcript response size limiter", () => {
+  it("cancels a present response body when Content-Length is oversized", async () => {
+    let canceled = false;
+    const res = {
+      headers: new Headers({ "content-length": "6" }),
+      body: {
+        async cancel() {
+          canceled = true;
+        },
+      },
+    } as unknown as Response;
+
+    await expect(readTranscriptTextWithLimit(res, 5)).rejects.toThrow(/transcript too large/i);
+    expect(canceled).toBe(true);
+  });
+
+  it("cancels the response body when a streamed response exceeds the byte cap", async () => {
+    let canceled = false;
+    let released = false;
+    const chunks = [new Uint8Array(4), new Uint8Array(4)];
+
+    const res = {
+      headers: new Headers({ "content-type": "text/plain" }),
+      body: {
+        getReader() {
+          return {
+            async read() {
+              const value = chunks.shift();
+              return value ? { done: false, value } : { done: true, value: undefined };
+            },
+            async cancel() {
+              canceled = true;
+            },
+            releaseLock() {
+              released = true;
+            },
+          };
+        },
+      },
+    } as unknown as Response;
+
+    await expect(readTranscriptTextWithLimit(res, 5)).rejects.toThrow(/transcript too large/i);
+    expect(canceled).toBe(true);
+    expect(released).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

This PR applies the resource-boundary lesson from #285 to transcript fetching: remote transcript/caption bodies should be capped before they are materialized in memory.

- Adds a shared byte-capped reader for remote transcript responses.
- Uses it for RSS `<podcast:transcript>` fetches and embedded HTML caption-track fetches.
- Rejects oversized `Content-Length` values before reading the body.
- Stops streamed responses once the byte cap is exceeded and cancels the response body.
- Keeps existing SSRF/network guard behavior intact for RSS transcript URLs.
- Adds focused regression coverage for RSS transcripts, embedded caption tracks, and over-limit stream cancellation, and cancellation of present bodies rejected from `Content-Length`.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Unbounded remote transcript body materialization | Feed-controlled RSS transcript URLs or page-controlled embedded caption tracks can return very large responses that are fully read before parsing, creating memory/CPU exhaustion risk during summarization. | Medium |

## Before this PR

- RSS `<podcast:transcript>` URLs were fetched through the existing network guard, but the response body had no byte limit.
- Embedded HTML caption tracks were also fetched and read with `res.text()` without a response-size boundary.
- Both paths could materialize large remote transcript/caption bodies before parsing.
- Existing tests covered RSS SSRF/network-guard behavior, but not remote transcript response-size limits or cancellation after an over-limit streamed body.

## After this PR

- Remote transcript/caption responses are capped at 5 MiB through a shared helper.
- Oversized `Content-Length` responses are rejected before body reads.
- Streaming responses without a known length are rejected once they exceed the cap.
- Over-limit streams are actively cancelled before returning failure.
- Small `text/plain`, VTT, and JSON transcript/caption responses still flow through the existing parser paths.
- Regression tests now lock in the size-limit behavior for both RSS transcript and embedded caption-track fetches, plus cancellation behavior for the shared streamed-response limiter.

## Compatibility boundary

This PR intentionally treats 5 MiB as the maintainer-visible compatibility boundary for remote transcript/caption files.

- Remote transcript/caption responses at or below the cap continue through the existing parser behavior.
- Remote transcript/caption responses above the cap are skipped/fail closed rather than being fully materialized.
- This may skip unusually large legitimate transcript files; that tradeoff is intentional for this PR because these files come from untrusted feed/page metadata and are currently read before parsing.
- The cap is centralized as `MAX_REMOTE_TRANSCRIPT_BYTES` so maintainers can adjust the boundary in one place if project compatibility expectations differ.

## Why this matters

#285 fixed a similar resource-budget gap for remote asset extraction by making sure URL extraction character budgets are honored after remote content is fetched and converted. This PR applies the same takeaway one layer earlier for transcript/caption fetches: untrusted remote content needs a bounded resource budget before the process builds large strings from it.

Podcast feeds and HTML pages can point transcript/caption metadata at attacker-controlled URLs. Even when URL resolution is guarded, the response body still needs an explicit resource boundary. Without a byte cap, a feed or page can point to a very large transcript body and force the summarizer to spend memory and CPU before the transcript parser can decide whether the content is useful.

## How this differs from related issue/PR

This is related to the same resource-boundary family as #285, but it covers different fetch paths and sinks:

- #285 capped remote asset extraction output in `src/run/flows/asset/extract.ts`.
- This PR caps transcript/caption response bodies in:
  - `packages/core/src/content/transcript/providers/podcast/rss-transcript.ts`
  - `packages/core/src/content/transcript/providers/generic-embedded.ts`
- The triggers here are feed/page transcript metadata (`<podcast:transcript>` and HTML caption tracks), not the asset-extraction flow.
- Both fixes are needed because each path fetches and materializes untrusted remote content independently.

## Attack flow

```text
Attacker-controlled or untrusted podcast/RSS feed or HTML page
    -> transcript metadata points at a very large text/VTT/JSON response
        -> transcript/caption fetch succeeds
            -> response body is read without a byte cap
                -> process memory/CPU can be exhausted before parsing completes
```

## Affected code

| Issue | Files |
|-------|-------|
| Unbounded remote transcript body materialization | `packages/core/src/content/transcript/providers/podcast/rss-transcript.ts`, `packages/core/src/content/transcript/providers/generic-embedded.ts`, `packages/core/src/content/transcript/providers/response-size-limit.ts`, `tests/security.rss-transcript-size-limit.test.ts`, `tests/security.embedded-caption-size-limit.test.ts`, `tests/security.transcript-response-size-limit.test.ts` |

## Root cause

Issue: Unbounded remote transcript body materialization

- The RSS transcript URL path had SSRF-oriented network guarding, but no response-size boundary.
- The embedded caption-track path also read remote caption bodies without a byte cap.
- Both paths used full-body text reads before parsing.
- Existing regression coverage did not exercise oversized transcript/caption responses or cancellation after a streamed response crossed the cap.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Unbounded remote transcript body materialization | 5.3 Medium | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L` |

Rationale:

- The impact is availability-focused: malicious or compromised feed/page metadata can force unnecessary memory/CPU consumption during summarization.
- User interaction is required in the typical workflow because a user or automation must summarize the attacker-controlled feed, podcast item, or page.
- The patch does not claim data disclosure or code execution.

## Safe reproduction steps

1. Use a feed item containing a `<podcast:transcript>` URL, or an HTML page with an embedded caption track URL, controlled by the test.
2. Serve or mock a transcript/caption response larger than the intended resource boundary.
3. On vulnerable code, observe that the transcript/caption body is accepted/materialized without a response-size rejection.
4. With this PR, run the focused regression tests and observe that oversized known-length and streamed responses are rejected while small transcripts/captions are accepted.

Docker verification was used for both sides of the proof:

- Before fix: a focused PoC in `node:24-bookworm` reproduced that an 8 MiB RSS transcript body was accepted/materialized by the vulnerable path.
- After fix: focused regression tests for RSS transcripts, embedded caption tracks, known-length cancellation, stream cancellation, and existing RSS transcript SSRF tests pass in `node:24-bookworm`.
- After fix: a real local HTTP server in `node:24-bookworm` served an oversized transcript response; the bounded reader rejected it and the server observed the client-side close/cancel. The port was redacted from the proof log.

## Expected vulnerable behavior

- A feed-supplied RSS transcript URL or page-supplied caption track URL can return a large body.
- The vulnerable code reads the entire response body before parsing.
- The safe proof signal is a bounded served or mocked transcript/caption body being fully accepted before the patch, then rejected after this PR once it exceeds the configured cap.

## Changes in this PR

- Adds `MAX_REMOTE_TRANSCRIPT_BYTES` and `readTranscriptTextWithLimit()` for remote transcript/caption responses.
- Replaces direct full-body reads in RSS transcript fetching with the shared bounded reader.
- Replaces direct full-body reads in embedded caption-track fetching with the shared bounded reader.
- Rejects oversized `Content-Length` before consuming the body.
- Enforces the same byte cap while reading streamed responses.
- Cancels present response bodies for known-length oversized responses and cancels the stream reader when a streamed response crosses the cap.
- Preserves existing RSS network guard and redirect handling.
- Adds regression tests for oversized `Content-Length`, streaming over-limit responses, small accepted responses, and over-limit cancellation.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Shared transcript hardening | `packages/core/src/content/transcript/providers/response-size-limit.ts` | Adds a byte-capped transcript response reader and cancels over-limit streams. |
| RSS transcript hardening | `packages/core/src/content/transcript/providers/podcast/rss-transcript.ts` | Uses the shared bounded reader for RSS transcript fetches. |
| Embedded caption hardening | `packages/core/src/content/transcript/providers/generic-embedded.ts` | Uses the shared bounded reader for embedded caption-track fetches. |
| Regression tests | `tests/security.rss-transcript-size-limit.test.ts`, `tests/security.embedded-caption-size-limit.test.ts`, `tests/security.transcript-response-size-limit.test.ts` | Covers known-length oversized, streamed oversized, small accepted responses, and cancellation of known-length and streamed over-limit responses. |

## Maintainer impact

- The change is limited to remote transcript/caption fetching.
- Existing RSS SSRF/network-guard behavior remains in place.
- Normal small transcripts and caption tracks continue to be accepted and parsed.
- Very large transcript/caption responses are now skipped rather than fully materialized.
- The 5 MiB cap is the explicit compatibility boundary introduced by this PR.
- No CLI, daemon, extension, release, or dependency changes are included.

## Fix rationale

The transcript and caption fetch paths already treat remote metadata as untrusted enough to parse carefully and, for RSS, to use a network guard. A response-size boundary belongs at the same trust boundary so the process does not need to fully allocate attacker-controlled response bodies before parsing. Checking `Content-Length` handles simple oversized responses early, while streaming enforcement covers unknown-length and misleading-length responses. Cancelling the reader on over-limit streams follows the existing capped-download cleanup pattern used elsewhere in the podcast provider code.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Docker before-fix proof: focused PoC reproduced vulnerable 8 MiB RSS transcript materialization in `node:24-bookworm`.
- [x] Docker after-fix validation:

```bash
docker run --rm -e CI=true -v "$PWD":/work -w /work node:24-bookworm bash -lc 'corepack enable && corepack prepare pnpm@10.33.2 --activate && pnpm install --frozen-lockfile --ignore-scripts && pnpm -s build && pnpm -s typecheck && pnpm -s format:check && pnpm -s lint && pnpm -s vitest run tests/security.transcript-response-size-limit.test.ts tests/security.rss-transcript-size-limit.test.ts tests/security.embedded-caption-size-limit.test.ts tests/security.rss-transcript-ssrf.test.ts && git diff --check'
```

Result:

```text
✓ tests/security.transcript-response-size-limit.test.ts (2 tests)
✓ tests/security.rss-transcript-size-limit.test.ts (3 tests)
✓ tests/security.embedded-caption-size-limit.test.ts (3 tests)
✓ tests/security.rss-transcript-ssrf.test.ts (13 tests)

Test Files  4 passed (4)
Tests       21 passed (21)
```

Also passed in the same Docker run:

- `pnpm -s build`
- `pnpm -s typecheck`
- `pnpm -s format:check`
- `pnpm -s lint`
- `git diff --check`

- [x] Docker after-fix served-response proof:

```bash
docker run --rm -e CI=true -v "$PWD":/work -w /work node:24-bookworm bash -lc 'corepack enable && corepack prepare pnpm@10.33.2 --activate >/dev/null && pnpm -s build >/dev/null && node .served-oversized-transcript-proof.mjs'
```

Redacted proof output:

```text
[client] fetching served oversized transcript URL: http://127.0.0.1:<redacted-port>/oversized-transcript.txt
[client] configured cap: 5242880 bytes
[server] response closed after attempting 5308416 bytes
[client] rejected oversized served body: transcript too large (5298866 bytes). Limit is 5242880 bytes.
[proof] PASS served oversized transcript was rejected and the response was closed/cancelled
```

The proof helper was not added to the repository; it was used only to produce the served-response validation log above.

## Disclosure notes

- This PR is intentionally scoped to remote transcript/caption response-size limits.
- It does not claim code execution, data disclosure, or a bypass of the existing RSS SSRF/network guard.
- It treats #285 as same-family prior resource-boundary hardening, not as an exact duplicate of these transcript/caption fetch paths.
- The 5 MiB cutoff is an explicit compatibility tradeoff for untrusted remote transcript/caption metadata.
- No unrelated files are changed.
