### PR TITLE
fix: invoke Gemini Nano session methods correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Chrome extension: invoke Gemini Nano session methods with their native receiver so Browser summaries complete instead of silently falling back.
 - Chrome extension: use Chrome's built-in Gemini Nano Summarizer API for daemonless Browser summaries when available, with first-use download progress and automatic extractive fallback.
 - Remote transcripts: cap RSS and embedded caption response bodies at 5 MiB and cancel oversized streams. Thanks @Hinotoi-agent.
 - Chrome extension: keep Browser runtime fully daemonless even with saved tokens, fail clearly when local extraction or transcription is unavailable, and hide daemon-backed chat and automation without an authenticated daemon.

--- a/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime.ts
@@ -1,6 +1,8 @@
 import { buildBrowserAiSummaryMarkdown } from "../../lib/browser-summary";
+import { logExtensionEvent } from "../../lib/extension-logs";
 import type { BgToPanel } from "../../lib/panel-contracts";
 import type { PanelStateAction } from "./panel-state-store";
+import { panelUrlsMatch } from "./session-policy";
 import type { PanelState } from "./types";
 
 type BrowserSummarySnapshot = Extract<BgToPanel, { type: "run:snapshot" }>;
@@ -33,8 +35,25 @@ export function createBrowserAiSnapshotRuntime(options: {
       })
       .then((summary) => {
         if (!summary) return;
-        if (options.panelState.runId !== runId) return;
-        if (options.panelState.currentSource?.url !== runUrl) return;
+        if (options.panelState.runId !== runId) {
+          logExtensionEvent({
+            event: "browser-ai:snapshot-discarded",
+            level: "verbose",
+            scope: "sidepanel",
+            detail: { reason: "run-changed" },
+          });
+          return;
+        }
+        const currentUrl = options.panelState.currentSource?.url;
+        if (!currentUrl || !panelUrlsMatch(currentUrl, runUrl)) {
+          logExtensionEvent({
+            event: "browser-ai:snapshot-discarded",
+            level: "verbose",
+            scope: "sidepanel",
+            detail: { reason: "url-changed", currentUrl, runUrl },
+          });
+          return;
+        }
         options.dispatchPanelState({
           type: "meta",
           meta: {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-summary-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-summary-runtime.ts
@@ -1,3 +1,4 @@
+import { logExtensionEvent } from "../../lib/extension-logs";
 import type { BrowserAiSummaryInput } from "../../lib/panel-contracts";
 
 type BrowserAiAvailability = "available" | "downloadable" | "downloading" | "unavailable";
@@ -50,6 +51,13 @@ function isQuotaError(error: unknown): boolean {
   if ((error as { name?: unknown } | null)?.name === "QuotaExceededError") return true;
   const message = error instanceof Error ? error.message : String(error);
   return /context window|input quota|quota exceeded/i.test(message);
+}
+
+function errorDetail(error: unknown) {
+  return {
+    error: error instanceof Error ? error.message : String(error),
+    errorName: (error as { name?: unknown } | null)?.name,
+  };
 }
 
 function splitLongUnit(value: string, target: number): string[] {
@@ -127,14 +135,13 @@ async function summarizeRecursively({
     throw new DOMException("Input exceeds the on-device context window", "QuotaExceededError");
 
   const inputQuota = session.inputQuota;
-  const measureInputUsage = session.measureInputUsage;
   if (
     typeof inputQuota === "number" &&
     Number.isFinite(inputQuota) &&
     inputQuota > 0 &&
-    measureInputUsage
+    session.measureInputUsage
   ) {
-    const usage = await measureInputUsage(text, context ? { context } : undefined);
+    const usage = await session.measureInputUsage(text, context ? { context } : undefined);
     if (usage <= inputQuota) {
       return await session.summarize(text, { context, signal });
     }
@@ -217,7 +224,13 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
           });
         },
       })
-      .catch(() => {
+      .catch((error) => {
+        logExtensionEvent({
+          event: "browser-ai:create-error",
+          level: "warn",
+          scope: "sidepanel",
+          detail: { length, ...errorDetail(error) },
+        });
         sessions.delete(length);
         return null;
       });
@@ -232,7 +245,15 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
     if (cached) return await cached;
     const api = getApi();
     if (!api) return null;
-    const availability = await api.availability().catch(() => "unavailable" as const);
+    const availability = await api.availability().catch((error) => {
+      logExtensionEvent({
+        event: "browser-ai:availability-error",
+        level: "warn",
+        scope: "sidepanel",
+        detail: errorDetail(error),
+      });
+      return "unavailable" as const;
+    });
     if (availability === "unavailable") return null;
     if (availability === "downloadable" && !isUserActive()) return null;
     return await createSession(api, length);
@@ -275,6 +296,12 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
     }
 
     options.setStatus("Summarizing with on-device AI…");
+    logExtensionEvent({
+      event: "browser-ai:summarize-start",
+      level: "verbose",
+      scope: "sidepanel",
+      detail: { chars: input.text.length, length: input.length },
+    });
     try {
       const result = await summarizeRecursively({
         session,
@@ -283,8 +310,26 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
         signal: controller.signal,
         depth: 0,
       });
-      return request === activeRequest && result.trim() ? result.trim() : null;
-    } catch {
+      const summary = request === activeRequest && result.trim() ? result.trim() : null;
+      logExtensionEvent({
+        event: summary ? "browser-ai:summarize-done" : "browser-ai:summarize-discarded",
+        level: summary ? "verbose" : "warn",
+        scope: "sidepanel",
+        detail: { chars: input.text.length, resultChars: result.trim().length },
+      });
+      return summary;
+    } catch (error) {
+      logExtensionEvent({
+        event: "browser-ai:summarize-error",
+        level: controller.signal.aborted ? "verbose" : "warn",
+        scope: "sidepanel",
+        detail: {
+          aborted: controller.signal.aborted,
+          chars: input.text.length,
+          length: input.length,
+          ...errorDetail(error),
+        },
+      });
       return null;
     } finally {
       if (request === activeRequest) {

--- a/apps/chrome-extension/src/lib/extension-logs.ts
+++ b/apps/chrome-extension/src/lib/extension-logs.ts
@@ -17,7 +17,10 @@ let flushTimer = 0;
 let flushInFlight = false;
 let pendingLines: string[] = [];
 
-const getStorage = () => chrome.storage?.session ?? chrome.storage?.local;
+const getStorage = () => {
+  if (typeof chrome === "undefined") return undefined;
+  return chrome.storage?.session ?? chrome.storage?.local;
+};
 
 const queueFlush = () => {
   if (flushTimer) return;

--- a/apps/chrome-extension/tests/sidepanel.browser-ai.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.browser-ai.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+import {
+  assertNoErrors,
+  closeExtension,
+  getBrowserFromProject,
+  launchExtension,
+  openExtensionPage,
+  sendBgMessage,
+  trackErrors,
+  waitForPanelPort,
+} from "./helpers/extension-harness";
+import { getPanelModel, getPanelSummaryMarkdown } from "./helpers/panel-hooks";
+
+test("browser AI keeps the native session receiver", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+      const session = {
+        inputQuota: 10_000,
+        async measureInputUsage(this: unknown, input: string) {
+          if (this !== session) throw new TypeError("Illegal invocation");
+          return input.length;
+        },
+        async summarize(this: unknown) {
+          if (this !== session) throw new TypeError("Illegal invocation");
+          return "* Native summary point\n* Another native point";
+        },
+      };
+      Object.defineProperty(globalThis, "Summarizer", {
+        configurable: true,
+        value: {
+          availability: async () => "available",
+          create: async () => session,
+        },
+      });
+    });
+    trackErrors(page, harness.pageErrors, harness.consoleErrors);
+    await waitForPanelPort(page);
+
+    await sendBgMessage(harness, {
+      type: "run:snapshot",
+      run: {
+        id: "browser-ai-test",
+        url: "https://example.com/article",
+        title: "Native summary",
+        model: "Browser",
+        reason: "manual",
+      },
+      markdown: "## Native summary\n\nFallback summary.",
+      browserAi: {
+        text: "A sufficiently detailed article for the native summarizer.",
+        length: "long",
+        keyMoments: [],
+      },
+    });
+
+    await expect.poll(() => getPanelModel(page)).toBe("Gemini Nano");
+    await expect.poll(() => getPanelSummaryMarkdown(page)).toContain("- Native summary point");
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});


### PR DESCRIPTION
## Summary

- preserve the native `Summarizer` session receiver when measuring input usage
- add Browser AI lifecycle diagnostics and canonical URL matching for completed summaries
- add regression coverage that enforces native-style method branding

## Testing

- live stock Chrome profile: Gemini Nano summarized a 9,251-character page input into an 882-character result
- `pnpm -s check`
- `pnpm -C apps/chrome-extension test:chrome` (72 passed, 4 expected live skips)
- structured autoreview: clean, no actionable findings