### PR TITLE
fix(chrome): cover full video in slide capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Chrome extension: preserve significant whitespace in SSE data fields while parsing daemon streams (#303, thanks @vincent-peng).
 - Chrome extension: invoke Gemini Nano session methods with their native receiver so Browser summaries complete instead of silently falling back.
+- Chrome extension slides: sample browser-captured frames across the full video duration so long videos include their final segment.
 - Chrome extension: use Chrome's built-in Gemini Nano Summarizer API for daemonless Browser summaries when available, with first-use download progress and automatic extractive fallback.
 - Remote transcripts: cap RSS and embedded caption response bodies at 5 MiB and cancel oversized streams. Thanks @Hinotoi-agent.
 - Chrome extension: keep Browser runtime fully daemonless even with saved tokens, fail clearly when local extraction or transcription is unavailable, and hide daemon-backed chat and automation without an authenticated daemon.

--- a/apps/chrome-extension/src/entrypoints/background/browser-slides.ts
+++ b/apps/chrome-extension/src/entrypoints/background/browser-slides.ts
@@ -29,12 +29,18 @@ function makeRunId() {
   return `browser-${random}`;
 }
 
-function chooseTimestamps(durationSeconds: number | null, maxSlides = MAX_LOCAL_SLIDES): number[] {
+export function chooseBrowserSlideTimestamps(
+  durationSeconds: number | null,
+  maxSlides = MAX_LOCAL_SLIDES,
+): number[] {
   if (!durationSeconds || durationSeconds <= 0 || !Number.isFinite(durationSeconds)) return [0];
   const count = Math.min(maxSlides, Math.max(1, Math.ceil(durationSeconds / 2)));
-  const step = durationSeconds / count;
+  const inset = Math.min(0.4, durationSeconds / 3);
+  if (count === 1) return [inset];
+  const end = Math.max(inset, durationSeconds - inset);
+  const step = (end - inset) / (count - 1);
   return Array.from({ length: count }, (_value, index) =>
-    Math.max(0, Math.min(durationSeconds - 0.1, index * step + Math.min(0.4, step / 3))),
+    Math.max(0, Math.min(durationSeconds - 0.1, inset + index * step)),
   );
 }
 
@@ -145,7 +151,7 @@ export async function runBrowserSlidesForTab(args: {
   if (captureMode === "seek" && args.getMediaInfo) {
     const media = await args.getMediaInfo(tabId);
     if (media.ok && isBrowserMediaUrl(media.mediaSrc)) {
-      const timestamps = chooseTimestamps(media.durationSeconds, args.maxSlides);
+      const timestamps = chooseBrowserSlideTimestamps(media.durationSeconds, args.maxSlides);
       try {
         const frames = await (args.extractFramesWithMediaBunny ?? extractBrowserMediaFrames)({
           mediaUrl: media.mediaSrc,
@@ -191,7 +197,7 @@ export async function runBrowserSlidesForTab(args: {
               ? first.data.currentTimeSeconds
               : 0,
           ]
-        : chooseTimestamps(first.data.durationSeconds, args.maxSlides);
+        : chooseBrowserSlideTimestamps(first.data.durationSeconds, args.maxSlides);
     const slides: SseSlidesData["slides"] = [];
     let lastCaptureAt = 0;
 

--- a/tests/chrome.browser-slides.test.ts
+++ b/tests/chrome.browser-slides.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { runBrowserSlidesForTab } from "../apps/chrome-extension/src/entrypoints/background/browser-slides";
+import {
+  chooseBrowserSlideTimestamps,
+  runBrowserSlidesForTab,
+} from "../apps/chrome-extension/src/entrypoints/background/browser-slides";
 
 const originalChrome = globalThis.chrome;
 const originalFetch = globalThis.fetch;
@@ -25,6 +28,19 @@ describe("chrome browser slide capture", () => {
       configurable: true,
       value: originalOffscreenCanvas,
     });
+  });
+
+  it("samples long videos through the final segment", () => {
+    for (const durationSeconds of [4203, 1787]) {
+      const timestamps = chooseBrowserSlideTimestamps(durationSeconds);
+
+      expect(timestamps).toHaveLength(6);
+      expect(timestamps[0]).toBeCloseTo(0.4, 5);
+      expect(timestamps.at(-1)).toBeCloseTo(durationSeconds - 0.4, 5);
+      for (let index = 1; index < timestamps.length; index += 1) {
+        expect(timestamps[index]).toBeGreaterThan(timestamps[index - 1]);
+      }
+    }
   });
 
   it("captures the current frame without seek setup or restore", async () => {
@@ -118,7 +134,7 @@ describe("chrome browser slide capture", () => {
     });
     const extractFramesWithMediaBunny = vi.fn(async () => [
       { imageUrl: "data:image/jpeg;base64,AQID", timestamp: 0.4 },
-      { imageUrl: "data:image/jpeg;base64,BAUG", timestamp: 2.4 },
+      { imageUrl: "data:image/jpeg;base64,BAUG", timestamp: 3.6 },
     ]);
     const beginFrameCapture = vi.fn();
 
@@ -146,7 +162,7 @@ describe("chrome browser slide capture", () => {
     expect(extractFramesWithMediaBunny).toHaveBeenCalledWith(
       expect.objectContaining({
         mediaUrl: "https://cdn.example.com/video.mp4",
-        timestamps: [0.4, 2.4],
+        timestamps: [0.4, 3.6],
       }),
     );
     expect(beginFrameCapture).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- spread browser slide samples across the complete video duration
- include the final segment instead of stopping one bucket early
- add regression coverage for 70:03 and 29:47 videos

## Root cause

The timestamp step divided duration by the slide count and sampled each bucket start. With six frames, the last sample landed at 5/6 of the duration, leaving the final sixth uncaptured.

## Validation

- `pnpm -s check` (2,800 tests passed)
- `pnpm -C apps/chrome-extension exec playwright test -c playwright.config.ts --project=chromium tests/sidepanel.browser-slides.spec.ts`
- live existing-Chrome E2E on a 70:03 keynote and a 29:47 slide-heavy session
- rebuilt live run sought `0:00, 5:58, 11:55, 17:52, 23:49, 29:46`, applied six browser-capture slides/descriptions, completed Gemini Nano summarization, and restored playback to `3:42` paused
- structured autoreview clean: no accepted/actionable findings