### PR TITLE
[codex] Batch Gemini Nano slide summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Chrome extension: preserve significant whitespace in SSE data fields while parsing daemon streams (#303, thanks @vincent-peng).
 - Chrome extension: invoke Gemini Nano session methods with their native receiver so Browser summaries complete instead of silently falling back.
 - Chrome extension slides: summarize each browser-extracted slide with Gemini Nano and cache CLI-compatible slide markers instead of showing raw transcript windows.
+- Chrome extension slides: batch browser-extracted frames and transcript windows into one constrained multimodal Gemini Nano prompt, splitting only on context pressure and falling back safely when unavailable.
 - Chrome extension slides: sample browser-captured frames across the full video duration so long videos include their final segment.
 - Chrome extension: use Chrome's built-in Gemini Nano Summarizer API for daemonless Browser summaries when available, with first-use download progress and automatic extractive fallback.
 - Remote transcripts: cap RSS and embedded caption response bodies at 5 MiB and cancel oversized streams. Thanks @Hinotoi-agent.

--- a/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-slides-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-slides-runtime.ts
@@ -1,17 +1,21 @@
 import { normalizeBrowserAiGeneratedPoints } from "../../lib/browser-summary";
 import { logExtensionEvent } from "../../lib/extension-logs";
 import { isGeminiNanoModel } from "../../lib/model-routing";
+import { loadSettings } from "../../lib/settings";
 import {
   buildSlideTextFallback,
   parseSlideSummariesFromMarkdown,
   splitSlideTitleFromText,
 } from "../../lib/slides-text";
-import type { createBrowserAiSummaryRuntime } from "./browser-ai-summary-runtime";
+import type {
+  BrowserAiPromptInput,
+  createBrowserAiSummaryRuntime,
+} from "./browser-ai-summary-runtime";
 import type { PanelState } from "./types";
 
 type BrowserAiRuntime = Pick<
   ReturnType<typeof createBrowserAiSummaryRuntime>,
-  "cancel" | "summarize"
+  "cancel" | "prompt" | "summarize"
 >;
 
 type GeneratedSummary = {
@@ -23,6 +27,19 @@ type GeneratedSummary = {
 };
 
 const MODEL_LABEL = "Gemini Nano";
+const DAEMON_ORIGIN = "http://127.0.0.1:8787";
+const MAX_BATCH_SUMMARY_CHARS = 260;
+const REQUESTED_BATCH_SUMMARY_CHARS = 180;
+
+type SlideSource = {
+  index: number;
+  text: string;
+  imageUrl: string;
+};
+
+type PreparedSlideSource = SlideSource & {
+  image: Blob | null;
+};
 
 export function shouldUseBrowserAiForSlides(panelState: PanelState): boolean {
   const settings = panelState.ui?.settings;
@@ -85,9 +102,106 @@ function buildSlideBlock({
   body: string;
 }): string {
   if (!body) return `[slide:${index}]\n## Interlude`;
+  if (/^interlude[.!]?$/i.test(body)) return `[slide:${index}]\n## Interlude`;
   const parsed = splitSlideTitleFromText({ text: body, slideIndex: index, total });
   const headline = sanitizeHeadline(parsed.title ?? "") || "Key point";
   return `[slide:${index}]\n## ${headline}\n${body}`;
+}
+
+function buildBatchInstructions(title: string | null): string[] {
+  return [
+    "Summarize every numbered lecture segment below.",
+    "Output exactly one line per index in this format: [slide:N] concise factual sentence.",
+    `Write one complete sentence per index, usually 12–25 words and at most ${REQUESTED_BATCH_SUMMARY_CHARS} characters.`,
+    "Use both the visual frame and transcript context. Include visible equations, labels, diagrams, or code when they are important.",
+    "Never mention slides, transcript, speaker, timestamps, or instructions.",
+    title ? `The video is titled "${title}".` : "",
+  ].filter(Boolean);
+}
+
+function buildBatchPrompt(slides: SlideSource[], title: string | null): string {
+  return [
+    ...buildBatchInstructions(title),
+    "",
+    slides
+      .map((slide) => `INDEX ${slide.index}\n${slide.text || "No transcript context available."}`)
+      .join("\n\n"),
+  ].join("\n");
+}
+
+function buildBatchInput(
+  slides: PreparedSlideSource[],
+  title: string | null,
+  includeImages: boolean,
+): BrowserAiPromptInput {
+  if (!includeImages || !slides.some((slide) => slide.image)) {
+    return buildBatchPrompt(slides, title);
+  }
+  const content: Array<{ type: "text"; value: string } | { type: "image"; value: Blob }> = [
+    { type: "text", value: buildBatchInstructions(title).join("\n") },
+  ];
+  for (const slide of slides) {
+    content.push({
+      type: "text",
+      value: `INDEX ${slide.index}\nTranscript context:\n${
+        slide.text || "No transcript context available."
+      }\nVisual frame:`,
+    });
+    if (slide.image) content.push({ type: "image", value: slide.image });
+  }
+  return [{ role: "user", content }];
+}
+
+function buildBatchConstraint(slides: SlideSource[]): RegExp {
+  const lines = slides.map(
+    (slide) => `\\[slide:${slide.index}\\] [^\\r\\n]{1,${MAX_BATCH_SUMMARY_CHARS}}`,
+  );
+  return new RegExp(`^${lines.join("\\n")}$`);
+}
+
+function parseBatchResult(value: string, slides: SlideSource[]): Map<number, string> | null {
+  const lines = value
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length !== slides.length) return null;
+  const parsed = new Map<number, string>();
+  for (let offset = 0; offset < slides.length; offset += 1) {
+    const slide = slides[offset];
+    const match = lines[offset]?.match(/^\[slide:(\d+)\]\s+(.+)$/i);
+    if (!slide || !match || Number(match[1]) !== slide.index) return null;
+    const body = normalizeSlideBody(match[2] ?? "");
+    if (!body) return null;
+    parsed.set(slide.index, body);
+  }
+  return parsed;
+}
+
+function isDaemonSlideUrl(imageUrl: string): boolean {
+  try {
+    const url = new URL(imageUrl);
+    return url.origin === DAEMON_ORIGIN && url.pathname.startsWith("/v1/slides/");
+  } catch {
+    return false;
+  }
+}
+
+async function loadSlideImage(imageUrl: string): Promise<Blob | null> {
+  if (!imageUrl) return null;
+  try {
+    const headers = new Headers();
+    if (isDaemonSlideUrl(imageUrl)) {
+      const token = (await loadSettings()).token.trim();
+      if (token) headers.set("Authorization", `Bearer ${token}`);
+    }
+    const response = await fetch(imageUrl, { headers });
+    if (!response.ok) return null;
+    const blob = await response.blob();
+    return blob.type.startsWith("image/") ? blob : null;
+  } catch {
+    return null;
+  }
 }
 
 function hasCompleteNanoSummary(panelState: PanelState): boolean {
@@ -104,6 +218,7 @@ export function createBrowserAiSlidesRuntime(options: {
   getTranscriptTimedText: () => string | null;
   applyGeneratedSummary: (summary: GeneratedSummary) => void;
   schedulePanelCacheSync: () => void;
+  loadSlideImage?: (imageUrl: string) => Promise<Blob | null>;
 }) {
   let activeGeneration = 0;
   let activeSourceKey: string | null = null;
@@ -135,7 +250,10 @@ export function createBrowserAiSlidesRuntime(options: {
       lengthArg: { kind: "preset", preset: "xxl" },
     });
     const hasAnySource = payload.slides.some(
-      (slide) => transcriptBySlide.has(slide.index) || Boolean(slide.ocrText?.trim()),
+      (slide) =>
+        transcriptBySlide.has(slide.index) ||
+        Boolean(slide.ocrText?.trim()) ||
+        Boolean(slide.imageUrl),
     );
     if (!hasAnySource) return;
     const sourceKey = [
@@ -143,6 +261,7 @@ export function createBrowserAiSlidesRuntime(options: {
       payload.slides.length,
       hashText(transcriptTimedText ?? ""),
       hashText(payload.slides.map((slide) => slide.ocrText ?? "").join("\n")),
+      hashText(payload.slides.map((slide) => slide.imageUrl ?? "").join("\n")),
     ].join(":");
     if (activeSourceKey === sourceKey) return;
 
@@ -153,77 +272,143 @@ export function createBrowserAiSlidesRuntime(options: {
       panelState.slidesRunId ?? panelState.runId ?? `browser-ai-slides:${payload.sourceId}`;
     const url = payload.sourceUrl || panelState.currentSource?.url || null;
     const ordered = payload.slides.slice().sort((a, b) => a.index - b.index);
-    const blocks: string[] = [];
-    let complete = true;
-    let hasGeneratedBody = false;
+    const sources = ordered.map((slide) => ({
+      index: slide.index,
+      text: transcriptBySlide.get(slide.index) ?? slide.ocrText?.trim() ?? "",
+      imageUrl: slide.imageUrl ?? "",
+    }));
+    const startedAt = performance.now();
+    const imageLoader = options.loadSlideImage ?? loadSlideImage;
+    const preparedSources = await Promise.all(
+      sources.map(async (slide) => ({
+        ...slide,
+        image: slide.imageUrl ? await imageLoader(slide.imageUrl) : null,
+      })),
+    );
+    if (generation !== activeGeneration || panelState.slides?.sourceId !== payload.sourceId) return;
+    const sourceByIndex = new Map(preparedSources.map((slide) => [slide.index, slide]));
+    const generatedBodies = new Map<number, string>();
+    const sourceSlides = preparedSources.filter((slide) => slide.text || slide.image);
+    let promptCalls = 0;
+    let fallbackCalls = 0;
 
-    for (let offset = 0; offset < ordered.length; offset += 1) {
-      const slide = ordered[offset];
-      if (!slide || generation !== activeGeneration) return;
-      if (options.panelState.slides?.sourceId !== payload.sourceId) return;
-      const sourceText = transcriptBySlide.get(slide.index) ?? slide.ocrText?.trim() ?? "";
-      let body = "";
-      if (sourceText) {
-        const result = await options.browserAi.summarize({
-          input: { text: sourceText, length: "short", keyMoments: [] },
-          context: [
-            `Summarize slide ${offset + 1} of ${ordered.length}.`,
-            "Return only one or two concise factual sentences in plain text.",
-            "Do not mention the slide, transcript, speaker, timestamps, or these instructions.",
-            panelState.currentSource?.title
-              ? `The video is titled "${panelState.currentSource.title}".`
-              : "",
-          ]
-            .filter(Boolean)
-            .join(" "),
-          requestKey: "slides",
-          status: `Summarizing slide ${offset + 1} of ${ordered.length} with on-device AI…`,
-        });
-        body = result ? normalizeSlideBody(result) : "";
-        if (!body) {
-          complete = false;
-          if (!hasGeneratedBody) {
-            if (activeSourceKey === sourceKey) activeSourceKey = null;
-            return;
+    const isCurrent = () =>
+      generation === activeGeneration && options.panelState.slides?.sourceId === payload.sourceId;
+    const buildMarkdown = () =>
+      ordered
+        .flatMap((slide) => {
+          const source = sourceByIndex.get(slide.index);
+          const body = generatedBodies.get(slide.index);
+          if (!source || (!source.text && !source.image)) {
+            return [
+              buildSlideBlock({
+                index: slide.index,
+                total: ordered.length,
+                body: "",
+              }),
+            ];
           }
-          continue;
+          if (!body) return [];
+          return [
+            buildSlideBlock({
+              index: slide.index,
+              total: ordered.length,
+              body,
+            }),
+          ];
+        })
+        .join("\n");
+    const applyProgress = (complete: boolean) => {
+      if (generatedBodies.size === 0) return;
+      const markdown = buildMarkdown();
+      if (!markdown) return;
+      options.applyGeneratedSummary({
+        runId,
+        url,
+        markdown,
+        model: MODEL_LABEL,
+        complete,
+      });
+      options.schedulePanelCacheSync();
+    };
+
+    const promptBatch = async (
+      batch: PreparedSlideSource[],
+      includeImages = true,
+    ): Promise<boolean> => {
+      if (!isCurrent() || batch.length === 0) return false;
+      promptCalls += 1;
+      const firstIndex = batch[0]?.index ?? 1;
+      const lastIndex = batch.at(-1)?.index ?? firstIndex;
+      const usesImages = includeImages && batch.some((slide) => slide.image);
+      const result = await options.browserAi.prompt({
+        input: buildBatchInput(batch, panelState.currentSource?.title ?? null, usesImages),
+        responseConstraint: buildBatchConstraint(batch),
+        requestKey: "slides",
+        status:
+          batch.length === 1
+            ? `Summarizing slide ${firstIndex} with on-device AI…`
+            : `Summarizing slides ${firstIndex}–${lastIndex} with on-device AI…`,
+      });
+      if (!isCurrent()) return false;
+      if (!result) {
+        if (!usesImages) return false;
+        const textBatch = batch.filter((slide) => slide.text);
+        return await promptBatch(textBatch, false);
+      }
+      if (result.kind === "success") {
+        const parsed = parseBatchResult(result.text, batch);
+        if (parsed) {
+          for (const [index, body] of parsed) generatedBodies.set(index, body);
+          applyProgress(false);
+          return true;
         }
-        hasGeneratedBody = true;
       }
-      if (generation !== activeGeneration) return;
-      blocks.push(
-        buildSlideBlock({
-          index: slide.index,
-          total: ordered.length,
-          body,
-        }),
-      );
-      if (hasGeneratedBody) {
-        options.applyGeneratedSummary({
-          runId,
-          url,
-          markdown: blocks.join("\n"),
-          model: MODEL_LABEL,
-          complete: false,
-        });
-        options.schedulePanelCacheSync();
-      }
+      if (batch.length <= 1) return false;
+      const midpoint = Math.ceil(batch.length / 2);
+      const left = await promptBatch(batch.slice(0, midpoint), includeImages);
+      const right = await promptBatch(batch.slice(midpoint), includeImages);
+      return left && right;
+    };
+
+    if (sourceSlides.length > 0) {
+      await promptBatch(sourceSlides);
+    }
+    if (!isCurrent()) return;
+
+    for (let offset = 0; offset < preparedSources.length; offset += 1) {
+      const slide = preparedSources[offset];
+      if (!slide?.text || generatedBodies.has(slide.index)) continue;
+      fallbackCalls += 1;
+      const result = await options.browserAi.summarize({
+        input: { text: slide.text, length: "short", keyMoments: [] },
+        context: [
+          `Summarize slide ${offset + 1} of ${ordered.length}.`,
+          "Return only one or two concise factual sentences in plain text.",
+          "Do not mention the slide, transcript, speaker, timestamps, or these instructions.",
+          panelState.currentSource?.title
+            ? `The video is titled "${panelState.currentSource.title}".`
+            : "",
+        ]
+          .filter(Boolean)
+          .join(" "),
+        requestKey: "slides",
+        status: `Summarizing slide ${offset + 1} of ${ordered.length} with on-device AI…`,
+      });
+      if (!isCurrent()) return;
+      const body = result ? normalizeSlideBody(result) : "";
+      if (!body) continue;
+      generatedBodies.set(slide.index, body);
+      applyProgress(false);
     }
 
-    if (generation !== activeGeneration) return;
-    if (!hasGeneratedBody || blocks.length === 0) {
+    if (!isCurrent()) return;
+    if (generatedBodies.size === 0) {
       if (activeSourceKey === sourceKey) activeSourceKey = null;
       return;
     }
-    const markdown = blocks.join("\n");
-    options.applyGeneratedSummary({
-      runId,
-      url,
-      markdown,
-      model: MODEL_LABEL,
-      complete,
-    });
-    options.schedulePanelCacheSync();
+    const complete = sourceSlides.every((slide) => generatedBodies.has(slide.index));
+    applyProgress(complete);
     if (activeSourceKey === sourceKey) activeSourceKey = null;
     logExtensionEvent({
       event: "browser-ai:slides-done",
@@ -231,6 +416,10 @@ export function createBrowserAiSlidesRuntime(options: {
       scope: "sidepanel",
       detail: {
         complete,
+        elapsedMs: Math.round(performance.now() - startedAt),
+        fallbackCalls,
+        imageSlides: sourceSlides.filter((slide) => slide.image).length,
+        promptCalls,
         slides: ordered.length,
         sourceKind: payload.sourceKind,
       },

--- a/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-summary-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-summary-runtime.ts
@@ -23,16 +23,113 @@ type BrowserSummarizerApi = {
   }) => Promise<BrowserSummarizerSession>;
 };
 
+type BrowserLanguageModelPromptOptions = {
+  responseConstraint: RegExp;
+  omitResponseConstraintInput: true;
+  signal?: AbortSignal;
+};
+
+type BrowserLanguageModelContent = { type: "text"; value: string } | { type: "image"; value: Blob };
+
+type BrowserLanguageModelMessage = {
+  role: "user";
+  content: BrowserLanguageModelContent[];
+};
+
+export type BrowserAiPromptInput = string | BrowserLanguageModelMessage[];
+
+type BrowserLanguageModelSession = {
+  contextWindow?: number;
+  measureContextUsage?: (
+    input: BrowserAiPromptInput,
+    options: Omit<BrowserLanguageModelPromptOptions, "signal">,
+  ) => Promise<number>;
+  prompt: (
+    input: BrowserAiPromptInput,
+    options: BrowserLanguageModelPromptOptions,
+  ) => Promise<string>;
+  destroy?: () => void;
+};
+
+type BrowserLanguageModelApi = {
+  availability: (options: BrowserLanguageModelCreateOptions) => Promise<BrowserAiAvailability>;
+  create: (
+    options: BrowserLanguageModelCreateOptions & {
+      monitor: (monitor: EventTarget) => void;
+    },
+  ) => Promise<BrowserLanguageModelSession>;
+};
+
+type BrowserLanguageModelCreateOptions = {
+  expectedInputs: Array<{ type: "text"; languages: ["en"] } | { type: "image" }>;
+  expectedOutputs: Array<{ type: "text"; languages: ["en"] }>;
+};
+
 type RuntimeOptions = {
   getApi?: () => BrowserSummarizerApi | null;
+  getLanguageModelApi?: () => BrowserLanguageModelApi | null;
   isUserActive?: () => boolean;
   setStatus: (status: string) => void;
 };
 
 export type BrowserAiRequestKey = "summary" | "slides";
+export type BrowserAiPromptResult =
+  | {
+      kind: "success";
+      text: string;
+      contextUsage: number | null;
+      contextWindow: number | null;
+    }
+  | {
+      kind: "too-large";
+      contextUsage: number | null;
+      contextWindow: number | null;
+    };
+
+function buildLanguageModelOptions(imageInput: boolean): BrowserLanguageModelCreateOptions {
+  return {
+    expectedInputs: [
+      { type: "text", languages: ["en"] },
+      ...(imageInput ? ([{ type: "image" }] as const) : []),
+    ],
+    expectedOutputs: [{ type: "text", languages: ["en"] }],
+  };
+}
+
+function promptUsesImages(input: BrowserAiPromptInput): boolean {
+  return (
+    typeof input !== "string" &&
+    input.some((message) => message.content.some((content) => content.type === "image"))
+  );
+}
+
+function promptTextLength(input: BrowserAiPromptInput): number {
+  if (typeof input === "string") return input.length;
+  return input.reduce(
+    (total, message) =>
+      total +
+      message.content.reduce(
+        (contentTotal, content) =>
+          contentTotal + (content.type === "text" ? content.value.length : 0),
+        0,
+      ),
+    0,
+  );
+}
 
 function defaultGetApi(): BrowserSummarizerApi | null {
   const api = (globalThis as typeof globalThis & { Summarizer?: BrowserSummarizerApi }).Summarizer;
+  return api && typeof api.availability === "function" && typeof api.create === "function"
+    ? api
+    : null;
+}
+
+function defaultGetLanguageModelApi(): BrowserLanguageModelApi | null {
+  const api = (
+    globalThis as typeof globalThis & {
+      LanguageModel?: BrowserLanguageModelApi;
+    }
+  ).LanguageModel;
   return api && typeof api.availability === "function" && typeof api.create === "function"
     ? api
     : null;
@@ -198,14 +295,18 @@ async function summarizeRecursively({
 
 export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
   const getApi = options.getApi ?? defaultGetApi;
+  const getLanguageModelApi = options.getLanguageModelApi ?? defaultGetLanguageModelApi;
   const isUserActive = options.isUserActive ?? defaultIsUserActive;
   const sessions = new Map<string, Promise<BrowserSummarizerSession | null>>();
+  const promptSessions = new Map<string, Promise<BrowserLanguageModelSession | null>>();
   const activeRequests = new Map<BrowserAiRequestKey, number>();
   const activeControllers = new Map<BrowserAiRequestKey, AbortController>();
   let statusOwner: { requestKey: BrowserAiRequestKey; token: symbol } | null = null;
 
   const sessionKey = (requestKey: BrowserAiRequestKey, length: BrowserAiSummaryInput["length"]) =>
     `${requestKey}:${length}`;
+  const promptSessionKey = (requestKey: BrowserAiRequestKey, imageInput: boolean) =>
+    `${requestKey}:${imageInput ? "image" : "text"}`;
   const setOwnedStatus = (requestKey: BrowserAiRequestKey, owner: symbol, status: string) => {
     statusOwner = { requestKey, token: owner };
     options.setStatus(status);
@@ -277,6 +378,67 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
     return await createSession(api, length, requestKey, statusToken);
   };
 
+  const createPromptSession = (
+    api: BrowserLanguageModelApi,
+    requestKey: BrowserAiRequestKey,
+    imageInput: boolean,
+    statusToken: symbol,
+  ): Promise<BrowserLanguageModelSession | null> => {
+    const key = promptSessionKey(requestKey, imageInput);
+    const promise = api
+      .create({
+        ...buildLanguageModelOptions(imageInput),
+        monitor(monitor) {
+          monitor.addEventListener("downloadprogress", (event) => {
+            const loaded = (event as Event & { loaded?: number }).loaded;
+            const percent =
+              typeof loaded === "number" && Number.isFinite(loaded)
+                ? ` ${Math.round(loaded * 100)}%`
+                : "";
+            setOwnedStatus(requestKey, statusToken, `Downloading on-device AI…${percent}`);
+          });
+        },
+      })
+      .catch((error) => {
+        logExtensionEvent({
+          event: "browser-ai:prompt-create-error",
+          level: "warn",
+          scope: "sidepanel",
+          detail: { imageInput, requestKey, ...errorDetail(error) },
+        });
+        promptSessions.delete(key);
+        return null;
+      });
+    promptSessions.set(key, promise);
+    return promise;
+  };
+
+  const ensurePromptSession = async (
+    requestKey: BrowserAiRequestKey,
+    imageInput: boolean,
+    statusToken: symbol,
+  ): Promise<BrowserLanguageModelSession | null> => {
+    const key = promptSessionKey(requestKey, imageInput);
+    const cached = promptSessions.get(key);
+    if (cached) return await cached;
+    const api = getLanguageModelApi();
+    if (!api) return null;
+    const availability = await api
+      .availability(buildLanguageModelOptions(imageInput))
+      .catch((error) => {
+        logExtensionEvent({
+          event: "browser-ai:prompt-availability-error",
+          level: "warn",
+          scope: "sidepanel",
+          detail: { imageInput, ...errorDetail(error) },
+        });
+        return "unavailable" as const;
+      });
+    if (availability === "unavailable") return null;
+    if (availability === "downloadable" && !isUserActive()) return null;
+    return await createPromptSession(api, requestKey, imageInput, statusToken);
+  };
+
   const prepare = (
     length: BrowserAiSummaryInput["length"],
     requestKey: BrowserAiRequestKey = "summary",
@@ -287,6 +449,21 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
     if (!api) return;
     const statusToken = Symbol(`browser-ai:${requestKey}:prepare`);
     void createSession(api, length, requestKey, statusToken).then(() => {
+      clearOwnedStatus(statusToken);
+    });
+  };
+
+  const preparePrompt = (
+    requestKey: BrowserAiRequestKey = "slides",
+    options: { imageInput?: boolean } = {},
+  ) => {
+    const imageInput = options.imageInput === true;
+    const key = promptSessionKey(requestKey, imageInput);
+    if (!isUserActive() || promptSessions.has(key)) return;
+    const api = getLanguageModelApi();
+    if (!api) return;
+    const statusToken = Symbol(`browser-ai:${requestKey}:prompt-prepare`);
+    void createPromptSession(api, requestKey, imageInput, statusToken).then(() => {
       clearOwnedStatus(statusToken);
     });
   };
@@ -382,13 +559,124 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
     }
   };
 
+  const prompt = async ({
+    input,
+    responseConstraint,
+    requestKey = "slides",
+    status = "Summarizing with on-device AI…",
+  }: {
+    input: BrowserAiPromptInput;
+    responseConstraint: RegExp;
+    requestKey?: BrowserAiRequestKey;
+    status?: string;
+  }): Promise<BrowserAiPromptResult | null> => {
+    const request = (activeRequests.get(requestKey) ?? 0) + 1;
+    activeRequests.set(requestKey, request);
+    activeControllers.get(requestKey)?.abort();
+    const controller = new AbortController();
+    activeControllers.set(requestKey, controller);
+    const statusToken = Symbol(`browser-ai:${requestKey}:prompt:${request}`);
+    const imageInput = promptUsesImages(input);
+    const key = promptSessionKey(requestKey, imageInput);
+    const chars = promptTextLength(input);
+    const session = await ensurePromptSession(requestKey, imageInput, statusToken);
+    if (!session || request !== activeRequests.get(requestKey)) {
+      if (request === activeRequests.get(requestKey)) {
+        activeControllers.delete(requestKey);
+        clearOwnedStatus(statusToken);
+      }
+      return null;
+    }
+
+    const promptOptions: BrowserLanguageModelPromptOptions = {
+      responseConstraint,
+      omitResponseConstraintInput: true,
+      signal: controller.signal,
+    };
+    let contextUsage: number | null = null;
+    const contextWindow =
+      typeof session.contextWindow === "number" && Number.isFinite(session.contextWindow)
+        ? session.contextWindow
+        : null;
+    setOwnedStatus(requestKey, statusToken, status);
+    logExtensionEvent({
+      event: "browser-ai:prompt-start",
+      level: "verbose",
+      scope: "sidepanel",
+      detail: { chars, imageInput, requestKey },
+    });
+    try {
+      if (session.measureContextUsage) {
+        contextUsage = await session.measureContextUsage(input, {
+          responseConstraint,
+          omitResponseConstraintInput: true,
+        });
+        if (
+          contextWindow != null &&
+          Number.isFinite(contextUsage) &&
+          contextUsage > Math.floor(contextWindow * 0.85)
+        ) {
+          return { kind: "too-large", contextUsage, contextWindow };
+        }
+      }
+      const result = await session.prompt(input, promptOptions);
+      const text = request === activeRequests.get(requestKey) && result.trim() ? result.trim() : "";
+      if (!text) return null;
+      logExtensionEvent({
+        event: "browser-ai:prompt-done",
+        level: "verbose",
+        scope: "sidepanel",
+        detail: {
+          chars,
+          contextUsage,
+          contextWindow,
+          imageInput,
+          requestKey,
+          resultChars: text.length,
+        },
+      });
+      return { kind: "success", text, contextUsage, contextWindow };
+    } catch (error) {
+      if (isQuotaError(error)) {
+        return { kind: "too-large", contextUsage, contextWindow };
+      }
+      logExtensionEvent({
+        event: "browser-ai:prompt-error",
+        level: controller.signal.aborted ? "verbose" : "warn",
+        scope: "sidepanel",
+        detail: {
+          aborted: controller.signal.aborted,
+          chars,
+          imageInput,
+          requestKey,
+          ...errorDetail(error),
+        },
+      });
+      return null;
+    } finally {
+      session.destroy?.();
+      const cached = promptSessions.get(key);
+      if (cached && (await cached) === session) {
+        promptSessions.delete(key);
+      }
+      if (request === activeRequests.get(requestKey)) {
+        activeControllers.delete(requestKey);
+        clearOwnedStatus(statusToken);
+      }
+    }
+  };
+
   const destroy = () => {
     cancel();
     for (const sessionPromise of sessions.values()) {
       void sessionPromise.then((session) => session?.destroy?.());
     }
+    for (const sessionPromise of promptSessions.values()) {
+      void sessionPromise.then((session) => session?.destroy?.());
+    }
     sessions.clear();
+    promptSessions.clear();
   };
 
-  return { cancel, destroy, prepare, summarize };
+  return { cancel, destroy, prepare, preparePrompt, prompt, summarize };
 }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime.ts
@@ -149,6 +149,7 @@ export function createSidepanelPresentationRuntime({
       const length = appearanceControls.getLengthValue();
       browserAiRuntime.prepare(length === "short" || length === "medium" ? length : "long");
       browserAiRuntime.prepare("short", "slides");
+      browserAiRuntime.preparePrompt("slides", { imageInput: true });
     },
   });
 

--- a/apps/chrome-extension/tests/sidepanel.browser-ai.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.browser-ai.spec.ts
@@ -81,6 +81,68 @@ test("browser AI creates distinct summaries for browser-extracted slides", async
 
   try {
     const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+      (
+        globalThis as typeof globalThis & {
+          __browserAiPromptCalls?: number;
+          __browserAiPromptImageInputs?: number;
+          __browserAiSlideSummarizerCalls?: number;
+        }
+      ).__browserAiPromptCalls = 0;
+      (
+        globalThis as typeof globalThis & {
+          __browserAiPromptImageInputs?: number;
+        }
+      ).__browserAiPromptImageInputs = 0;
+      (
+        globalThis as typeof globalThis & {
+          __browserAiSlideSummarizerCalls?: number;
+        }
+      ).__browserAiSlideSummarizerCalls = 0;
+      Object.defineProperty(globalThis, "LanguageModel", {
+        configurable: true,
+        value: {
+          availability: async () => "available",
+          create: async (createOptions?: { expectedInputs?: Array<{ type?: string }> }) => ({
+            contextWindow: 9_216,
+            async measureContextUsage() {
+              return 500;
+            },
+            async prompt(
+              input:
+                | string
+                | Array<{
+                    content?: Array<{ type?: string; value?: unknown }>;
+                  }>,
+              options?: { responseConstraint?: RegExp },
+            ) {
+              const scope = globalThis as typeof globalThis & {
+                __browserAiPromptCalls?: number;
+                __browserAiPromptImageInputs?: number;
+              };
+              scope.__browserAiPromptCalls = (scope.__browserAiPromptCalls ?? 0) + 1;
+              scope.__browserAiPromptImageInputs =
+                typeof input === "string"
+                  ? 0
+                  : input
+                      .flatMap((message) => message.content ?? [])
+                      .filter(
+                        (content) => content.type === "image" && content.value instanceof Blob,
+                      ).length;
+              if (!createOptions?.expectedInputs?.some((expected) => expected.type === "image")) {
+                throw new DOMException("Missing image modality", "NotSupportedError");
+              }
+              const result =
+                "[slide:1] Linear classifiers learn a decision boundary between labeled examples.\n" +
+                "[slide:2] The sigmoid converts model scores into class probabilities.";
+              if (!options?.responseConstraint?.test(result)) {
+                throw new DOMException("Constraint mismatch", "SyntaxError");
+              }
+              return result;
+            },
+            destroy() {},
+          }),
+        },
+      });
       Object.defineProperty(globalThis, "Summarizer", {
         configurable: true,
         value: {
@@ -88,9 +150,19 @@ test("browser AI creates distinct summaries for browser-extracted slides", async
           create: async () => ({
             async summarize(input: string, options?: { context?: string }) {
               if (options?.context?.includes("slide 1 of 2")) {
+                const scope = globalThis as typeof globalThis & {
+                  __browserAiSlideSummarizerCalls?: number;
+                };
+                scope.__browserAiSlideSummarizerCalls =
+                  (scope.__browserAiSlideSummarizerCalls ?? 0) + 1;
                 return "Linear classifiers learn a decision boundary between labeled examples.";
               }
               if (options?.context?.includes("slide 2 of 2")) {
+                const scope = globalThis as typeof globalThis & {
+                  __browserAiSlideSummarizerCalls?: number;
+                };
+                scope.__browserAiSlideSummarizerCalls =
+                  (scope.__browserAiSlideSummarizerCalls ?? 0) + 1;
                 return "The sigmoid converts model scores into class probabilities.";
               }
               return `Overall summary of ${input.slice(0, 20)}.`;
@@ -142,8 +214,18 @@ test("browser AI creates distinct summaries for browser-extracted slides", async
         "[00:00] The first section explains linear decision boundaries and labeled examples.\n" +
         "[01:00] The second section derives the sigmoid and probability interpretation.",
       slides: [
-        { index: 1, timestamp: 0, imageUrl: "" },
-        { index: 2, timestamp: 60, imageUrl: "" },
+        {
+          index: 1,
+          timestamp: 0,
+          imageUrl:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2xZkAAAAASUVORK5CYII=",
+        },
+        {
+          index: 2,
+          timestamp: 60,
+          imageUrl:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2xZkAAAAASUVORK5CYII=",
+        },
       ],
     });
 
@@ -159,6 +241,38 @@ test("browser AI creates distinct summaries for browser-extracted slides", async
       [1, "Linear classifiers learn a decision boundary between labeled examples."],
       [2, "The sigmoid converts model scores into class probabilities."],
     ]);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              globalThis as typeof globalThis & {
+                __browserAiPromptCalls?: number;
+              }
+            ).__browserAiPromptCalls ?? 0,
+        ),
+      )
+      .toBe(1);
+    expect(
+      await page.evaluate(
+        () =>
+          (
+            globalThis as typeof globalThis & {
+              __browserAiPromptImageInputs?: number;
+            }
+          ).__browserAiPromptImageInputs ?? 0,
+      ),
+    ).toBe(2);
+    expect(
+      await page.evaluate(
+        () =>
+          (
+            globalThis as typeof globalThis & {
+              __browserAiSlideSummarizerCalls?: number;
+            }
+          ).__browserAiSlideSummarizerCalls ?? 0,
+      ),
+    ).toBe(0);
     assertNoErrors(harness);
   } finally {
     await closeExtension(harness.context, harness.userDataDir);

--- a/tests/sidepanel.browser-ai-slides-runtime.test.ts
+++ b/tests/sidepanel.browser-ai-slides-runtime.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBrowserAiSlidesRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-slides-runtime";
 import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { PanelState, UiState } from "../apps/chrome-extension/src/entrypoints/sidepanel/types";
+import { defaultSettings } from "../apps/chrome-extension/src/lib/settings";
 
 function buildUiState(overrides: Partial<UiState["settings"]> = {}): UiState {
   return {
@@ -60,40 +61,69 @@ function buildPanelState(): PanelState {
 }
 
 describe("sidepanel browser AI slides runtime", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("builds canonical per-slide Nano summaries instead of transcript fallbacks", async () => {
     const panelState = buildPanelState();
+    if (!panelState.slides) throw new Error("Missing slides fixture");
+    panelState.slides.slides[0]!.imageUrl = "data:image/jpeg;base64,one";
+    panelState.slides.slides[1]!.imageUrl = "data:image/jpeg;base64,two";
+    const images = new Map([
+      ["data:image/jpeg;base64,one", new Blob(["one"], { type: "image/jpeg" })],
+      ["data:image/jpeg;base64,two", new Blob(["two"], { type: "image/jpeg" })],
+    ]);
     const applyGeneratedSummary = vi.fn((value) => {
       panelState.slidesSummary = {
         ...panelState.slidesSummary,
         ...value,
       };
     });
-    const summarize = vi.fn(async ({ input }: { input: { text: string } }) =>
-      input.text.includes("linear decision")
-        ? "Linear classifiers divide examples with a learned decision boundary."
-        : "The sigmoid maps scores into probabilities for logistic regression.",
-    );
+    const prompt = vi.fn(async () => ({
+      kind: "success" as const,
+      text:
+        "[slide:1] Linear classifiers divide examples with a learned decision boundary.\n" +
+        "[slide:2] The sigmoid maps scores into probabilities for logistic regression.",
+      contextUsage: 400,
+      contextWindow: 9_216,
+    }));
+    const summarize = vi.fn();
     const runtime = createBrowserAiSlidesRuntime({
       panelState,
       browserAi: {
         cancel: vi.fn(),
+        prompt,
         summarize,
       },
       getTranscriptTimedText: () => panelState.slides?.transcriptTimedText ?? null,
       applyGeneratedSummary,
       schedulePanelCacheSync: vi.fn(),
+      loadSlideImage: vi.fn(async (imageUrl) => images.get(imageUrl) ?? null),
     });
 
     await runtime.refresh();
 
-    expect(summarize).toHaveBeenCalledTimes(2);
-    expect(summarize).toHaveBeenNthCalledWith(
-      1,
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(prompt).toHaveBeenCalledWith(
       expect.objectContaining({
         requestKey: "slides",
-        status: "Summarizing slide 1 of 2 with on-device AI…",
+        status: "Summarizing slides 1–2 with on-device AI…",
       }),
     );
+    const promptInput = prompt.mock.calls[0]?.[0]?.input;
+    expect(promptInput).toEqual([
+      {
+        role: "user",
+        content: expect.arrayContaining([
+          expect.objectContaining({ type: "text", value: expect.stringContaining("INDEX 1") }),
+          { type: "image", value: images.get("data:image/jpeg;base64,one") },
+          expect.objectContaining({ type: "text", value: expect.stringContaining("INDEX 2") }),
+          { type: "image", value: images.get("data:image/jpeg;base64,two") },
+        ]),
+      },
+    ]);
+    expect(summarize).not.toHaveBeenCalled();
     const final = applyGeneratedSummary.mock.calls.at(-1)?.[0];
     expect(final).toEqual(
       expect.objectContaining({
@@ -107,7 +137,7 @@ describe("sidepanel browser AI slides runtime", () => {
     expect(final?.markdown).not.toContain("The first section explains");
 
     await runtime.refresh();
-    expect(summarize).toHaveBeenCalledTimes(2);
+    expect(prompt).toHaveBeenCalledOnce();
   });
 
   it("does not use Nano when a direct provider model is selected", async () => {
@@ -121,6 +151,7 @@ describe("sidepanel browser AI slides runtime", () => {
       panelState,
       browserAi: {
         cancel: vi.fn(),
+        prompt: vi.fn(),
         summarize,
       },
       getTranscriptTimedText: () => panelState.slides?.transcriptTimedText ?? null,
@@ -142,6 +173,7 @@ describe("sidepanel browser AI slides runtime", () => {
       panelState: daemonState,
       browserAi: {
         cancel: vi.fn(),
+        prompt: vi.fn(),
         summarize: daemonSummarize,
       },
       getTranscriptTimedText: () => daemonState.slides?.transcriptTimedText ?? null,
@@ -154,11 +186,14 @@ describe("sidepanel browser AI slides runtime", () => {
 
     const browserState = buildPanelState();
     const applyGeneratedSummary = vi.fn();
+    const prompt = vi.fn(async () => null);
+    const summarize = vi.fn(async () => null);
     const browserRuntime = createBrowserAiSlidesRuntime({
       panelState: browserState,
       browserAi: {
         cancel: vi.fn(),
-        summarize: vi.fn(async () => null),
+        prompt,
+        summarize,
       },
       getTranscriptTimedText: () => browserState.slides?.transcriptTimedText ?? null,
       applyGeneratedSummary,
@@ -166,6 +201,112 @@ describe("sidepanel browser AI slides runtime", () => {
     });
 
     await browserRuntime.refresh();
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(summarize).toHaveBeenCalledTimes(2);
     expect(applyGeneratedSummary).not.toHaveBeenCalled();
+  });
+
+  it("splits a batch when Chrome reports context pressure", async () => {
+    const panelState = buildPanelState();
+    const prompt = vi
+      .fn()
+      .mockResolvedValueOnce({
+        kind: "too-large",
+        contextUsage: 10_000,
+        contextWindow: 9_216,
+      })
+      .mockResolvedValueOnce({
+        kind: "success",
+        text: "[slide:1] Linear classifiers learn a decision boundary.",
+        contextUsage: 300,
+        contextWindow: 9_216,
+      })
+      .mockResolvedValueOnce({
+        kind: "success",
+        text: "[slide:2] The sigmoid converts scores into probabilities.",
+        contextUsage: 300,
+        contextWindow: 9_216,
+      });
+    const summarize = vi.fn();
+    const applyGeneratedSummary = vi.fn();
+    const runtime = createBrowserAiSlidesRuntime({
+      panelState,
+      browserAi: {
+        cancel: vi.fn(),
+        prompt,
+        summarize,
+      },
+      getTranscriptTimedText: () => panelState.slides?.transcriptTimedText ?? null,
+      applyGeneratedSummary,
+      schedulePanelCacheSync: vi.fn(),
+    });
+
+    await runtime.refresh();
+
+    expect(prompt).toHaveBeenCalledTimes(3);
+    expect(summarize).not.toHaveBeenCalled();
+    expect(applyGeneratedSummary.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        complete: true,
+        markdown: expect.stringContaining("[slide:2]"),
+      }),
+    );
+  });
+
+  it("only sends the daemon token to the fixed daemon slide origin", async () => {
+    const panelState = buildPanelState();
+    if (!panelState.slides) throw new Error("Missing slides fixture");
+    panelState.slides.slides[0]!.imageUrl = "http://127.0.0.1:8787/v1/slides/run/1";
+    panelState.slides.slides[1]!.imageUrl = "http://localhost:9999/v1/slides/run/2";
+    const settingsResult = {
+      settings: {
+        ...defaultSettings,
+        token: "daemon-secret",
+      },
+    };
+    vi.stubGlobal("chrome", {
+      storage: {
+        local: {
+          get: vi.fn((_key: string, callback: (value: typeof settingsResult) => void) => {
+            callback(settingsResult);
+            return Promise.resolve(settingsResult);
+          }),
+        },
+      },
+    });
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob(["image"], { type: "image/jpeg" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const runtime = createBrowserAiSlidesRuntime({
+      panelState,
+      browserAi: {
+        cancel: vi.fn(),
+        prompt: vi.fn(async () => ({
+          kind: "success" as const,
+          text:
+            "[slide:1] The first frame contains a decision boundary.\n" +
+            "[slide:2] The second frame contains a sigmoid curve.",
+          contextUsage: 400,
+          contextWindow: 9_216,
+        })),
+        summarize: vi.fn(),
+      },
+      getTranscriptTimedText: () => panelState.slides?.transcriptTimedText ?? null,
+      applyGeneratedSummary: vi.fn(),
+      schedulePanelCacheSync: vi.fn(),
+    });
+
+    await runtime.refresh();
+
+    const daemonCall = fetchMock.mock.calls.find(([url]) => String(url).includes("127.0.0.1:8787"));
+    const untrustedCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("localhost:9999"),
+    );
+    const daemonHeaders = new Headers(daemonCall?.[1]?.headers);
+    const untrustedHeaders = new Headers(untrustedCall?.[1]?.headers);
+    expect(daemonHeaders.get("Authorization")).toBe("Bearer daemon-secret");
+    expect(untrustedHeaders.get("Authorization")).toBeNull();
   });
 });

--- a/tests/sidepanel.browser-ai-summary-runtime.test.ts
+++ b/tests/sidepanel.browser-ai-summary-runtime.test.ts
@@ -169,4 +169,132 @@ describe("sidepanel browser AI summary runtime", () => {
     await expect(overall).resolves.toBe("Overall result");
     expect(create).toHaveBeenCalledTimes(2);
   });
+
+  it("prewarms and runs a constrained Prompt API request", async () => {
+    const session = {
+      contextWindow: 9_216,
+      measureContextUsage: vi.fn(async () => 700),
+      prompt: vi.fn(async () => "[slide:1] A concise summary."),
+      destroy: vi.fn(),
+    };
+    const create = vi.fn(async () => session);
+    const availability = vi.fn(async () => "downloadable" as const);
+    const runtime = createBrowserAiSummaryRuntime({
+      getApi: () => null,
+      getLanguageModelApi: () => ({ availability, create }),
+      isUserActive: () => true,
+      setStatus: vi.fn(),
+    });
+    const constraint = /^\[slide:1\] [^\r\n]{1,180}$/;
+
+    runtime.preparePrompt();
+    await Promise.resolve();
+    const result = await runtime.prompt({
+      input: "INDEX 1\nSource text",
+      responseConstraint: constraint,
+      status: "Summarizing slides…",
+    });
+
+    expect(result).toEqual({
+      kind: "success",
+      text: "[slide:1] A concise summary.",
+      contextUsage: 700,
+      contextWindow: 9_216,
+    });
+    expect(create).toHaveBeenCalledOnce();
+    expect(availability).not.toHaveBeenCalled();
+    expect(session.prompt).toHaveBeenCalledWith("INDEX 1\nSource text", {
+      responseConstraint: constraint,
+      omitResponseConstraintInput: true,
+      signal: expect.any(AbortSignal),
+    });
+    expect(session.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("creates a multimodal Prompt API session for slide images", async () => {
+    const image = new Blob(["image"], { type: "image/jpeg" });
+    const input = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, value: "INDEX 1" },
+          { type: "image" as const, value: image },
+        ],
+      },
+    ];
+    const session = {
+      contextWindow: 9_216,
+      measureContextUsage: vi.fn(async () => 900),
+      prompt: vi.fn(async () => "[slide:1] A visible equation is explained."),
+      destroy: vi.fn(),
+    };
+    const create = vi.fn(async () => session);
+    const availability = vi.fn(async () => "downloadable" as const);
+    const runtime = createBrowserAiSummaryRuntime({
+      getApi: () => null,
+      getLanguageModelApi: () => ({ availability, create }),
+      isUserActive: () => true,
+      setStatus: vi.fn(),
+    });
+
+    runtime.preparePrompt("slides", { imageInput: true });
+    await Promise.resolve();
+    await expect(
+      runtime.prompt({
+        input,
+        responseConstraint: /^\[slide:1\] [^\r\n]{1,260}$/,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "success",
+        text: "[slide:1] A visible equation is explained.",
+      }),
+    );
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedInputs: [{ type: "text", languages: ["en"] }, { type: "image" }],
+      }),
+    );
+    expect(availability).not.toHaveBeenCalled();
+    expect(session.prompt).toHaveBeenCalledWith(
+      input,
+      expect.objectContaining({
+        omitResponseConstraintInput: true,
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("reports context pressure before prompting", async () => {
+    const session = {
+      contextWindow: 1_000,
+      measureContextUsage: vi.fn(async () => 900),
+      prompt: vi.fn(),
+      destroy: vi.fn(),
+    };
+    const runtime = createBrowserAiSummaryRuntime({
+      getApi: () => null,
+      getLanguageModelApi: () => ({
+        availability: vi.fn(async () => "available" as const),
+        create: vi.fn(async () => session),
+      }),
+      isUserActive: () => false,
+      setStatus: vi.fn(),
+    });
+
+    await expect(
+      runtime.prompt({
+        input: "Oversized source",
+        responseConstraint: /^.+$/,
+      }),
+    ).resolves.toEqual({
+      kind: "too-large",
+      contextUsage: 900,
+      contextWindow: 1_000,
+    });
+    expect(session.prompt).not.toHaveBeenCalled();
+    expect(session.destroy).toHaveBeenCalledOnce();
+  });
 });


### PR DESCRIPTION
## Summary

- batch browser-extracted slide frames and transcript windows into one constrained Gemini Nano Prompt API request
- include captured images so on-device summaries can describe visible equations, labels, diagrams, and code
- split only when Chrome reports context pressure or invalid constrained output, then retain the per-slide Summarizer fallback
- prewarm the multimodal Prompt API session and restrict daemon-token image fetches to the fixed daemon origin

## Why

The previous browser slide path called Gemini Nano once per slide and only supplied transcript text. This was slower than the daemon path and could not summarize important visual slide content.

## Impact

For a six-segment benchmark, the model phase dropped from about 9.2 seconds across six sequential Summarizer calls to about 4.5-5 seconds for one constrained multimodal call. An 83-minute YouTube lecture completed end to end in about 36 seconds, with frame capture and transcript extraction now dominating the runtime.

## Validation

- `pnpm -C apps/chrome-extension test:chrome` (92 passed, 4 skipped)
- `pnpm -s check` (2,834 passed, 43 skipped)
- `pnpm -C apps/chrome-extension build`
- focused Prompt API unit tests and Chromium E2E: one multimodal prompt call, zero per-slide fallback calls
- live Chrome test against a long Stanford lecture and direct multi-frame Gemini Nano visual-description probes
- Codex autoreview clean after fixing daemon-token origin handling
