### PR TITLE
feat(chrome-extension): make local daemon port configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.19.1 - Unreleased
 
+### Features
+
+- Chrome extension: allow the local daemon port to be configured under **Options → Runtime → Daemon**, with consistent routing for daemon calls and authenticated slide images (#312, thanks @enieuwy).
+
 ### Fixes
 
 - Streaming: share EOF-safe, whitespace-preserving SSE parsing across core, CLI providers, and extension clients.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ YouTube slide screenshots (from the browser):
 3. Choose Browser media for daemonless transcription/slides. Optional: install the CLI and pair the daemon for native tools, CLI model fallbacks, OCR, and broader media support:
    - **npm** (cross-platform): `npm i -g @steipete/summarize`
    - **Homebrew** (Homebrew/core): `brew install summarize`
-   - `summarize daemon install --token <TOKEN>`
+   - `summarize daemon install --token <TOKEN> --port 8787`
 
 Why a daemon/service?
 
@@ -56,8 +56,9 @@ Notes:
 - Summarization only runs when the Side Panel is open.
 - Auto mode summarizes on navigation (incl. SPAs); otherwise use the button.
 - Daemon is localhost-only and requires a shared token; rerunning `summarize daemon install --token <TOKEN>` adds another paired browser token instead of invalidating the old one.
+- Non-default port: install with `summarize daemon install --token <TOKEN> --port <PORT>`, then set the same value in **Options → Runtime → Daemon → Port**.
 - Autostart: macOS (launchd), Linux (systemd user), Windows (Scheduled Task).
-- Windows containers: `summarize daemon install` starts the daemon for the current container session but does not register a Scheduled Task. Run it each time the container starts or add that command to your container startup, and publish port `8787` so the host browser can reach the daemon.
+- Windows containers: `summarize daemon install` starts the daemon for the current container session but does not register a Scheduled Task. Run it each time the container starts or add that command to your container startup, publish the configured port (default `8787`), and set the same port in the extension.
 - Tip: configure `free` via `summarize refresh-free` (needs `OPENROUTER_API_KEY`). Add `--set-default` to set model=`free`.
 
 More:
@@ -861,6 +862,7 @@ pnpm check
   - Reload the tab once.
 - "Failed to fetch" / daemon unreachable:
   - `summarize daemon status`
+  - For a non-default port, confirm **Options → Runtime → Daemon → Port** matches the daemon configuration.
   - Logs: `~/.summarize/logs/daemon.err.log`
 
 License: MIT

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -77,8 +77,9 @@ Media/slides can independently use **Browser** or **Daemon**. Browser media uses
    - Windows: Start menu → Terminal (or PowerShell) — **right-click → Run as administrator**
    - Linux: your Terminal app
 4. Paste the command from the Setup screen and press Enter.
-   - Installed binary: `summarize daemon install --token <TOKEN>`
-   - Repo/dev checkout: `pnpm summarize daemon install --token <TOKEN> --dev`
+   - Installed binary: `summarize daemon install --token <TOKEN> --port 8787`
+   - Repo/dev checkout: `pnpm summarize daemon install --token <TOKEN> --port 8787 --dev`
+   - Non-default port: replace `8787`, then enter the same port under **Options → Runtime → Daemon → Port**.
 5. Back in your browser, the Daemon runtime setup screen should disappear once the daemon is running.
 6. Verify / troubleshoot:
    - `summarize daemon status`

--- a/apps/chrome-extension/src/automation/tools/summarize.ts
+++ b/apps/chrome-extension/src/automation/tools/summarize.ts
@@ -1,6 +1,7 @@
 import { parseSseStream } from "@steipete/summarize-core/runtime";
 import { buildBrowserSummaryPayload } from "../../lib/browser-summary";
 import { fetchBrowserUrlContent } from "../../lib/browser-url-content";
+import { daemonOrigin } from "../../lib/daemon-url";
 import {
   buildDirectSummaryPrompt,
   DIRECT_SUMMARY_SYSTEM_PROMPT,
@@ -152,7 +153,8 @@ export async function executeSummarizeTool(args: SummarizeToolArgs): Promise<Sum
     body.maxCharacters = settings.maxChars;
   }
 
-  const res = await fetch("http://127.0.0.1:8787/v1/summarize", {
+  const origin = daemonOrigin(settings.daemonPort);
+  const res = await fetch(`${origin}/v1/summarize`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -174,7 +176,7 @@ export async function executeSummarizeTool(args: SummarizeToolArgs): Promise<Sum
   }
   if (!("id" in json) || !json.id) throw new Error("Missing summarize run id");
 
-  const streamRes = await fetch(`http://127.0.0.1:8787/v1/summarize/${json.id}/events`, {
+  const streamRes = await fetch(`${origin}/v1/summarize/${json.id}/events`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!streamRes.ok) throw new Error(`${streamRes.status} ${streamRes.statusText}`);

--- a/apps/chrome-extension/src/entrypoints/background/daemon-client.ts
+++ b/apps/chrome-extension/src/entrypoints/background/daemon-client.ts
@@ -1,3 +1,5 @@
+import { getDaemonOrigin } from "../../lib/daemon-url";
+
 const DAEMON_STATUS_TIMEOUT_MS = 5000;
 const DAEMON_STATUS_RETRY_DELAY_MS = 400;
 const DAEMON_STATUS_MAX_ATTEMPTS = 2;
@@ -47,9 +49,11 @@ async function withDaemonRetry(
 }
 
 export async function daemonHealth(): Promise<{ ok: boolean; error?: string }> {
+  const origin = await getDaemonOrigin();
+
   return await withDaemonRetry(
     async (signal) => {
-      return await fetch("http://127.0.0.1:8787/health", { signal });
+      return await fetch(`${origin}/health`, { signal });
     },
     {
       timeout: "Timed out",
@@ -61,9 +65,11 @@ export async function daemonHealth(): Promise<{ ok: boolean; error?: string }> {
 }
 
 export async function daemonPing(token: string): Promise<{ ok: boolean; error?: string }> {
+  const origin = await getDaemonOrigin();
+
   return await withDaemonRetry(
     async (signal) => {
-      return await fetch("http://127.0.0.1:8787/v1/ping", {
+      return await fetch(`${origin}/v1/ping`, {
         headers: { Authorization: `Bearer ${token}` },
         signal,
       });

--- a/apps/chrome-extension/src/entrypoints/background/extract-cache.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extract-cache.ts
@@ -1,4 +1,5 @@
 import { shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
+import { daemonOrigin } from "../../lib/daemon-url";
 import { createCachedExtract, type CachedExtract } from "./cached-extract";
 import type { ExtractResponse } from "./content-script-bridge";
 import { routeExtract, type ExtractLog, type ExtractorContext } from "./extractors/router";
@@ -19,6 +20,7 @@ type LoadSettingsResult = {
   slideRuntime: "browser" | "daemon";
   slidesEnabled: boolean;
   token: string;
+  daemonPort: string;
 };
 
 const MIN_CHAT_CHARS = 100;
@@ -127,8 +129,10 @@ export async function ensureChatExtract({
     slides?: SlidesPayload | null;
     error?: string;
   };
+  const origin = daemonOrigin(settings.daemonPort);
+
   try {
-    res = await fetchImpl("http://127.0.0.1:8787/v1/summarize", {
+    res = await fetchImpl(`${origin}/v1/summarize`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${settings.token.trim()}`,

--- a/apps/chrome-extension/src/entrypoints/background/extractors/url-daemon.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extractors/url-daemon.ts
@@ -1,3 +1,4 @@
+import { getDaemonOrigin } from "../../../lib/daemon-url";
 import type { Extractor, ExtractorContext, ExtractorResult } from "./types";
 
 type UrlDaemonExtractResponse = {
@@ -25,7 +26,9 @@ export const urlDaemonExtractor: Extractor = {
   name: "url-daemon",
   match: (ctx) => ctx.allowDaemon !== false && Boolean(ctx.token.trim()),
   async extract(ctx: ExtractorContext): Promise<ExtractorResult | null> {
-    const res = await ctx.fetchImpl("http://127.0.0.1:8787/v1/summarize", {
+    const origin = await getDaemonOrigin();
+
+    const res = await ctx.fetchImpl(`${origin}/v1/summarize`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${ctx.token.trim()}`,

--- a/apps/chrome-extension/src/entrypoints/background/hover-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/background/hover-controller.ts
@@ -1,5 +1,6 @@
 import { parseSseStream } from "@steipete/summarize-core/runtime";
 import { fetchBrowserUrlContent, isPublicBrowserUrl } from "../../lib/browser-url-content";
+import { daemonOrigin } from "../../lib/daemon-url";
 import { streamDirectModel } from "../../lib/direct-provider";
 import { logExtensionEvent } from "../../lib/extension-logs";
 import { resolveCapabilityExecution, resolveCapabilityModel } from "../../lib/model-routing";
@@ -192,8 +193,9 @@ ${content.text}
         mode: "url",
         timeout: "30s",
       };
+      const origin = daemonOrigin(settings.daemonPort);
 
-      const res = await fetch("http://127.0.0.1:8787/v1/summarize", {
+      const res = await fetch(`${origin}/v1/summarize`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -212,7 +214,7 @@ ${content.text}
       notifyStart({ ok: true });
       logHover("stream-start", { tabId, requestId: msg.requestId, url: msg.url, runId: json.id });
 
-      const streamRes = await fetch(`http://127.0.0.1:8787/v1/summarize/${json.id}/events`, {
+      const streamRes = await fetch(`${origin}/v1/summarize/${json.id}/events`, {
         headers: { Authorization: `Bearer ${token}` },
         signal: controller.signal,
       });

--- a/apps/chrome-extension/src/entrypoints/background/panel-chat.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-chat.ts
@@ -4,6 +4,7 @@ import type {
 } from "@steipete/summarize-core/runtime";
 import { readAgentResponse } from "../../lib/agent-response";
 import { buildChatPageContent } from "../../lib/chat-context";
+import { daemonOrigin } from "../../lib/daemon-url";
 import {
   buildDirectAgentSystemPrompt,
   normalizeDirectMessages,
@@ -167,7 +168,9 @@ export async function handlePanelAgentRequest({
       return;
     }
 
-    const res = await fetchImpl("http://127.0.0.1:8787/v1/agent", {
+    const origin = daemonOrigin(settings.daemonPort);
+
+    const res = await fetchImpl(`${origin}/v1/agent`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${settings.token.trim()}`,
@@ -259,8 +262,10 @@ export async function handlePanelChatHistoryRequest({
     summaryText,
   });
 
+  const origin = daemonOrigin(settings.daemonPort);
+
   try {
-    const res = await fetchImpl("http://127.0.0.1:8787/v1/agent/history", {
+    const res = await fetchImpl(`${origin}/v1/agent/history`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${settings.token.trim()}`,

--- a/apps/chrome-extension/src/entrypoints/background/panel-slides-context.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-slides-context.ts
@@ -1,3 +1,4 @@
+import { daemonOrigin } from "../../lib/daemon-url";
 import { logExtensionEvent } from "../../lib/extension-logs";
 import { createCachedExtract, type CachedExtract } from "./cached-extract";
 import type { PanelSession } from "./panel-session-store";
@@ -66,8 +67,10 @@ export async function handlePanelSlidesContextRequest<Recovery, Status>(options:
   let transcriptTimedText = cached?.transcriptTimedText ?? null;
 
   if (!transcriptTimedText && settings.token.trim()) {
+    const origin = daemonOrigin(settings.daemonPort);
+
     try {
-      const res = await (fetchImpl ?? fetch)("http://127.0.0.1:8787/v1/summarize", {
+      const res = await (fetchImpl ?? fetch)(`${origin}/v1/summarize`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${settings.token.trim()}`,

--- a/apps/chrome-extension/src/entrypoints/background/panel-summary-daemon.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-summary-daemon.ts
@@ -1,3 +1,4 @@
+import { daemonOrigin } from "../../lib/daemon-url";
 import type { Settings } from "../../lib/settings";
 import type { ExtractResponse } from "./content-script-bridge";
 
@@ -44,7 +45,8 @@ export async function startPanelDaemonSummary(options: {
     slidesParallel: false,
     timestamps: options.timestamps,
   });
-  const response = await options.fetchImpl("http://127.0.0.1:8787/v1/summarize", {
+  const origin = daemonOrigin(options.settings.daemonPort);
+  const response = await options.fetchImpl(`${origin}/v1/summarize`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${options.settings.token.trim()}`,

--- a/apps/chrome-extension/src/entrypoints/options/bindings.ts
+++ b/apps/chrome-extension/src/entrypoints/options/bindings.ts
@@ -1,3 +1,4 @@
+import { normalizeDaemonPort } from "../../lib/settings";
 import type { createLogsViewer } from "./logs-viewer";
 import type { createModelPresetsController } from "./model-presets";
 import type { createProcessesViewer } from "./processes-viewer";
@@ -74,6 +75,7 @@ export function bindOptionsInputs({
   elements.daemonPortEl.addEventListener("input", () => {
     window.clearTimeout(portRefreshTimer);
     portRefreshTimer = window.setTimeout(() => {
+      elements.daemonPortEl.value = normalizeDaemonPort(elements.daemonPortEl.value);
       // Persist first: the daemon origin is derived from the saved port, so the
       // status/preset/log checks below must read the new port from storage.
       void saveNow().then(() => {

--- a/apps/chrome-extension/src/entrypoints/options/bindings.ts
+++ b/apps/chrome-extension/src/entrypoints/options/bindings.ts
@@ -6,6 +6,7 @@ type OptionsBindingsArgs = {
   elements: {
     formEl: HTMLFormElement;
     tokenEl: HTMLInputElement;
+    daemonPortEl: HTMLInputElement;
     tokenCopyBtn: HTMLButtonElement;
     modelPresetEl: HTMLSelectElement;
     modelCustomEl: HTMLInputElement;
@@ -67,6 +68,21 @@ export function bindOptionsInputs({
       processesViewer.handleTokenChanged();
     }, 350);
     scheduleAutoSave(600);
+  });
+
+  let portRefreshTimer = 0;
+  elements.daemonPortEl.addEventListener("input", () => {
+    window.clearTimeout(portRefreshTimer);
+    portRefreshTimer = window.setTimeout(() => {
+      // Persist first: the daemon origin is derived from the saved port, so the
+      // status/preset/log checks below must read the new port from storage.
+      void saveNow().then(() => {
+        void modelPresets.refreshPresets(elements.tokenEl.value);
+        void checkDaemonStatus(elements.tokenEl.value);
+        logsViewer.handleTokenChanged();
+        processesViewer.handleTokenChanged();
+      });
+    }, 500);
   });
 
   elements.tokenCopyBtn.addEventListener("click", () => {

--- a/apps/chrome-extension/src/entrypoints/options/daemon-status.ts
+++ b/apps/chrome-extension/src/entrypoints/options/daemon-status.ts
@@ -1,3 +1,5 @@
+import { getDaemonOrigin } from "../../lib/daemon-url";
+
 const DAEMON_STATUS_TIMEOUT_MS = 5000;
 const DAEMON_STATUS_RETRY_DELAY_MS = 400;
 const DAEMON_STATUS_MAX_ATTEMPTS = 2;
@@ -78,7 +80,8 @@ export function createDaemonStatusChecker({
     setDaemonStatus("Checking daemon…");
 
     try {
-      const res = await fetchWithRetry("http://127.0.0.1:8787/health");
+      const origin = await getDaemonOrigin();
+      const res = await fetchWithRetry(`${origin}/health`);
       if (checkId !== daemonCheckId) return;
       if (!res.ok) {
         setDaemonStatus(
@@ -93,7 +96,7 @@ export function createDaemonStatusChecker({
       const versionNote = daemonVersion ? `v${daemonVersion}` : "version unknown";
 
       try {
-        const ping = await fetchWithRetry("http://127.0.0.1:8787/v1/ping", {
+        const ping = await fetchWithRetry(`${origin}/v1/ping`, {
           headers: { Authorization: `Bearer ${trimmedToken}` },
         });
         if (checkId !== daemonCheckId) return;

--- a/apps/chrome-extension/src/entrypoints/options/elements.ts
+++ b/apps/chrome-extension/src/entrypoints/options/elements.ts
@@ -11,6 +11,7 @@ export function getOptionsElements() {
     formEl: byId<HTMLFormElement>("form"),
     statusEl: byId<HTMLSpanElement>("status"),
     tokenEl: byId<HTMLInputElement>("token"),
+    daemonPortEl: byId<HTMLInputElement>("daemonPort"),
     tokenCopyBtn: byId<HTMLButtonElement>("tokenCopy"),
     summaryRuntimeModeRoot: byId<HTMLDivElement>("summaryRuntimeMode"),
     providerEl: byId<HTMLSelectElement>("provider"),

--- a/apps/chrome-extension/src/entrypoints/options/form-state.ts
+++ b/apps/chrome-extension/src/entrypoints/options/form-state.ts
@@ -5,6 +5,7 @@ import type { createModelPresetsController } from "./model-presets";
 
 type FormElements = {
   tokenEl: HTMLInputElement;
+  daemonPortEl: HTMLInputElement;
   providerEl: HTMLSelectElement;
   providerApiKeyEl: HTMLInputElement;
   providerBaseUrlEl: HTMLInputElement;
@@ -60,6 +61,7 @@ export function buildSavedOptionsSettings({
 }): Settings {
   return {
     token: elements.tokenEl.value || defaults.token,
+    daemonPort: elements.daemonPortEl.value || defaults.daemonPort,
     summaryRuntime: booleans.summaryRuntime,
     provider: elements.providerEl.value as DirectProvider,
     providerApiKeys: {
@@ -127,6 +129,7 @@ export function applyLoadedOptionsSettings({
   elements: FormElements;
 }) {
   elements.tokenEl.value = settings.token;
+  elements.daemonPortEl.value = settings.daemonPort;
   elements.providerEl.value = settings.provider;
   elements.providerApiKeyEl.value = settings.providerApiKeys[settings.provider] ?? "";
   elements.providerBaseUrlEl.value = settings.providerBaseUrls[settings.provider] ?? "";

--- a/apps/chrome-extension/src/entrypoints/options/index.html
+++ b/apps/chrome-extension/src/entrypoints/options/index.html
@@ -280,7 +280,22 @@
           </section>
 
           <section class="section">
-            <h2>Daemon token</h2>
+            <h2>Daemon</h2>
+            <label>
+              <span>Port</span>
+              <input
+                id="daemonPort"
+                type="number"
+                min="1"
+                max="65535"
+                inputmode="numeric"
+                placeholder="8787"
+              />
+            </label>
+            <div class="hint">
+              Local Summarize daemon port (default 8787). Must match the running daemon — see
+              <code>summarize daemon status</code>.
+            </div>
             <label>
               <span>Token</span>
               <div class="inputRow">

--- a/apps/chrome-extension/src/entrypoints/options/logs-viewer.ts
+++ b/apps/chrome-extension/src/entrypoints/options/logs-viewer.ts
@@ -1,3 +1,4 @@
+import { getDaemonOrigin } from "../../lib/daemon-url";
 import { readExtensionLogs } from "../../lib/extension-logs";
 
 type LogLevel = "info" | "warn" | "error" | "verbose";
@@ -335,8 +336,9 @@ export function createLogsViewer(options: LogsViewerOptions): LogsViewer {
         setLines(result.lines);
         return;
       }
+      const origin = await getDaemonOrigin();
 
-      const url = new URL("http://127.0.0.1:8787/v1/logs");
+      const url = new URL(`${origin}/v1/logs`);
       url.searchParams.set("source", source);
       url.searchParams.set("tail", String(tail));
       const res = await (fetchImpl ?? fetch)(url.toString(), {

--- a/apps/chrome-extension/src/entrypoints/options/main.ts
+++ b/apps/chrome-extension/src/entrypoints/options/main.ts
@@ -28,6 +28,7 @@ const {
   formEl,
   statusEl,
   tokenEl,
+  daemonPortEl,
   tokenCopyBtn,
   summaryRuntimeModeRoot,
   providerEl,
@@ -221,6 +222,7 @@ let booleanSettings: ReturnType<typeof createBooleanSettingsRuntime> | null = nu
 let refreshRuntimeStatus = (_token = tokenEl.value) => {};
 const settingsElements = {
   tokenEl,
+  daemonPortEl,
   providerEl,
   providerApiKeyEl,
   providerBaseUrlEl,
@@ -487,6 +489,7 @@ bindOptionsInputs({
   elements: {
     formEl,
     tokenEl,
+    daemonPortEl,
     tokenCopyBtn,
     modelPresetEl,
     modelCustomEl,

--- a/apps/chrome-extension/src/entrypoints/options/model-presets.ts
+++ b/apps/chrome-extension/src/entrypoints/options/model-presets.ts
@@ -1,3 +1,5 @@
+import { getDaemonOrigin } from "../../lib/daemon-url";
+
 export function createModelPresetsController({
   presetEl,
   customEl,
@@ -118,7 +120,8 @@ export function createModelPresetsController({
       return;
     }
     try {
-      const res = await fetchImpl("http://127.0.0.1:8787/v1/models", {
+      const origin = await getDaemonOrigin();
+      const res = await fetchImpl(`${origin}/v1/models`, {
         headers: { Authorization: `Bearer ${trimmed}` },
       });
       if (!isCurrentRequest()) return;

--- a/apps/chrome-extension/src/entrypoints/options/persistence.ts
+++ b/apps/chrome-extension/src/entrypoints/options/persistence.ts
@@ -9,6 +9,7 @@ export function createOptionsSaveRuntime(options: {
   let saveInFlight = false;
   let saveQueued = false;
   let saveSequence = 0;
+  let queuedResolvers: Array<() => void> = [];
 
   const formatSaveError = (error: unknown) => {
     const message = error instanceof Error ? error.message.trim() : String(error).trim();
@@ -17,7 +18,13 @@ export function createOptionsSaveRuntime(options: {
 
   const saveNow = async () => {
     if (saveInFlight) {
+      // A save is already running. Queue one follow-up that captures the latest
+      // form state and resolve this call only after that write commits, so
+      // callers awaiting saveNow() observe the persisted result.
       saveQueued = true;
+      await new Promise<void>((resolve) => {
+        queuedResolvers.push(resolve);
+      });
       return;
     }
     saveInFlight = true;
@@ -37,7 +44,13 @@ export function createOptionsSaveRuntime(options: {
       saveInFlight = false;
       if (saveQueued) {
         saveQueued = false;
-        void saveNow();
+        const resolvers = queuedResolvers;
+        queuedResolvers = [];
+        void saveNow().finally(() => {
+          for (const resolve of resolvers) {
+            resolve();
+          }
+        });
       }
     }
   };

--- a/apps/chrome-extension/src/entrypoints/options/processes-viewer.ts
+++ b/apps/chrome-extension/src/entrypoints/options/processes-viewer.ts
@@ -1,3 +1,5 @@
+import { getDaemonOrigin } from "../../lib/daemon-url";
+
 type ProcessStatus = "running" | "exited" | "error";
 
 type ProcessListItem = {
@@ -215,7 +217,8 @@ export function createProcessesViewer(options: ProcessesViewerOptions): Processe
     const stream =
       streamEl.value === "stdout" || streamEl.value === "stderr" ? streamEl.value : "merged";
     try {
-      const url = new URL(`http://127.0.0.1:8787/v1/processes/${requestedId}/logs`);
+      const origin = await getDaemonOrigin();
+      const url = new URL(`${origin}/v1/processes/${requestedId}/logs`);
       url.searchParams.set("tail", String(tail));
       url.searchParams.set("stream", stream);
       const res = await (fetchImpl ?? fetch)(url.toString(), {
@@ -265,7 +268,8 @@ export function createProcessesViewer(options: ProcessesViewerOptions): Processe
       setMeta("Loading processes…");
     }
     try {
-      const url = new URL("http://127.0.0.1:8787/v1/processes");
+      const origin = await getDaemonOrigin();
+      const url = new URL(`${origin}/v1/processes`);
       url.searchParams.set("includeCompleted", showCompletedEl.checked ? "true" : "false");
       url.searchParams.set("limit", String(limit));
       const res = await (fetchImpl ?? fetch)(url.toString(), {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-slides-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-slides-runtime.ts
@@ -1,4 +1,5 @@
 import { normalizeBrowserAiGeneratedPoints } from "../../lib/browser-summary";
+import { daemonOrigin } from "../../lib/daemon-url";
 import { logExtensionEvent } from "../../lib/extension-logs";
 import { isGeminiNanoModel } from "../../lib/model-routing";
 import { loadSettings } from "../../lib/settings";
@@ -27,7 +28,6 @@ type GeneratedSummary = {
 };
 
 const MODEL_LABEL = "Gemini Nano";
-const DAEMON_ORIGIN = "http://127.0.0.1:8787";
 const MAX_BATCH_SUMMARY_CHARS = 260;
 const REQUESTED_BATCH_SUMMARY_CHARS = 180;
 
@@ -178,10 +178,10 @@ function parseBatchResult(value: string, slides: SlideSource[]): Map<number, str
   return parsed;
 }
 
-function isDaemonSlideUrl(imageUrl: string): boolean {
+function isDaemonSlideUrl(imageUrl: string, origin: string): boolean {
   try {
     const url = new URL(imageUrl);
-    return url.origin === DAEMON_ORIGIN && url.pathname.startsWith("/v1/slides/");
+    return url.origin === origin && url.pathname.startsWith("/v1/slides/");
   } catch {
     return false;
   }
@@ -190,9 +190,10 @@ function isDaemonSlideUrl(imageUrl: string): boolean {
 async function loadSlideImage(imageUrl: string): Promise<Blob | null> {
   if (!imageUrl) return null;
   try {
+    const settings = await loadSettings();
     const headers = new Headers();
-    if (isDaemonSlideUrl(imageUrl)) {
-      const token = (await loadSettings()).token.trim();
+    if (isDaemonSlideUrl(imageUrl, daemonOrigin(settings.daemonPort))) {
+      const token = settings.token.trim();
       if (token) headers.set("Authorization", `Bearer ${token}`);
     }
     const response = await fetch(imageUrl, { headers });

--- a/apps/chrome-extension/src/entrypoints/sidepanel/model-presets.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/model-presets.ts
@@ -1,5 +1,6 @@
 import { parseSseStream } from "@steipete/summarize-core/runtime";
 import { readPresetOrCustomValue } from "../../lib/combo";
+import { daemonOrigin, getDaemonOrigin } from "../../lib/daemon-url";
 import { parseSseEvent } from "../../lib/runtime-contracts";
 import type { Settings } from "../../lib/settings";
 
@@ -145,7 +146,8 @@ export function createModelPresetsController({
       return;
     }
     try {
-      const response = await fetch("http://127.0.0.1:8787/v1/models", {
+      const origin = await getDaemonOrigin();
+      const response = await fetch(`${origin}/v1/models`, {
         headers: { Authorization: `Bearer ${trimmed}` },
       });
       if (!isCurrentRequest()) return;
@@ -216,7 +218,9 @@ export function createModelPresetsController({
 
   const runRefreshFree = async () => {
     if (refreshFreeRunning) return;
-    const token = (await loadSettings()).token.trim();
+    const settings = await loadSettings();
+    const token = settings.token.trim();
+    const origin = daemonOrigin(settings.daemonPort);
     if (!token) {
       setStatus("Setup required (missing token).", "error");
       return;
@@ -227,7 +231,7 @@ export function createModelPresetsController({
     let winnerModel: string | null = null;
 
     try {
-      const response = await fetch("http://127.0.0.1:8787/v1/refresh-free", {
+      const response = await fetch(`${origin}/v1/refresh-free`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -240,10 +244,9 @@ export function createModelPresetsController({
         throw new Error(json.error || `${response.status} ${response.statusText}`);
       }
 
-      const streamResponse = await fetch(
-        `http://127.0.0.1:8787/v1/refresh-free/${json.id}/events`,
-        { headers: { Authorization: `Bearer ${token}` } },
-      );
+      const streamResponse = await fetch(`${origin}/v1/refresh-free/${json.id}/events`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
       if (!streamResponse.ok)
         throw new Error(`${streamResponse.status} ${streamResponse.statusText}`);
       if (!streamResponse.body) throw new Error("Missing stream body");

--- a/apps/chrome-extension/src/entrypoints/sidepanel/setup-controls-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/setup-controls-runtime.ts
@@ -69,6 +69,7 @@ export function createSetupControlsRuntime({
   const setupRuntime = createSetupRuntime({
     setupEl,
     loadToken: async () => (await loadSettings()).token.trim(),
+    loadDaemonPort: async () => (await loadSettings()).daemonPort,
     ensureToken,
     patchSettings,
     generateToken,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/setup-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/setup-runtime.ts
@@ -28,6 +28,7 @@ export function friendlyFetchError(err: unknown, context: string): string {
 export function createSetupRuntime(options: {
   setupEl: HTMLDivElement;
   loadToken: () => Promise<string>;
+  loadDaemonPort: () => Promise<string>;
   ensureToken: () => Promise<string>;
   patchSettings: typeof import("../../lib/settings").patchSettings;
   generateToken: typeof import("../../lib/token").generateToken;
@@ -36,7 +37,7 @@ export function createSetupRuntime(options: {
 }) {
   const platformKind = resolvePlatformKind();
 
-  const renderSetup = (
+  const renderSetup = async (
     token: string,
     copy: {
       headline: string;
@@ -47,9 +48,11 @@ export function createSetupRuntime(options: {
         "Install summarize, then register the daemon so the side panel can stream summaries.",
     },
   ) => {
+    const daemonPort = await options.loadDaemonPort();
     options.setupEl.classList.remove("hidden");
     options.setupEl.innerHTML = installStepsHtml({
       token,
+      daemonPort,
       headline: copy.headline,
       message: copy.message,
       platformKind,
@@ -57,12 +60,15 @@ export function createSetupRuntime(options: {
     wireSetupButtons({
       setupEl: options.setupEl,
       token,
+      daemonPort,
       platformKind,
       headerSetStatus: options.headerSetStatus,
       getStatusResetText: options.getStatusResetText,
       patchSettings: options.patchSettings,
       generateToken: options.generateToken,
-      renderSetup: (nextToken) => renderSetup(nextToken, copy),
+      renderSetup: (nextToken) => {
+        void renderSetup(nextToken, copy);
+      },
     });
   };
 
@@ -98,16 +104,18 @@ export function createSetupRuntime(options: {
           };
     if (!state.settings.tokenPresent) {
       void options.ensureToken().then((token) => {
-        renderSetup(token, copy);
+        void renderSetup(token, copy);
       });
       return display;
     }
     if (!state.daemon.ok || !state.daemon.authed) {
       options.setupEl.classList.remove("hidden");
-      void options.loadToken().then((token) => {
-        options.setupEl.innerHTML = `
+      void Promise.all([options.loadToken(), options.loadDaemonPort()]).then(
+        ([token, daemonPort]) => {
+          options.setupEl.innerHTML = `
           ${installStepsHtml({
             token,
+            daemonPort,
             headline:
               display === "advisory" ? "Daemon capabilities unavailable" : "Daemon not reachable",
             message: state.daemon.error ?? "Check that the LaunchAgent is installed.",
@@ -115,17 +123,21 @@ export function createSetupRuntime(options: {
             showTroubleshooting: true,
           })}
         `;
-        wireSetupButtons({
-          setupEl: options.setupEl,
-          token,
-          platformKind,
-          headerSetStatus: options.headerSetStatus,
-          getStatusResetText: options.getStatusResetText,
-          patchSettings: options.patchSettings,
-          generateToken: options.generateToken,
-          renderSetup: (nextToken) => renderSetup(nextToken, copy),
-        });
-      });
+          wireSetupButtons({
+            setupEl: options.setupEl,
+            token,
+            daemonPort,
+            platformKind,
+            headerSetStatus: options.headerSetStatus,
+            getStatusResetText: options.getStatusResetText,
+            patchSettings: options.patchSettings,
+            generateToken: options.generateToken,
+            renderSetup: (nextToken) => {
+              void renderSetup(nextToken, copy);
+            },
+          });
+        },
+      );
       return display;
     }
     options.setupEl.classList.add("hidden");

--- a/apps/chrome-extension/src/entrypoints/sidepanel/setup-view.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/setup-view.ts
@@ -4,12 +4,14 @@ type PlatformKind = "mac" | "windows" | "linux" | "other";
 
 export function installStepsHtml({
   token,
+  daemonPort,
   headline,
   message,
   platformKind,
   showTroubleshooting,
 }: {
   token: string;
+  daemonPort: string;
   headline: string;
   message?: string;
   platformKind: PlatformKind;
@@ -17,7 +19,7 @@ export function installStepsHtml({
 }) {
   const npmCmd = "npm i -g @steipete/summarize";
   const brewCmd = "brew install summarize";
-  const daemonCmd = `summarize daemon install --token ${token}`;
+  const daemonCmd = `summarize daemon install --token ${token} --port ${daemonPort}`;
   const isMac = platformKind === "mac";
   const isLinux = platformKind === "linux";
   const isWindows = platformKind === "windows";
@@ -124,6 +126,7 @@ export function installStepsHtml({
 export function wireSetupButtons({
   setupEl,
   token,
+  daemonPort,
   platformKind,
   headerSetStatus,
   getStatusResetText,
@@ -133,6 +136,7 @@ export function wireSetupButtons({
 }: {
   setupEl: HTMLElement;
   token: string;
+  daemonPort: string;
   platformKind: PlatformKind;
   headerSetStatus: (text: string) => void;
   getStatusResetText: () => string;
@@ -142,7 +146,7 @@ export function wireSetupButtons({
 }) {
   const npmCmd = "npm i -g @steipete/summarize";
   const brewCmd = "brew install summarize";
-  const daemonCmd = `summarize daemon install --token ${token}`;
+  const daemonCmd = `summarize daemon install --token ${token} --port ${daemonPort}`;
   const isMac = platformKind === "mac";
   const installMethodKey = "summarize.installMethod";
   type InstallMethod = "npm" | "brew";

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slide-images.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slide-images.ts
@@ -1,3 +1,4 @@
+import { daemonOrigin } from "../../lib/daemon-url";
 import { logExtensionEvent } from "../../lib/extension-logs";
 import { loadSettings, type Settings } from "../../lib/settings";
 
@@ -10,7 +11,18 @@ export function normalizeSlideImageUrl(
   index: number,
 ): string {
   if (!imageUrl) return "";
-  const stablePrefix = `http://127.0.0.1:8787/v1/slides/${sourceId}`;
+  if (!imageUrl.includes("/v1/slides/") && !imageUrl.includes("/v1/summarize/")) return imageUrl;
+  let url: URL;
+  try {
+    url = new URL(imageUrl);
+  } catch {
+    return imageUrl;
+  }
+  // Only ever rewrite URLs served by the local daemon (127.0.0.1). Never turn a
+  // foreign-origin, daemon-shaped URL into a stable daemon URL — the loader below
+  // attaches the daemon token, which must stay on the local daemon origin.
+  if (url.hostname !== "127.0.0.1") return imageUrl;
+  const stablePrefix = `${url.origin}/v1/slides/${sourceId}`;
   if (imageUrl.startsWith(stablePrefix)) return imageUrl;
   if (!imageUrl.includes("/v1/summarize/")) return imageUrl;
   const queryIndex = imageUrl.indexOf("?");
@@ -99,6 +111,15 @@ export function createSlideImageLoader(
         const settings = await loadSettingsFn();
         const token = settings.token.trim();
         if (!token) return null;
+        // Never send the daemon bearer token anywhere but the configured local
+        // daemon origin, even if a slide payload carries a foreign-origin URL.
+        let sameDaemonOrigin = false;
+        try {
+          sameDaemonOrigin = new URL(imageUrl).origin === daemonOrigin(settings.daemonPort);
+        } catch {
+          return null;
+        }
+        if (!sameDaemonOrigin) return null;
         const res = await fetch(imageUrl, { headers: { Authorization: `Bearer ${token}` } });
         if (!res.ok) {
           if (settings.extendedLogging) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-hydrator.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-hydrator.ts
@@ -1,3 +1,4 @@
+import { getDaemonOrigin } from "../../lib/daemon-url";
 import type { SseSlidesData } from "../../lib/runtime-contracts";
 import { normalizeSlidesPayload } from "./slides-payload";
 import {
@@ -82,10 +83,10 @@ export function createSlidesHydrator(options: SlidesHydratorOptions): SlidesHydr
       }
       const token = (await getToken()).trim();
       if (!token) return;
-      const res = await (snapshotFetchImpl ?? fetch)(
-        `http://127.0.0.1:8787/v1/summarize/${runId}/slides`,
-        { headers: { Authorization: `Bearer ${token}` } },
-      );
+      const origin = await getDaemonOrigin();
+      const res = await (snapshotFetchImpl ?? fetch)(`${origin}/v1/summarize/${runId}/slides`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
       if (!res.ok) return;
       const json = (await res.json()) as SnapshotResponse;
       if (!json?.ok || !json.slides) return;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-stream-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-stream-controller.ts
@@ -1,4 +1,5 @@
 import { parseSseStream, type RawSseMessage } from "@steipete/summarize-core/runtime";
+import { getDaemonOrigin } from "../../lib/daemon-url";
 import { parseSseEvent, type SseSlidesData } from "../../lib/runtime-contracts";
 
 export type SlidesStreamController = {
@@ -73,13 +74,11 @@ export function createSlidesStreamController(
     let sawDone = false;
 
     try {
-      const res = await (fetchImpl ?? fetch)(
-        `http://127.0.0.1:8787/v1/summarize/${runId}/slides/events`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-          signal: nextController.signal,
-        },
-      );
+      const origin = await getDaemonOrigin();
+      const res = await (fetchImpl ?? fetch)(`${origin}/v1/summarize/${runId}/slides/events`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: nextController.signal,
+      });
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
       if (!res.body) throw new Error("Missing stream body");
 

--- a/apps/chrome-extension/src/entrypoints/sidepanel/stream-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/stream-controller.ts
@@ -1,4 +1,5 @@
 import { parseSseStream, type RawSseMessage } from "@steipete/summarize-core/runtime";
+import { getDaemonOrigin } from "../../lib/daemon-url";
 import { parseSseEvent, type SseMetaData, type SseSlidesData } from "../../lib/runtime-contracts";
 import {
   accumulateChatChunk,
@@ -174,13 +175,11 @@ export function createStreamController(options: StreamControllerOptions): Stream
     onStatus("Connecting…");
 
     try {
-      const res = await (fetchImpl ?? fetch)(
-        `http://127.0.0.1:8787/v1/summarize/${run.id}/events`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-          signal: nextController.signal,
-        },
-      );
+      const origin = await getDaemonOrigin();
+      const res = await (fetchImpl ?? fetch)(`${origin}/v1/summarize/${run.id}/events`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: nextController.signal,
+      });
       if (generation !== activeGeneration) return;
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
       if (!res.body) throw new Error("Missing stream body");

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime.ts
@@ -1,3 +1,4 @@
+import { getDaemonOrigin } from "../../lib/daemon-url";
 import type { Settings, SlidesLayout } from "../../lib/settings";
 import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
 import type { SlideTextMode } from "./slides-state";
@@ -42,7 +43,8 @@ async function fetchSlideTools(
 ): Promise<{ ok: boolean; missing: string[] }> {
   const token = tokenValue.trim();
   if (!token) return { ok: false, missing: ["daemon token"] };
-  const res = await fetch("http://127.0.0.1:8787/v1/tools", {
+  const origin = await getDaemonOrigin();
+  const res = await fetch(`${origin}/v1/tools`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) return { ok: false, missing: ["daemon tools endpoint"] };

--- a/apps/chrome-extension/src/lib/daemon-url.ts
+++ b/apps/chrome-extension/src/lib/daemon-url.ts
@@ -11,7 +11,7 @@ import { loadSettings } from "./settings";
 
 /** Build the daemon origin (scheme + host + port) for an explicit port. */
 export function daemonOrigin(port: string): string {
-  return `http://127.0.0.1:${port}`;
+  return new URL(`http://127.0.0.1:${port}`).origin;
 }
 
 /** Resolve the daemon origin from stored settings (defaults to port 8787). */

--- a/apps/chrome-extension/src/lib/daemon-url.ts
+++ b/apps/chrome-extension/src/lib/daemon-url.ts
@@ -1,0 +1,21 @@
+import { loadSettings } from "./settings";
+
+/**
+ * Single source of truth for the local Summarize daemon origin.
+ *
+ * The daemon listens on 127.0.0.1 and its port is user-configurable via
+ * settings (`daemonPort`, default 8787). Never hardcode the origin: build it
+ * from the configured port so a non-default daemon port keeps the extension
+ * working.
+ */
+
+/** Build the daemon origin (scheme + host + port) for an explicit port. */
+export function daemonOrigin(port: string): string {
+  return `http://127.0.0.1:${port}`;
+}
+
+/** Resolve the daemon origin from stored settings (defaults to port 8787). */
+export async function getDaemonOrigin(): Promise<string> {
+  const { daemonPort } = await loadSettings();
+  return daemonOrigin(daemonPort);
+}

--- a/apps/chrome-extension/src/lib/settings.ts
+++ b/apps/chrome-extension/src/lib/settings.ts
@@ -18,6 +18,7 @@ type TranscriberSetting = "" | NonNullable<SummarizeRequestOverrides["transcribe
 
 export type Settings = {
   token: string;
+  daemonPort: string;
   summaryRuntime: SummaryRuntime;
   provider: DirectProvider;
   providerApiKeys: Partial<Record<DirectProvider, string>>;
@@ -86,6 +87,7 @@ export const MAX_MAX_CHARS = 2_000_000;
 const MIN_MAX_OUTPUT_TOKENS = 16;
 const MIN_FONT_SIZE = 12;
 const MAX_FONT_SIZE = 20;
+export const DEFAULT_DAEMON_PORT = "8787";
 
 const legacyFontFamilyMap = new Map<string, string>([
   [
@@ -365,8 +367,18 @@ function normalizeLineHeight(value: unknown): number {
   return Math.round(value * 100) / 100;
 }
 
+function normalizeDaemonPort(value: unknown): string {
+  if (typeof value !== "string" && typeof value !== "number") return DEFAULT_DAEMON_PORT;
+  const trimmed = String(value).trim();
+  if (!/^\d+$/.test(trimmed)) return DEFAULT_DAEMON_PORT;
+  const port = Number(trimmed);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return DEFAULT_DAEMON_PORT;
+  return String(port);
+}
+
 export const defaultSettings: Settings = {
   token: "",
+  daemonPort: DEFAULT_DAEMON_PORT,
   summaryRuntime: "direct",
   provider: "openai",
   providerApiKeys: {},
@@ -414,6 +426,7 @@ export async function loadSettings(): Promise<Settings> {
     ...defaultSettings,
     ...raw,
     token: typeof raw.token === "string" ? raw.token : defaultSettings.token,
+    daemonPort: normalizeDaemonPort(raw.daemonPort),
     summaryRuntime: normalizeSummaryRuntime(raw.summaryRuntime, raw),
     provider: normalizeProvider(raw.provider),
     providerApiKeys: normalizeProviderMap(raw.providerApiKeys),
@@ -487,6 +500,7 @@ export async function loadSettings(): Promise<Settings> {
 export async function saveSettings(settings: Settings): Promise<void> {
   const normalized = {
     ...settings,
+    daemonPort: normalizeDaemonPort(settings.daemonPort),
     summaryRuntime: normalizeSummaryRuntime(settings.summaryRuntime),
     provider: normalizeProvider(settings.provider),
     providerApiKeys: normalizeProviderMap(settings.providerApiKeys),

--- a/apps/chrome-extension/src/lib/settings.ts
+++ b/apps/chrome-extension/src/lib/settings.ts
@@ -367,7 +367,7 @@ function normalizeLineHeight(value: unknown): number {
   return Math.round(value * 100) / 100;
 }
 
-function normalizeDaemonPort(value: unknown): string {
+export function normalizeDaemonPort(value: unknown): string {
   if (typeof value !== "string" && typeof value !== "number") return DEFAULT_DAEMON_PORT;
   const trimmed = String(value).trim();
   if (!/^\d+$/.test(trimmed)) return DEFAULT_DAEMON_PORT;

--- a/apps/chrome-extension/tests/options.spec.ts
+++ b/apps/chrome-extension/tests/options.spec.ts
@@ -404,6 +404,9 @@ test("options persists a custom daemon port", async ({ browserName: _browserName
         return settings.daemonPort;
       })
       .toBe("8788");
+    await page.locator("#daemonPort").fill("65536");
+    await expect(page.locator("#daemonPort")).toHaveValue("8787");
+    await expect.poll(async () => (await getSettings(harness)).daemonPort).toBe("8787");
     assertNoErrors(harness);
   } finally {
     await closeExtension(harness.context, harness.userDataDir);

--- a/apps/chrome-extension/tests/options.spec.ts
+++ b/apps/chrome-extension/tests/options.spec.ts
@@ -198,7 +198,8 @@ test("options exposes two AI connections and independent slide runtimes", async 
     await expect(page.locator("#modelPreset")).toContainText("Gemini Nano (on-device)");
     await page.click("#tab-runtime");
     await expect(page.locator("#panel-runtime")).toContainText("Browser cache");
-    await expect(page.locator("#panel-runtime")).toContainText("Daemon token");
+    await expect(page.locator("#panel-runtime #daemonPort")).toBeVisible();
+    await expect(page.locator("#panel-runtime #token")).toBeVisible();
     await expect(page.locator("#panel-runtime")).not.toContainText("Show summary first");
     await expect(page.locator("#browserCacheStatus")).toContainText(/entries? · /);
     await page.locator("#browserCacheClear").click();
@@ -382,6 +383,27 @@ test("options footer links to summarize site", async ({ browserName: _browserNam
     const page = await openExtensionPage(harness, "options.html", "#tabs");
     const summarizeLink = page.locator(".pageFooter a", { hasText: "Summarize" });
     await expect(summarizeLink).toHaveAttribute("href", /summarize\.sh/);
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
+test("options persists a custom daemon port", async ({ browserName: _browserName }, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, { daemonPort: "9931" });
+    const page = await openExtensionPage(harness, "options.html", "#tabs");
+    await page.click("#tab-runtime");
+    await expect(page.locator("#daemonPort")).toHaveValue("9931");
+    await page.locator("#daemonPort").fill("8788");
+    await expect
+      .poll(async () => {
+        const settings = await getSettings(harness);
+        return settings.daemonPort;
+      })
+      .toBe("8788");
     assertNoErrors(harness);
   } finally {
     await closeExtension(harness.context, harness.userDataDir);

--- a/apps/chrome-extension/tests/sidepanel.slides-stream.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.slides-stream.spec.ts
@@ -518,3 +518,143 @@ test("sidepanel streams split slide summary chunks into gallery cards", async ({
     await closeExtension(harness.context, harness.userDataDir);
   }
 });
+
+test("daemon slides use the configured port and never leak the token off-origin", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, {
+      token: "test-token",
+      daemonPort: "8799",
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+    });
+    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+    await waitForPanelPort(page);
+    await waitForSettingsHydratedHook(page);
+
+    const sseBody = (text: string) =>
+      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+        "\n",
+      );
+
+    // Summary + slides streams are served only from the CONFIGURED port (8799): if the
+    // extension still hardcoded 8787 these routes would never be hit and the run would stall.
+    await page.route("http://127.0.0.1:8799/v1/summarize/run-x/events", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: sseBody("Summary X"),
+      });
+    });
+
+    const slidesPayload = {
+      sourceUrl: "https://www.youtube.com/watch?v=port123",
+      sourceId: "port-run",
+      sourceKind: "youtube",
+      ocrAvailable: true,
+      slides: [
+        {
+          index: 1,
+          timestamp: 0,
+          imageUrl: "http://127.0.0.1:8799/v1/slides/port-run/1?v=1",
+          ocrText: "Daemon slide one has enough OCR text to pass thresholds.",
+        },
+        {
+          index: 2,
+          timestamp: 10,
+          // Hostile daemon-shaped URL on a foreign origin: must never receive the token.
+          imageUrl: "http://evil.test/v1/summarize/port-run/2?v=1",
+          ocrText: "Foreign slide two has enough OCR text to pass thresholds.",
+        },
+      ],
+    };
+    const slidesStreamBody = [
+      "event: slides",
+      `data: ${JSON.stringify(slidesPayload)}`,
+      "",
+      "event: done",
+      "data: {}",
+      "",
+    ].join("\n");
+    await page.route("http://127.0.0.1:8799/v1/summarize/run-x/slides/events", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: slidesStreamBody,
+      });
+    });
+
+    const placeholderPng = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+      "base64",
+    );
+    let daemonImageRequests = 0;
+    let daemonImageAuth: string | null = null;
+    await page.route("http://127.0.0.1:8799/v1/slides/**", async (route) => {
+      daemonImageRequests += 1;
+      daemonImageAuth = route.request().headers().authorization ?? null;
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "image/png", "x-summarize-slide-ready": "1" },
+        body: placeholderPng,
+      });
+    });
+    let foreignImageRequests = 0;
+    let foreignImageAuth: string | null = null;
+    await page.route("http://evil.test/**", async (route) => {
+      foreignImageRequests += 1;
+      foreignImageAuth = route.request().headers().authorization ?? null;
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "image/png", "x-summarize-slide-ready": "1" },
+        body: placeholderPng,
+      });
+    });
+
+    const tabState = buildUiState({
+      tab: { id: 1, url: "https://www.youtube.com/watch?v=port123", title: "Port Video" },
+      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+      settings: {
+        autoSummarize: false,
+        slidesEnabled: true,
+        slidesParallel: true,
+        slidesOcrEnabled: true,
+        tokenPresent: true,
+      },
+    });
+    await sendBgMessage(harness, { type: "ui:state", state: tabState });
+    await sendBgMessage(harness, {
+      type: "run:start",
+      run: {
+        id: "run-x",
+        url: "https://www.youtube.com/watch?v=port123",
+        title: "Port Video",
+        model: "auto",
+        reason: "manual",
+        slides: true,
+      },
+    });
+
+    // Custom-port proof: the run streams from 8799 and renders both slides.
+    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary X");
+    await expect
+      .poll(async () => (await getPanelSlideDescriptions(page)).length)
+      .toBeGreaterThanOrEqual(2);
+    await expect.poll(() => daemonImageRequests).toBeGreaterThanOrEqual(1);
+    expect(daemonImageAuth).toBe("Bearer test-token");
+
+    // Security: the daemon token never follows a foreign-origin slide URL.
+    await page.waitForTimeout(500);
+    expect(foreignImageRequests).toBe(0);
+    expect(foreignImageAuth).toBeNull();
+
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});

--- a/apps/chrome-extension/wxt.config.ts
+++ b/apps/chrome-extension/wxt.config.ts
@@ -100,7 +100,7 @@ export default defineConfig({
         ...(browser === "firefox" ? [] : ["debugger" as const]),
       ],
       optional_permissions: browser === "firefox" ? ["userScripts"] : [],
-      host_permissions: ["<all_urls>", "http://127.0.0.1:8787/*"],
+      host_permissions: ["<all_urls>", "http://127.0.0.1/*"],
       background: {
         type: "module",
         service_worker: "background.js",

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -21,7 +21,8 @@ Quickstart:
   - `brew install summarize` (macOS, Linux)
 - Firefox sidebar build: `pnpm -C apps/chrome-extension build:firefox` (load via `about:debugging` → temporary add-on)
 - Open side panel → copy token install command → run for daemon mode:
-  - `summarize daemon install --token <TOKEN>` (macOS: LaunchAgent, Linux: systemd user, Windows: Scheduled Task)
+  - `summarize daemon install --token <TOKEN> --port 8787` (macOS: LaunchAgent, Linux: systemd user, Windows: Scheduled Task)
+  - Non-default port: replace `8787`, then set the same value in **Options → Runtime → Daemon → Port**.
 - Verify:
   - `summarize daemon status`
   - Restart (if needed): `summarize daemon restart`
@@ -44,6 +45,7 @@ Dev (repo checkout):
 
 - “Daemon not reachable”:
   - `summarize daemon status`
+  - If the daemon uses a non-default port, confirm **Options → Runtime → Daemon → Port** matches the daemon configuration.
   - Logs: `~/.summarize/logs/daemon.err.log`
 - Windows install:
   - `summarize daemon install` registers a Scheduled Task via `schtasks /Create /XML`, which requires an **elevated** shell. Run it from an Administrator PowerShell/cmd; otherwise you'll see `schtasks create failed: ERROR: Access is denied.`
@@ -54,7 +56,7 @@ Dev (repo checkout):
   - Re-run: `summarize daemon install --token <TOKEN>`.
 - Windows containers:
   - `summarize daemon install --token <TOKEN>` starts the daemon for the current container session but does not create a Scheduled Task.
-  - Run that command manually each time the container starts, or add it to your container startup. Also publish the daemon port in `docker-compose.yml`:
+  - Run that command manually each time the container starts, or add it to your container startup. Also publish the configured daemon port in `docker-compose.yml` (default `8787`):
     `ports: ['8787:8787']`
     `command: ['cmd', '/c', 'summarize daemon install --token <TOKEN>']`
   - Then restart the container and verify `http://127.0.0.1:8787/health`.
@@ -77,7 +79,7 @@ Dev (repo checkout):
   - The content script wasn’t injected (yet), or Chrome blocked site access.
   - Chrome → extension details → “Site access” → “On all sites” (or allow the domain), then reload the tab.
 - “<site> wants to look for and connect to any device on your local network”:
-  - Trigger: content scripts (page context) hitting the daemon on `http://127.0.0.1:8787` (hover summaries) can cause Chrome to attribute the request to the current origin and prompt per-site.
+  - Trigger: content scripts (page context) hitting the configured daemon origin (default `http://127.0.0.1:8787`) can cause Chrome to attribute the request to the current origin and prompt per-site.
   - Fix: hover summaries must proxy daemon calls via the extension background service worker (reload the extension after updating).
   - Verify daemon: `summarize daemon status` (or `curl http://127.0.0.1:8787/health`).
   - Repro/dev: `pnpm -C apps/chrome-extension dev` then enable “Hover summaries” and hover a link.
@@ -160,6 +162,7 @@ See `docs/media.md` for detection and transcript rules.
   - AI connection (Options → Runtime): Direct | Daemon.
   - Direct provider and credential/base URL (Options → Runtime). `auto` uses the configured provider, otherwise Gemini Nano; an explicit provider prefix overrides the selection.
   - Media/slide runtime (Options → Runtime): Browser | Daemon.
+  - Daemon port (Options → Runtime; default `8787`): must match the installed daemon port.
   - Model preset: `auto` | Gemini Nano | `free` | custom string (e.g. `openai/gpt-5-mini`, `openrouter/...`, `github-copilot/...`). Explicit Gemini Nano summaries stay on-device in either connection mode.
   - Length: `short|medium|long|xl|xxl` (or a character target like `20k`). Tooltips show target ranges + paragraph guidance (from `packages/core/src/prompts/summary-lengths.ts`).
   - Language: `auto` (match source) or a tag like `en`, `de`, `pt-BR` (or free-form like “German”).
@@ -191,11 +194,12 @@ Problem: daemon must be secured; extension must discover and pair with it.
 - Side panel “Setup” state:
   - Generates token (random, 32+ bytes).
   - Shows:
-    - `summarize daemon install --token <TOKEN>` (macOS: LaunchAgent, Linux: systemd user, Windows: Scheduled Task)
+    - `summarize daemon install --token <TOKEN> --port <PORT>` (macOS: LaunchAgent, Linux: systemd user, Windows: Scheduled Task)
     - `summarize daemon status`
   - “Copy command” button.
 - Daemon stores paired tokens in `~/.summarize/daemon.json`.
 - Extension stores token in `chrome.storage.local`.
+- The manifest permits HTTP to `127.0.0.1` on any port; bearer tokens are attached only for the exact configured daemon origin.
 - If daemon unreachable or 401: show Setup state + troubleshooting.
 
 ## Daemon Endpoints
@@ -270,7 +274,7 @@ Notes:
 ## Daemon Autostart
 
 - CLI commands:
-  - `summarize daemon install --token <token> [--port 8787]`
+  - `summarize daemon install --token <token> [--port <PORT>]`
     - Writes `~/.summarize/daemon.json`
     - Installs platform autostart service; verifies `/health`
   - `summarize daemon uninstall`

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -92,9 +92,10 @@ Dev (repo checkout):
   - Direct provider adapters: OpenAI-compatible SSE, Anthropic Messages SSE, and Gemini SSE, normalized to the same summary/chat/tool-call contracts.
   - Panel page streams SSE directly (MV3 service workers can be flaky for long-lived streams).
 - **Daemon (local, autostart service)**
-  - HTTP server on `127.0.0.1:8787` only.
+  - HTTP server on `127.0.0.1` (default port `8787`).
   - Token-authenticated API.
   - Runs the existing summarize pipeline (env/config-based) and streams tokens to client via SSE.
+  - Port is configurable: set **Options → Runtime → Daemon → Port** to match a daemon started with `summarize daemon install --port <n>` (e.g. when `8787` is taken by another service). The extension talks to `127.0.0.1:<port>` for every daemon call.
 
 ## Data Flow
 

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -70,7 +70,7 @@ summarize daemon run --port 8787
 ## Options
 
 `--port <n>`
-: TCP port. Default `8787`. The Side Panel reads it from `~/.summarize/daemon.json`.
+: TCP port. Default `8787`. For a non-default port, set the same value in the extension under **Options → Runtime → Daemon → Port**; browser extensions cannot read `~/.summarize/daemon.json`.
 
 `--token <token>`
 : Bearer token. Required for `install`. Stored in `~/.summarize/daemon.json` (mode `0600`).
@@ -96,9 +96,9 @@ The daemon is documented in detail in [Chrome extension](../chrome-extension.md)
 
 ## Notes
 
-- **Containers** — `install` starts the daemon for the current container session but does not register a Scheduled Task / unit. Run `summarize daemon run` from your entrypoint instead, and publish port `8787` so the host browser can reach it.
+- **Containers** — `install` starts the daemon for the current container session but does not register a Scheduled Task / unit. Run `summarize daemon run` from your entrypoint instead, publish the configured port (default `8787`), and set the same port in the extension.
 - **Token rotation** — running `install --token <NEW>` adds a new paired browser; old browsers keep working. Edit `daemon.json` by hand to revoke.
-- **Multiple installs** — only one daemon per user. Reinstall to upgrade.
+- **Multiple installs** — only one daemon per user. Reinstall to upgrade; omitting `--port` preserves the configured port.
 
 ## See also
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -129,7 +129,7 @@ Use `PORT=4001 ./scripts/docs-serve.sh` to pick another port.
 ## Notes (Windows / containers)
 
 - **Windows native:** `summarize` runs under Node 24. The daemon registers a Scheduled Task on first install.
-- **Windows containers:** `summarize daemon install` starts the daemon for the current container session but does not register a Scheduled Task. Run the install on each startup or add it to the container entrypoint, and publish port `8787` so a host browser can reach the daemon.
+- **Windows containers:** `summarize daemon install` starts the daemon for the current container session but does not register a Scheduled Task. Run the install on each startup or add it to the container entrypoint, publish the configured port (default `8787`), and set the same port under **Options → Runtime → Daemon → Port**.
 - **WSL2:** treat as Linux. The daemon installs as a systemd user service if `systemd` is available; otherwise run `summarize daemon run` in a long-lived shell.
 
 Next: head to [Quickstart](quickstart.md).

--- a/src/daemon/cli.ts
+++ b/src/daemon/cli.ts
@@ -55,7 +55,7 @@ function readPortArg(argv: string[]): number | null {
   const portRaw = readArgValue(argv, "--port");
   if (!portRaw) return null;
   const port = Number(portRaw);
-  if (!Number.isFinite(port) || port <= 0 || port >= 65535) throw new Error("Invalid --port");
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) throw new Error("Invalid --port");
   return Math.floor(port);
 }
 
@@ -103,11 +103,12 @@ export async function handleDaemonRequest({
   if (sub === "install") {
     const token = readArgValue(normalizedArgv, "--token");
     if (!token) throw new Error("Missing --token");
-    const port = readPortArg(normalizedArgv) ?? DAEMON_PORT_DEFAULT;
+    const requestedPort = readPortArg(normalizedArgv);
     const dev = hasArg(normalizedArgv, "--dev");
 
     const envSnapshot = buildEnvSnapshotFromEnv(envForRun);
     const existingConfig = await readDaemonConfig({ env: envForRun });
+    const port = requestedPort ?? existingConfig?.port ?? DAEMON_PORT_DEFAULT;
     const mergedTokens = existingConfig
       ? Array.from(new Set([...daemonConfigTokens(existingConfig), token.trim()]))
       : [token.trim()];

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -109,7 +109,7 @@ export function isAuthorizedDaemonToken(candidate: string, tokens: readonly stri
 
 export function normalizeDaemonPort(raw: unknown): number {
   const port = typeof raw === "number" ? raw : DAEMON_PORT_DEFAULT;
-  if (!Number.isFinite(port) || port <= 0 || port >= 65535) {
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
     throw new Error(`Invalid port: ${String(raw)}`);
   }
   return Math.floor(port);

--- a/src/run/help.ts
+++ b/src/run/help.ts
@@ -431,6 +431,7 @@ export function buildDaemonHelp(): string {
     "  --dev            Install service that runs src/cli.ts via Node (repo dev mode)",
     "  --port <n>       (default: 8787)",
     "  --token <token>  (required for install)",
+    "  Custom ports must also be set in Extension Options → Runtime → Daemon → Port.",
   ].join("\n");
 }
 

--- a/tests/chrome.daemon-url.test.ts
+++ b/tests/chrome.daemon-url.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { daemonOrigin } from "../apps/chrome-extension/src/lib/daemon-url";
+
+describe("extension daemon URL", () => {
+  it("canonicalizes the default HTTP port", () => {
+    expect(daemonOrigin("80")).toBe("http://127.0.0.1");
+  });
+
+  it("keeps non-default ports explicit", () => {
+    expect(daemonOrigin("8787")).toBe("http://127.0.0.1:8787");
+  });
+});

--- a/tests/chrome.panel-slides-context.test.ts
+++ b/tests/chrome.panel-slides-context.test.ts
@@ -13,7 +13,11 @@ describe("chrome panel slides context", () => {
       session: { windowId: 1 } as never,
       requestId: "slides-1",
       requestedUrl: null,
-      loadSettings: vi.fn(async () => ({ token: "", extendedLogging: false })) as never,
+      loadSettings: vi.fn(async () => ({
+        token: "",
+        daemonPort: "8787",
+        extendedLogging: false,
+      })) as never,
       getActiveTab: vi.fn(async () => null) as never,
       canSummarizeUrl: () => false,
       panelSessionStore: {
@@ -51,7 +55,11 @@ describe("chrome panel slides context", () => {
       session: { windowId: 7 } as never,
       requestId: "slides-2",
       requestedUrl: "https://example.com/video",
-      loadSettings: vi.fn(async () => ({ token: "secret", extendedLogging: false })) as never,
+      loadSettings: vi.fn(async () => ({
+        token: "secret",
+        daemonPort: "8787",
+        extendedLogging: false,
+      })) as never,
       getActiveTab: vi.fn(async () => ({
         id: 4,
         url: "https://example.com/video",

--- a/tests/daemon.cli.test.ts
+++ b/tests/daemon.cli.test.ts
@@ -174,7 +174,7 @@ describe("daemon cli", () => {
     };
 
     const handled = await handleDaemonRequest({
-      normalizedArgv: ["daemon", "run", "--token", "dev-token-123456", "--port", "18787"],
+      normalizedArgv: ["daemon", "run", "--token", "dev-token-123456", "--port", "65535"],
       envForRun,
       fetchImpl: fetch,
       stdout: new PassThrough(),
@@ -189,7 +189,7 @@ describe("daemon cli", () => {
         version: 2,
         token: "dev-token-123456",
         tokens: ["dev-token-123456"],
-        port: 18787,
+        port: 65535,
         env: expect.objectContaining({
           PATH: "/usr/bin:/bin",
           OPENAI_API_KEY: "from-run",
@@ -239,7 +239,7 @@ describe("daemon cli", () => {
       version: 2,
       token: "existing-token-1234",
       tokens: ["existing-token-1234"],
-      port: 8787,
+      port: 9931,
       env: {},
       installedAt: "2026-01-01T00:00:00.000Z",
     });
@@ -268,6 +268,7 @@ describe("daemon cli", () => {
       config: expect.objectContaining({
         token: "existing-token-1234",
         tokens: ["existing-token-1234", "new-token-123456"],
+        port: 9931,
       }),
     });
   });

--- a/tests/daemon.config.test.ts
+++ b/tests/daemon.config.test.ts
@@ -40,8 +40,10 @@ describe("daemon config", () => {
 
     expect(normalizeDaemonPort(undefined)).toBe(DAEMON_PORT_DEFAULT);
     expect(normalizeDaemonPort(3000.9)).toBe(3000);
+    expect(normalizeDaemonPort(65535)).toBe(65535);
     expect(() => normalizeDaemonPort(Number.NaN)).toThrow(/Invalid port/);
     expect(() => normalizeDaemonPort(0)).toThrow(/Invalid port/);
+    expect(() => normalizeDaemonPort(65536)).toThrow(/Invalid port/);
     expect(() => normalizeDaemonPort(70000)).toThrow(/Invalid port/);
   });
 

--- a/tests/options.persistence.test.ts
+++ b/tests/options.persistence.test.ts
@@ -33,9 +33,8 @@ describe("options persistence", () => {
 
     const first = queuedRuntime.saveNow();
     const second = queuedRuntime.saveNow();
-    await second;
     await vi.advanceTimersByTimeAsync(20);
-    await first;
+    await Promise.all([first, second]);
 
     expect(blockedPersist).toHaveBeenCalledTimes(2);
     vi.useRealTimers();

--- a/tests/sidepanel.setup-controls-runtime.test.ts
+++ b/tests/sidepanel.setup-controls-runtime.test.ts
@@ -17,6 +17,7 @@ const drawerControls = { toggleDrawer: vi.fn(), toggleAdvancedSettings: vi.fn() 
 let capturedSetupOptions: {
   ensureToken: () => Promise<string>;
   loadToken: () => Promise<string>;
+  loadDaemonPort: () => Promise<string>;
 } | null = null;
 
 vi.mock("../apps/chrome-extension/src/entrypoints/sidepanel/model-presets", () => ({
@@ -35,7 +36,7 @@ vi.mock("../apps/chrome-extension/src/entrypoints/sidepanel/setup-runtime", () =
 }));
 
 function buildRuntime(loadToken = "token") {
-  const loadSettings = vi.fn(async () => ({ token: loadToken }));
+  const loadSettings = vi.fn(async () => ({ token: loadToken, daemonPort: "9931" }));
   const patchSettings = vi.fn(async () => ({}));
   const generateToken = vi.fn(() => "generated-token");
 
@@ -87,5 +88,6 @@ describe("sidepanel setup controls runtime", () => {
     expect(missing.generateToken).toHaveBeenCalledOnce();
     expect(missing.patchSettings).toHaveBeenCalledWith({ token: "generated-token" });
     expect(await capturedSetupOptions?.loadToken()).toBe("");
+    expect(await capturedSetupOptions?.loadDaemonPort()).toBe("9931");
   });
 });

--- a/tests/sidepanel.setup-runtime.behavior.test.ts
+++ b/tests/sidepanel.setup-runtime.behavior.test.ts
@@ -5,16 +5,18 @@ const setupViewMocks = vi.hoisted(() => ({
   installStepsHtml: vi.fn(
     ({
       token,
+      daemonPort,
       headline,
       message,
       showTroubleshooting,
     }: {
       token: string;
+      daemonPort: string;
       headline: string;
       message?: string;
       showTroubleshooting?: boolean;
     }) =>
-      `headline=${headline};token=${token};message=${message ?? ""};troubleshooting=${
+      `headline=${headline};token=${token};port=${daemonPort};message=${message ?? ""};troubleshooting=${
         showTroubleshooting ? "yes" : "no"
       }`,
   ),
@@ -38,6 +40,8 @@ function stubNavigator(value: Partial<Navigator> & { userAgentData?: { platform?
 function flushPromises() {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
+
+const loadDaemonPort = vi.fn(async () => "9931");
 
 function makeUiState(overrides?: Partial<UiState>): UiState {
   return {
@@ -110,6 +114,7 @@ describe("sidepanel setup runtime behavior", () => {
       setupEl,
       ensureToken,
       loadToken,
+      loadDaemonPort,
       patchSettings: vi.fn() as never,
       generateToken: vi.fn() as never,
       headerSetStatus: vi.fn(),
@@ -155,6 +160,7 @@ describe("sidepanel setup runtime behavior", () => {
       setupEl,
       ensureToken: vi.fn(async () => "unused-token"),
       loadToken,
+      loadDaemonPort,
       patchSettings: vi.fn() as never,
       generateToken: vi.fn() as never,
       headerSetStatus: vi.fn(),
@@ -192,6 +198,7 @@ describe("sidepanel setup runtime behavior", () => {
       setupEl,
       ensureToken: vi.fn(async () => "unused-token"),
       loadToken: vi.fn(async () => "unused-token"),
+      loadDaemonPort,
       patchSettings: vi.fn() as never,
       generateToken: vi.fn() as never,
       headerSetStatus: vi.fn(),
@@ -211,6 +218,7 @@ describe("sidepanel setup runtime behavior", () => {
       setupEl,
       ensureToken,
       loadToken,
+      loadDaemonPort,
       patchSettings: vi.fn() as never,
       generateToken: vi.fn() as never,
       headerSetStatus: vi.fn(),
@@ -245,6 +253,7 @@ describe("sidepanel setup runtime behavior", () => {
       setupEl,
       ensureToken,
       loadToken,
+      loadDaemonPort,
       patchSettings: vi.fn() as never,
       generateToken: vi.fn() as never,
       headerSetStatus: vi.fn(),
@@ -284,6 +293,7 @@ describe("sidepanel setup runtime behavior", () => {
       setupEl,
       ensureToken,
       loadToken: vi.fn(async () => "unused-token"),
+      loadDaemonPort,
       patchSettings: vi.fn() as never,
       generateToken: vi.fn() as never,
       headerSetStatus: vi.fn(),
@@ -318,6 +328,7 @@ describe("sidepanel setup runtime behavior", () => {
       setupEl,
       ensureToken,
       loadToken,
+      loadDaemonPort,
       patchSettings: vi.fn() as never,
       generateToken: vi.fn() as never,
       headerSetStatus: vi.fn(),

--- a/tests/sidepanel.setup-view.test.ts
+++ b/tests/sidepanel.setup-view.test.ts
@@ -5,17 +5,20 @@ describe("sidepanel setup view", () => {
   it("renders the official Homebrew formula for mac setup", () => {
     const html = installStepsHtml({
       token: "token",
+      daemonPort: "9931",
       headline: "Setup",
       platformKind: "mac",
     });
 
     expect(html).toContain("brew install summarize");
+    expect(html).toContain("summarize daemon install --token token --port 9931");
     expect(html).not.toContain("steipete/tap/summarize");
   });
 
   it("shows npm guidance for non-mac setup instead of the old tap warning", () => {
     const html = installStepsHtml({
       token: "token",
+      daemonPort: "8787",
       headline: "Setup",
       platformKind: "linux",
     });

--- a/tests/sidepanel.slide-images.loader.test.ts
+++ b/tests/sidepanel.slide-images.loader.test.ts
@@ -67,7 +67,8 @@ describe("slide image loader", () => {
     mockCreateObjectUrl(() => "blob:mock");
 
     const loader = createSlideImageLoader({
-      loadSettings: async () => ({ token: "t", extendedLogging: false }) as Settings,
+      loadSettings: async () =>
+        ({ token: "t", daemonPort: "8787", extendedLogging: false }) as Settings,
     });
     const wrapper = document.createElement("div");
     wrapper.className = "slideStrip__thumb";
@@ -91,7 +92,8 @@ describe("slide image loader", () => {
     mockCreateObjectUrl(() => "blob:mock");
 
     const loader = createSlideImageLoader({
-      loadSettings: async () => ({ token: "t", extendedLogging: false }) as Settings,
+      loadSettings: async () =>
+        ({ token: "t", daemonPort: "8787", extendedLogging: false }) as Settings,
     });
     const wrapper = document.createElement("div");
     wrapper.className = "slideStrip__thumb";
@@ -113,7 +115,8 @@ describe("slide image loader", () => {
     mockCreateObjectUrl(() => "blob:cache");
 
     const loader = createSlideImageLoader({
-      loadSettings: async () => ({ token: "t", extendedLogging: false }) as Settings,
+      loadSettings: async () =>
+        ({ token: "t", daemonPort: "8787", extendedLogging: false }) as Settings,
     });
     const url = "http://127.0.0.1:8787/v1/slides/abc/3";
 
@@ -153,7 +156,8 @@ describe("slide image loader", () => {
     mockCreateObjectUrl(() => objectUrls.shift() ?? "blob:next");
 
     const loader = createSlideImageLoader({
-      loadSettings: async () => ({ token: "t", extendedLogging: false }) as Settings,
+      loadSettings: async () =>
+        ({ token: "t", daemonPort: "8787", extendedLogging: false }) as Settings,
     });
     const wrapper = document.createElement("div");
     wrapper.className = "slideStrip__thumb";
@@ -186,7 +190,8 @@ describe("slide image loader", () => {
     globalThis.fetch = fetchSpy;
 
     const loader = createSlideImageLoader({
-      loadSettings: async () => ({ token: "", extendedLogging: true }) as Settings,
+      loadSettings: async () =>
+        ({ token: "", daemonPort: "8787", extendedLogging: true }) as Settings,
     });
     const wrapper = document.createElement("div");
     wrapper.className = "slideStrip__thumb";
@@ -228,7 +233,8 @@ describe("slide image loader", () => {
     mockCreateObjectUrl(() => "blob:io");
 
     const loader = createSlideImageLoader({
-      loadSettings: async () => ({ token: "t", extendedLogging: false }) as Settings,
+      loadSettings: async () =>
+        ({ token: "t", daemonPort: "8787", extendedLogging: false }) as Settings,
     });
     const wrapper = document.createElement("div");
     wrapper.className = "slideStrip__thumb";
@@ -273,7 +279,8 @@ describe("slide image loader", () => {
     mockCreateObjectUrl(() => "blob:visible");
 
     const loader = createSlideImageLoader({
-      loadSettings: async () => ({ token: "t", extendedLogging: false }) as Settings,
+      loadSettings: async () =>
+        ({ token: "t", daemonPort: "8787", extendedLogging: false }) as Settings,
     });
     const wrapper = document.createElement("div");
     wrapper.className = "slideStrip__thumb";
@@ -320,7 +327,8 @@ describe("slide image loader", () => {
     mockCreateObjectUrl(() => "blob:late-visible");
 
     const loader = createSlideImageLoader({
-      loadSettings: async () => ({ token: "t", extendedLogging: false }) as Settings,
+      loadSettings: async () =>
+        ({ token: "t", daemonPort: "8787", extendedLogging: false }) as Settings,
     });
     const wrapper = document.createElement("div");
     wrapper.className = "slideStrip__thumb";
@@ -395,7 +403,8 @@ describe("slide image loader", () => {
     const revokeSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
 
     const loader = createSlideImageLoader({
-      loadSettings: async () => ({ token: "t", extendedLogging: false }) as Settings,
+      loadSettings: async () =>
+        ({ token: "t", daemonPort: "8787", extendedLogging: false }) as Settings,
       maxCacheEntries: 2,
     });
 


### PR DESCRIPTION
## What & why

The extension hardcoded the daemon origin to `http://127.0.0.1:8787` in ~28 places across 20 files, so a daemon running on a non-default port (e.g. when `8787` is already taken by another local service) was unreachable, with no way to change it from the UI.

This makes the daemon port configurable.

## Changes

- **Setting:** add `daemonPort` (default `"8787"`, validated 1–65535) to the settings schema, normalized on both load and save.
- **Single source of truth:** new `src/lib/daemon-url.ts` — `daemonOrigin(port)` (sync) and `getDaemonOrigin()` (async, reads settings). Every hardcoded origin across background, options, sidepanel, and automation now resolves through it (sync form where a `Settings` is in scope, async otherwise).
- **UI:** new **Port** field in **Options → Runtime → Daemon** (above the Token field), with a hint pointing at `summarize daemon status`. Editing it persists, then re-checks daemon status/presets/logs against the new port.
- **Slide images:** `normalizeSlideImageUrl` derives the origin from the daemon-provided URL but only rewrites local `127.0.0.1` URLs; the slide-image loader sends the daemon bearer token **only** to the configured local daemon origin (`http://127.0.0.1:<port>`) and refuses any foreign origin, so a daemon-shaped slide URL on another host can never receive the token.
- **Permissions:** `host_permissions` `http://127.0.0.1:8787/*` → `http://127.0.0.1/*` (any localhost port; `<all_urls>` was already granted, so no new exposure).
- **Docs:** `docs/chrome-extension.md` updated.

## Compatibility

Fully backward compatible: the default port is `8787`, so existing installs behave identically. No migration needed.

## Tests & commands run

- `pnpm -C apps/chrome-extension build` (Chrome) and `build:firefox` — both pass; built manifest = `http://127.0.0.1/*`, port input present, no `8787` left in the bundle.
- `oxlint --type-aware` — clean.
- `oxfmt --check` — clean.
- New e2e test `options persists a custom daemon port` (seeds a custom port, asserts it loads, edits it, polls until persisted).
- New e2e test `daemon slides use the configured port and never leak the token off-origin` — runs the full slide stream against a **non-default port (8799)**, asserts the summary/slides/images are fetched from `127.0.0.1:8799` with the token, and that a foreign-origin slide URL receives **0** requests and never the token.
- Playwright chromium specs covering the changed paths (options, extension, sidepanel core/chat/slides-stream/cache-state) — all pass.

## UI

The change adds a **Port** number input to the Daemon section of the Runtime tab (additive; the Token field is unchanged).

![Options → Runtime → Daemon → Port field](https://github.com/enieuwy/summarize/releases/download/pr-312-assets/summarize-daemon-port-field.png)

