### PR TITLE
[codex] fix direct hover without daemon token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - LLM summaries: retry transient API and pre-output streaming failures such as HTTP 502 instead of failing immediately.
 - Dependencies: update eligible runtime, test, lint, formatting, and extension tooling releases.
+- Chrome extension: allow Direct and Ollama hover summaries without a daemon token (#317, thanks @vincent-peng).
 
 ## 0.20.0 - 2026-06-19
 

--- a/apps/chrome-extension/src/entrypoints/hover.content.ts
+++ b/apps/chrome-extension/src/entrypoints/hover.content.ts
@@ -119,7 +119,7 @@ export function shouldHandleHoverTriggerEvent(event: Pick<Event, "isTrusted">): 
 }
 
 export function shouldStartHoverRequest(
-  settings: Pick<Settings, "hoverSummaries" | "token"> | null,
+  settings: Pick<Settings, "hoverSummaries"> | null,
 ): boolean {
   return Boolean(settings?.hoverSummaries);
 }

--- a/apps/chrome-extension/src/entrypoints/hover.content.ts
+++ b/apps/chrome-extension/src/entrypoints/hover.content.ts
@@ -118,6 +118,12 @@ export function shouldHandleHoverTriggerEvent(event: Pick<Event, "isTrusted">): 
   return event.isTrusted === true;
 }
 
+export function shouldStartHoverRequest(
+  settings: Pick<Settings, "hoverSummaries" | "token"> | null,
+): boolean {
+  return Boolean(settings?.hoverSummaries);
+}
+
 function ensureTooltip(): Tooltip {
   ensureStyle();
   let el = document.getElementById(TOOLTIP_ID) as HTMLDivElement | null;
@@ -346,10 +352,9 @@ export default defineContentScript({
 
     const handleHover = async (anchor: HTMLAnchorElement) => {
       if (!settingsLoaded) await refreshSettings();
-      if (!settings?.hoverSummaries) return;
+      if (!shouldStartHoverRequest(settings)) return;
       const url = resolveUrl(anchor);
       if (!url) return;
-      if (!settings.token.trim()) return;
 
       activeAnchor = anchor;
       activeUrl = url;

--- a/apps/chrome-extension/tests/hover.direct-provider.spec.ts
+++ b/apps/chrome-extension/tests/hover.direct-provider.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "@playwright/test";
+import {
+  activateTabByUrl,
+  assertNoErrors,
+  closeExtension,
+  getBrowserFromProject,
+  launchExtension,
+  maybeBringToFront,
+  seedSettings,
+  trackErrors,
+  waitForActiveTabUrl,
+} from "./helpers/extension-harness";
+import { allowFirefoxExtensionTests } from "./helpers/extension-test-config";
+
+function openAiStream(text: string) {
+  return [
+    `data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}`,
+    "",
+    "data: [DONE]",
+    "",
+  ].join("\n");
+}
+
+test.skip(
+  ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
+  "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
+);
+
+test("hover tooltip summarizes through a direct provider without a daemon token", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, {
+      token: "",
+      hoverSummaries: true,
+      summaryRuntime: "direct",
+      provider: "openai",
+      providerApiKeys: { openai: "test-key" },
+      providerBaseUrls: { openai: "https://api.openai.test/v1" },
+      model: "openai/test-model",
+      maxChars: 60_000,
+    });
+
+    let articleFetches = 0;
+    await harness.context.route("https://example.com/hover-proof", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: `
+          <main>
+            <h1>Hover proof page</h1>
+            <a id="target" href="https://example.com/hover-proof-target">Summarize target</a>
+          </main>
+        `,
+      });
+    });
+    await harness.context.route("https://example.com/hover-proof-target", async (route) => {
+      articleFetches += 1;
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/html" },
+        body: `<article><h1>Target article</h1><p>${"Direct provider hover content. ".repeat(
+          80,
+        )}</p></article>`,
+      });
+    });
+
+    let providerCalls = 0;
+    let daemonSummarizeCalls = 0;
+    const requestBodies: Array<Record<string, unknown>> = [];
+    await harness.context.route("https://api.openai.test/v1/chat/completions", async (route) => {
+      providerCalls += 1;
+      requestBodies.push(route.request().postDataJSON() as Record<string, unknown>);
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: openAiStream("Direct hover proof without daemon token."),
+      });
+    });
+    await harness.context.route(
+      /http:\/\/127\.0\.0\.1:8787\/v1\/summarize(?:\/.*)?$/,
+      async (route) => {
+        daemonSummarizeCalls += 1;
+        await route.fulfill({
+          status: 500,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ ok: false, error: "daemon should not be called" }),
+        });
+      },
+    );
+
+    const page = await harness.context.newPage();
+    trackErrors(page, harness.pageErrors, harness.consoleErrors);
+    await page.goto("https://example.com/hover-proof", { waitUntil: "domcontentloaded" });
+    await maybeBringToFront(page);
+    await activateTabByUrl(harness, "https://example.com/hover-proof");
+    await waitForActiveTabUrl(harness, "https://example.com/hover-proof");
+
+    await page.locator("#target").hover();
+
+    const tooltip = page.locator('#__summarize_hover_tooltip__[data-visible="true"] .summary');
+    await expect(tooltip).toContainText("Direct hover proof without daemon token.");
+    await expect.poll(() => articleFetches).toBe(1);
+    await expect.poll(() => providerCalls).toBe(1);
+    await expect.poll(() => daemonSummarizeCalls).toBe(0);
+    expect(requestBodies[0]?.model).toBe("test-model");
+    expect(JSON.stringify(requestBodies[0]?.messages)).toContain("Direct provider hover content");
+
+    const screenshotPath = process.env.HOVER_PROOF_SCREENSHOT;
+    if (screenshotPath) {
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+    }
+
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});

--- a/tests/hover.controller.test.ts
+++ b/tests/hover.controller.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHoverController } from "../apps/chrome-extension/src/entrypoints/background/hover-controller.js";
+import { defaultSettings, type Settings } from "../apps/chrome-extension/src/lib/settings.js";
+
+const mocks = vi.hoisted(() => ({
+  fetchBrowserUrlContent: vi.fn(),
+  loadSettings: vi.fn(),
+  streamDirectModel: vi.fn(),
+}));
+
+vi.mock("../apps/chrome-extension/src/lib/browser-url-content.js", async (importOriginal) => {
+  const original =
+    await importOriginal<
+      typeof import("../apps/chrome-extension/src/lib/browser-url-content.js")
+    >();
+  return {
+    ...original,
+    fetchBrowserUrlContent: mocks.fetchBrowserUrlContent,
+  };
+});
+
+vi.mock("../apps/chrome-extension/src/lib/direct-provider.js", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../apps/chrome-extension/src/lib/direct-provider.js")>();
+  return {
+    ...original,
+    streamDirectModel: mocks.streamDirectModel,
+  };
+});
+
+vi.mock("../apps/chrome-extension/src/lib/settings.js", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../apps/chrome-extension/src/lib/settings.js")>();
+  return {
+    ...original,
+    loadSettings: mocks.loadSettings,
+  };
+});
+
+function makeSettings(overrides: Partial<Settings>): Settings {
+  return {
+    ...defaultSettings,
+    ...overrides,
+    providerApiKeys: overrides.providerApiKeys ?? defaultSettings.providerApiKeys,
+    providerBaseUrls: overrides.providerBaseUrls ?? defaultSettings.providerBaseUrls,
+  };
+}
+
+function installChromeMocks() {
+  const sendMessage = vi.fn(async () => undefined);
+  const query = vi.fn(async () => [{ id: 7, active: true, url: "https://example.com" }]);
+  vi.stubGlobal("chrome", {
+    tabs: {
+      query,
+      sendMessage,
+    },
+  });
+  return { query, sendMessage };
+}
+
+function createController() {
+  return createHoverController({
+    hoverControllersByTabId: new Map(),
+    buildDaemonRequestBody: vi.fn(() => ({})) as never,
+    resolveLogLevel: () => "verbose",
+  });
+}
+
+function sender(): chrome.runtime.MessageSender {
+  return { tab: { id: 7, url: "https://example.com" } as chrome.tabs.Tab };
+}
+
+async function waitForResponse(sendResponse: ReturnType<typeof vi.fn>) {
+  await expect.poll(() => sendResponse.mock.calls.length).toBeGreaterThan(0);
+  return sendResponse.mock.calls.at(-1)?.[0] as { ok?: boolean; error?: string };
+}
+
+describe("hover controller token routing", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.fetchBrowserUrlContent.mockReset();
+    mocks.loadSettings.mockReset();
+    mocks.streamDirectModel.mockReset();
+  });
+
+  it("starts direct hover summaries without a daemon token", async () => {
+    const chromeMocks = installChromeMocks();
+    mocks.loadSettings.mockResolvedValue(
+      makeSettings({
+        token: "",
+        summaryRuntime: "direct",
+        provider: "ollama",
+        model: "auto",
+      }),
+    );
+    mocks.fetchBrowserUrlContent.mockResolvedValue({
+      url: "https://example.com/article",
+      title: "Article",
+      text: "Article text",
+    });
+    mocks.streamDirectModel.mockImplementation(async function* () {
+      yield { type: "text", text: "Direct hover" };
+    });
+    const controller = createController();
+    const sendResponse = vi.fn();
+
+    const handled = controller.handleRuntimeMessage(
+      {
+        type: "hover:summarize",
+        requestId: "hover-1",
+        url: "https://example.com/article",
+        title: "Article",
+      },
+      sender(),
+      sendResponse,
+    );
+
+    expect(handled).toBe(true);
+    await expect.poll(() => chromeMocks.sendMessage.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(await waitForResponse(sendResponse)).toEqual({ ok: true });
+    expect(chromeMocks.sendMessage).toHaveBeenCalledWith(7, {
+      type: "hover:chunk",
+      requestId: "hover-1",
+      url: "https://example.com/article",
+      text: "Direct hover",
+    });
+    expect(chromeMocks.sendMessage).toHaveBeenCalledWith(7, {
+      type: "hover:done",
+      requestId: "hover-1",
+      url: "https://example.com/article",
+    });
+  });
+
+  it("still rejects daemon hover summaries without a daemon token", async () => {
+    const chromeMocks = installChromeMocks();
+    mocks.loadSettings.mockResolvedValue(
+      makeSettings({
+        token: "",
+        summaryRuntime: "daemon",
+      }),
+    );
+    const controller = createController();
+    const sendResponse = vi.fn();
+
+    const handled = controller.handleRuntimeMessage(
+      {
+        type: "hover:summarize",
+        requestId: "hover-2",
+        url: "https://example.com/article",
+        title: "Article",
+      },
+      sender(),
+      sendResponse,
+    );
+
+    expect(handled).toBe(true);
+    expect(await waitForResponse(sendResponse)).toEqual({
+      ok: false,
+      error: "Setup required (missing token)",
+    });
+    expect(chromeMocks.sendMessage).toHaveBeenCalledWith(7, {
+      type: "hover:error",
+      requestId: "hover-2",
+      url: "https://example.com/article",
+      message: "Setup required (missing token)",
+    });
+    expect(mocks.fetchBrowserUrlContent).not.toHaveBeenCalled();
+    expect(mocks.streamDirectModel).not.toHaveBeenCalled();
+  });
+});

--- a/tests/hover.security.test.ts
+++ b/tests/hover.security.test.ts
@@ -15,11 +15,11 @@ describe("hover summary security boundaries", () => {
   });
 
   it("does not require a daemon token before asking the background to summarize", () => {
-    expect(shouldStartHoverRequest({ hoverSummaries: true, token: "" })).toBe(true);
+    expect(shouldStartHoverRequest({ hoverSummaries: true })).toBe(true);
   });
 
   it("respects disabled hover summaries before asking the background to summarize", () => {
-    expect(shouldStartHoverRequest({ hoverSummaries: false, token: "token" })).toBe(false);
+    expect(shouldStartHoverRequest({ hoverSummaries: false })).toBe(false);
     expect(shouldStartHoverRequest(null)).toBe(false);
   });
 

--- a/tests/hover.security.test.ts
+++ b/tests/hover.security.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { isHoverSummarizeUrlAllowed } from "../apps/chrome-extension/src/entrypoints/background/hover-controller.js";
-import { shouldHandleHoverTriggerEvent } from "../apps/chrome-extension/src/entrypoints/hover.content.js";
+import {
+  shouldHandleHoverTriggerEvent,
+  shouldStartHoverRequest,
+} from "../apps/chrome-extension/src/entrypoints/hover.content.js";
 
 describe("hover summary security boundaries", () => {
   it("ignores synthetic hover events from page script", () => {
@@ -9,6 +12,15 @@ describe("hover summary security boundaries", () => {
 
   it("accepts browser-trusted hover events", () => {
     expect(shouldHandleHoverTriggerEvent({ isTrusted: true })).toBe(true);
+  });
+
+  it("does not require a daemon token before asking the background to summarize", () => {
+    expect(shouldStartHoverRequest({ hoverSummaries: true, token: "" })).toBe(true);
+  });
+
+  it("respects disabled hover summaries before asking the background to summarize", () => {
+    expect(shouldStartHoverRequest({ hoverSummaries: false, token: "token" })).toBe(false);
+    expect(shouldStartHoverRequest(null)).toBe(false);
   });
 
   it("rejects hover summaries for localhost and private literal hosts", () => {


### PR DESCRIPTION
## Summary

- allow hover-enabled content scripts to ask the background for a summary even when no daemon token is stored
- keep token requirements in the background controller, where daemon mode is already distinguished from direct provider mode
- add focused coverage that hover preflight does not treat daemon-token presence as a prerequisite
- add an installed Chrome extension e2e proof for Direct provider hover with an empty daemon token

## Root cause

The hover content script returned early when `settings.token` was empty. That was correct for daemon-backed hover summaries, but wrong for direct provider/Ollama hover summaries because the background controller can run those without a daemon token.

## Real behavior proof

Redacted local Chrome extension proof run on the built MV3 extension:

- Stored settings included `token: ""`, `hoverSummaries: true`, `summaryRuntime: "direct"`, `provider: "openai"`, and mocked provider base URL `https://api.openai.test/v1`.
- The test opened `https://example.com/hover-proof`, then used Playwright `locator.hover()` on a real link so the content script received a trusted hover event.
- The background fetched the linked public page once: `articleFetches === 1`.
- The direct provider endpoint was called once: `providerCalls === 1`.
- The daemon summarize endpoint was not called: `daemonSummarizeCalls === 0`.
- The visible hover tooltip rendered: `Direct hover proof without daemon token.`
- Local screenshot captured during proof run: `/tmp/summarize-hover-direct-no-token.png`.

Proof command:

```sh
HOVER_PROOF_SCREENSHOT=/tmp/summarize-hover-direct-no-token.png pnpm -C apps/chrome-extension exec playwright test --config playwright.config.ts --project=chromium tests/hover.direct-provider.spec.ts
```

Proof output:

```text
Running 1 test using 1 worker
  ✓  1 [chromium] › tests/hover.direct-provider.spec.ts:29:1 › hover tooltip summarizes through a direct provider without a daemon token (2.2s)

  1 passed (2.8s)
```

## Validation

- `pnpm vitest run tests/hover.controller.test.ts tests/hover.security.test.ts tests/chrome.model-routing.test.ts` - 15 passed
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm -C apps/chrome-extension test:e2e` - 95 passed, 5 skipped
