### PR TITLE
[codex] Fix file URL input parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- File inputs: parse `file:` URLs with Node's platform-aware conversion, including Windows drive and UNC paths (#318, thanks @vincent-peng).
 - LLM summaries: retry transient API and pre-output streaming failures such as HTTP 502 instead of failing immediately.
 - Dependencies: update eligible runtime, test, lint, formatting, and extension tooling releases.
 - Chrome extension: allow Direct and Ollama hover summaries without a daemon token (#317, thanks @vincent-peng).

--- a/src/content/asset.ts
+++ b/src/content/asset.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Message } from "@earendil-works/pi-ai";
 import { fileTypeFromBuffer } from "file-type";
 import mime from "mime";
@@ -24,6 +25,16 @@ export type AssetAttachment = {
 };
 
 const MAX_ASSET_BYTES_DEFAULT = 50 * 1024 * 1024;
+
+export function resolveFileUrlPath(url: URL, options?: { windows?: boolean }): string {
+  const normalized = new URL(url.href);
+  normalized.search = "";
+  normalized.hash = "";
+  if (typeof options?.windows === "boolean") {
+    return fileURLToPath(normalized, { windows: options.windows });
+  }
+  return fileURLToPath(normalized);
+}
 
 function normalizeUrlInput(raw: string): string {
   return (
@@ -222,7 +233,7 @@ export function resolveInputTarget(raw: string): InputTarget {
   }
 
   if (parsed.protocol === "file:") {
-    const filePath = path.resolve(decodeURIComponent(parsed.pathname));
+    const filePath = resolveFileUrlPath(parsed);
     return { kind: "file", filePath };
   }
 

--- a/tests/input.resolve-input-target.test.ts
+++ b/tests/input.resolve-input-target.test.ts
@@ -103,6 +103,14 @@ describe("resolveInputTarget", () => {
     expect(() => resolveInputTarget("file:///tmp/a%2Fb.txt")).toThrow(/encoded .* characters/i);
   });
 
+  it("keeps encoded filename characters while ignoring file URL query and hash", () => {
+    expect(
+      resolveFileUrlPath(new URL("file:///tmp/report%23final%3F.txt?download=1#preview"), {
+        windows: false,
+      }),
+    ).toBe("/tmp/report#final?.txt");
+  });
+
   it("uses Node file URL parsing for Windows drive and UNC paths", () => {
     expect(resolveFileUrlPath(new URL("file:///C:/Users/Alice/input.txt"), { windows: true })).toBe(
       "C:\\Users\\Alice\\input.txt",

--- a/tests/input.resolve-input-target.test.ts
+++ b/tests/input.resolve-input-target.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveInputTarget } from "../src/content/asset.js";
+import { resolveFileUrlPath, resolveInputTarget } from "../src/content/asset.js";
 
 describe("resolveInputTarget", () => {
   it("accepts valid URLs unchanged", () => {
@@ -91,6 +91,30 @@ describe("resolveInputTarget", () => {
     expect(resolveInputTarget("  -  ")).toEqual({
       kind: "stdin",
     });
+  });
+
+  it("rejects non-local file URL hosts on POSIX", () => {
+    expect(() =>
+      resolveFileUrlPath(new URL("file://not-localhost/tmp/summarize.txt"), { windows: false }),
+    ).toThrow(/File URL host/i);
+  });
+
+  it("rejects encoded path separators in file URLs", () => {
+    expect(() => resolveInputTarget("file:///tmp/a%2Fb.txt")).toThrow(/encoded .* characters/i);
+  });
+
+  it("uses Node file URL parsing for Windows drive and UNC paths", () => {
+    expect(resolveFileUrlPath(new URL("file:///C:/Users/Alice/input.txt"), { windows: true })).toBe(
+      "C:\\Users\\Alice\\input.txt",
+    );
+    expect(resolveFileUrlPath(new URL("file://server/share/input.txt"), { windows: true })).toBe(
+      "\\\\server\\share\\input.txt",
+    );
+    expect(
+      resolveFileUrlPath(new URL("file:///C:/Users/Alice/My%20Docs/resume.pdf"), {
+        windows: true,
+      }),
+    ).toBe("C:\\Users\\Alice\\My Docs\\resume.pdf");
   });
 
   it("throws when neither file nor URL can be resolved", () => {


### PR DESCRIPTION
## Summary
- Parse `file:` URL inputs with Node's `fileURLToPath` instead of manually decoding `pathname` and passing it through `path.resolve`.
- Preserve existing query/hash stripping for file URLs before path conversion.
- Add regression coverage for encoded path separators, POSIX host rejection, and Windows drive / UNC conversion through Node's `{ windows: true }` behavior.

## Why
The previous manual parsing treated some invalid POSIX file URLs as valid local paths and produced wrong Windows paths. Examples:
- `file://not-localhost/tmp/summarize-proof.txt` was coerced to `/tmp/summarize-proof.txt` on POSIX instead of following Node's host validation.
- `file:///tmp/a%2Fb.txt` was decoded into `/tmp/a/b.txt` instead of rejecting encoded path separators.
- Windows drive and UNC file URLs need Node's platform-aware file URL conversion.

## Real CLI proof
Successful valid file URL input, using `--extract` to avoid any model/API dependency:

```text
$ pnpm summarize --extract file:///private/tmp/summarize-fileurl/tests/fixtures/image-only.pdf

> @steipete/summarize@0.20.0 summarize /private/tmp/summarize-fileurl
> pnpm dev:cli --extract file:///private/tmp/summarize-fileurl/tests/fixtures/image-only.pdf

> @steipete/summarize@0.20.0 dev:cli /private/tmp/summarize-fileurl
> node --import ./scripts/register-typescript.mjs src/cli.ts --extract file:///private/tmp/summarize-fileurl/tests/fixtures/image-only.pdf

## Page 1

*[Image OCR]
OCR LIVE SMOKE TEXT 2468
[End OCR]*

23s · markdown via markitdown+ocr
```

Malformed file URLs now fail with Node's file URL parser instead of being coerced into local paths:

```text
$ pnpm summarize --extract file:///tmp/a%2Fb.txt

File URL path must not include encoded / characters
ELIFECYCLE Command failed with exit code 1.

$ pnpm summarize --extract file://not-localhost/tmp/summarize-proof.txt

File URL host must be "localhost" or empty on darwin
ELIFECYCLE Command failed with exit code 1.
```

## Review swarm
- Behavioral/intent reviewer: no findings.
- Security/privacy reviewer: no findings.
- Performance/reliability reviewer: found a POSIX-specific test assertion; addressed by asserting POSIX behavior through `resolveFileUrlPath(..., { windows: false })` while keeping Windows UNC coverage explicit.
- Contract/coverage reviewer: same portability finding; addressed.

## Validation
- `pnpm exec vitest run tests/input.resolve-input-target.test.ts tests/content.asset.test.ts` (31 tests)
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- GitHub CI: `test (24)`, `extension-e2e`, `extension-firefox-smoke`, `GitGuardian Security Checks` all passed on `31af54488947611cb77a9de07d01a21c27f41c98`.
