### PR TITLE
fix(anthropic): request adaptive thinking for synthetic custom-gateway models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - LLM summaries: retry transient API and pre-output streaming failures such as HTTP 502 instead of failing immediately.
 - Dependencies: update eligible runtime, test, lint, formatting, and extension tooling releases.
 - Chrome extension: allow Direct and Ollama hover summaries without a daemon token (#317, thanks @vincent-peng).
+- Anthropic custom gateways: request adaptive thinking for synthetic models so Bedrock-compatible proxies accept configured reasoning (#321, thanks @wangwllu).
 
 ## 0.20.0 - 2026-06-19
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typecheck": "pnpm -C packages/core typecheck && tsgo -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.79.4",
+    "@earendil-works/pi-ai": "^0.80.2",
     "@steipete/summarize-core": "workspace:*",
     "bpe-lite": "^0.5.2",
     "commander": "^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
   .:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: ^0.79.4
-        version: 0.79.4(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.2
+        version: 0.80.2(ws@8.21.0)(zod@4.4.3)
       '@steipete/summarize-core':
         specifier: workspace:*
         version: link:packages/core
@@ -332,8 +332,8 @@ packages:
     engines: {node: '>= 0.10.4'}
     hasBin: true
 
-  '@earendil-works/pi-ai@0.79.4':
-    resolution: {integrity: sha512-Z1j+YP+6ZyPBKDUoc5m0GO/o1hPK17fWeErtDgegCTpm2dcKzuFvL/7GTqHeJkVkfpeXRwO37xOfgozQbK6EUw==}
+  '@earendil-works/pi-ai@0.80.2':
+    resolution: {integrity: sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -603,8 +603,13 @@ packages:
   '@mdn/browser-compat-data@8.0.2':
     resolution: {integrity: sha512-bT8u6Ll/vuV8qC9tn8cqvxoAtBpKcCwhKMW51qJRK9+G3JUtAx3lc1wjij4GJzGCfqA0keRbJUFetCgwwYaskA==}
 
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@mozilla/readability@0.6.0':
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
@@ -622,6 +627,10 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
@@ -3746,7 +3755,7 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.25.0
       '@smithy/fetch-http-handler': 5.5.0
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.8.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -3969,12 +3978,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@earendil-works/pi-ai@0.79.4(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.2(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.1
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -4211,11 +4221,14 @@ snapshots:
 
   '@mdn/browser-compat-data@8.0.2': {}
 
-  '@mistralai/mistralai@2.2.1':
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
     dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
       ws: 8.21.0
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4231,8 +4244,9 @@ snapshots:
 
   '@nodable/entities@2.2.0': {}
 
-  '@opentelemetry/api@1.9.0':
-    optional: true
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@oxc-project/types@0.133.0': {}
 

--- a/src/daemon/agent-model.ts
+++ b/src/daemon/agent-model.ts
@@ -1,5 +1,5 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { getModel } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai/compat";
 import { isOpenRouterBaseUrl } from "@steipete/summarize-core";
 import { createRunConfigInput } from "../application/config-state.js";
 import { resolveRunContextState } from "../application/context.js";

--- a/src/daemon/agent.ts
+++ b/src/daemon/agent.ts
@@ -1,5 +1,5 @@
 import type { Api, AssistantMessage, Model, Tool } from "@earendil-works/pi-ai";
-import { completeSimple, streamSimple } from "@earendil-works/pi-ai";
+import { completeSimple, streamSimple } from "@earendil-works/pi-ai/compat";
 import { buildPromptHash } from "../cache.js";
 import {
   resolveGitHubModelsCompatFallbackModelId,

--- a/src/daemon/models.ts
+++ b/src/daemon/models.ts
@@ -1,4 +1,4 @@
-import { getModels } from "@earendil-works/pi-ai";
+import { getModels } from "@earendil-works/pi-ai/compat";
 import { isOpenRouterBaseUrl } from "@steipete/summarize-core";
 import { resolveEnvState } from "../application/environment-state.js";
 import { resolveCliAvailability } from "../application/environment.js";

--- a/src/llm/generate-text-stream.ts
+++ b/src/llm/generate-text-stream.ts
@@ -1,5 +1,5 @@
-import { streamSimple } from "@earendil-works/pi-ai";
 import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
+import { streamSimple } from "@earendil-works/pi-ai/compat";
 import { createUnsupportedFunctionalityError } from "./errors.js";
 import {
   resolveEffectiveTemperature,
@@ -358,14 +358,14 @@ export async function streamTextWithContext({
     if (providerProfile.execution === "anthropic") {
       const apiKey = apiKeys.anthropicApiKey;
       if (!apiKey) throw new Error("Missing ANTHROPIC_API_KEY for anthropic/... model");
-      const baseModel = resolveAnthropicModel({
+      const { model: baseModel, isSyntheticCustomGateway } = resolveAnthropicModel({
         modelId: parsed.model,
         context,
         anthropicBaseUrlOverride,
       });
       const { model, reasoning } = prepareAnthropicReasoning({
-        modelId: parsed.model,
         baseModel,
+        isSyntheticCustomGateway,
         reasoningEffort: requestOptions?.reasoningEffort,
       });
       const stream = streamSimple(model, context, {

--- a/src/llm/generate-text.ts
+++ b/src/llm/generate-text.ts
@@ -1,5 +1,5 @@
 import type { Context } from "@earendil-works/pi-ai";
-import { completeSimple } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 import { maybeGenerateDocumentText } from "./generate-text-document.js";
 import {
   computeRetryDelayMs,

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -25,17 +25,24 @@ function effortToThinkingLevel(
  * Decide the model and `reasoning` option to pass into the pi-ai Anthropic
  * adapter. Shared by non-streaming and streaming text dispatch.
  *
- * pi-ai 0.75.5 enables extended thinking whenever the caller passes a
- * `reasoning` option, regardless of `model.reasoning`. So:
+ * pi-ai enables extended thinking whenever the caller passes a `reasoning`
+ * option (provided `model.reasoning` is true). So:
  *
  * - Registered models with `reasoning: true` (Claude 4+): forward `reasoning`.
+ *   Registered Claude 4.x models also carry `compat.forceAdaptiveThinking`, so
+ *   pi-ai emits the adaptive thinking form their backends expect.
  * - Registered models with `reasoning: false` (Claude 3 / 3.5): drop
  *   `reasoning` entirely; forwarding it would have pi-ai send a `thinking`
  *   block to an API that rejects it.
  * - Synthetic models (`tryGetModel` miss — typically custom
- *   `ANTHROPIC_BASE_URL` proxies in front of newer Claude versions):
- *   `createSyntheticModel` hard-codes `reasoning: false`, so we flip a copy
- *   to `reasoning: true` and forward the effort level.
+ *   `ANTHROPIC_BASE_URL` proxies/gateways in front of newer Claude versions):
+ *   `createSyntheticModel` hard-codes `reasoning: false` and sets no `compat`,
+ *   so we flip a copy to `reasoning: true` AND set
+ *   `compat.forceAdaptiveThinking`. Without the latter, pi-ai sends
+ *   `thinking: { type: "enabled", budget_tokens }`, which Anthropic-on-Bedrock
+ *   gateways reject (they require `thinking: { type: "adaptive" }` +
+ *   `output_config.effort`). Setting it makes the synthetic model emit the same
+ *   adaptive form that registered Claude 4.x models already do.
  */
 export function prepareAnthropicReasoning({
   modelId,
@@ -51,7 +58,14 @@ export function prepareAnthropicReasoning({
   const isSynthetic = !tryGetModel("anthropic", modelId);
   if (!baseModel.reasoning) {
     if (isSynthetic) {
-      return { model: { ...baseModel, reasoning: true }, reasoning };
+      return {
+        model: {
+          ...baseModel,
+          reasoning: true,
+          compat: { ...baseModel.compat, forceAdaptiveThinking: true },
+        },
+        reasoning,
+      };
     }
     // Registered but flagged unsupported (e.g. Claude 3/3.5): drop reasoning
     // so pi-ai does not enable thinking on a model the API rejects it for.

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1,6 +1,6 @@
 import type { Context, Model, ThinkingLevel } from "@earendil-works/pi-ai";
 import type { Api } from "@earendil-works/pi-ai";
-import { completeSimple } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 import type { Attachment } from "../attachments.js";
 import type { OpenAiReasoningEffort } from "../model-options.js";
 import type { LlmTokenUsage } from "../types.js";
@@ -11,7 +11,6 @@ import {
   extractText,
   resolveBaseUrlOverride,
   throwIfAssistantMessageFailed,
-  tryGetModel,
 } from "./shared.js";
 
 function effortToThinkingLevel(
@@ -34,8 +33,8 @@ function effortToThinkingLevel(
  * - Registered models with `reasoning: false` (Claude 3 / 3.5): drop
  *   `reasoning` entirely; forwarding it would have pi-ai send a `thinking`
  *   block to an API that rejects it.
- * - Synthetic models (`tryGetModel` miss — typically custom
- *   `ANTHROPIC_BASE_URL` proxies/gateways in front of newer Claude versions):
+ * - Synthetic custom-gateway models (registry miss plus explicit
+ *   `ANTHROPIC_BASE_URL` in front of newer Claude versions):
  *   `createSyntheticModel` hard-codes `reasoning: false` and sets no `compat`,
  *   so we flip a copy to `reasoning: true` AND set
  *   `compat.forceAdaptiveThinking`. Without the latter, pi-ai sends
@@ -45,19 +44,18 @@ function effortToThinkingLevel(
  *   adaptive form that registered Claude 4.x models already do.
  */
 export function prepareAnthropicReasoning({
-  modelId,
   baseModel,
+  isSyntheticCustomGateway,
   reasoningEffort,
 }: {
-  modelId: string;
   baseModel: Model<Api>;
+  isSyntheticCustomGateway: boolean;
   reasoningEffort?: OpenAiReasoningEffort;
 }): { model: Model<Api>; reasoning?: ThinkingLevel } {
   const reasoning = effortToThinkingLevel(reasoningEffort);
   if (!reasoning) return { model: baseModel };
-  const isSynthetic = !tryGetModel("anthropic", modelId);
   if (!baseModel.reasoning) {
-    if (isSynthetic) {
+    if (isSyntheticCustomGateway) {
       return {
         model: {
           ...baseModel,
@@ -138,12 +136,16 @@ export async function completeAnthropicText({
   signal: AbortSignal;
   anthropicBaseUrlOverride?: string | null;
 }): Promise<{ text: string; usage: LlmTokenUsage | null }> {
-  const baseModel = resolveAnthropicModel({
+  const { model: baseModel, isSyntheticCustomGateway } = resolveAnthropicModel({
     modelId,
     context,
     anthropicBaseUrlOverride,
   });
-  const { model, reasoning } = prepareAnthropicReasoning({ modelId, baseModel, reasoningEffort });
+  const { model, reasoning } = prepareAnthropicReasoning({
+    baseModel,
+    isSyntheticCustomGateway,
+    reasoningEffort,
+  });
   const result = await completeSimple(model, context, {
     ...(typeof temperature === "number" ? { temperature } : {}),
     ...(typeof maxOutputTokens === "number" ? { maxTokens: maxOutputTokens } : {}),

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -1,5 +1,5 @@
 import type { Context } from "@earendil-works/pi-ai";
-import { completeSimple } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 import type { Attachment } from "../attachments.js";
 import type { LlmTokenUsage } from "../types.js";
 import { normalizeGoogleUsage, normalizeTokenUsage } from "../usage.js";

--- a/src/llm/providers/models.ts
+++ b/src/llm/providers/models.ts
@@ -264,31 +264,36 @@ export function resolveAnthropicModel({
   modelId: string;
   context: Context;
   anthropicBaseUrlOverride?: string | null;
-}): Model<Api> {
+}): { model: Model<Api>; isSyntheticCustomGateway: boolean } {
   const allowImages = wantsImages(context);
   const base = tryGetModel("anthropic", modelId);
   const override = resolveBaseUrlOverride(anthropicBaseUrlOverride);
   if (override) {
     return {
-      ...(base ??
-        createSyntheticModel({
-          provider: "anthropic",
-          modelId,
-          api: "anthropic-messages",
-          baseUrl: override,
-          allowImages,
-        })),
-      baseUrl: override,
+      model: {
+        ...(base ??
+          createSyntheticModel({
+            provider: "anthropic",
+            modelId,
+            api: "anthropic-messages",
+            baseUrl: override,
+            allowImages,
+          })),
+        baseUrl: override,
+      },
+      isSyntheticCustomGateway: !base,
     };
   }
-  return (
-    base ??
-    createSyntheticModel({
-      provider: "anthropic",
-      modelId,
-      api: "anthropic-messages",
-      baseUrl: "https://api.anthropic.com",
-      allowImages,
-    })
-  );
+  return {
+    model:
+      base ??
+      createSyntheticModel({
+        provider: "anthropic",
+        modelId,
+        api: "anthropic-messages",
+        baseUrl: "https://api.anthropic.com",
+        allowImages,
+      }),
+    isSyntheticCustomGateway: false,
+  };
 }

--- a/src/llm/providers/openai.ts
+++ b/src/llm/providers/openai.ts
@@ -1,5 +1,5 @@
 import type { Context } from "@earendil-works/pi-ai";
-import { completeSimple } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 export {
   resolveOpenAiClientConfig,
   type OpenAiClientConfigInput,

--- a/src/llm/providers/shared.ts
+++ b/src/llm/providers/shared.ts
@@ -1,5 +1,5 @@
 import type { Api, AssistantMessage, Context, KnownProvider, Model } from "@earendil-works/pi-ai";
-import { getModel } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai/compat";
 
 export function resolveBaseUrlOverride(raw: string | null | undefined): string | null {
   const trimmed = typeof raw === "string" ? raw.trim() : "";

--- a/src/model-auto.ts
+++ b/src/model-auto.ts
@@ -1,4 +1,4 @@
-import * as piAi from "@earendil-works/pi-ai";
+import * as piAi from "@earendil-works/pi-ai/compat";
 import type { AutoRuleKind, CliProvider, SummarizeConfig } from "./config.js";
 import { normalizeGatewayStyleModelId, parseGatewayStyleModelId } from "./llm/model-id.js";
 import type { ModelRequestOptions } from "./llm/model-options.js";

--- a/tests/cli.asset.audio-file-errors.test.ts
+++ b/tests/cli.asset.audio-file-errors.test.ts
@@ -29,7 +29,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.audio-file.test.ts
+++ b/tests/cli.asset.audio-file.test.ts
@@ -35,7 +35,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.local-file.test.ts
+++ b/tests/cli.asset.local-file.test.ts
@@ -34,7 +34,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.local-pdf-extract.test.ts
+++ b/tests/cli.asset.local-pdf-extract.test.ts
@@ -26,7 +26,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.local-pdf-ocr-fallback.test.ts
+++ b/tests/cli.asset.local-pdf-ocr-fallback.test.ts
@@ -27,7 +27,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.media-api-key.test.ts
+++ b/tests/cli.asset.media-api-key.test.ts
@@ -64,7 +64,7 @@ mocks.completeSimple.mockResolvedValue(
   }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.unsupported.test.ts
+++ b/tests/cli.asset.unsupported.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.auto.always-summarize.test.ts
+++ b/tests/cli.auto.always-summarize.test.ts
@@ -32,7 +32,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.auto.fallback.test.ts
+++ b/tests/cli.auto.fallback.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.auto.no-model-needed.test.ts
+++ b/tests/cli.auto.no-model-needed.test.ts
@@ -28,7 +28,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.auto.youtube-always-summarize.test.ts
+++ b/tests/cli.auto.youtube-always-summarize.test.ts
@@ -55,7 +55,7 @@ const htmlResponse = (html: string, status = 200) =>
     headers: { "Content-Type": "text/html" },
   });
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: () => {
     throw new Error("unexpected pi-ai streamSimple call");

--- a/tests/cli.cache.no-cache.test.ts
+++ b/tests/cli.cache.no-cache.test.ts
@@ -47,7 +47,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.cache.summary.test.ts
+++ b/tests/cli.cache.summary.test.ts
@@ -46,7 +46,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.config-apikeys-legacy.test.ts
+++ b/tests/cli.config-apikeys-legacy.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.config-env.test.ts
+++ b/tests/cli.config-env.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.config-precedence.test.ts
+++ b/tests/cli.config-precedence.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.cost.finish-line.test.ts
+++ b/tests/cli.cost.finish-line.test.ts
@@ -41,7 +41,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.empty-summary.test.ts
+++ b/tests/cli.empty-summary.test.ts
@@ -24,7 +24,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "   ", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.google.streaming-fallback.test.ts
+++ b/tests/cli.google.streaming-fallback.test.ts
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.input-limit.test.ts
+++ b/tests/cli.input-limit.test.ts
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.json.cost-report.test.ts
+++ b/tests/cli.json.cost-report.test.ts
@@ -33,7 +33,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.language.test.ts
+++ b/tests/cli.language.test.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.llm.providers.test.ts
+++ b/tests/cli.llm.providers.test.ts
@@ -40,7 +40,7 @@ mocks.completeSimple.mockImplementation(
     }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.max-output-tokens.openrouter-ignored.test.ts
+++ b/tests/cli.max-output-tokens.openrouter-ignored.test.ts
@@ -24,7 +24,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.max-output-tokens.test.ts
+++ b/tests/cli.max-output-tokens.test.ts
@@ -24,7 +24,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.metrics.openrouter-label.test.ts
+++ b/tests/cli.metrics.openrouter-label.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.openai.chat-completions.test.ts
+++ b/tests/cli.openai.chat-completions.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.preprocess.test.ts
+++ b/tests/cli.preprocess.test.ts
@@ -33,7 +33,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.prompt-config.test.ts
+++ b/tests/cli.prompt-config.test.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.render.hyperlinks.test.ts
+++ b/tests/cli.render.hyperlinks.test.ts
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.render.md.reference-links.test.ts
+++ b/tests/cli.render.md.reference-links.test.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.spinner-output.test.ts
+++ b/tests/cli.spinner-output.test.ts
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.stream-merge.test.ts
+++ b/tests/cli.stream-merge.test.ts
@@ -33,7 +33,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.streamed-markdown-lines.test.ts
+++ b/tests/cli.streamed-markdown-lines.test.ts
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.streamed-markdown-render.test.ts
+++ b/tests/cli.streamed-markdown-render.test.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.twitter.skip-summary.json.test.ts
+++ b/tests/cli.twitter.skip-summary.json.test.ts
@@ -63,7 +63,7 @@ mocks.completeSimple.mockImplementation(async () =>
   }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/daemon.agent-history.test.ts
+++ b/tests/daemon.agent-history.test.ts
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,
   streamSimple: mocks.streamSimple,

--- a/tests/daemon.agent.test.ts
+++ b/tests/daemon.agent.test.ts
@@ -21,7 +21,7 @@ vi.mock("../src/llm/cli.js", async (importOriginal) => {
   };
 });
 
-vi.mock("@earendil-works/pi-ai", () => {
+vi.mock("@earendil-works/pi-ai/compat", () => {
   return {
     completeSimple: mockCompleteSimple,
     getModel: mockGetModel,

--- a/tests/daemon.cache.summary.test.ts
+++ b/tests/daemon.cache.summary.test.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/live/openrouter-fallback.live.test.ts
+++ b/tests/live/openrouter-fallback.live.test.ts
@@ -1,4 +1,4 @@
-import { getModels } from "@earendil-works/pi-ai";
+import { getModels } from "@earendil-works/pi-ai/compat";
 import { describe, expect, it } from "vitest";
 import type { SummarizeConfig } from "../../src/config.js";
 import { generateTextWithModelId } from "../../src/llm/generate-text.js";

--- a/tests/llm.anthropic-reasoning.test.ts
+++ b/tests/llm.anthropic-reasoning.test.ts
@@ -55,8 +55,8 @@ describe("prepareAnthropicReasoning", () => {
   });
 
   it("drops reasoning on registered unsupported models (Claude 3/3.5) so pi-ai does not enable thinking", () => {
-    // pi-ai 0.75.5 enables extended thinking whenever `options.reasoning` is
-    // present, regardless of `model.reasoning`. For Claude 3/3.5 the API
+    // pi-ai enables extended thinking whenever `options.reasoning` is
+    // present and `model.reasoning` is true. For Claude 3/3.5 the API
     // rejects thinking blocks, so we must drop the reasoning option entirely
     // when the user has a global `thinking` setting active.
     const baseModel = makeBase("claude-3-5-sonnet-20241022", false);
@@ -70,11 +70,14 @@ describe("prepareAnthropicReasoning", () => {
     expect(result.reasoning).toBeUndefined();
   });
 
-  it("opts synthetic models into thinking so the request body carries thinking", () => {
+  it("opts synthetic models into adaptive thinking so Bedrock gateways accept the request", () => {
     // A custom modelId not in the pi-ai registry (e.g. `Claude-Opus-4.7`
     // routed through a jdcloud-style proxy) is built via createSyntheticModel
-    // with reasoning: false. Without opting in, the pi-ai Anthropic adapter
-    // would silently drop the thinking block.
+    // with reasoning: false and no compat. Without opting in, the pi-ai
+    // Anthropic adapter would silently drop the thinking block; and without
+    // `forceAdaptiveThinking` it would send `thinking.type="enabled"` +
+    // `budget_tokens`, which Anthropic-on-Bedrock gateways reject in favor of
+    // `thinking.type="adaptive"` + `output_config.effort`.
     const baseModel = makeBase(
       "Definitely-Not-A-Real-Claude-Model-Id-42",
       false,
@@ -88,8 +91,12 @@ describe("prepareAnthropicReasoning", () => {
     expect(result.reasoning).toBe("xhigh");
     expect(result.model).not.toBe(baseModel);
     expect(result.model.reasoning).toBe(true);
+    // Custom-gateway models must request adaptive thinking.
+    expect(result.model.compat?.forceAdaptiveThinking).toBe(true);
     // Other model fields should be preserved.
     expect(result.model.id).toBe(baseModel.id);
     expect(result.model.baseUrl).toBe(baseModel.baseUrl);
+    // The original model object must not be mutated.
+    expect(baseModel.compat).toBeUndefined();
   });
 });

--- a/tests/llm.anthropic-reasoning.test.ts
+++ b/tests/llm.anthropic-reasoning.test.ts
@@ -24,7 +24,10 @@ function makeBase(
 describe("prepareAnthropicReasoning", () => {
   it("returns the base model untouched when no effort is requested", () => {
     const baseModel = makeBase("claude-opus-4-5", true);
-    const result = prepareAnthropicReasoning({ modelId: "claude-opus-4-5", baseModel });
+    const result = prepareAnthropicReasoning({
+      baseModel,
+      isSyntheticCustomGateway: false,
+    });
     expect(result.model).toBe(baseModel);
     expect(result.reasoning).toBeUndefined();
   });
@@ -32,8 +35,8 @@ describe("prepareAnthropicReasoning", () => {
   it("treats 'none' as off and does not forward reasoning", () => {
     const baseModel = makeBase("claude-opus-4-5", true);
     const result = prepareAnthropicReasoning({
-      modelId: "claude-opus-4-5",
       baseModel,
+      isSyntheticCustomGateway: false,
       reasoningEffort: "none",
     });
     expect(result.reasoning).toBeUndefined();
@@ -45,8 +48,8 @@ describe("prepareAnthropicReasoning", () => {
     // returns it intact so we should not flip any flags.
     const baseModel = makeBase("claude-opus-4-5", true);
     const result = prepareAnthropicReasoning({
-      modelId: "claude-opus-4-5",
       baseModel,
+      isSyntheticCustomGateway: false,
       reasoningEffort: "xhigh",
     });
     expect(result.reasoning).toBe("xhigh");
@@ -61,8 +64,8 @@ describe("prepareAnthropicReasoning", () => {
     // when the user has a global `thinking` setting active.
     const baseModel = makeBase("claude-3-5-sonnet-20241022", false);
     const result = prepareAnthropicReasoning({
-      modelId: "claude-3-5-sonnet-20241022",
       baseModel,
+      isSyntheticCustomGateway: false,
       reasoningEffort: "high",
     });
     expect(result.model).toBe(baseModel);
@@ -84,8 +87,8 @@ describe("prepareAnthropicReasoning", () => {
       "https://proxy.example/anthropic",
     );
     const result = prepareAnthropicReasoning({
-      modelId: "Definitely-Not-A-Real-Claude-Model-Id-42",
       baseModel,
+      isSyntheticCustomGateway: true,
       reasoningEffort: "xhigh",
     });
     expect(result.reasoning).toBe("xhigh");

--- a/tests/llm.generate-text.more-branches.test.ts
+++ b/tests/llm.generate-text.more-branches.test.ts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/llm.generate-text.test.ts
+++ b/tests/llm.generate-text.test.ts
@@ -28,7 +28,7 @@ mocks.streamSimple.mockImplementation((_model: MockModel) =>
   makeTextDeltaStream(["o", "k"], makeAssistantMessage({ text: "ok" })),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/llm.openai-provider.test.ts
+++ b/tests/llm.openai-provider.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   completeSimple: vi.fn(),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
 }));
 


### PR DESCRIPTION
## What

Set `compat.forceAdaptiveThinking` on **synthetic** Anthropic models (custom `ANTHROPIC_BASE_URL` ids that aren't in pi-ai's model registry) so pi-ai requests **adaptive** thinking instead of the budget-based form.

Refs #320.

## Why

For a custom-gateway model id, `resolveAnthropicModel` builds a synthetic model and `prepareAnthropicReasoning` flips it to `reasoning: true` (added in #233) so a thinking block is actually sent. But the synthetic model has no `compat`, so pi-ai falls back to:

```jsonc
"thinking": { "type": "enabled", "budget_tokens": ... }
```

Anthropic models served via **AWS Bedrock** reject that form — they require:

```jsonc
"thinking": { "type": "adaptive", "display": "summarized" },
"output_config": { "effort": "<level>" }
```

So the request fails upstream and the user gets an empty summary. Registered Claude 4.x models already carry `compat.forceAdaptiveThinking: true` in pi-ai's registry, which is exactly why they work and custom-gateway ids pointing at the same model family don't. This change gives synthetic models the same flag.

## The fix

In `prepareAnthropicReasoning`, the synthetic branch now sets `compat.forceAdaptiveThinking: true` alongside `reasoning: true`:

```ts
return {
  model: {
    ...baseModel,
    reasoning: true,
    compat: { ...baseModel.compat, forceAdaptiveThinking: true },
  },
  reasoning,
};
```

Scope notes:
- **Synthetic-only.** Registered models (registry hits) are untouched and keep their own compat.
- **No effort/`thinkingLevelMap` change.** With `forceAdaptiveThinking` and no level map, pi-ai's `mapThinkingLevelToEffort` maps `xhigh → high` (its conservative default) for synthetic ids, which Bedrock accepts. Honoring `xhigh` exactly for custom gateways could be a small follow-up (a `thinkingLevelMap: { xhigh: "xhigh" }`) but is intentionally left out here to keep the change minimal and avoid assuming the backend supports `xhigh`.

## Verification

Confirmed against a real Anthropic-on-Bedrock gateway (Opus 4.x) using the pinned `@earendil-works/pi-ai@^0.79.1`:

- With `forceAdaptiveThinking`, pi-ai emits `thinking.type="adaptive"` + `output_config.effort` and the gateway returns **200** (vs. the rejected `enabled`+`budget_tokens` form). Verified by capturing the outgoing request body.
- End-to-end `completeSimple(reasoning: "xhigh")` returns **non-empty text even when the response contains a thinking block** (3/3 runs: thinking block 576/707/847 chars + text ~1.6k chars, `stopReason: "stop"`). I'd earlier noted a streaming concern on #320 (text coming back empty when a thinking block was present) — that reproduced on pi-ai **0.75.5** but **not** on **0.79.1**; the streamed text is retained on the pinned version, so this summarize-side change is sufficient on its own.

## Tests

`tests/llm.anthropic-reasoning.test.ts` — the synthetic-model case now also asserts `compat.forceAdaptiveThinking === true` and that the original model object is not mutated.

- `pnpm typecheck` ✓
- `pnpm test` ✓ (full suite)
- `pnpm format:check` / `pnpm lint` ✓ (changed files)
