### PR TITLE
fix(anthropic): preserve base URL path prefix for PDF document requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.20.2 - Unreleased
 
+### Fixes
+
+- Anthropic custom gateways: preserve path prefixes when sending PDF document requests (#325, thanks @wangwllu).
+
 ## 0.20.1 - 2026-06-24
 
 ### Fixes

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -184,7 +184,12 @@ export async function completeAnthropicDocument({
     throw new Error("Internal error: expected a document attachment for Anthropic.");
   }
   const baseUrl = resolveBaseUrlOverride(anthropicBaseUrlOverride) ?? "https://api.anthropic.com";
-  const url = new URL("/v1/messages", baseUrl);
+  // Join onto the base URL so a path prefix on the override survives. Using
+  // `new URL("/v1/messages", baseUrl)` would treat the absolute path as
+  // root-relative and discard any prefix (e.g. a custom Anthropic-compatible
+  // gateway exposed at `https://host/anthropic` would lose `/anthropic` and
+  // POST to `https://host/v1/messages`). Mirror completeGoogleDocument's join.
+  const url = new URL(`${baseUrl.replace(/\/$/, "")}/v1/messages`);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   const payload = {

--- a/tests/llm.anthropic-document-url.test.ts
+++ b/tests/llm.anthropic-document-url.test.ts
@@ -66,6 +66,30 @@ describe("completeAnthropicDocument request URL", () => {
     expect(captured[0]).toBe("https://gateway.example/anthropic/v1/messages");
   });
 
+  it("matches the Anthropic SDK/text path for an already-versioned base (no special-casing)", async () => {
+    // The streaming/text path stores ANTHROPIC_BASE_URL verbatim as the model
+    // baseUrl (see resolveAnthropicModel) and lets @anthropic-ai/sdk append
+    // `/v1/messages` via string concat. For a base that already ends in `/v1`
+    // the SDK therefore produces `/v1/v1/messages`. The document path must stay
+    // byte-for-byte consistent with that path rather than inventing a
+    // document-only `/v1`-as-root heuristic (which would make PDF requests
+    // diverge from text/streaming requests for the same configured base).
+    const captured: string[] = [];
+    const { completeAnthropicDocument } = await import("../src/llm/providers/anthropic.js");
+
+    await completeAnthropicDocument({
+      modelId: "claude-opus-4-x",
+      apiKey: "test-key",
+      promptText: "Summarize this document",
+      document: docInput,
+      timeoutMs: 30000,
+      fetchImpl: mockOkFetch(captured) as unknown as typeof fetch,
+      anthropicBaseUrlOverride: "https://anthropic.example/v1",
+    });
+
+    expect(captured[0]).toBe("https://anthropic.example/v1/v1/messages");
+  });
+
   it("defaults to api.anthropic.com when no override is given", async () => {
     const captured: string[] = [];
     const { completeAnthropicDocument } = await import("../src/llm/providers/anthropic.js");

--- a/tests/llm.anthropic-document-url.test.ts
+++ b/tests/llm.anthropic-document-url.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+// completeAnthropicDocument posts a base64 PDF document block to the Anthropic
+// Messages API. The request URL must be built by JOINING `/v1/messages` onto the
+// (optionally overridden) base URL so that a path prefix on a custom
+// Anthropic-compatible gateway is preserved. Using `new URL("/v1/messages", base)`
+// treats the path as root-relative and silently drops any prefix, so a gateway at
+// `https://host/anthropic` would wrongly POST to `https://host/v1/messages` (404/400).
+
+const docInput = {
+  kind: "document" as const,
+  mediaType: "application/pdf" as const,
+  bytes: new Uint8Array([1, 2, 3]),
+  filename: "test.pdf",
+};
+
+function mockOkFetch(captured: string[]) {
+  return vi.fn(async (url: string) => {
+    captured.push(String(url));
+    return {
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          content: [{ type: "text", text: "Summary result" }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        }),
+    } as unknown as Response;
+  });
+}
+
+describe("completeAnthropicDocument request URL", () => {
+  it("preserves a path prefix on a custom gateway base URL", async () => {
+    const captured: string[] = [];
+    const { completeAnthropicDocument } = await import("../src/llm/providers/anthropic.js");
+
+    await completeAnthropicDocument({
+      modelId: "claude-opus-4-x",
+      apiKey: "test-key",
+      promptText: "Summarize this document",
+      document: docInput,
+      maxOutputTokens: 256,
+      timeoutMs: 30000,
+      fetchImpl: mockOkFetch(captured) as unknown as typeof fetch,
+      anthropicBaseUrlOverride: "https://gateway.example/anthropic",
+    });
+
+    expect(captured.length).toBe(1);
+    expect(captured[0]).toBe("https://gateway.example/anthropic/v1/messages");
+  });
+
+  it("tolerates a trailing slash on the override", async () => {
+    const captured: string[] = [];
+    const { completeAnthropicDocument } = await import("../src/llm/providers/anthropic.js");
+
+    await completeAnthropicDocument({
+      modelId: "claude-opus-4-x",
+      apiKey: "test-key",
+      promptText: "Summarize this document",
+      document: docInput,
+      timeoutMs: 30000,
+      fetchImpl: mockOkFetch(captured) as unknown as typeof fetch,
+      anthropicBaseUrlOverride: "https://gateway.example/anthropic/",
+    });
+
+    expect(captured[0]).toBe("https://gateway.example/anthropic/v1/messages");
+  });
+
+  it("defaults to api.anthropic.com when no override is given", async () => {
+    const captured: string[] = [];
+    const { completeAnthropicDocument } = await import("../src/llm/providers/anthropic.js");
+
+    await completeAnthropicDocument({
+      modelId: "claude-opus-4-x",
+      apiKey: "test-key",
+      promptText: "Summarize this document",
+      document: docInput,
+      timeoutMs: 30000,
+      fetchImpl: mockOkFetch(captured) as unknown as typeof fetch,
+    });
+
+    expect(captured[0]).toBe("https://api.anthropic.com/v1/messages");
+  });
+});


### PR DESCRIPTION
Fixes #324.

### Problem

`completeAnthropicDocument()` (the PDF document path for Anthropic models) built its request URL with:

```ts
const url = new URL("/v1/messages", baseUrl);
```

`new URL("/v1/messages", base)` treats the path as **root-relative**, discarding any path prefix on a custom `ANTHROPIC_BASE_URL`. A gateway exposed at `https://host/anthropic` would lose `/anthropic` and POST to `https://host/v1/messages` → 400/404. The default `https://api.anthropic.com` (no prefix) is unaffected, and the streaming/text path (via pi-ai, which concatenates `baseURL + path`) was never affected — only this hand-rolled `fetch`.

### Fix

Join onto the base instead, mirroring `completeGoogleDocument` in `src/llm/providers/google.ts` which already does this correctly:

```ts
const url = new URL(`${baseUrl.replace(/\/$/, "")}/v1/messages`);
```

- `https://api.anthropic.com` → `https://api.anthropic.com/v1/messages` (unchanged)
- `https://host/anthropic` → `https://host/anthropic/v1/messages` (fixed)
- `https://host/anthropic/` → same (trailing slash stripped)

This keeps the existing contract shared with `google.ts`: `ANTHROPIC_BASE_URL` is a provider/gateway base (host + optional prefix) onto which the code appends `/v1/messages`, not a fully-versioned Messages endpoint. The default remains exactly correct.

### Test

Adds `tests/llm.anthropic-document-url.test.ts` (mirroring the `tests/llm.google-document.test.ts` mockFetch style) asserting the captured request URL for:

- a path-prefixed override (`https://gateway.example/anthropic`),
- a trailing-slash override,
- the default base (no override).

### Verification

- `vitest run` — new test (3) + `llm.google-document` (4) pass.
- typecheck (`tsgo`) + `oxlint` clean.
- Built `dist` and tested end-to-end against a live Anthropic-compatible gateway exposed under `/anthropic`: PDF summarize went from `Anthropic API error (400)` (before) to a real summary (after).

### Scope

One-line change in `src/llm/providers/anthropic.ts` + a regression test. I deliberately kept this minimal rather than refactoring `google.ts` and `anthropic.ts` into a shared `joinUrl()` helper; happy to do that as a follow-up if you'd prefer.


---

### Behavior proof (redacted, generic example values)

A local logging proxy stood in for the gateway and printed the path it received before forwarding. Same PDF input, same config; only the build differs:

```text
# BEFORE (current main): new URL("/v1/messages", base) drops the /anthropic prefix
ANTHROPIC_BASE_URL=http://<proxy>/anthropic  summarize acme.pdf
  GATEWAY RECEIVED PATH: /v1/messages
  GATEWAY RESPONSE: 400
  CLI: "Anthropic API error (400)."

# AFTER (this PR): prefix preserved
ANTHROPIC_BASE_URL=http://<proxy>/anthropic  summarize acme.pdf
  GATEWAY RECEIVED PATH: /anthropic/v1/messages
  GATEWAY RESPONSE: 200
  CLI: "## Acme Corp Q3 2026 Summary ..." (real summary)
```

(Tested against `@anthropic-ai/sdk@0.91.1` / `pi-ai@0.80.2`, the versions this PR ships with.)

### On the `/v1`-base shape

This PR intentionally does **not** special-case a base already ending in `/v1`. The streaming/text path stores `ANTHROPIC_BASE_URL` verbatim as the model `baseUrl` (`resolveAnthropicModel`, `src/llm/providers/models.ts`) and lets `@anthropic-ai/sdk` append `/v1/messages`, so it produces the same URLs the document path now produces — including `/v1/v1/messages` for a `/v1` base. Verified end-to-end against the real SDK:

| `ANTHROPIC_BASE_URL` | Anthropic SDK / text path | document path (this PR) |
| --- | --- | --- |
| `https://api.anthropic.com` | `…/v1/messages` | same |
| `https://anthropic.example/v1` | `…/v1/v1/messages` | same |
| `https://gateway.example/anthropic` | `…/anthropic/v1/messages` | same |
| `https://gateway.example/anthropic/` | `…/anthropic/v1/messages` | same |

So `/v1` was never a working end-to-end contract on the dominant Anthropic path; the document path only *appeared* to tolerate it because the old `new URL(absolute, base)` discarded the path. A document-only `/v1`-as-root heuristic would make PDF summaries diverge from text/streaming for the same base. The added test documents this parity (including the `/v1` case) so it's explicit, not accidental. Happy to normalize the base once for **both** paths as a separate change if maintainers prefer supporting endpoint-style `/v1` overrides.
