### PR TITLE
[codex] Sync extract and slides input docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Use `summarize --help` or `summarize help` for the full help text.
 - `--preprocess off|auto|always`: controls `uvx markitdown` usage (default `auto`)
   - Install `uvx`: `brew install uv` (or https://astral.sh/uv/)
   - Image-only PDFs can fall back to OpenAI vision OCR when `OPENAI_API_KEY` is set; override the OCR model with `MARKITDOWN_OCR_MODEL` or page render DPI with `MARKITDOWN_OCR_DPI`.
-- `--extract`: print extracted content and exit (URLs only; stdin `-` is not supported)
+- `--extract`: print extracted content and exit (URLs, YouTube/direct media, local audio/video, and local PDFs; stdin `-` is not supported)
   - Deprecated alias: `--extract-only`
 - `--slides`: extract slides for YouTube, direct video URLs, or local video files and render them inline in the summary narrative (auto-renders inline in supported terminals)
 - `--slides-ocr`: run OCR on extracted slides (requires `tesseract`)

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -12,7 +12,7 @@ summary: "Every summarize subcommand and flag, with examples."
 ## Subcommands
 
 - [`summarize`](summarize.md) — main command. Takes a URL, file, or stdin and produces a summary or extracted content.
-- [`summarize slides`](slides.md) — extract scene-change keyframes from a video URL into PNGs (and optional OCR text). Standalone version of the `--slides` flag.
+- [`summarize slides`](slides.md) — extract scene-change keyframes from a YouTube URL, direct video URL, or local video file into PNGs (and optional OCR text). Standalone version of the `--slides` flag.
 - [`summarize transcriber`](transcriber.md) — set up local ONNX transcription (Parakeet, Canary). Prints the env vars you need.
 - [`summarize daemon`](daemon.md) — manage the local HTTP daemon that the Chrome Side Panel talks to. Subcommands: `install`, `restart`, `status`, `uninstall`, `run`.
 - [`summarize refresh-free`](refresh-free.md) — scan OpenRouter `:free` models, write working candidates to `~/.summarize/config.json`.

--- a/docs/commands/slides.md
+++ b/docs/commands/slides.md
@@ -2,16 +2,16 @@
 title: summarize slides
 permalink: /docs/commands/slides.html
 kicker: command
-summary: "Extract scene-change keyframes from a video URL into PNG files."
+summary: "Extract scene-change keyframes from a video source into PNG files."
 ---
 
 # `summarize slides`
 
 ```text
-summarize slides <url> [flags]
+summarize slides <source> [flags]
 ```
 
-Extracts slide-shaped keyframes from a YouTube or direct video URL using FFmpeg scene detection. Native ffmpeg is preferred; bundled FFmpeg WebAssembly is used when native `ffmpeg`/`ffprobe` are unavailable. Output is a directory of PNGs (and optional OCR text). This is the standalone form of the `--slides` flag on the main command — useful when you only want the slides without a summary.
+Extracts slide-shaped keyframes from a YouTube URL, direct video URL, or local video file using FFmpeg scene detection. Native ffmpeg is preferred; bundled FFmpeg WebAssembly is used when native `ffmpeg`/`ffprobe` are unavailable. Output is a directory of PNGs (and optional OCR text). This is the standalone form of the `--slides` flag on the main command — useful when you only want the slides without a summary.
 
 ## Synopsis
 
@@ -20,6 +20,7 @@ summarize slides "https://youtu.be/..."
 summarize slides "https://youtu.be/..." --render auto
 summarize slides "https://youtu.be/..." --slides-ocr -o ./out
 summarize slides "https://example.com/lecture.mp4" --slides-max 12
+summarize slides ./lecture.mp4 --slides-max 12
 ```
 
 ## Requirements

--- a/docs/commands/summarize.md
+++ b/docs/commands/summarize.md
@@ -11,7 +11,7 @@ summary: "Main command. URL, file, or stdin → clean text → summary."
 summarize [input] [flags]
 ```
 
-Takes a URL, local file path, or `-` for stdin and produces a summary. With `--extract`, prints cleaned content instead of summarizing.
+Takes a URL, local file path, or `-` for stdin and produces a summary. With `--extract`, prints cleaned content instead of summarizing; stdin is not supported in extract mode.
 
 ## Synopsis
 
@@ -37,7 +37,8 @@ If `[input]` is omitted, summarize prints concise help and exits.
 ### Extraction
 
 `--extract`
-: Print extracted content and exit. No LLM call. The `--extract-only` alias is hidden but still works.
+: Print extracted content and exit. No LLM call. Supports URLs, YouTube/direct media, local audio/video, and local PDFs; `-` stdin is not supported. The `--extract-only` alias is hidden but still works.
+: Extraction can still use configured remote transcription, OCR, or Markdown providers for media/PDF inputs.
 
 `--format <format>`
 : `md` or `text`. Controls website extraction format and whether files are preprocessed to Markdown for model compatibility. Default: `text`. Default in `--extract` mode for URLs: `md`.
@@ -87,7 +88,7 @@ If `[input]` is omitted, summarize prints concise help and exits.
 ### Slides
 
 `--slides [value]`
-: Extract slides from a video URL and render inline alongside the summary. Combine with `--extract` to interleave slides in the full transcript. See [Slides mode](../slides.md).
+: Extract slides from a YouTube URL, direct video URL, or local video file and render inline alongside the summary. Combine with `--extract` to interleave slides in the full transcript. See [Slides mode](../slides.md).
 
 `--slides-ocr`
 : Run OCR on extracted slides. Requires `tesseract`.

--- a/docs/extract-only.md
+++ b/docs/extract-only.md
@@ -15,7 +15,8 @@ Deprecated alias: `--extract-only`.
 ## Notes
 
 - No summarization LLM call happens in this mode.
-- Input must be a URL (`-` stdin is not supported with `--extract`).
+- Supported inputs are URLs, YouTube/direct media, local audio/video, and local PDF files (`-` stdin is not supported with `--extract`).
+- Extraction can still use configured remote transcription, OCR, or Markdown providers for media/PDF inputs. For sensitive files, use local transcription/provider settings for media and `--preprocess off` when you need to block PDF/Markdown preprocessing.
 - No extraction cap is applied. Use `--max-extract-characters <count>` to cap output if needed.
 - `--format md` may still convert HTML to Markdown (depending on `--markdown-mode` and available tools).
 - `--length` is intended for summarization guidance; extraction prints full content.

--- a/docs/slides.md
+++ b/docs/slides.md
@@ -57,13 +57,13 @@ read_when:
 
 ## CLI
 
-- `summarize <url> --slides` streams a short intro paragraph and then a continuous narrative with slide images inserted inline where `[slide:N]` markers appear.
+- `summarize <source> --slides` streams a short intro paragraph and then a continuous narrative with slide images inserted inline where `[slide:N]` markers appear. The source can be a YouTube URL, direct video URL, or local video file.
   - The model is responsible for inserting every slide marker in order; text length is still governed by `--length`.
   - If inline images are unsupported, the CLI prints text-only output and notes how to export slides to disk.
   - Timestamp links use OSC-8 when supported (YouTube/Vimeo/Loom/Dropbox).
   - Progress line reports slide extraction steps (includes slide counts when available).
-- `summarize <url> --slides --extract` prints the full timed transcript and inserts slide images inline at matching timestamps.
-- `summarize slides <url>` extracts slides without summarizing (use `--render auto|kitty|iterm` for inline thumbnails).
+- `summarize <source> --slides --extract` prints the full timed transcript and inserts slide images inline at matching timestamps.
+- `summarize slides <source>` extracts slides without summarizing (use `--render auto|kitty|iterm` for inline thumbnails).
 - Defaults to writing images under `./slides/<sourceId>/` (override via `--slides-dir` / `--output`).
 
 ## Implementation notes

--- a/src/run/help.ts
+++ b/src/run/help.ts
@@ -79,7 +79,7 @@ export function buildProgram() {
     )
     .option(
       "--slides [value]",
-      "Extract slides for YouTube/direct video URLs and render them inline inside the summary narrative (when supported). Combine with --extract to interleave slides in the full transcript.",
+      "Extract slides for YouTube/direct video URLs or local video files and render them inline inside the summary narrative (when supported). Combine with --extract to interleave slides in the full transcript.",
     )
     .option("--slides-debug", "Show slide image paths instead of rendering inline images.", false)
     .option("--slides-ocr", "Run OCR on extracted slides (requires tesseract).", false)
@@ -193,7 +193,11 @@ export function buildProgram() {
         "Use a CLI provider: claude, gemini, codex, agent, openclaw, opencode, copilot, agy, pi (equivalent to --model cli/<provider>). If omitted, use auto selection with CLI enabled.",
       ),
     )
-    .option("--extract", "Print extracted content and exit (no LLM summary)", false)
+    .option(
+      "--extract",
+      "Print extracted content and exit: URLs, media, and local PDFs; stdin is unsupported.",
+      false,
+    )
     .addOption(new Option("--extract-only", "Deprecated alias for --extract").hideHelp())
     .option("--json", "Output structured JSON (includes prompt + metrics)", false)
     .option(
@@ -248,8 +252,10 @@ export function applyHelpStyle(
 export function buildSlidesProgram() {
   return new Command()
     .name("summarize slides")
-    .description("Extract slide screenshots from a YouTube or direct video URL.")
-    .argument("<url>", "YouTube or direct video URL")
+    .description(
+      "Extract slide screenshots from a YouTube URL, direct video URL, or local video file.",
+    )
+    .argument("<source>", "YouTube URL, direct video URL, or local video file")
     .option("--slides-ocr", "Run OCR on extracted slides (requires tesseract).", false)
     .option("--slides-dir <dir>", "Base output dir for slides (default: ./slides).", "slides")
     .option("-o, --output <dir>", "Alias for --slides-dir.", undefined)

--- a/tests/package-bin.test.ts
+++ b/tests/package-bin.test.ts
@@ -171,6 +171,17 @@ describe("package bin wrappers", () => {
     }
   });
 
+  it("documents extract and local video support in visible help", () => {
+    const mainHelp = buildProgram().helpInformation();
+    expect(mainHelp).toMatch(/URLs,\s+media,\s+and local PDFs/);
+    expect(mainHelp).toContain("stdin is unsupported");
+    expect(mainHelp).toContain("or local video files");
+
+    const slidesHelp = buildSlidesProgram().helpInformation();
+    expect(slidesHelp).toContain("Usage: summarize slides [options] <source>");
+    expect(slidesHelp).toMatch(/local\s+video\s+file/);
+  });
+
   it("routes fish subcommands from the first CLI argument", async () => {
     const fish = await readFile("completions/summarize.fish", "utf8");
 


### PR DESCRIPTION
## Summary

- Sync `--extract` docs with current input support: URLs, YouTube/direct media, local audio/video, and local PDFs; keep stdin called out as unsupported for extract mode.
- Sync `--slides` and `summarize slides` help/docs with local video file support.
- Add a focused help contract test for visible extract/slides wording.

## Why

The current docs still described `--extract` as URL-only in a couple of places, even though local media/PDF extraction is supported and stdin extract is intentionally rejected. Some slides docs and help also still said URL-only even though local video files are supported.

This PR keeps the behavior unchanged and updates the docs/help to match the tested contract. It also adds a privacy caveat that extract mode avoids summarization LLM calls, but media/PDF extraction can still use configured remote transcription, OCR, or Markdown providers.

## Real behavior proof

Captured from this branch with `pnpm dev:cli`:

```text
## main help proof: --extract
  --extract                         Print extracted content and exit: URLs,
                                    media, and local PDFs; stdin is unsupported.
                                    (default: false)
  --json                            Output structured JSON (includes prompt +
                                    metrics) (default: false)

## main help proof: --slides
  --slides [value]                  Extract slides for YouTube/direct video URLs
                                    or local video files and render them inline
                                    inside the summary narrative (when
                                    supported). Combine with --extract to
                                    interleave slides in the full transcript.
  --slides-debug                    Show slide image paths instead of rendering

## slides help proof

> @steipete/summarize@0.20.1 dev:cli /private/tmp/summarize-latest
> node --import ./scripts/register-typescript.mjs src/cli.ts slides --help

Usage: summarize slides [options] <source>

Extract slide screenshots from a YouTube URL, direct video URL, or local video
file.

Arguments:
  source                            YouTube URL, direct video URL, or local
                                    video file
```

## Validation

- `pnpm format:check`
- `pnpm docs:build`
- `pnpm exec vitest run tests/cli.asset.local-pdf-extract.test.ts tests/cli.stdin.test.ts tests/runner-slides.test.ts tests/input.resolve-input-target.test.ts tests/package-bin.test.ts` — 38 passed