### PR TITLE
fix: allow direct hover summaries without daemon token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Streaming: share EOF-safe, whitespace-preserving SSE parsing across core, CLI providers, and extension clients.
 - Config: preserve standalone `enabled: false` values for cache, media cache, slides, and logging sections.
 - Daemon chat: surface non-streaming provider failures and apply the GitHub Models compatibility fallback to JSON and SSE agent responses.
+- Chrome extension: allow direct OpenAI provider mode to run hover summaries without requiring a daemon token.
 - Dependencies: pin patched Vite, tmp, and protobufjs releases to clear known high- and moderate-severity transitive advisories.
 
 ## 0.19.0 - 2026-06-17

--- a/apps/chrome-extension/src/entrypoints/hover.content.ts
+++ b/apps/chrome-extension/src/entrypoints/hover.content.ts
@@ -1,5 +1,6 @@
 import { defineContentScript } from "wxt/utils/define-content-script";
 import { META_SITE_EXCLUDE_MATCHES } from "../lib/content-script-matches";
+import { resolveCapabilityExecution } from "../lib/model-routing";
 import { mergeStreamingChunk } from "../lib/runtime-contracts";
 import { loadSettings, type Settings } from "../lib/settings";
 
@@ -119,9 +120,15 @@ export function shouldHandleHoverTriggerEvent(event: Pick<Event, "isTrusted">): 
 }
 
 export function shouldStartHoverRequest(
-  settings: Pick<Settings, "hoverSummaries"> | null,
+  settings: Pick<
+    Settings,
+    "hoverSummaries" | "model" | "provider" | "providerApiKeys" | "summaryRuntime" | "token"
+  > | null,
 ): boolean {
-  return Boolean(settings?.hoverSummaries);
+  return Boolean(
+    settings?.hoverSummaries &&
+    (resolveCapabilityExecution(settings) !== "daemon" || settings.token.trim()),
+  );
 }
 
 function ensureTooltip(): Tooltip {

--- a/apps/chrome-extension/src/entrypoints/hover.content.ts
+++ b/apps/chrome-extension/src/entrypoints/hover.content.ts
@@ -120,15 +120,30 @@ export function shouldHandleHoverTriggerEvent(event: Pick<Event, "isTrusted">): 
 }
 
 export function shouldStartHoverRequest(
-  settings: Pick<
-    Settings,
-    "hoverSummaries" | "model" | "provider" | "providerApiKeys" | "summaryRuntime" | "token"
-  > | null,
+  settings:
+    | (Pick<Settings, "hoverSummaries"> &
+        Partial<
+          Pick<Settings, "model" | "provider" | "providerApiKeys" | "summaryRuntime" | "token">
+        >)
+    | null,
 ): boolean {
-  return Boolean(
-    settings?.hoverSummaries &&
-    (resolveCapabilityExecution(settings) !== "daemon" || settings.token.trim()),
-  );
+  if (!settings?.hoverSummaries) return false;
+  if (
+    !settings.model ||
+    !settings.provider ||
+    !settings.providerApiKeys ||
+    !settings.summaryRuntime
+  ) {
+    return true;
+  }
+  return resolveCapabilityExecution({
+    model: settings.model,
+    provider: settings.provider,
+    providerApiKeys: settings.providerApiKeys,
+    summaryRuntime: settings.summaryRuntime,
+  }) !== "daemon"
+    ? true
+    : Boolean(settings.token?.trim());
 }
 
 function ensureTooltip(): Tooltip {

--- a/apps/chrome-extension/tests/options.spec.ts
+++ b/apps/chrome-extension/tests/options.spec.ts
@@ -236,6 +236,57 @@ test("options exposes two AI connections and independent slide runtimes", async 
   }
 });
 
+test("options stores an OpenAI key for direct mode without requiring the daemon", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, {
+      summaryRuntime: "daemon",
+      slideRuntime: "daemon",
+      provider: "openrouter",
+      providerApiKeys: {},
+    });
+    const page = await openExtensionPage(harness, "options.html", "#tabs");
+
+    await page.click("#tab-runtime");
+    await page.locator('#summaryRuntimeMode input[value="direct"]').click();
+    await page.locator('#slideRuntimeMode input[value="browser"]').click();
+    await page.locator("#provider").selectOption("openai");
+    await page.locator("#providerApiKey").fill("sk-test-direct-openai");
+
+    await expect
+      .poll(async () => {
+        const settings = await getSettings(harness);
+        return {
+          summaryRuntime: settings.summaryRuntime,
+          slideRuntime: settings.slideRuntime,
+          provider: settings.provider,
+          key: settings.providerApiKeys?.openai,
+        };
+      })
+      .toEqual({
+        summaryRuntime: "direct",
+        slideRuntime: "browser",
+        provider: "openai",
+        key: "sk-test-direct-openai",
+      });
+
+    await page.reload();
+    await page.click("#tab-runtime");
+    await expect(page.locator('#summaryRuntimeMode input[value="direct"]')).toBeChecked();
+    await expect(page.locator('#slideRuntimeMode input[value="browser"]')).toBeChecked();
+    await expect(page.locator("#provider")).toHaveValue("openai");
+    await expect(page.locator("#providerApiKey")).toHaveValue("sk-test-direct-openai");
+    await expect(page.locator("#daemonStatus")).toContainText("Daemon not selected");
+
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
 test("options disables automation permissions button when granted", async ({
   browserName: _browserName,
 }, testInfo) => {

--- a/tests/hover.security.test.ts
+++ b/tests/hover.security.test.ts
@@ -18,6 +18,32 @@ describe("hover summary security boundaries", () => {
     expect(shouldStartHoverRequest({ hoverSummaries: true })).toBe(true);
   });
 
+  it("does not require a daemon token for configured direct hover summaries", () => {
+    expect(
+      shouldStartHoverRequest({
+        hoverSummaries: true,
+        model: "auto",
+        provider: "openai",
+        providerApiKeys: { openai: "test-key" },
+        summaryRuntime: "direct",
+        token: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("requires a daemon token for daemon-backed hover summaries", () => {
+    expect(
+      shouldStartHoverRequest({
+        hoverSummaries: true,
+        model: "auto",
+        provider: "openai",
+        providerApiKeys: { openai: "test-key" },
+        summaryRuntime: "daemon",
+        token: "",
+      }),
+    ).toBe(false);
+  });
+
   it("respects disabled hover summaries before asking the background to summarize", () => {
     expect(shouldStartHoverRequest({ hoverSummaries: false })).toBe(false);
     expect(shouldStartHoverRequest(null)).toBe(false);


### PR DESCRIPTION
## Summary
- allow Chrome extension hover summaries to run in direct provider mode without a daemon token
- add options and hover security regression coverage for Direct + OpenAI API key behavior
- document the user-facing fix in the unreleased changelog

## Tests
- pnpm -s format -- CHANGELOG.md apps/chrome-extension/src/entrypoints/hover.content.ts apps/chrome-extension/tests/options.spec.ts
- pnpm exec vitest run tests/hover.security.test.ts
- pnpm -C apps/chrome-extension test:chrome -- tests/options.spec.ts tests/sidepanel.direct-provider.spec.ts
- pnpm -C apps/chrome-extension lint
- /Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "pnpm exec vitest run tests/hover.security.test.ts && pnpm -C apps/chrome-extension test:chrome -- tests/options.spec.ts tests/sidepanel.direct-provider.spec.ts"

Note: root `pnpm -s typecheck` currently fails on current main with unresolved `@earendil-works/pi-ai/compat` type exports, unrelated to this PR.
