### PR TITLE
[codex] Update pi-ai compat imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typecheck": "pnpm -C packages/core typecheck && tsgo -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.79.9",
+    "@earendil-works/pi-ai": "^0.80.2",
     "@steipete/summarize-core": "workspace:*",
     "bpe-lite": "^0.5.2",
     "commander": "^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
   .:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: ^0.79.9
-        version: 0.79.9(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.2
+        version: 0.80.2(ws@8.21.0)(zod@4.4.3)
       '@steipete/summarize-core':
         specifier: workspace:*
         version: link:packages/core
@@ -332,8 +332,8 @@ packages:
     engines: {node: '>= 0.10.4'}
     hasBin: true
 
-  '@earendil-works/pi-ai@0.79.9':
-    resolution: {integrity: sha512-fHmgNMONwCCE7bQAKbcz76sgm3iQuA7km1mpIc4H5xXd9+zhPh/faULz6ARkgjQE0EufHnfZPJY39+lNf8Sa9g==}
+  '@earendil-works/pi-ai@0.80.2':
+    resolution: {integrity: sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -3978,7 +3978,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@earendil-works/pi-ai@0.79.9(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.2(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0

--- a/src/daemon/agent-model.ts
+++ b/src/daemon/agent-model.ts
@@ -1,5 +1,5 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { getModel } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai/compat";
 import { isOpenRouterBaseUrl } from "@steipete/summarize-core";
 import { createRunConfigInput } from "../application/config-state.js";
 import { resolveRunContextState } from "../application/context.js";

--- a/src/daemon/agent.ts
+++ b/src/daemon/agent.ts
@@ -1,5 +1,5 @@
 import type { Api, AssistantMessage, Model, Tool } from "@earendil-works/pi-ai";
-import { completeSimple, streamSimple } from "@earendil-works/pi-ai";
+import { completeSimple, streamSimple } from "@earendil-works/pi-ai/compat";
 import { buildPromptHash } from "../cache.js";
 import {
   resolveGitHubModelsCompatFallbackModelId,

--- a/src/daemon/models.ts
+++ b/src/daemon/models.ts
@@ -1,4 +1,4 @@
-import { getModels } from "@earendil-works/pi-ai";
+import { getModels } from "@earendil-works/pi-ai/compat";
 import { isOpenRouterBaseUrl } from "@steipete/summarize-core";
 import { resolveEnvState } from "../application/environment-state.js";
 import { resolveCliAvailability } from "../application/environment.js";

--- a/src/llm/generate-text-stream.ts
+++ b/src/llm/generate-text-stream.ts
@@ -1,5 +1,5 @@
 import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
-import { streamSimple } from "@earendil-works/pi-ai";
+import { streamSimple } from "@earendil-works/pi-ai/compat";
 import { createUnsupportedFunctionalityError } from "./errors.js";
 import {
   resolveEffectiveTemperature,

--- a/src/llm/generate-text.ts
+++ b/src/llm/generate-text.ts
@@ -1,5 +1,5 @@
 import type { Context } from "@earendil-works/pi-ai";
-import { completeSimple } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 import { maybeGenerateDocumentText } from "./generate-text-document.js";
 import {
   computeRetryDelayMs,

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1,6 +1,6 @@
 import type { Context, Model, ThinkingLevel } from "@earendil-works/pi-ai";
 import type { Api } from "@earendil-works/pi-ai";
-import { completeSimple } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 import type { Attachment } from "../attachments.js";
 import type { OpenAiReasoningEffort } from "../model-options.js";
 import type { LlmTokenUsage } from "../types.js";

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -1,5 +1,5 @@
 import type { Context } from "@earendil-works/pi-ai";
-import { completeSimple } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 import type { Attachment } from "../attachments.js";
 import type { LlmTokenUsage } from "../types.js";
 import { normalizeGoogleUsage, normalizeTokenUsage } from "../usage.js";

--- a/src/llm/providers/openai.ts
+++ b/src/llm/providers/openai.ts
@@ -1,5 +1,5 @@
 import type { Context } from "@earendil-works/pi-ai";
-import { completeSimple } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 export {
   resolveOpenAiClientConfig,
   type OpenAiClientConfigInput,

--- a/src/llm/providers/shared.ts
+++ b/src/llm/providers/shared.ts
@@ -1,5 +1,5 @@
 import type { Api, AssistantMessage, Context, KnownProvider, Model } from "@earendil-works/pi-ai";
-import { getModel } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai/compat";
 
 export function resolveBaseUrlOverride(raw: string | null | undefined): string | null {
   const trimmed = typeof raw === "string" ? raw.trim() : "";

--- a/src/model-auto.ts
+++ b/src/model-auto.ts
@@ -1,4 +1,4 @@
-import * as piAi from "@earendil-works/pi-ai";
+import * as piAi from "@earendil-works/pi-ai/compat";
 import type { AutoRuleKind, CliProvider, SummarizeConfig } from "./config.js";
 import { normalizeGatewayStyleModelId, parseGatewayStyleModelId } from "./llm/model-id.js";
 import type { ModelRequestOptions } from "./llm/model-options.js";

--- a/tests/cli.asset.audio-file-errors.test.ts
+++ b/tests/cli.asset.audio-file-errors.test.ts
@@ -29,7 +29,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.audio-file.test.ts
+++ b/tests/cli.asset.audio-file.test.ts
@@ -35,7 +35,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.local-file.test.ts
+++ b/tests/cli.asset.local-file.test.ts
@@ -34,7 +34,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.local-pdf-extract.test.ts
+++ b/tests/cli.asset.local-pdf-extract.test.ts
@@ -26,7 +26,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.local-pdf-ocr-fallback.test.ts
+++ b/tests/cli.asset.local-pdf-ocr-fallback.test.ts
@@ -27,7 +27,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.media-api-key.test.ts
+++ b/tests/cli.asset.media-api-key.test.ts
@@ -64,7 +64,7 @@ mocks.completeSimple.mockResolvedValue(
   }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.asset.unsupported.test.ts
+++ b/tests/cli.asset.unsupported.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.auto.always-summarize.test.ts
+++ b/tests/cli.auto.always-summarize.test.ts
@@ -32,7 +32,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.auto.fallback.test.ts
+++ b/tests/cli.auto.fallback.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.auto.no-model-needed.test.ts
+++ b/tests/cli.auto.no-model-needed.test.ts
@@ -28,7 +28,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.auto.youtube-always-summarize.test.ts
+++ b/tests/cli.auto.youtube-always-summarize.test.ts
@@ -55,7 +55,7 @@ const htmlResponse = (html: string, status = 200) =>
     headers: { "Content-Type": "text/html" },
   });
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: () => {
     throw new Error("unexpected pi-ai streamSimple call");

--- a/tests/cli.cache.no-cache.test.ts
+++ b/tests/cli.cache.no-cache.test.ts
@@ -47,7 +47,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.cache.summary.test.ts
+++ b/tests/cli.cache.summary.test.ts
@@ -46,7 +46,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.config-apikeys-legacy.test.ts
+++ b/tests/cli.config-apikeys-legacy.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.config-env.test.ts
+++ b/tests/cli.config-env.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.config-precedence.test.ts
+++ b/tests/cli.config-precedence.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.cost.finish-line.test.ts
+++ b/tests/cli.cost.finish-line.test.ts
@@ -41,7 +41,7 @@ mocks.streamSimple.mockImplementation(() =>
   ),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.empty-summary.test.ts
+++ b/tests/cli.empty-summary.test.ts
@@ -24,7 +24,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "   ", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.google.streaming-fallback.test.ts
+++ b/tests/cli.google.streaming-fallback.test.ts
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.help.test.ts
+++ b/tests/cli.help.test.ts
@@ -50,4 +50,22 @@ describe("--help output", () => {
     expect(out).toContain('summarize "https://example.com"');
     expect(out).toContain("Env Vars");
   });
+
+  it("prints refresh-free options supported by the CLI parser", async () => {
+    const stdout = collectStream();
+    const stderr = collectStream();
+
+    await runCli(["refresh-free", "--help"], {
+      env: {},
+      fetch: globalThis.fetch.bind(globalThis),
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+    });
+
+    const out = stdout.getText();
+    expect(out).toContain("Usage: summarize refresh-free");
+    expect(out).toContain("--max-age-days 180");
+    expect(out).toContain("--set-default");
+    expect(stderr.getText()).toBe("");
+  });
 });

--- a/tests/cli.input-limit.test.ts
+++ b/tests/cli.input-limit.test.ts
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.json.cost-report.test.ts
+++ b/tests/cli.json.cost-report.test.ts
@@ -33,7 +33,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.language.test.ts
+++ b/tests/cli.language.test.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.llm.providers.test.ts
+++ b/tests/cli.llm.providers.test.ts
@@ -40,7 +40,7 @@ mocks.completeSimple.mockImplementation(
     }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.max-output-tokens.openrouter-ignored.test.ts
+++ b/tests/cli.max-output-tokens.openrouter-ignored.test.ts
@@ -24,7 +24,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.max-output-tokens.test.ts
+++ b/tests/cli.max-output-tokens.test.ts
@@ -24,7 +24,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.metrics.openrouter-label.test.ts
+++ b/tests/cli.metrics.openrouter-label.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.openai.chat-completions.test.ts
+++ b/tests/cli.openai.chat-completions.test.ts
@@ -27,7 +27,7 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
   makeAssistantMessage({ text: "OK", provider: model.provider, model: model.id, api: model.api }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/cli.preprocess.test.ts
+++ b/tests/cli.preprocess.test.ts
@@ -33,7 +33,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.prompt-config.test.ts
+++ b/tests/cli.prompt-config.test.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.render.hyperlinks.test.ts
+++ b/tests/cli.render.hyperlinks.test.ts
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.render.md.reference-links.test.ts
+++ b/tests/cli.render.md.reference-links.test.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.spinner-output.test.ts
+++ b/tests/cli.spinner-output.test.ts
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,

--- a/tests/cli.stream-merge.test.ts
+++ b/tests/cli.stream-merge.test.ts
@@ -33,7 +33,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.streamed-markdown-lines.test.ts
+++ b/tests/cli.streamed-markdown-lines.test.ts
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.streamed-markdown-render.test.ts
+++ b/tests/cli.streamed-markdown-render.test.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/cli.twitter.skip-summary.json.test.ts
+++ b/tests/cli.twitter.skip-summary.json.test.ts
@@ -63,7 +63,7 @@ mocks.completeSimple.mockImplementation(async () =>
   }),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/daemon.agent-history.test.ts
+++ b/tests/daemon.agent-history.test.ts
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,
   streamSimple: mocks.streamSimple,

--- a/tests/daemon.agent.test.ts
+++ b/tests/daemon.agent.test.ts
@@ -21,7 +21,7 @@ vi.mock("../src/llm/cli.js", async (importOriginal) => {
   };
 });
 
-vi.mock("@earendil-works/pi-ai", () => {
+vi.mock("@earendil-works/pi-ai/compat", () => {
   return {
     completeSimple: mockCompleteSimple,
     getModel: mockGetModel,

--- a/tests/daemon.cache.summary.test.ts
+++ b/tests/daemon.cache.summary.test.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));

--- a/tests/live/openrouter-fallback.live.test.ts
+++ b/tests/live/openrouter-fallback.live.test.ts
@@ -1,4 +1,4 @@
-import { getModels } from "@earendil-works/pi-ai";
+import { getModels } from "@earendil-works/pi-ai/compat";
 import { describe, expect, it } from "vitest";
 import type { SummarizeConfig } from "../../src/config.js";
 import { generateTextWithModelId } from "../../src/llm/generate-text.js";

--- a/tests/llm.generate-text.more-branches.test.ts
+++ b/tests/llm.generate-text.more-branches.test.ts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/llm.generate-text.test.ts
+++ b/tests/llm.generate-text.test.ts
@@ -28,7 +28,7 @@ mocks.streamSimple.mockImplementation((_model: MockModel) =>
   makeTextDeltaStream(["o", "k"], makeAssistantMessage({ text: "ok" })),
 );
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,

--- a/tests/llm.openai-provider.test.ts
+++ b/tests/llm.openai-provider.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   completeSimple: vi.fn(),
 }));
 
-vi.mock("@earendil-works/pi-ai", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
 }));
 


### PR DESCRIPTION
## Summary

- upgrade `@earendil-works/pi-ai` from the temporary policy-compatible `0.79.9` pin to newly eligible `0.80.2`
- switch legacy pi-ai runtime calls (`completeSimple`, `streamSimple`, `getModel`, `getModels`) and matching tests to the 0.80 `/compat` entrypoint
- add focused CLI help coverage for `refresh-free --help` so the documented `--max-age-days` option stays aligned with the parser and generated help

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm format:check`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm typecheck`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm test tests/cli.help.test.ts tests/run.cli-preflight.test.ts tests/cli.refresh-free.test.ts tests/llm.generate-text.test.ts tests/daemon.agent.test.ts`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm lint`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm -s check`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm -s build`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm -s dev:cli refresh-free --help`

## Notes

- PR #328 remains untouched; blocker recorded from the sweep: its native-message router incorrectly captures Direct-provider `127.0.0.1` requests.
- Issue #319 remains a maintainer/product decision item; this PR does not guess ownership, npm packaging, or OpenClaw synchronization.
