### PR TITLE
docs: add canonical summarize agent skill

### DIFF
--- a/.agents/skills/summarize/SKILL.md
+++ b/.agents/skills/summarize/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: summarize
+description: "Summarize CLI: URLs, files, YouTube, transcripts, media, extraction, and JSON output."
+---
+
+# Summarize
+
+Use the `summarize` CLI as the canonical interface. Prefer a released binary on `PATH`; inside this repository, use `pnpm -s summarize` for the current checkout.
+
+## Start
+
+1. Confirm the command and current contract:
+
+   ```bash
+   summarize --version
+   summarize --help
+   ```
+
+2. Inspect model/provider readiness when a summary needs an LLM:
+
+   ```bash
+   summarize status
+   summarize status --json
+   ```
+
+3. Run the narrowest workflow below. Quote URLs and paths. Add `--timeout 2m` for slow remote or media inputs.
+
+Never print, request, or copy API-key values. `summarize status` reports availability without exposing secrets.
+
+## Summarize
+
+Web page or remote document:
+
+```bash
+summarize "https://example.com/article"
+summarize "https://example.com/report.pdf" --length short
+```
+
+Local file or stdin:
+
+```bash
+summarize "./report.pdf"
+summarize "./recording.m4a"
+printf '%s\n' "Long text to summarize" | summarize -
+```
+
+Use `--plain` for unrendered Markdown/text. Use `--language`, `--length`, `--prompt`, or `--prompt-file` only when the task requires an override. Use `--cli codex`, `--cli claude`, or another installed CLI provider when the user requests that provider or no direct API provider is configured.
+
+## Extract without a summary
+
+Use `--extract` to stop after extraction or transcription:
+
+```bash
+summarize "https://example.com/article" --extract --format md
+summarize "./report.pdf" --extract --format md
+summarize "https://youtu.be/VIDEO_ID" --extract --format md
+```
+
+`--extract` does not support stdin. Extraction can still call configured transcription, OCR, Firecrawl, or Markdown services; it only skips the final summary call. `--markdown-mode llm` also invokes an LLM to reshape extracted text.
+
+## YouTube, audio, and video
+
+Default transcript selection:
+
+```bash
+summarize "https://youtu.be/VIDEO_ID"
+summarize "https://youtu.be/VIDEO_ID" --extract --format md --timestamps
+```
+
+Use `--youtube web` to require web captions or `--youtube yt-dlp` to require the download/transcription path. Keep `auto` unless the user needs a specific source.
+
+Local or remote audio/video:
+
+```bash
+summarize "./interview.mp3" --extract
+summarize "./interview.mp4" --extract --timestamps
+summarize "./interview.mp3" --extract --diarize
+```
+
+`--transcriber auto` is the default. Use an explicit transcriber only when requested or diagnosing a provider. Diarization may require configured ElevenLabs or OpenAI access. Speaker identification is a separate opt-in step; do not infer identities without evidence.
+
+For slides:
+
+```bash
+summarize "https://youtu.be/VIDEO_ID" --slides
+summarize "./talk.mp4" --slides --extract
+```
+
+Slide extraction may require `yt-dlp`; OCR requires `tesseract`.
+
+## JSON for automation
+
+Use JSON when another command or agent will parse the result:
+
+```bash
+summarize "https://example.com" --json --metrics off > result.json
+jq -r '.summary // .extracted.content // empty' result.json
+```
+
+The stable top-level envelope contains `input`, `env`, `extracted`, `prompt`, `llm`, `metrics`, and `summary`. `summary` or `llm` can be `null` when extraction or a no-model path handles the input. In `--extract --json` mode, read extracted text from `.extracted.content`.
+
+JSON stays on stdout. Progress, warnings, and finish metrics stay on stderr. Do not merge stderr into stdout before parsing. Use `--metrics detailed` only when the task needs usage details.
+
+## Configuration and dependencies
+
+Precedence: CLI flags, process environment, `~/.summarize/config.json`, built-in defaults. Prefer flags for one run; change config only when the user asks for a persistent default.
+
+Useful diagnostics:
+
+```bash
+summarize status --verbose
+summarize status --probe
+summarize "INPUT" --verbose
+```
+
+Plain web summaries need no media tools. Media paths may use `ffmpeg`, `yt-dlp`, local Whisper/ONNX, or configured cloud transcription. Website fallback may use Firecrawl. Confirm the exact missing capability from the error before installing tools or changing config.
+
+Inputs may be sent to the selected model, extraction, OCR, or transcription provider. For confidential material, confirm the approved provider or use an approved local path before running the command.
+
+## Verify
+
+After every run:
+
+- Require exit status `0`.
+- Require non-empty summary or extracted content.
+- For JSON, parse stdout with `jq` or another JSON parser.
+- For source-sensitive work, inspect `extracted`, `llm`, and stderr diagnostics rather than assuming the selected path.
+- Re-run the exact final command after changing provider, config, or flags.
+
+For current option details, run `summarize --help` and read the repository documentation:
+
+- [Quickstart](../../../docs/quickstart.md)
+- [Main command](../../../docs/commands/summarize.md)
+- [Configuration](../../../docs/config.md)
+- [YouTube](../../../docs/youtube.md)
+- [Media](../../../docs/media.md)
+- [Extraction](../../../docs/extract-only.md)
+
+## Ownership
+
+This file is the canonical agent workflow for the Summarize product. Keep generic agent workflows in `openclaw/agent-skills`; keep Summarize CLI behavior here. Downstream integrations should link to this file at a released tag or pinned commit and retain only their packaging or integration-specific notes. Do not maintain a second broad command guide downstream.

--- a/.agents/skills/summarize/agents/openai.yaml
+++ b/.agents/skills/summarize/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Summarize"
+  short_description: "Summarize URLs, files, and media with the CLI"
+  default_prompt: "Use $summarize to extract or summarize this URL, file, or media input."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.20.2 - Unreleased
 
+### Features
+
+- Agent workflows: add the canonical repository-owned Summarize skill for URLs, files, media, extraction, and structured JSON usage (#319, thanks @coygeek).
+
 ### Fixes
 
 - Anthropic custom gateways: preserve path prefixes when sending PDF document requests (#325, thanks @wangwllu).

--- a/README.md
+++ b/README.md
@@ -847,6 +847,7 @@ pnpm check
 
 ## More
 
+- Canonical agent skill: [`.agents/skills/summarize/SKILL.md`](.agents/skills/summarize/SKILL.md). Summarize-specific CLI guidance lives here; downstream integrations should link to this source and keep only integration-specific notes.
 - Docs index: [docs/README.md](docs/README.md)
 - CLI providers and config: [docs/cli.md](docs/cli.md)
 - Auto model rules: [docs/model-auto.md](docs/model-auto.md)

--- a/tests/skill.summarize.test.ts
+++ b/tests/skill.summarize.test.ts
@@ -1,0 +1,58 @@
+import { access, readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildProgram } from "../src/run/help.js";
+
+const skillPath = resolve(".agents/skills/summarize/SKILL.md");
+
+describe("canonical summarize skill", () => {
+  it("has routable frontmatter and matching UI metadata", async () => {
+    const skill = await readFile(skillPath, "utf8");
+    const metadata = await readFile(resolve(dirname(skillPath), "agents/openai.yaml"), "utf8");
+
+    expect(skill).toMatch(
+      /^---\nname: summarize\ndescription: "Summarize CLI: URLs, files, YouTube, transcripts, media, extraction, and JSON output\."\n---\n/,
+    );
+    expect(metadata).toContain('display_name: "Summarize"');
+    expect(metadata).toContain("$summarize");
+  });
+
+  it("keeps documented core flags aligned with visible CLI help", async () => {
+    const skill = await readFile(skillPath, "utf8");
+    const help = buildProgram().helpInformation();
+
+    for (const flag of [
+      "--cli",
+      "--diarize",
+      "--extract",
+      "--format",
+      "--json",
+      "--language",
+      "--length",
+      "--markdown-mode",
+      "--metrics",
+      "--plain",
+      "--prompt-file",
+      "--slides",
+      "--timestamps",
+      "--transcriber",
+      "--youtube",
+    ]) {
+      expect(skill, `skill must document ${flag}`).toContain(flag);
+      expect(help, `CLI help must expose ${flag}`).toContain(flag);
+    }
+  });
+
+  it("links only to existing repository documentation", async () => {
+    const skill = await readFile(skillPath, "utf8");
+    const links = Array.from(
+      skill.matchAll(/\]\((\.\.\/\.\.\/\.\.\/[^)]+\.md)\)/g),
+      (match) => match[1],
+    );
+
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) {
+      await expect(access(resolve(dirname(skillPath), link))).resolves.toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add the canonical repository-owned Summarize product skill under `.agents/skills/summarize`
- cover URL/file/media summaries, extraction, YouTube/transcription, structured JSON, provider readiness, privacy, and exact verification
- add Codex UI metadata, README/changelog ownership pointers, and a repository test that keeps frontmatter, metadata, docs links, and core flags aligned

Related: https://github.com/steipete/summarize/issues/319

## Ownership decision

Public shared-skill conventions put product-specific skills in the repository they describe and generic workflows in `openclaw/agent-skills`. The canonical Summarize path is therefore:

https://github.com/steipete/summarize/blob/e813113a4ac519f1d1ba69f7e6545e0d929a5ae9/.agents/skills/summarize/SKILL.md

Downstream integrations should pin or link that file and keep only their packaging or integration-specific notes. This PR intentionally does not inspect or modify `openclaw/openclaw`; that reference update remains the downstream handoff before https://github.com/steipete/summarize/issues/319 is fully complete.

## Verification

- `python3 /Users/steipete/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/summarize`
- YAML safe-load check for exactly `name` and `description`
- `pnpm exec oxfmt --check tests/skill.summarize.test.ts .agents/skills/summarize/SKILL.md .agents/skills/summarize/agents/openai.yaml README.md CHANGELOG.md`
- `pnpm -s test tests/skill.summarize.test.ts`
- `pnpm -s check` — 571 test files; 2,900 tests passed
- `pnpm -s build`
- `pnpm -s docs:build`
- live `pnpm -s summarize 'https://example.com' --extract --format md --timeout 30s`
- live `pnpm -s summarize 'https://example.com' --extract --json --metrics off --timeout 30s | jq ...` — parsed URL input, 148 extracted characters, null LLM/metrics/summary as required for extract mode
- ephemeral read-only Codex invocation with `Use $summarize` returned the skill-prescribed extraction and JSON parsing commands
- autoreview: clean; no accepted/actionable findings
- public model identifier gate: PASS; candidate additions contain no model identifiers

No browser/UI path changed; browser screenshots are not applicable.
