### PR TITLE
chore(deps): update Chrome typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Anthropic custom gateways: preserve path prefixes when sending PDF document requests (#325, thanks @wangwllu).
 - Dependencies: use the latest policy-eligible `pi-ai` release so clean installs satisfy the seven-day minimum release age.
-- Dependencies: refresh eligible browser media, test, lint, formatting, and extension tooling releases.
+- Dependencies: refresh eligible browser media, typings, test, lint, formatting, and extension tooling releases.
 
 ## 0.20.1 - 2026-06-24
 

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.61.1",
-    "@types/chrome": "^0.1.43",
+    "@types/chrome": "^0.2.0",
     "typescript": "^6.0.3",
     "web-ext": "10.4.0",
     "wxt": "0.20.27"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: 1.61.1
         version: 1.61.1
       '@types/chrome':
-        specifier: ^0.1.43
-        version: 0.1.43
+        specifier: ^0.2.0
+        version: 0.2.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1251,8 +1251,8 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/chrome@0.1.43':
-    resolution: {integrity: sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==}
+  '@types/chrome@0.2.0':
+    resolution: {integrity: sha512-K/i7EKEVSpmyXXjE0ev5oASWBYMY6yM8LFSutG2PkM1DmxJUggZsoaTc0W1RsVwDDKrsZEjpHFAbqqxlRxGsSg==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -4618,7 +4618,7 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/chrome@0.1.43':
+  '@types/chrome@0.2.0':
     dependencies:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,6 @@ packages:
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - "@earendil-works/pi-ai@0.79.1"
-  - "@types/chrome@0.1.43"
   - "@types/node@24.13.1"
   - "@typescript/native-preview@7.0.0-dev.20260609.1"
   - "@typescript/native-preview-*"


### PR DESCRIPTION
## Summary

- update the Chrome extension typings from `@types/chrome` 0.1.43 to policy-eligible 0.2.0
- remove the obsolete minimum-release-age exception for 0.1.43
- keep the unreleased dependency changelog entry accurate

`@types/chrome` 0.2.0 was published on 2026-06-20, so it clears the repository's seven-day stabilization window. Version 0.2.1 was published today and remains excluded by policy.

## Verification

- `pnpm -C apps/chrome-extension lint`
- `pnpm -C apps/chrome-extension build`
- `pnpm -s check` — 572 test files; 2,949 tests passed
- `pnpm -C apps/chrome-extension test:chrome` — native-host E2E passed; supported suite 106 passed, 5 skipped
- `pnpm audit --json` — zero vulnerabilities across all severity levels
- autoreview — clean; no accepted/actionable findings
- public model identifier gate — PASS; dependency metadata diff contains no model identifiers

No runtime behavior changes; live external-service proof and screenshots are not applicable to this typings-only development dependency update.
