### PR TITLE
[codex] preserve Deepgram fallback media and timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.21.1 - Unreleased
 
+### Fixes
+
+- Deepgram transcription: preserve full media across failed OpenAI fallbacks and retain timestamped utterances through podcast and native YouTube paths.
+
 ## 0.21.0 - 2026-07-03
 
 ### Features

--- a/packages/core/src/content/transcript/providers/podcast/media.ts
+++ b/packages/core/src/content/transcript/providers/podcast/media.ts
@@ -8,6 +8,7 @@ import {
   probeMediaDurationSecondsWithFfprobe,
   transcribeMediaFileWithWhisper,
   transcribeMediaWithWhisper,
+  type TranscriptionSegment,
 } from "../../../../transcription/whisper.js";
 import {
   resolveTranscriptionConfig,
@@ -49,6 +50,7 @@ export type TranscriptionResult = {
   text: string | null;
   provider: string | null;
   error: Error | null;
+  segments?: TranscriptionSegment[] | null;
 };
 
 export async function transcribeMediaUrl({
@@ -185,7 +187,12 @@ export async function transcribeMediaUrl({
       },
     });
     if (transcript.notes.length > 0) notes.push(...transcript.notes);
-    return { text: transcript.text, provider: transcript.provider, error: transcript.error };
+    return {
+      text: transcript.text,
+      provider: transcript.provider,
+      error: transcript.error,
+      segments: transcript.segments ?? null,
+    };
   }
 
   const tmpFile = join(tmpdir(), `summarize-podcast-${randomUUID()}.bin`);
@@ -248,7 +255,12 @@ export async function transcribeMediaUrl({
       },
     });
     if (transcript.notes.length > 0) notes.push(...transcript.notes);
-    return { text: transcript.text, provider: transcript.provider, error: transcript.error };
+    return {
+      text: transcript.text,
+      provider: transcript.provider,
+      error: transcript.error,
+      segments: transcript.segments ?? null,
+    };
   } finally {
     await fs.unlink(tmpFile).catch(() => {});
   }

--- a/packages/core/src/content/transcript/providers/podcast/provider-flow.ts
+++ b/packages/core/src/content/transcript/providers/podcast/provider-flow.ts
@@ -140,6 +140,7 @@ export async function tryPodcastYtDlpTranscript(
     return {
       text: result.text,
       source: result.text ? "yt-dlp" : null,
+      segments: result.segments ?? null,
       attemptedProviders: flow.attemptedProviders,
       notes: joinNotes(flow.notes),
       metadata: { provider: "podcast", kind: "yt_dlp", transcriptionProvider: result.provider },

--- a/packages/core/src/content/transcript/providers/podcast/results.ts
+++ b/packages/core/src/content/transcript/providers/podcast/results.ts
@@ -22,6 +22,7 @@ export function buildWhisperResult({
     return {
       text: outcome.text,
       source: "whisper",
+      segments: outcome.segments ?? null,
       attemptedProviders,
       notes: joinNotes(notes),
       metadata: {

--- a/packages/core/src/content/transcript/providers/youtube/native-media.ts
+++ b/packages/core/src/content/transcript/providers/youtube/native-media.ts
@@ -47,6 +47,7 @@ export async function tryNativeYoutubeMediaTranscript(
     return {
       text: normalizeTranscriptText(result.text),
       source: "youtube-media",
+      segments: result.segments ?? null,
       metadata: {
         provider: "youtube-media",
         resolver: media.resolver,

--- a/packages/core/src/transcription/whisper/remote-provider-attempts.ts
+++ b/packages/core/src/transcription/whisper/remote-provider-attempts.ts
@@ -208,6 +208,7 @@ const BYTE_PROVIDER_EXECUTORS: Record<
     transcribeOversizedBytesWithChunking,
   }) => {
     let nextState = state;
+    let truncatedForOpenAi = false;
     if (
       nextState.bytes.byteLength > MAX_OPENAI_UPLOAD_BYTES &&
       transcribeOversizedBytesWithChunking &&
@@ -233,6 +234,7 @@ const BYTE_PROVIDER_EXECUTORS: Record<
         ...nextState,
         bytes: nextState.bytes.slice(0, MAX_OPENAI_UPLOAD_BYTES),
       };
+      truncatedForOpenAi = true;
     }
 
     let error: Error | null = null;
@@ -290,7 +292,8 @@ const BYTE_PROVIDER_EXECUTORS: Record<
       }
     }
 
-    return { state: nextState, result: null, error };
+    // OpenAI's upload cap must not discard source bytes accepted by later providers.
+    return { state: truncatedForOpenAi ? state : nextState, result: null, error };
   },
   fal: async ({ state, falApiKey, notes }) => {
     if (!state.mediaType.toLowerCase().startsWith("audio/")) {

--- a/tests/transcript.podcast-provider.transcribe-media-url-branches.test.ts
+++ b/tests/transcript.podcast-provider.transcribe-media-url-branches.test.ts
@@ -134,7 +134,7 @@ describe("podcast provider - transcribeMediaUrl branch coverage", () => {
       Response.json({
         results: {
           channels: [{ alternatives: [{ transcript: "Deepgram podcast transcript" }] }],
-          utterances: [],
+          utterances: [{ start: 0.25, end: 1.5, transcript: "Deepgram podcast transcript" }],
         },
       }),
     );
@@ -148,13 +148,63 @@ describe("podcast provider - transcribeMediaUrl branch coverage", () => {
           fetch: fetchImpl as unknown as typeof fetch,
           openaiApiKey: null,
           deepgramApiKey: "DG",
+          transcriptTimestamps: true,
         },
       );
 
       expect(result.source).toBe("whisper");
       expect(result.text).toBe("Deepgram podcast transcript");
+      expect(result.segments).toEqual([
+        { startMs: 250, endMs: 1500, text: "Deepgram podcast transcript" },
+      ]);
       expect(result.metadata?.transcriptionProvider).toBe("deepgram");
       expect(String(result.notes)).not.toContain("ffmpeg not available");
+    } finally {
+      vi.unstubAllGlobals();
+      vi.doUnmock("node:child_process");
+    }
+  });
+
+  it("preserves Deepgram timestamp segments for in-memory podcast media", async () => {
+    const { fetchTranscript } = await importPodcastProvider({ spawnPlan: "ffmpeg-missing" });
+    const enclosureUrl = "https://example.com/short.mp3";
+    const xml = `<rss><channel><item><enclosure url="${enclosureUrl}" type="audio/mpeg"/></item></channel></rss>`;
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if ((init?.method ?? "GET").toUpperCase() === "HEAD") {
+        return new Response(null, {
+          status: 200,
+          headers: { "content-type": "audio/mpeg", "content-length": "3" },
+        });
+      }
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "audio/mpeg" },
+      });
+    });
+    const deepgramFetch = vi.fn(async () =>
+      Response.json({
+        results: {
+          channels: [{ alternatives: [{ transcript: "Short episode" }] }],
+          utterances: [{ start: 1, end: 2.25, transcript: "Short episode" }],
+        },
+      }),
+    );
+
+    try {
+      vi.stubGlobal("fetch", deepgramFetch);
+      const result = await fetchTranscript(
+        { url: "https://example.com/feed.xml", html: xml, resourceKey: null },
+        {
+          ...baseOptions,
+          fetch: fetchImpl as unknown as typeof fetch,
+          openaiApiKey: null,
+          deepgramApiKey: "DG",
+          transcriptTimestamps: true,
+        },
+      );
+
+      expect(result.text).toBe("Short episode");
+      expect(result.segments).toEqual([{ startMs: 1000, endMs: 2250, text: "Short episode" }]);
     } finally {
       vi.unstubAllGlobals();
       vi.doUnmock("node:child_process");

--- a/tests/transcript.podcast-provider.yt-dlp-branch.test.ts
+++ b/tests/transcript.podcast-provider.yt-dlp-branch.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
     text: "ok",
     provider: "openai" as const,
     notes: ["yt-dlp used"],
+    segments: [{ startMs: 100, endMs: 900, text: "ok" }],
   })),
 }));
 
@@ -34,6 +35,7 @@ describe("podcast transcript provider - yt-dlp branch", () => {
     );
     expect(result.source).toBe("yt-dlp");
     expect(result.text).toBe("ok");
+    expect(result.segments).toEqual([{ startMs: 100, endMs: 900, text: "ok" }]);
     expect(result.metadata?.kind).toBe("yt_dlp");
     expect(result.notes).toContain("yt-dlp used");
   });

--- a/tests/transcript.youtube-native-media.test.ts
+++ b/tests/transcript.youtube-native-media.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  extractYoutubePlayerBootstrap: vi.fn(),
+  resolveYoutubeAudio: vi.fn(),
+  transcribeMediaUrl: vi.fn(),
+}));
+
+vi.mock("../packages/core/src/content/youtube.js", () => ({
+  extractYoutubePlayerBootstrap: mocks.extractYoutubePlayerBootstrap,
+  resolveYoutubeAudio: mocks.resolveYoutubeAudio,
+}));
+
+vi.mock("../packages/core/src/content/transcript/providers/podcast/media.js", () => ({
+  transcribeMediaUrl: mocks.transcribeMediaUrl,
+}));
+
+import { tryNativeYoutubeMediaTranscript } from "../packages/core/src/content/transcript/providers/youtube/native-media.js";
+import type { YouTubeProviderFlow } from "../packages/core/src/content/transcript/providers/youtube/provider-flow.js";
+
+describe("YouTube native media transcript", () => {
+  it("preserves Deepgram timestamp segments", async () => {
+    mocks.extractYoutubePlayerBootstrap.mockReturnValue({
+      apiKey: "YOUTUBE",
+      visitorData: "VISITOR",
+    });
+    mocks.resolveYoutubeAudio.mockResolvedValue({
+      url: "https://example.com/audio.mp3",
+      filename: "audio.mp3",
+      durationSeconds: 12,
+      resolver: "android-vr",
+    });
+    mocks.transcribeMediaUrl.mockResolvedValue({
+      text: "Native audio transcript",
+      provider: "deepgram",
+      error: null,
+      segments: [{ startMs: 500, endMs: 1750, text: "Native audio transcript" }],
+    });
+
+    const result = await tryNativeYoutubeMediaTranscript({
+      canTranscribe: true,
+      effectiveVideoId: "abcdefghijk",
+      htmlText: "<html>ytInitialPlayerResponse</html>",
+      context: {
+        url: "https://www.youtube.com/watch?v=abcdefghijk",
+        html: "<html>ytInitialPlayerResponse</html>",
+        resourceKey: "abcdefghijk",
+      },
+      options: {
+        fetch: vi.fn() as unknown as typeof fetch,
+        apifyApiToken: null,
+        youtubeTranscriptMode: "auto",
+        mediaTranscriptMode: "auto",
+        transcriptTimestamps: true,
+        ytDlpPath: null,
+      },
+      transcription: {},
+      attemptedProviders: [],
+      notes: [],
+      durationMetadata: {},
+      canRunYtDlp: false,
+      pushHint: vi.fn(),
+    } as YouTubeProviderFlow);
+
+    expect(result?.text).toBe("Native audio transcript");
+    expect(result?.segments).toEqual([
+      { startMs: 500, endMs: 1750, text: "Native audio transcript" },
+    ]);
+    expect(result?.metadata?.transcriptionProvider).toBe("deepgram");
+  });
+});

--- a/tests/transcription.whisper.test.ts
+++ b/tests/transcription.whisper.test.ts
@@ -803,6 +803,50 @@ describe("transcription/whisper", () => {
     }
   });
 
+  it("preserves oversized source bytes when OpenAI fails before Deepgram fallback", async () => {
+    const whisper = await importWhisperWithNoFfmpeg();
+    const originalSize = whisper.MAX_OPENAI_UPLOAD_BYTES + 1;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.includes("/v1/audio/transcriptions")) {
+        const form = init?.body as FormData;
+        expect((form.get("file") as Blob).size).toBe(whisper.MAX_OPENAI_UPLOAD_BYTES);
+        return new Response("unauthorized", { status: 401 });
+      }
+      if (url.includes("api.deepgram.com/v1/listen")) {
+        expect((init?.body as Blob).size).toBe(originalSize);
+        return Response.json({
+          results: {
+            channels: [{ alternatives: [{ transcript: "Deepgram fallback" }] }],
+            utterances: [],
+          },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    try {
+      vi.stubGlobal("fetch", fetchMock);
+      const result = await whisper.transcribeMediaWithWhisper({
+        bytes: new Uint8Array(originalSize),
+        mediaType: "audio/mpeg",
+        filename: "audio.mp3",
+        groqApiKey: null,
+        openaiApiKey: "OPENAI",
+        falApiKey: null,
+        deepgramApiKey: "DEEPGRAM",
+      });
+
+      expect(result.text).toBe("Deepgram fallback");
+      expect(result.provider).toBe("deepgram");
+      expect(result.notes.join(" ")).toContain("falling back to Deepgram");
+    } finally {
+      vi.unstubAllGlobals();
+      vi.doUnmock("node:child_process");
+      vi.restoreAllMocks();
+    }
+  });
+
   it("returns a helpful error when FAL returns empty content", async () => {
     falMocks.createFalClient.mockReset().mockReturnValue({
       storage: {


### PR DESCRIPTION
## Summary

- keep the original media bytes available when an oversized OpenAI attempt fails after applying its provider-specific upload cap
- propagate transcription segments through podcast media, podcast yt-dlp, and native YouTube result adapters
- add exact regressions for full-byte Deepgram fallback and timestamp preservation across the affected paths
- document the correction under 0.21.1 Unreleased

## Root cause

The OpenAI byte attempt returned its capped request buffer as shared fallback state, so Deepgram received only 24 MiB after an OpenAI failure. Separately, several media adapters copied transcript text and provider metadata but omitted the Deepgram utterance segments.

This is a post-merge correctness follow-up to #336. It does not publish or authorize a release.

## Validation

- `pnpm exec vitest run --reporter=verbose tests/transcription.whisper.test.ts tests/transcription.whisper.deepgram.test.ts tests/transcript.podcast-provider.transcribe-media-url-branches.test.ts tests/transcript.podcast-provider.yt-dlp-branch.test.ts tests/transcript.youtube-native-media.test.ts tests/transcript.yt-dlp.test.ts` (6 files, 73 tests)
- `pnpm -C packages/core typecheck`
- `pnpm -s check` (574 files, 2,962 tests; 2,919 passed and 43 skipped)
- authenticated Deepgram E2E with two distinct synthesized MP3s: both returned live timestamped transcripts; the exact podcast path reported `deepgram` and one 0-2560 ms utterance segment; empty media failed cleanly
- autoreview: clean, no accepted or actionable findings
- public text audit: no internal or private model identifiers added
