### PR TITLE
fix: tilde expansion bug for paths like ~somepath, consolidate LlmProvider type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Cache paths: keep non-slash tilde-prefixed paths relative instead of corrupting them during home-directory expansion (#338, thanks @fix2015).
 - Deepgram transcription: preserve full media across failed OpenAI fallbacks and retain timestamped utterances through podcast and native YouTube paths.
 - Dependencies: update the Node 24 typings after the stabilization window.
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -171,7 +171,7 @@ export function resolveCachePath({
   const home = resolveHomeDir(env);
   const raw = cachePath?.trim();
   if (raw && raw.length > 0) {
-    if (raw.startsWith("~")) {
+    if (raw === "~" || raw.startsWith("~/")) {
       if (!home) return null;
       const expanded = raw === "~" ? home : join(home, raw.slice(2));
       return resolvePath(expanded);

--- a/src/costs.ts
+++ b/src/costs.ts
@@ -1,16 +1,7 @@
 import type { LlmTokenUsage } from "./llm/generate-text.js";
+import type { LlmProvider as BaseLlmProvider } from "./llm/model-id.js";
 
-export type LlmProvider =
-  | "xai"
-  | "openai"
-  | "google"
-  | "anthropic"
-  | "zai"
-  | "nvidia"
-  | "minimax"
-  | "github-copilot"
-  | "ollama"
-  | "cli";
+export type LlmProvider = BaseLlmProvider | "cli";
 
 export type LlmCall = {
   provider: LlmProvider;

--- a/tests/cache.path.test.ts
+++ b/tests/cache.path.test.ts
@@ -17,6 +17,12 @@ describe("resolveCachePath", () => {
     expect(tilde).toBe(resolvePath(join(home, "cache.sqlite")));
   });
 
+  it("keeps non-slash tilde prefixes as relative paths", () => {
+    const home = "/tmp/summarize-home";
+    const resolved = resolveCachePath({ env: { HOME: home }, cachePath: "~somepath" });
+    expect(resolved).toBe(resolvePath(join(home, "~somepath")));
+  });
+
   it("returns null when no home is available", () => {
     expect(resolveCachePath({ env: {}, cachePath: null })).toBeNull();
   });


### PR DESCRIPTION
Two things:

- `resolveCachePath` in cache.ts was checking `raw.startsWith("~")` which also matches paths like `~somepath` (no slash). For those, `raw.slice(2)` produces `omepath` and joins it as `$HOME/omepath` which is wrong. The media-cache version of the same logic correctly checks for `~/` or bare `~` — matched cache.ts to the same pattern.

- `LlmProvider` was defined in two separate files with different members — `costs.ts` included `"cli"` but `model-id.ts` didn't. Having two exported types with the same name but different shapes is a type inconsistency waiting to bite someone. Consolidated costs.ts to import from model-id.ts and extend with `| "cli"` locally.

## Maintainer proof

- added an exact regression test for the non-slash tilde prefix and a changelog entry
- focused cache-path test: 5 passed
- full `pnpm -s check`: 545 files passed, 29 skipped; 2,920 tests passed, 43 skipped
- `pnpm -s build`: passed
- source-blind CLI cache-path validation: non-slash tilde, slash tilde, and absolute-path cases passed
- autoreview: clean, no actionable findings

### Source-blind CLI output

```text
Cache path: /tmp/summarize-pr338-behavior.JnxXR4/relative-home/~somepath
Cache is empty.
Cache path: /tmp/summarize-pr338-behavior.JnxXR4/slash-home/cache.sqlite
Cache is empty.
Cache path: /tmp/summarize-pr338-behavior.JnxXR4/absolute-cache.sqlite
Cache is empty.
```

All three commands exited successfully. The fixtures used distinct HOME directories for the non-slash and slash-tilde cases; the absolute path was outside either HOME.
