### PR TITLE
fix: polish extension picker and input styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Chrome extension: keep the font picker value on one line and truncate it with an ellipsis in narrow side panels.
+- Chrome extension: keep the font picker value on one line with an ellipsis in narrow side panels and apply themed styles to password and URL fields.
 
 ## 0.21.1 - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.21.2 - Unreleased
 
+### Fixes
+
+- Chrome extension: keep the font picker value on one line and truncate it with an ellipsis in narrow side panels.
+
 ## 0.21.1 - 2026-07-03
 
 ### Fixes

--- a/apps/chrome-extension/src/entrypoints/options/style.css
+++ b/apps/chrome-extension/src/entrypoints/options/style.css
@@ -1204,6 +1204,8 @@ label > span {
 
 input[type="text"],
 input[type="number"],
+input[type="password"],
+input[type="url"],
 textarea,
 select {
   border: 1px solid var(--border);
@@ -1220,6 +1222,8 @@ select {
 
 input[type="text"],
 input[type="number"],
+input[type="password"],
+input[type="url"],
 select {
   min-width: 0;
   overflow: hidden;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/styles/controls.css
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/styles/controls.css
@@ -74,6 +74,13 @@ select {
   margin-left: auto;
 }
 
+.font .pickerTrigger > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .modeIcon {
   display: inline-flex;
   align-items: center;

--- a/apps/chrome-extension/tests/options.spec.ts
+++ b/apps/chrome-extension/tests/options.spec.ts
@@ -53,6 +53,52 @@ test("options pickers apply overlay selection", async ({ browserName: _browserNa
   }
 });
 
+test("options themes password and URL fields like the provider control", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    await seedSettings(harness, {
+      colorMode: "dark",
+      colorScheme: "slate",
+      provider: "openai",
+      summaryRuntime: "daemon",
+    });
+    const page = await openExtensionPage(harness, "options.html", "#tabs");
+    await page.click("#tab-runtime");
+    await expect(page.locator("#panel-runtime")).toBeVisible();
+    await expect(page.locator("html")).toHaveAttribute("data-mode", "dark");
+
+    const readControlStyle = (selector: string) =>
+      page.locator(selector).evaluate((element) => {
+        const style = getComputedStyle(element);
+        return {
+          backgroundColor: style.backgroundColor,
+          borderColor: style.borderColor,
+          borderRadius: style.borderRadius,
+          borderStyle: style.borderStyle,
+          borderWidth: style.borderWidth,
+          color: style.color,
+          fontFamily: style.fontFamily,
+          fontSize: style.fontSize,
+        };
+      });
+
+    const [providerStyle, apiKeyStyle, baseUrlStyle] = await Promise.all([
+      readControlStyle("#provider"),
+      readControlStyle("#providerApiKey"),
+      readControlStyle("#providerBaseUrl"),
+    ]);
+
+    expect(apiKeyStyle).toEqual(providerStyle);
+    expect(baseUrlStyle).toEqual(providerStyle);
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
 test("options keeps custom model selected while presets refresh", async ({
   browserName: _browserName,
 }, testInfo) => {

--- a/apps/chrome-extension/tests/sidepanel.core.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.core.spec.ts
@@ -227,6 +227,46 @@ test("sidepanel scheme picker applies overlay selection", async ({
   }
 });
 
+test("sidepanel font picker truncates its value on narrow panels", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+    await page.setViewportSize({ width: 360, height: 640 });
+    await waitForPanelPort(page);
+    await waitForSettingsHydratedHook(page);
+    await page.click("#drawerToggle");
+    await expect(page.locator("#drawer")).toBeVisible();
+
+    const fontTrigger = page.locator("label.font .pickerTrigger");
+    await fontTrigger.evaluate((element) => {
+      element.style.width = "70px";
+    });
+    const fontValue = fontTrigger.locator(":scope > span");
+    await expect(fontValue).toHaveText("San Francisco");
+    const layout = await fontValue.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        clientWidth: element.clientWidth,
+        overflow: style.overflow,
+        scrollWidth: element.scrollWidth,
+        textOverflow: style.textOverflow,
+        whiteSpace: style.whiteSpace,
+      };
+    });
+
+    expect(layout.whiteSpace).toBe("nowrap");
+    expect(layout.overflow).toBe("hidden");
+    expect(layout.textOverflow).toBe("ellipsis");
+    expect(layout.scrollWidth).toBeGreaterThan(layout.clientWidth);
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
 test("sidepanel refresh free models from advanced settings", async ({
   browserName: _browserName,
 }, testInfo) => {


### PR DESCRIPTION
## Summary

- keep the font picker value on one line with an ellipsis in narrow side panels
- theme password and URL inputs consistently with the extension's other controls
- add computed-style and overflow regressions plus an Unreleased changelog entry

## Testing

- `pnpm -s check` (2,920 passed, 43 skipped)
- `pnpm -C apps/chrome-extension test:chrome` (108 passed, 5 skipped)
- focused font-overflow and Runtime input-style browser regressions
- Codex autoreview: clean
