### PR TITLE
fix(chrome): repair daemon YouTube summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 - Chrome extension: keep the font picker value on one line with an ellipsis in narrow side panels and apply themed styles to password and URL fields.
+- Chrome extension: connect daemon requests from the MV3 service worker directly to the native host so daemon-mode summaries work from the side panel.
+- Chrome extension: keep YouTube requests on the daemon URL path when slides are enabled so browser transcripts do not suppress frame extraction.
 
 ## 0.21.1 - 2026-07-03
 

--- a/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
@@ -459,7 +459,7 @@ export async function summarizeActiveTab({
   let id: string;
   try {
     const requestInputMode =
-      browserTranscriptTimedText && resolvedPayload.text.trim().length > 0
+      browserTranscriptTimedText && resolvedPayload.text.trim().length > 0 && !wantsDaemonSlides
         ? "page"
         : effectiveInputMode;
     id = await startPanelDaemonSummary({

--- a/apps/chrome-extension/src/lib/daemon-fetch.ts
+++ b/apps/chrome-extension/src/lib/daemon-fetch.ts
@@ -79,13 +79,18 @@ async function buildNativeRequest(
   return message;
 }
 
-async function nativeDaemonFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+async function nativeDaemonFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  connectPort: () => chrome.runtime.Port = () =>
+    chrome.runtime.connect({ name: DAEMON_BRIDGE_PORT_NAME }),
+): Promise<Response> {
   const requestMessage = await buildNativeRequest(input, init);
   const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
   if (signal?.aborted) throw new DOMException("The operation was aborted", "AbortError");
 
   return await new Promise<Response>((resolve, reject) => {
-    const port = chrome.runtime.connect({ name: DAEMON_BRIDGE_PORT_NAME });
+    const port = connectPort();
     let responseController: ReadableStreamDefaultController<Uint8Array> | null = null;
     let settled = false;
     let finished = false;
@@ -170,6 +175,18 @@ async function nativeDaemonFetch(input: RequestInfo | URL, init?: RequestInit): 
 export async function daemonFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   if (__SUMMARIZE_E2E_HTTP_TRANSPORT__) return await fetch(input, init);
   if (import.meta.env.BROWSER === "firefox") return await fetch(input, init);
+  // Chrome does not dispatch runtime.onConnect when an MV3 service worker connects
+  // back to its own extension. Background requests must open the native host directly;
+  // extension pages still use the bridge so nativeMessaging stays out of page contexts.
+  if (typeof document === "undefined") {
+    const policy = await readDaemonPolicy();
+    if (!policy.daemonAllowed) throw new Error("Local companion disabled by administrator");
+    const permitted = await chrome.permissions.contains({ permissions: ["nativeMessaging"] });
+    if (!permitted) throw new Error("Local companion permission is not enabled");
+    return await nativeDaemonFetch(input, init, () =>
+      chrome.runtime.connectNative(NATIVE_MESSAGING_HOST_NAME),
+    );
+  }
   return await nativeDaemonFetch(input, init);
 }
 

--- a/apps/chrome-extension/tests/helpers/extension-harness.ts
+++ b/apps/chrome-extension/tests/helpers/extension-harness.ts
@@ -515,6 +515,50 @@ export async function activateTabByUrl(harness: ExtensionHarness, expectedPrefix
   }, expectedPrefix);
 }
 
+export async function activateTabByUrlInPanelWindow(
+  harness: ExtensionHarness,
+  panel: Page,
+  expectedPrefix: string,
+) {
+  await waitForPanelPort(panel);
+  const portName = await panel.evaluate(
+    () =>
+      (
+        window as {
+          __summarizePanelPort?: { name?: string };
+        }
+      ).__summarizePanelPort?.name ?? null,
+  );
+  const windowId =
+    portName?.startsWith("sidepanel:") === true
+      ? Number.parseInt(portName.slice("sidepanel:".length), 10)
+      : Number.NaN;
+  if (!Number.isFinite(windowId)) throw new Error(`Invalid panel port name: ${portName ?? "none"}`);
+
+  const background = await getBackground(harness);
+  await background.evaluate(
+    async ({ prefix, targetWindowId }) => {
+      const tabs = await chrome.tabs.query({});
+      const target = tabs.find((tab) => tab.url?.startsWith(prefix));
+      if (!target?.id) throw new Error(`Tab not found: ${prefix}`);
+      if (target.windowId !== targetWindowId) {
+        await chrome.tabs.move(target.id, { windowId: targetWindowId, index: -1 });
+      }
+      await chrome.windows.update(targetWindowId, { focused: true }).catch(() => {});
+      await chrome.tabs.update(target.id, { active: true });
+    },
+    { prefix: expectedPrefix, targetWindowId: windowId },
+  );
+  await expect
+    .poll(async () => {
+      return await background.evaluate(async (targetWindowId) => {
+        const [tab] = await chrome.tabs.query({ active: true, windowId: targetWindowId });
+        return tab?.url ?? "";
+      }, windowId);
+    })
+    .toContain(expectedPrefix);
+}
+
 export async function openExtensionPage(
   harness: ExtensionHarness,
   pathname: string,

--- a/apps/chrome-extension/tests/helpers/extension-harness.ts
+++ b/apps/chrome-extension/tests/helpers/extension-harness.ts
@@ -536,7 +536,7 @@ export async function activateTabByUrlInPanelWindow(
   if (!Number.isFinite(windowId)) throw new Error(`Invalid panel port name: ${portName ?? "none"}`);
 
   const background = await getBackground(harness);
-  await background.evaluate(
+  const tabId = await background.evaluate(
     async ({ prefix, targetWindowId }) => {
       const tabs = await chrome.tabs.query({});
       const target = tabs.find((tab) => tab.url?.startsWith(prefix));
@@ -546,6 +546,7 @@ export async function activateTabByUrlInPanelWindow(
       }
       await chrome.windows.update(targetWindowId, { focused: true }).catch(() => {});
       await chrome.tabs.update(target.id, { active: true });
+      return target.id;
     },
     { prefix: expectedPrefix, targetWindowId: windowId },
   );
@@ -557,6 +558,7 @@ export async function activateTabByUrlInPanelWindow(
       }, windowId);
     })
     .toContain(expectedPrefix);
+  return tabId;
 }
 
 export async function openExtensionPage(

--- a/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
+++ b/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
@@ -227,8 +227,6 @@ test("installed native host carries status, models, and summary streaming end to
     await article.goto(articleUrl);
     await activateTabByUrlInPanelWindow(harness, panel, articleUrl);
     await waitForExtractReady(harness, articleUrl);
-    await sendPanelMessage(panel, { type: "panel:ping" });
-    await expect(panel.locator("#render")).toContainText("Native bridge article");
     await sendPanelMessage(panel, { type: "panel:summarize", refresh: true, inputMode: "page" });
     await expect(panel.locator("#render")).toContainText("Background native summary");
 

--- a/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
+++ b/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
@@ -9,10 +9,12 @@ import { NATIVE_MESSAGING_HOST_NAME } from "../../../src/daemon/constants.js";
 import { buildNativeMessagingManifest } from "../../../src/daemon/native-messaging-install.js";
 import {
   activateTabByUrlInPanelWindow,
+  buildUiState,
   closeExtension,
   getExtensionUrl,
   getExtensionPath,
   seedSettings,
+  sendBgMessage,
   sendPanelMessage,
   trackErrors,
   waitForExtractReady,
@@ -225,8 +227,22 @@ test("installed native host carries status, models, and summary streaming end to
     const articleUrl = `http://localhost:${port}/article`;
     const article = await harness.context.newPage();
     await article.goto(articleUrl);
-    await activateTabByUrlInPanelWindow(harness, panel, articleUrl);
+    const articleTabId = await activateTabByUrlInPanelWindow(harness, panel, articleUrl);
     await waitForExtractReady(harness, articleUrl);
+    await sendBgMessage(harness, {
+      type: "ui:state",
+      state: buildUiState({
+        tab: { id: articleTabId, url: articleUrl, title: "Native bridge article" },
+        settings: {
+          autoSummarize: false,
+          slidesEnabled: false,
+          slidesParallel: true,
+          slideRuntime: "browser",
+          summaryRuntime: "daemon",
+          tokenPresent: true,
+        },
+      }),
+    });
     await sendPanelMessage(panel, { type: "panel:summarize", refresh: true, inputMode: "page" });
     await expect(panel.locator("#render")).toContainText("Background native summary");
 

--- a/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
+++ b/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
@@ -8,13 +8,13 @@ import { chromium, expect, test } from "@playwright/test";
 import { NATIVE_MESSAGING_HOST_NAME } from "../../../src/daemon/constants.js";
 import { buildNativeMessagingManifest } from "../../../src/daemon/native-messaging-install.js";
 import {
-  buildUiState,
   closeExtension,
   getExtensionUrl,
   getExtensionPath,
   seedSettings,
-  sendBgMessage,
+  sendPanelMessage,
   trackErrors,
+  waitForExtractReady,
   waitForPanelPort,
   type ExtensionHarness,
 } from "./helpers/extension-harness";
@@ -166,12 +166,29 @@ test("installed native host carries status, models, and summary streaming end to
       );
       return;
     }
-    if (request.url === "/v1/summarize/native-run/events") {
+    if (request.url === "/article") {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      response.end(`<!doctype html><html><head><title>Native bridge article</title></head><body>
+        <main><article><h1>Native bridge article</h1>
+        <p>This article verifies that daemon requests originating in the extension service worker
+        connect directly to the installed native messaging host. The browser page supplies enough
+        readable content for the normal background extraction and summarization path.</p>
+        <p>A successful result proves both the background request and the side panel stream use the
+        native companion without relying on direct localhost access from the page.</p></article></main>
+      </body></html>`);
+      return;
+    }
+    if (request.url === "/v1/summarize" && request.method === "POST") {
+      request.resume();
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, id: "native-background-run" }));
+      return;
+    }
+    if (request.url === "/v1/summarize/native-background-run/events") {
       response.writeHead(200, { "content-type": "text/event-stream" });
-      response.write('event: chunk\ndata: {"text":"Native "}\n\n');
-      setTimeout(() => {
-        response.end('event: chunk\ndata: {"text":"summary"}\n\nevent: done\ndata: {}\n\n');
-      }, 30);
+      response.end(
+        'event: chunk\ndata: {"text":"Background native summary"}\n\nevent: done\ndata: {}\n\n',
+      );
       return;
     }
     response.writeHead(404, { "content-type": "application/json" });
@@ -203,30 +220,13 @@ test("installed native host carries status, models, and summary streaming end to
     trackErrors(panel, harness.pageErrors, harness.consoleErrors);
     await panel.goto(getExtensionUrl(harness, "sidepanel.html"));
     await waitForPanelPort(panel);
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: "https://example.com/native", title: "Native E2E" },
-        settings: {
-          summaryRuntime: "daemon",
-          slideRuntime: "browser",
-          autoSummarize: false,
-          tokenPresent: true,
-          slidesEnabled: false,
-        },
-      }),
-    });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "native-run",
-        url: "https://example.com/native",
-        title: "Native E2E",
-        model: "auto",
-        reason: "manual",
-      },
-    });
-    await expect(panel.locator("#render")).toContainText("Native summary");
+
+    const articleUrl = `http://localhost:${port}/article`;
+    const article = await harness.context.newPage();
+    await article.goto(articleUrl);
+    await waitForExtractReady(harness, articleUrl);
+    await sendPanelMessage(panel, { type: "panel:summarize", refresh: true, inputMode: "page" });
+    await expect(panel.locator("#render")).toContainText("Background native summary");
 
     expect(seen).toEqual(
       expect.arrayContaining([
@@ -240,7 +240,12 @@ test("installed native host carries status, models, and summary streaming end to
           authorization: "Bearer native-e2e-token",
         }),
         expect.objectContaining({
-          url: "/v1/summarize/native-run/events",
+          method: "POST",
+          url: "/v1/summarize",
+          authorization: "Bearer native-e2e-token",
+        }),
+        expect.objectContaining({
+          url: "/v1/summarize/native-background-run/events",
           authorization: "Bearer native-e2e-token",
         }),
       ]),

--- a/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
+++ b/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
@@ -227,6 +227,7 @@ test("installed native host carries status, models, and summary streaming end to
     await article.goto(articleUrl);
     await activateTabByUrlInPanelWindow(harness, panel, articleUrl);
     await waitForExtractReady(harness, articleUrl);
+    await sendPanelMessage(panel, { type: "panel:ping" });
     await expect(panel.locator("#render")).toContainText("Native bridge article");
     await sendPanelMessage(panel, { type: "panel:summarize", refresh: true, inputMode: "page" });
     await expect(panel.locator("#render")).toContainText("Background native summary");

--- a/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
+++ b/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
@@ -8,15 +8,13 @@ import { chromium, expect, test } from "@playwright/test";
 import { NATIVE_MESSAGING_HOST_NAME } from "../../../src/daemon/constants.js";
 import { buildNativeMessagingManifest } from "../../../src/daemon/native-messaging-install.js";
 import {
-  activateTabByUrl,
+  activateTabByUrlInPanelWindow,
   closeExtension,
   getExtensionUrl,
   getExtensionPath,
-  maybeBringToFront,
   seedSettings,
   sendPanelMessage,
   trackErrors,
-  waitForActiveTabUrl,
   waitForExtractReady,
   waitForPanelPort,
   type ExtensionHarness,
@@ -227,9 +225,7 @@ test("installed native host carries status, models, and summary streaming end to
     const articleUrl = `http://localhost:${port}/article`;
     const article = await harness.context.newPage();
     await article.goto(articleUrl);
-    await maybeBringToFront(article);
-    await activateTabByUrl(harness, articleUrl);
-    await waitForActiveTabUrl(harness, articleUrl);
+    await activateTabByUrlInPanelWindow(harness, panel, articleUrl);
     await waitForExtractReady(harness, articleUrl);
     await expect(panel.locator("#render")).toContainText("Native bridge article");
     await sendPanelMessage(panel, { type: "panel:summarize", refresh: true, inputMode: "page" });

--- a/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
+++ b/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
@@ -8,12 +8,15 @@ import { chromium, expect, test } from "@playwright/test";
 import { NATIVE_MESSAGING_HOST_NAME } from "../../../src/daemon/constants.js";
 import { buildNativeMessagingManifest } from "../../../src/daemon/native-messaging-install.js";
 import {
+  activateTabByUrl,
   closeExtension,
   getExtensionUrl,
   getExtensionPath,
+  maybeBringToFront,
   seedSettings,
   sendPanelMessage,
   trackErrors,
+  waitForActiveTabUrl,
   waitForExtractReady,
   waitForPanelPort,
   type ExtensionHarness,
@@ -224,7 +227,11 @@ test("installed native host carries status, models, and summary streaming end to
     const articleUrl = `http://localhost:${port}/article`;
     const article = await harness.context.newPage();
     await article.goto(articleUrl);
+    await maybeBringToFront(article);
+    await activateTabByUrl(harness, articleUrl);
+    await waitForActiveTabUrl(harness, articleUrl);
     await waitForExtractReady(harness, articleUrl);
+    await expect(panel.locator("#render")).toContainText("Native bridge article");
     await sendPanelMessage(panel, { type: "panel:summarize", refresh: true, inputMode: "page" });
     await expect(panel.locator("#render")).toContainText("Background native summary");
 

--- a/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
+++ b/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
@@ -244,7 +244,21 @@ test("installed native host carries status, models, and summary streaming end to
       }),
     });
     await sendPanelMessage(panel, { type: "panel:summarize", refresh: true, inputMode: "page" });
-    await expect(panel.locator("#render")).toContainText("Background native summary");
+    await expect
+      .poll(
+        () => seen.some((request) => request.method === "POST" && request.url === "/v1/summarize"),
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+    await expect
+      .poll(
+        () => seen.some((request) => request.url === "/v1/summarize/native-background-run/events"),
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+    await expect(panel.locator("#render")).toContainText("Background native summary", {
+      timeout: 30_000,
+    });
 
     expect(seen).toEqual(
       expect.arrayContaining([

--- a/apps/chrome-extension/tests/sidepanel.media-selection.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.media-selection.spec.ts
@@ -397,7 +397,8 @@ test("sidepanel falls back to current YouTube transcript panel rows", async ({
       .toContain("Panel first caption");
 
     const body = (await getSummarizeLastBody(harness)) as Record<string, unknown>;
-    expect(body.mode).toBe("page");
+    expect(body.mode).toBe("url");
+    expect(body.slides).toBe(true);
     expect(body.text).toContain("[0:00] Panel first caption.");
     expect(body.text).toContain("[0:02] Panel second caption.");
     assertNoErrors(harness);

--- a/tests/chrome.panel-summarize.test.ts
+++ b/tests/chrome.panel-summarize.test.ts
@@ -116,6 +116,31 @@ describe("chrome panel summarize", () => {
     expect(harness.session.lastSummarizedUrl).toBeNull();
   });
 
+  it("keeps daemon slides on YouTube URL mode when Chrome already has a transcript", async () => {
+    const harness = createHarness();
+
+    await harness.summarize({
+      extractYouTubeTranscript: vi.fn(async () => ({
+        ok: true as const,
+        url: youtubeUrl,
+        text: "Caption transcript.",
+        transcriptTimedText: "[0:00] Caption transcript.",
+        truncated: false,
+        durationSeconds: 42,
+      })),
+    });
+
+    expect(harness.fetchImpl).toHaveBeenCalledOnce();
+    const [, init] = harness.fetchImpl.mock.calls[0];
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      url: youtubeUrl,
+      mode: "url",
+      timestamps: true,
+      slides: true,
+    });
+  });
+
   it("dedupes automatic starts for the current inflight URL", async () => {
     const harness = createHarness();
     harness.session.inflightUrl = youtubeUrl;


### PR DESCRIPTION
## Summary

- connect MV3 service-worker daemon requests directly to the installed native host while preserving the extension-page bridge
- keep YouTube daemon-slide summaries on URL mode even when Chrome supplies transcript text
- add background native-host and browser-transcript-plus-slides regressions

## Proof

- `pnpm check` — 545 files passed, 29 skipped; 2,921 tests passed, 43 skipped
- `pnpm test:extension-e2e` — native-host E2E passed; Chromium suite 107 passed, 6 skipped
- `pnpm -C apps/chrome-extension test:firefox` — build and temporary-add-on smoke passed
- AutoReview — clean, no accepted/actionable findings
- Existing-profile Chrome live test on `https://www.youtube.com/watch?v=jNQXAC9IVRw` — daemon summary completed via `cli/codex`; three rendered slide images and descriptions; fresh 320x240 artifacts written by forced refresh

## Risk

Low and scoped to Chrome daemon transport/routing. Extension pages retain the existing runtime bridge, Firefox retains direct HTTP transport, and policy plus `nativeMessaging` permission checks still gate the service-worker native connection.
