### PR TITLE
[codex] fix negated slides flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- CLI slides: accept `--no-slides` and `--no-slides-ocr` so configured slide defaults can be disabled per run.
+- CLI slides: accept `--no-slides` and `--no-slides-ocr` so configured slide defaults can be disabled per run (#345, thanks @vincent-peng).
 - Slides: bound optional calibration probes so the bundled FFmpeg fallback cannot stall for minutes when Node shutdown lingers.
 - Daemon setup: report native messaging hosts installed for valid unpacked Chrome extension IDs instead of falsely marking them missing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- CLI slides: accept `--no-slides` and `--no-slides-ocr` so configured slide defaults can be disabled per run.
 - Slides: bound optional calibration probes so the bundled FFmpeg fallback cannot stall for minutes when Node shutdown lingers.
 - Daemon setup: report native messaging hosts installed for valid unpacked Chrome extension IDs instead of falsely marking them missing.
 

--- a/README.md
+++ b/README.md
@@ -367,7 +367,9 @@ Use `summarize --help` or `summarize help` for the full help text.
 - `--extract`: print extracted content and exit (URLs, YouTube/direct media, local audio/video, and local PDFs; stdin `-` is not supported)
   - Deprecated alias: `--extract-only`
 - `--slides`: extract slides for YouTube, direct video URLs, or local video files and render them inline in the summary narrative (auto-renders inline in supported terminals)
+- `--no-slides`: disable slide extraction enabled in `~/.summarize/config.json` for one run
 - `--slides-ocr`: run OCR on extracted slides (requires `tesseract`)
+- `--no-slides-ocr`: disable slide OCR enabled in `~/.summarize/config.json` for one run
 - `--slides-dir <dir>`: base output dir for slide images (default `./slides`)
 - `--slides-scene-threshold <value>`: scene detection threshold (0.1-1.0)
 - `--slides-max <count>`: maximum slides to extract (default `6`)

--- a/completions/summarize.fish
+++ b/completions/summarize.fish
@@ -62,8 +62,10 @@ for cmd in summarize summarizer
 
     # Slides options
     complete -c $cmd -n '__summarize_no_subcommand' -l slides -d 'Extract slides for video URLs' -xa 'true false yes no on off 1 0'
+    complete -c $cmd -n '__summarize_no_subcommand' -l no-slides -d 'Disable configured slide extraction'
     complete -c $cmd -n '__summarize_no_subcommand' -l slides-debug -d 'Show slide image paths'
     complete -c $cmd -n '__summarize_no_subcommand' -l slides-ocr -d 'Run OCR on extracted slides'
+    complete -c $cmd -n '__summarize_no_subcommand' -l no-slides-ocr -d 'Disable configured slide OCR'
     complete -c $cmd -n '__summarize_no_subcommand' -l slides-dir -d 'Base output dir for slides' -rF
     complete -c $cmd -n '__summarize_no_subcommand' -l slides-scene-threshold -d 'Scene detection threshold (0.1-1.0)' -x
     complete -c $cmd -n '__summarize_no_subcommand' -l slides-max -d 'Maximum slides to extract' -x

--- a/docs/commands/summarize.md
+++ b/docs/commands/summarize.md
@@ -87,11 +87,13 @@ If `[input]` is omitted, summarize prints concise help and exits.
 
 ### Slides
 
-`--slides [value]`
+`--slides [value]` / `--no-slides`
 : Extract slides from a YouTube URL, direct video URL, or local video file and render inline alongside the summary. Combine with `--extract` to interleave slides in the full transcript. See [Slides mode](../slides.md).
+: Use `--no-slides` to disable slide extraction enabled in the config file for one run.
 
-`--slides-ocr`
+`--slides-ocr` / `--no-slides-ocr`
 : Run OCR on extracted slides. Requires `tesseract`.
+: Use `--no-slides-ocr` to disable configured slide OCR while retaining slide extraction.
 
 `--slides-debug`
 : Print slide image paths instead of rendering inline (useful in non-image terminals).

--- a/src/run/help.ts
+++ b/src/run/help.ts
@@ -81,8 +81,10 @@ export function buildProgram() {
       "--slides [value]",
       "Extract slides for YouTube/direct video URLs or local video files and render them inline inside the summary narrative (when supported). Combine with --extract to interleave slides in the full transcript.",
     )
+    .option("--no-slides", "Disable configured slide extraction for this run.")
     .option("--slides-debug", "Show slide image paths instead of rendering inline images.", false)
     .option("--slides-ocr", "Run OCR on extracted slides (requires tesseract).", false)
+    .option("--no-slides-ocr", "Disable configured slide OCR for this run.")
     .option("--slides-dir <dir>", "Base output dir for slides (default: ./slides).", "slides")
     .option(
       "--slides-scene-threshold <value>",

--- a/src/run/runner-slides.ts
+++ b/src/run/runner-slides.ts
@@ -30,13 +30,18 @@ export function resolveRunnerSlidesSettings(options: {
     (arg) => arg === "--slides-min-duration" || arg.startsWith("--slides-min-duration="),
   );
   const slidesConfig = config?.slides;
+  const slidesValue = slidesExplicitlySet
+    ? programOpts.slides
+    : (slidesConfig?.enabled ?? programOpts.slides);
+  const slidesDisabledExplicitly = normalizedArgv.includes("--no-slides");
+  const slidesOcrValue = slidesOcrExplicitlySet
+    ? programOpts.slidesOcr
+    : slidesDisabledExplicitly
+      ? false
+      : (slidesConfig?.ocr ?? programOpts.slidesOcr);
   const slidesSettings = resolveSlideSettings({
-    slides: slidesExplicitlySet
-      ? programOpts.slides
-      : (slidesConfig?.enabled ?? programOpts.slides),
-    slidesOcr: slidesOcrExplicitlySet
-      ? programOpts.slidesOcr
-      : (slidesConfig?.ocr ?? programOpts.slidesOcr),
+    slides: slidesValue,
+    slidesOcr: slidesOcrValue,
     slidesDir: slidesDirExplicitlySet
       ? programOpts.slidesDir
       : (slidesConfig?.dir ?? programOpts.slidesDir),

--- a/tests/package-bin.test.ts
+++ b/tests/package-bin.test.ts
@@ -182,6 +182,13 @@ describe("package bin wrappers", () => {
     expect(slidesHelp).toMatch(/local\s+video\s+file/);
   });
 
+  it("accepts negated slides flags for configured defaults", () => {
+    const program = buildProgram();
+    program.parse(["--no-slides", "--no-slides-ocr"], { from: "user" });
+
+    expect(program.opts()).toMatchObject({ slides: false, slidesOcr: false });
+  });
+
   it("routes fish subcommands from the first CLI argument", async () => {
     const fish = await readFile("completions/summarize.fish", "utf8");
 

--- a/tests/runner-slides.test.ts
+++ b/tests/runner-slides.test.ts
@@ -25,6 +25,53 @@ describe("resolveRunnerSlidesSettings", () => {
     expect(settings?.autoTuneThreshold).toBe(false);
   });
 
+  it("lets --no-slides disable configured slide extraction", () => {
+    const settings = resolveRunnerSlidesSettings({
+      normalizedArgv: ["--no-slides"],
+      programOpts: { slides: false },
+      config: { slides: { enabled: true, ocr: true } },
+      inputTarget: { kind: "url", url: "https://www.youtube.com/watch?v=EYSQGkpuzAA" },
+    });
+
+    expect(settings).toBeNull();
+  });
+
+  it("keeps --slides=false compatible with configured OCR defaults", () => {
+    const settings = resolveRunnerSlidesSettings({
+      normalizedArgv: ["--slides=false"],
+      programOpts: { slides: "false" },
+      config: { slides: { ocr: true } },
+      inputTarget: { kind: "file", filePath: "/tmp/video.webm" },
+    });
+
+    expect(settings?.enabled).toBe(true);
+    expect(settings?.ocr).toBe(true);
+  });
+
+  it("lets explicit --slides-ocr override --no-slides for the current run", () => {
+    const settings = resolveRunnerSlidesSettings({
+      normalizedArgv: ["--no-slides", "--slides-ocr"],
+      programOpts: { slides: false, slidesOcr: true },
+      config: { slides: { enabled: true, ocr: false } },
+      inputTarget: { kind: "file", filePath: "/tmp/video.webm" },
+    });
+
+    expect(settings?.enabled).toBe(true);
+    expect(settings?.ocr).toBe(true);
+  });
+
+  it("lets --no-slides-ocr disable configured OCR without disabling slides", () => {
+    const settings = resolveRunnerSlidesSettings({
+      normalizedArgv: ["--no-slides-ocr"],
+      programOpts: { slidesOcr: false },
+      config: { slides: { enabled: true, ocr: true } },
+      inputTarget: { kind: "file", filePath: "/tmp/video.webm" },
+    });
+
+    expect(settings?.enabled).toBe(true);
+    expect(settings?.ocr).toBe(false);
+  });
+
   it("rejects slides for stdin", () => {
     expect(() =>
       resolveRunnerSlidesSettings({


### PR DESCRIPTION
## Summary

- Accept `--no-slides` and `--no-slides-ocr` in the top-level CLI so configured slide defaults can be disabled per run.
- Preserve existing `--slides=false` behavior with configured OCR defaults while making `--no-slides` a hard disable for configured slide/OCR defaults unless OCR is explicitly requested in the same invocation.
- Add fish completions, changelog entry, and regression coverage for the new precedence cases.

## Root Cause

`runner-slides.ts` already treated negated slide flags as explicit argv overrides, but `help.ts` never registered those flags with Commander, so the CLI rejected them before settings resolution could run.

## Validation

- `pnpm test tests/runner-slides.test.ts tests/package-bin.test.ts`
- `pnpm -s check`

## Behavior Proof

This uses a temporary `HOME` with slide extraction and OCR enabled by default. The actual CLI accepts both negated flags, exits successfully, and verbose output shows `timestamps=off`, which means the configured slide defaults were disabled for this run.

```text
$ config at <TEMP_HOME>/.summarize/config.json
{"slides":{"enabled":true,"ocr":true,"max":1}}

$ HOME=<TEMP_HOME> NO_COLOR=1 pnpm -s summarize "https://example.com" --extract --format text --no-slides --no-slides-ocr --verbose --timeout 10s
[summarize] config url=https://example.com timeoutMs=10000 youtube=auto firecrawl=auto length=long maxOutputTokens=none retries=1 json=false extract=true format=text preprocess=auto markdownMode=off model=auto videoMode=auto embeddedVideo=auto timestamps=off diarize=off stream=off plain=false
[summarize] configFile path=<TEMP_HOME>/.summarize/config.json model=none
[summarize] env xaiKey=false openaiKey=false zaiKey=false googleKey=false anthropicKey=false openrouterKey=false apifyToken=false firecrawlKey=false
[summarize] markdown htmlRequested=false transcriptRequested=false provider=none
[summarize] extract start
[summarize] cache miss extract
[summarize] cache write extract
[summarize] extract done strategy=html siteName=example.com title=Example Domain transcriptSource=none
[summarize] extract stats characters=101 words=15 transcriptCharacters=none transcriptLines=none
[summarize] extract firecrawl attempted=false used=false notes=none
[summarize] extract markdown requested=false used=false provider=none notes=none
[summarize] extract transcript textProvided=false provider=none attemptedProviders=none notes=none
[summarize] cache miss transcript
This domain is for use in documentation examples without needing permission. Avoid use in operations.

0.3s · text

exit=0
```