### PR TITLE
fix: recover Reddit thread extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Reddit extraction: retry verification-blocked threads through old Reddit and preserve the post plus comments in Markdown (#343, thanks @manfredlift).
 - CLI slides: accept `--no-slides` and `--no-slides-ocr` so configured slide defaults can be disabled per run (#345, thanks @vincent-peng).
 - Slides: bound optional calibration probes so the bundled FFmpeg fallback cannot stall for minutes when Node shutdown lingers.
 - Daemon setup: report native messaging hosts installed for valid unpacked Chrome extension IDs instead of falsely marking them missing.

--- a/packages/core/src/content/link-preview/content/article.ts
+++ b/packages/core/src/content/link-preview/content/article.ts
@@ -50,8 +50,11 @@ export function sanitizeHtmlForMarkdownConversion(html: string): string {
   });
 }
 
-export function extractArticleContent(html: string): string {
-  const segments = collectSegmentsFromHtml(html);
+export function extractArticleContent(
+  html: string,
+  options?: { preserveShortSegments?: boolean },
+): string {
+  const segments = collectSegmentsFromHtml(html, options);
   if (segments.length > 0) {
     return segments.join("\n");
   }
@@ -59,7 +62,11 @@ export function extractArticleContent(html: string): string {
   return fallback ?? "";
 }
 
-export function collectSegmentsFromHtml(html: string): string[] {
+export function collectSegmentsFromHtml(
+  html: string,
+  options?: { preserveShortSegments?: boolean },
+): string[] {
+  const minimumSegmentLength = options?.preserveShortSegments ? 1 : MIN_SEGMENT_LENGTH;
   const sanitized = sanitizeHtml(stripHiddenHtml(html), {
     allowedTags: [
       "article",
@@ -117,11 +124,11 @@ export function collectSegmentsFromHtml(html: string): string[] {
       }
 
       if (tag === "li") {
-        if (text.length >= 20) segments.push(`• ${text}`);
+        if (text.length >= Math.min(20, minimumSegmentLength)) segments.push(`• ${text}`);
         continue;
       }
 
-      if (text.length >= MIN_SEGMENT_LENGTH) segments.push(text);
+      if (text.length >= minimumSegmentLength) segments.push(text);
     }
 
     if (segments.length === 0) {

--- a/packages/core/src/content/link-preview/content/html.ts
+++ b/packages/core/src/content/link-preview/content/html.ts
@@ -65,6 +65,8 @@ export async function buildResultFromHtmlDocument({
   timeoutMs,
   deps,
   readabilityCandidate,
+  isNormalizedRedditThread = false,
+  mediaHtml = html,
 }: {
   url: string;
   html: string;
@@ -82,6 +84,8 @@ export async function buildResultFromHtmlDocument({
   timeoutMs: number;
   deps: LinkPreviewDeps;
   readabilityCandidate: Awaited<ReturnType<typeof extractReadabilityFromHtml>> | null;
+  isNormalizedRedditThread?: boolean;
+  mediaHtml?: string;
 }): Promise<ExtractedLinkContent> {
   const extractionStartedAt = Date.now();
   if (isYouTubeVideoUrl(url) && !extractYouTubeVideoId(url)) {
@@ -97,11 +101,14 @@ export async function buildResultFromHtmlDocument({
   const readabilityText = readability?.text ? normalizeForPrompt(readability.text) : "";
   const readabilityHtml = toReadabilityHtml(readability);
 
-  const normalizedSegmentsFromHtml = normalizeForPrompt(extractArticleContent(html));
+  const normalizedSegmentsFromHtml = normalizeForPrompt(
+    extractArticleContent(html, { preserveShortSegments: isNormalizedRedditThread }),
+  );
   const normalizedSegmentsFromReadabilityHtml = readabilityHtml
     ? normalizeForPrompt(extractArticleContent(readabilityHtml))
     : "";
   const preferReadabilityHtml =
+    !isNormalizedRedditThread &&
     normalizedSegmentsFromReadabilityHtml.length >= MIN_READABILITY_CONTENT_CHARACTERS &&
     (normalizedSegmentsFromHtml.length < MIN_HTML_CONTENT_CHARACTERS ||
       normalizedSegmentsFromReadabilityHtml.length >=
@@ -111,6 +118,7 @@ export async function buildResultFromHtmlDocument({
     : normalizedSegmentsFromHtml;
 
   const preferReadabilityText =
+    !isNormalizedRedditThread &&
     !preferReadabilityHtml &&
     readabilityText.length >= MIN_READABILITY_CONTENT_CHARACTERS &&
     (normalizedSegmentsFromHtml.length < MIN_HTML_CONTENT_CHARACTERS ||
@@ -129,7 +137,7 @@ export async function buildResultFromHtmlDocument({
   const effectiveNormalizedWithDescription = preferDescription
     ? descriptionCandidate
     : effectiveNormalized;
-  const videoDetection = detectPrimaryVideoDetailsFromHtml(html, url);
+  const videoDetection = detectPrimaryVideoDetailsFromHtml(mediaHtml, url);
   const detectedVideo = videoDetection?.video ?? null;
   const resolvedEmbeddedVideoMode = embeddedVideoMode ?? "auto";
   const embeddedYoutube = resolveEmbeddedYoutubeDecision({
@@ -139,7 +147,7 @@ export async function buildResultFromHtmlDocument({
     youtubeTranscriptMode: youtubeTranscriptMode ?? "auto",
     mediaTranscriptMode: mediaTranscriptMode ?? "auto",
   });
-  const transcriptResolution = await resolveTranscriptForLink(url, html, deps, {
+  const transcriptResolution = await resolveTranscriptForLink(url, mediaHtml, deps, {
     timeoutMs,
     youtubeTranscriptMode: embeddedYoutube.youtubeTranscriptMode,
     mediaTranscriptMode: embeddedYoutube.mediaTranscriptMode,
@@ -151,7 +159,7 @@ export async function buildResultFromHtmlDocument({
   });
   await refreshYoutubeSourceMetrics({
     url,
-    html,
+    html: mediaHtml,
     detectedVideo,
     transcriptResolution,
     deps,
@@ -160,7 +168,7 @@ export async function buildResultFromHtmlDocument({
   });
 
   const youtubeDescription =
-    transcriptResolution.text === null ? extractYouTubeShortDescription(html) : null;
+    transcriptResolution.text === null ? extractYouTubeShortDescription(mediaHtml) : null;
   let articleContent = youtubeDescription
     ? normalizeForPrompt(youtubeDescription)
     : effectiveNormalizedWithDescription;
@@ -198,7 +206,9 @@ export async function buildResultFromHtmlDocument({
 
     try {
       const htmlForMarkdown =
-        markdownMode === "readability" && readabilityHtml ? readabilityHtml : html;
+        markdownMode === "readability" && readabilityHtml && !isNormalizedRedditThread
+          ? readabilityHtml
+          : html;
       const sanitizedHtml = sanitizeHtmlForMarkdownConversion(htmlForMarkdown);
       const markdown = await deps.convertHtmlToMarkdown({
         url,
@@ -223,7 +233,7 @@ export async function buildResultFromHtmlDocument({
         used: true,
         provider: "llm",
         notes:
-          markdownMode === "readability" && readabilityHtml
+          markdownMode === "readability" && readabilityHtml && !isNormalizedRedditThread
             ? "Readability HTML used for markdown input"
             : null,
       };

--- a/packages/core/src/content/link-preview/content/index.ts
+++ b/packages/core/src/content/link-preview/content/index.ts
@@ -9,6 +9,11 @@ import { fetchHtmlDocument, fetchWithFirecrawl, isAssetLikeHtmlFetchError } from
 import { buildResultFromFirecrawl, shouldFallbackToFirecrawl } from "./firecrawl.js";
 import { buildResultFromHtmlDocument } from "./html.js";
 import { extractReadabilityFromHtml } from "./readability.js";
+import {
+  isBlockedRedditThreadHtml,
+  normalizeOldRedditThreadHtml,
+  toOldRedditThreadUrl,
+} from "./reddit.js";
 import { tryTranscriptOnlyStrategy } from "./transcript-only-strategies.js";
 import {
   isAnubisHtml,
@@ -375,11 +380,58 @@ export async function fetchLinkContent(
     );
   }
 
-  const html = htmlResult.html;
+  let html = htmlResult.html;
   const effectiveUrl = htmlResult.finalUrl || url;
-  let readabilityCandidate: Awaited<ReturnType<typeof extractReadabilityFromHtml>> | null = null;
+  let mediaHtml = html;
+  let isNormalizedRedditThread = false;
+  const oldRedditUrl = toOldRedditThreadUrl(effectiveUrl);
+  if (
+    oldRedditUrl &&
+    oldRedditUrl !== effectiveUrl &&
+    isBlockedRedditThreadHtml(effectiveUrl, html)
+  ) {
+    try {
+      const oldRedditResult = await fetchHtmlDocument(deps.fetch, oldRedditUrl, {
+        timeoutMs,
+        onProgress: deps.onProgress ?? null,
+        rejectNonHtmlText: options?.throwOnAssetLikeHtmlError ?? false,
+      });
+      const oldRedditEffectiveUrl = oldRedditResult.finalUrl || oldRedditUrl;
+      const normalizedOldRedditHtml = normalizeOldRedditThreadHtml(
+        oldRedditEffectiveUrl,
+        oldRedditResult.html,
+        { canonicalUrl: effectiveUrl },
+      );
+      if (
+        normalizedOldRedditHtml &&
+        !isBlockedRedditThreadHtml(oldRedditEffectiveUrl, oldRedditResult.html)
+      ) {
+        html = normalizedOldRedditHtml;
+        mediaHtml = oldRedditResult.html;
+        isNormalizedRedditThread = true;
+      }
+    } catch {
+      // Keep the original verification response so Firecrawl can still handle it below.
+    }
+  }
 
-  if (firecrawlMode === "auto" && shouldFallbackToFirecrawl(html)) {
+  const normalizedRedditHtml = normalizeOldRedditThreadHtml(effectiveUrl, html);
+  if (normalizedRedditHtml) {
+    html = normalizedRedditHtml;
+    isNormalizedRedditThread = true;
+  }
+  let readabilityCandidate: Awaited<ReturnType<typeof extractReadabilityFromHtml>> | null = null;
+  const blockedRedditThread =
+    !isNormalizedRedditThread && isBlockedRedditThreadHtml(effectiveUrl, html);
+
+  if (firecrawlMode === "auto" && blockedRedditThread) {
+    const firecrawlResult = await attemptFirecrawl(
+      "Reddit returned a verification page; falling back to Firecrawl",
+    );
+    if (firecrawlResult) {
+      return firecrawlResult;
+    }
+  } else if (firecrawlMode === "auto" && shouldFallbackToFirecrawl(html)) {
     readabilityCandidate = await extractReadabilityFromHtml(html, effectiveUrl);
     const readabilityText = readabilityCandidate?.text
       ? normalizeForPrompt(readabilityCandidate.text)
@@ -392,6 +444,12 @@ export async function fetchLinkContent(
         return firecrawlResult;
       }
     }
+  }
+
+  if (blockedRedditThread) {
+    throw new Error(
+      "Unable to fetch Reddit thread content: Reddit returned a verification page and the old.reddit.com fallback was unavailable.",
+    );
   }
 
   const htmlExtracted = await buildResultFromHtmlDocument({
@@ -411,6 +469,8 @@ export async function fetchLinkContent(
     timeoutMs,
     deps,
     readabilityCandidate,
+    isNormalizedRedditThread,
+    mediaHtml,
   });
   if (twitterStatus && isBlockedTwitterContent(htmlExtracted.content)) {
     const birdNote = !deps.readTweetWithBird

--- a/packages/core/src/content/link-preview/content/reddit.ts
+++ b/packages/core/src/content/link-preview/content/reddit.ts
@@ -1,0 +1,179 @@
+import { parseHtmlDocument } from "../../html-document.js";
+import { sanitizeHtmlForMarkdownConversion } from "./article.js";
+import { normalizeCandidate } from "./cleaner.js";
+
+const REDDIT_HOSTS = new Set([
+  "reddit.com",
+  "www.reddit.com",
+  "new.reddit.com",
+  "old.reddit.com",
+  "np.reddit.com",
+]);
+const REDDIT_THREAD_PATH_PATTERN = /^\/(?:r\/[^/]+\/)?comments\/([a-z0-9]+)(?:\/|$)/i;
+const REDDIT_VERIFICATION_PATTERN =
+  /reddit\s*-\s*please wait for verification|please wait for verification|whoa there, pardner/i;
+
+function parseRedditThreadUrl(input: string): URL | null {
+  try {
+    const url = new URL(input);
+    if (!REDDIT_HOSTS.has(url.hostname.toLowerCase())) return null;
+    if (!REDDIT_THREAD_PATH_PATTERN.test(url.pathname)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function redditThreadId(url: URL): string | null {
+  return url.pathname.match(REDDIT_THREAD_PATH_PATTERN)?.[1]?.toLowerCase() ?? null;
+}
+
+export function toOldRedditThreadUrl(input: string): string | null {
+  const url = parseRedditThreadUrl(input);
+  if (!url) return null;
+  url.protocol = "https:";
+  url.hostname = "old.reddit.com";
+  url.port = "";
+  return url.href;
+}
+
+export function isBlockedRedditThreadHtml(inputUrl: string, html: string): boolean {
+  const redditUrl = parseRedditThreadUrl(inputUrl);
+  if (!redditUrl) return false;
+
+  const parsed = parseHtmlDocument(html, redditUrl.href);
+  try {
+    const threadId = redditThreadId(redditUrl);
+    if (
+      parsed.document.querySelector(
+        `#thing_t3_${threadId}.thing[data-type="link"], .thing[data-fullname="t3_${threadId}"][data-type="link"], shreddit-post, [data-testid="post-container"]`,
+      )
+    ) {
+      return false;
+    }
+
+    const title = normalizeCandidate(parsed.document.querySelector("title")?.textContent) ?? "";
+    if (REDDIT_VERIFICATION_PATTERN.test(title)) return true;
+
+    const body = normalizeCandidate(parsed.document.body?.textContent) ?? "";
+    return body.length <= 1_000 && REDDIT_VERIFICATION_PATTERN.test(body);
+  } finally {
+    parsed.close();
+  }
+}
+
+function directChildWithClass(element: Element, className: string): Element | null {
+  return Array.from(element.children).find((child) => child.classList.contains(className)) ?? null;
+}
+
+function thingEntry(thing: Element): Element | null {
+  return directChildWithClass(thing, "entry");
+}
+
+function entryBody(entry: Element | null): Element | null {
+  return entry?.querySelector(".usertext-body .md") ?? null;
+}
+
+function safeBodyHtml(body: Element | null): string {
+  return body ? sanitizeHtmlForMarkdownConversion(body.outerHTML) : "";
+}
+
+function commentDepth(comment: Element): number {
+  let depth = 0;
+  let ancestor = comment.parentElement;
+  while (ancestor) {
+    if (ancestor.classList.contains("thing") && ancestor.classList.contains("comment")) {
+      depth += 1;
+    }
+    ancestor = ancestor.parentElement;
+  }
+  return depth;
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function resolveHttpUrl(input: string | null | undefined, baseUrl: URL): string | null {
+  if (!input) return null;
+  try {
+    const resolved = new URL(input, baseUrl);
+    return resolved.protocol === "http:" || resolved.protocol === "https:" ? resolved.href : null;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeOldRedditThreadHtml(
+  inputUrl: string,
+  html: string,
+  options?: { canonicalUrl?: string },
+): string | null {
+  const redditUrl = parseRedditThreadUrl(inputUrl);
+  if (!redditUrl) return null;
+
+  const parsed = parseHtmlDocument(html, redditUrl.href);
+  try {
+    const threadId = redditThreadId(redditUrl);
+    if (!threadId) return null;
+    const post = parsed.document.querySelector(
+      `#thing_t3_${threadId}.thing[data-type="link"], .thing[data-fullname="t3_${threadId}"][data-type="link"]`,
+    );
+    if (!post || post.classList.contains("promoted")) return null;
+
+    const postEntry = thingEntry(post);
+    const titleLink = postEntry?.querySelector("a.title") ?? null;
+    const title = normalizeCandidate(titleLink?.textContent) ?? null;
+    if (!title) return null;
+    const isSelfPost =
+      post.classList.contains("self") ||
+      (post.getAttribute("data-domain") ?? "").toLowerCase().startsWith("self.");
+    const titleUrl = resolveHttpUrl(
+      isSelfPost && options?.canonicalUrl ? options.canonicalUrl : titleLink?.getAttribute("href"),
+      redditUrl,
+    );
+
+    const postAuthor = normalizeCandidate(
+      postEntry?.querySelector(".tagline .author")?.textContent,
+    );
+    const subreddit = normalizeCandidate(post.getAttribute("data-subreddit"));
+    const postBody = safeBodyHtml(entryBody(postEntry));
+    const postByline = [postAuthor ? `u/${postAuthor}` : null, subreddit ? `r/${subreddit}` : null]
+      .filter(Boolean)
+      .join(" in ");
+
+    const commentSections: string[] = [];
+    for (const comment of parsed.document.querySelectorAll(".thing.comment")) {
+      const entry = thingEntry(comment);
+      const body = entryBody(entry);
+      const bodyText = normalizeCandidate(body?.textContent);
+      if (!bodyText) continue;
+
+      const author = normalizeCandidate(entry?.querySelector(".tagline .author")?.textContent);
+      const headingLevel = Math.min(6, 3 + commentDepth(comment));
+      const heading = author ? `Comment by u/${author}` : "Comment";
+      commentSections.push(
+        `<section><h${headingLevel}>${escapeHtml(heading)}</h${headingLevel}>${safeBodyHtml(body)}</section>`,
+      );
+    }
+
+    const bylineHtml = postByline ? `<p>Posted by ${escapeHtml(postByline)}</p>` : "";
+    const commentsHtml =
+      commentSections.length > 0 ? `<h2>Comments</h2>${commentSections.join("")}` : "";
+    const titleHtml = titleUrl
+      ? `<a href="${escapeHtml(titleUrl)}">${escapeHtml(title)}</a>`
+      : escapeHtml(title);
+    const outboundLinkHtml =
+      titleUrl && !isSelfPost
+        ? `<p>Link: <a href="${escapeHtml(titleUrl)}">${escapeHtml(titleUrl)}</a></p>`
+        : "";
+    return `<!doctype html><html><head><title>${escapeHtml(title)}</title><meta property="og:site_name" content="Reddit"></head><body><article><h1>${titleHtml}</h1>${bylineHtml}${outboundLinkHtml}${postBody}${commentsHtml}</article></body></html>`;
+  } finally {
+    parsed.close();
+  }
+}

--- a/tests/link-preview.reddit.test.ts
+++ b/tests/link-preview.reddit.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isBlockedRedditThreadHtml,
+  normalizeOldRedditThreadHtml,
+  toOldRedditThreadUrl,
+} from "../packages/core/src/content/link-preview/content/reddit.js";
+import { createLinkPreviewClient } from "../src/content/index.js";
+
+const threadUrl = "https://www.reddit.com/r/example/comments/abc123/thread_title/";
+const oldThreadUrl = "https://old.reddit.com/r/example/comments/abc123/thread_title/";
+const blockedHtml = `<!doctype html><html><head><title>Reddit - Please wait for verification</title></head><body><p>Reddit - Please wait for verification</p></body></html>`;
+const oldRedditHtml = `<!doctype html><html><head><title>Old Reddit</title></head><body>
+  <nav><p>Navigation noise that must not survive extraction.</p></nav>
+  <div class="thing link" id="thing_t3_abc123" data-type="link" data-subreddit="example" data-domain="example.com">
+    <div class="entry unvoted">
+      <a class="title may-blank" href="https://example.com/source">Thread title</a>
+      <p class="tagline"><a class="author">original-poster</a></p>
+      <div class="usertext-body"><div class="md"><p>Original post body with enough useful detail.</p></div></div>
+    </div>
+  </div>
+  <div class="thing comment" id="thing_t1_first">
+    <div class="entry unvoted">
+      <p class="tagline"><a class="author">first-user</a></p>
+      <div class="usertext-body"><div class="md"><p>First useful comment body with enough detail to retain.</p></div></div>
+    </div>
+    <div class="child">
+      <div class="thing comment" id="thing_t1_reply">
+        <div class="entry unvoted">
+          <p class="tagline"><a class="author">reply-user</a></p>
+          <div class="usertext-body"><div class="md"><p>Works, thanks!</p></div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer><p>Footer noise that must not survive extraction.</p></footer>
+</body></html>`;
+
+const htmlResponse = (html: string, status = 200) =>
+  new Response(html, { status, headers: { "Content-Type": "text/html" } });
+
+describe("link preview extraction (Reddit)", () => {
+  it("retries verification-blocked threads through old Reddit and extracts the discussion", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url === threadUrl) return htmlResponse(blockedHtml);
+      if (url === oldThreadUrl) return htmlResponse(oldRedditHtml);
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    const client = createLinkPreviewClient({ fetch: fetchMock as unknown as typeof fetch });
+
+    const result = await client.fetchLinkContent(threadUrl, {
+      firecrawl: "off",
+      format: "text",
+      timeoutMs: 2000,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.title).toBe("Thread title");
+    expect(result.siteName).toBe("Reddit");
+    expect(result.url).toBe(threadUrl);
+    expect(result.content).toContain("Original post body with enough useful detail.");
+    expect(result.content).toContain("Comment by u/first-user");
+    expect(result.content).toContain("First useful comment body with enough detail to retain.");
+    expect(result.content).toContain("Comment by u/reply-user");
+    expect(result.content).toContain("Works, thanks!");
+    expect(result.content).toContain("Link: https://example.com/source");
+    expect(result.content).not.toContain("Navigation noise");
+    expect(result.content).not.toContain("Footer noise");
+  });
+
+  it("keeps source media detection while normalizing the discussion", async () => {
+    const videoRedditHtml = oldRedditHtml.replace(
+      "<head>",
+      '<head><meta property="og:video" content="https://cdn.example.com/post.mp4">',
+    );
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url === threadUrl) return htmlResponse(blockedHtml);
+      if (url === oldThreadUrl) return htmlResponse(videoRedditHtml);
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    const client = createLinkPreviewClient({ fetch: fetchMock as unknown as typeof fetch });
+
+    const result = await client.fetchLinkContent(threadUrl, {
+      embeddedVideo: "off",
+      firecrawl: "off",
+      format: "text",
+      timeoutMs: 2000,
+    });
+
+    expect(result.url).toBe(threadUrl);
+    expect(result.video).toEqual({ kind: "direct", url: "https://cdn.example.com/post.mp4" });
+    expect(result.content).toContain("Original post body with enough useful detail.");
+  });
+
+  it("passes the normalized thread, not page chrome, to Markdown conversion", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url === oldThreadUrl) return htmlResponse(oldRedditHtml);
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    const convertHtmlToMarkdown = vi.fn(async ({ html }: { html: string }) => {
+      expect(html).toContain("Original post body with enough useful detail.");
+      expect(html).toContain("First useful comment body with enough detail to retain.");
+      expect(html).toContain("Works, thanks!");
+      expect(html).toContain('href="https://example.com/source"');
+      expect(html).not.toContain("Navigation noise");
+      expect(html).not.toContain("Footer noise");
+      return "# Thread title\n\nOriginal post body.\n\n## Comments\n\nFirst useful comment body.";
+    });
+    const client = createLinkPreviewClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      convertHtmlToMarkdown,
+    });
+
+    const result = await client.fetchLinkContent(oldThreadUrl, {
+      firecrawl: "off",
+      format: "markdown",
+      markdownMode: "readability",
+      timeoutMs: 2000,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(convertHtmlToMarkdown).toHaveBeenCalledTimes(1);
+    expect(result.content).toContain("## Comments");
+  });
+
+  it("does not mistake user-authored verification phrases for a challenge page", async () => {
+    const phraseInPost = oldRedditHtml.replace(
+      "Original post body with enough useful detail.",
+      "Please wait for verification is user-authored text inside a valid Reddit post.",
+    );
+    const fetchMock = vi.fn(async () => htmlResponse(phraseInPost));
+    const client = createLinkPreviewClient({ fetch: fetchMock as unknown as typeof fetch });
+
+    const result = await client.fetchLinkContent(oldThreadUrl, {
+      firecrawl: "off",
+      format: "text",
+      timeoutMs: 2000,
+    });
+
+    expect(isBlockedRedditThreadHtml(oldThreadUrl, phraseInPost)).toBe(false);
+    expect(result.content).toContain("Please wait for verification is user-authored text");
+  });
+
+  it("does not trust a normalized-thread marker from fetched HTML", async () => {
+    const untrustedMarkerHtml = `<!doctype html><html><head><title>Ordinary page</title></head><body>
+      <script>const spoof = 'data-reddit-thread="true"';</script>
+      <main><p>This ordinary page has enough useful content for normal extraction behavior.</p></main>
+    </body></html>`;
+    const fetchMock = vi.fn(async () => htmlResponse(untrustedMarkerHtml));
+    const client = createLinkPreviewClient({ fetch: fetchMock as unknown as typeof fetch });
+
+    const result = await client.fetchLinkContent("https://example.com/article", {
+      firecrawl: "off",
+      format: "text",
+      timeoutMs: 2000,
+    });
+
+    expect(result.content).not.toContain("const spoof");
+  });
+
+  it("fails clearly when both Reddit HTML surfaces return verification pages", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url === threadUrl) return htmlResponse(blockedHtml);
+      if (url === oldThreadUrl) {
+        return htmlResponse("<!doctype html><html><body>Log in to continue.</body></html>");
+      }
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    const client = createLinkPreviewClient({ fetch: fetchMock as unknown as typeof fetch });
+
+    await expect(
+      client.fetchLinkContent(threadUrl, {
+        firecrawl: "off",
+        format: "text",
+        timeoutMs: 2000,
+      }),
+    ).rejects.toThrow(/Reddit returned a verification page.*old\.reddit\.com fallback/i);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps Firecrawl as the final fallback when old Reddit is unavailable", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url === threadUrl) return htmlResponse(blockedHtml);
+      if (url === oldThreadUrl) return htmlResponse("Unavailable", 403);
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    const scrapeWithFirecrawl = vi.fn(async () => ({
+      markdown: "# Thread title\n\nRecovered Reddit discussion.",
+      html: "<html><head><title>Thread title</title></head><body></body></html>",
+      metadata: { title: "Thread title", siteName: "Reddit" },
+    }));
+    const client = createLinkPreviewClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      scrapeWithFirecrawl,
+    });
+
+    const result = await client.fetchLinkContent(threadUrl, {
+      firecrawl: "auto",
+      format: "text",
+      timeoutMs: 2000,
+    });
+
+    expect(result.diagnostics.strategy).toBe("firecrawl");
+    expect(result.content).toContain("Recovered Reddit discussion.");
+    expect(scrapeWithFirecrawl).toHaveBeenCalledOnce();
+  });
+
+  it("only rewrites supported Reddit thread URLs", () => {
+    expect(toOldRedditThreadUrl(threadUrl)).toBe(oldThreadUrl);
+    expect(toOldRedditThreadUrl(`${threadUrl}?sort=new`)).toBe(`${oldThreadUrl}?sort=new`);
+    expect(toOldRedditThreadUrl("not a URL")).toBeNull();
+    expect(
+      toOldRedditThreadUrl("https://example.com/r/example/comments/abc123/thread/"),
+    ).toBeNull();
+    expect(toOldRedditThreadUrl("https://www.reddit.com/r/example/new/")).toBeNull();
+    expect(isBlockedRedditThreadHtml("https://example.com", blockedHtml)).toBe(false);
+  });
+
+  it("requires a real old Reddit post and rejects unsafe title links", () => {
+    expect(
+      normalizeOldRedditThreadHtml(
+        oldThreadUrl,
+        "<!doctype html><html><body><p>No post here.</p></body></html>",
+      ),
+    ).toBeNull();
+    expect(
+      normalizeOldRedditThreadHtml(oldThreadUrl, oldRedditHtml.replace("Thread title", "")),
+    ).toBeNull();
+
+    const unsafeLinkHtml = oldRedditHtml.replace(
+      "https://example.com/source",
+      "javascript:alert(1)",
+    );
+    expect(normalizeOldRedditThreadHtml(oldThreadUrl, unsafeLinkHtml)).not.toContain("javascript:");
+
+    const selfPostHtml = oldRedditHtml
+      .replace('class="thing link"', 'class="thing link self"')
+      .replace('data-domain="example.com"', 'data-domain="self.example"');
+    expect(normalizeOldRedditThreadHtml(oldThreadUrl, selfPostHtml)).not.toContain("<p>Link:");
+  });
+
+  it("selects the requested post instead of a preceding promoted link", () => {
+    const promotedHtml = oldRedditHtml.replace(
+      '<div class="thing link" id="thing_t3_abc123"',
+      `<div class="thing link promoted" id="thing_t3_advert" data-type="link">
+        <div class="entry"><a class="title" href="https://ads.example.com">Sponsored title</a></div>
+      </div>
+      <div class="thing link" id="thing_t3_abc123"`,
+    );
+
+    const normalized = normalizeOldRedditThreadHtml(oldThreadUrl, promotedHtml);
+
+    expect(normalized).toContain("Thread title");
+    expect(normalized).not.toContain("Sponsored title");
+    expect(
+      normalizeOldRedditThreadHtml(
+        oldThreadUrl,
+        promotedHtml.replace('id="thing_t3_abc123"', 'id="thing_t3_other"'),
+      ),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- retry verification-blocked Reddit threads through the official old Reddit HTML surface
- normalize the requested post and nested comments while preserving short replies, link targets, canonical URLs, and media detection
- keep Firecrawl as the final configured fallback and return a clear error when every Reddit surface is unavailable

## Proof

- `pnpm -s check` (546 test files, 2,938 tests; 85.00% branch coverage)
- focused Reddit/extraction/video suite (34 tests)
- live cache-bypassed extraction of the reporter URL: 30,066 characters, 69 comment headings, post body and short comments present, no verification or navigation chrome
- autoreview clean

Fixes #343
