### PR TITLE
fix: harden browser media and remote CLI attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.21.4 - Unreleased
 
+### Fixes
+
+- Security: block private browser-media URLs in the extension and stop remote binary attachments from auto-enabling broad CLI tool permissions.
+
 ## 0.21.3 - 2026-07-06
 
 ### Fixes

--- a/apps/chrome-extension/src/entrypoints/background/browser-media.ts
+++ b/apps/chrome-extension/src/entrypoints/background/browser-media.ts
@@ -7,6 +7,7 @@ import {
   type WrappedCanvas,
   UrlSource,
 } from "mediabunny";
+import { isPublicBrowserUrl } from "../../lib/browser-url-content";
 import { BrowserPcmAccumulator } from "./browser-media-audio";
 
 const MAX_BROWSER_MEDIA_BYTES = 128 * 1024 * 1024;
@@ -45,12 +46,7 @@ export type BrowserAudioProcessResult = {
 };
 
 export function isBrowserMediaUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
+  return isPublicBrowserUrl(value);
 }
 
 export async function fetchBrowserMediaWithLimit(
@@ -295,7 +291,11 @@ function createMediaUrlInput(
 ): Input {
   return new Input({
     source: new UrlSource(mediaUrl, {
-      fetchFn: (input, init) => fetchBrowserMediaWithLimit(fetchImpl, input, init),
+      fetchFn: (input, init) =>
+        fetchBrowserMediaWithLimit(fetchImpl, input, {
+          ...(init ?? {}),
+          targetAddressSpace: "public",
+        } as RequestInit & { targetAddressSpace: "public" }),
       getRetryDelay: (previousAttempts, error) =>
         error instanceof BrowserMediaLimitError ? null : previousAttempts < 2 ? 0.1 : null,
       maxCacheSize: BROWSER_MEDIA_URL_CACHE_BYTES,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,6 +113,8 @@ path-based prompt and enables the required tool flags:
 - Antigravity: `agy --print`; does not auto-approve tools for attachment prompts
 - pi: `pi --print --mode json`; passes `--system-prompt`, sends prompt over stdin, and uses `--no-tools` for isolated summaries
 
+Remote image and binary-file URLs are limited to native providers and CLI backends that can consume the staged attachment without broad tool approval. Local file inputs keep the existing path-based CLI behavior because they are operator-selected files rather than untrusted remote content.
+
 ## Config
 
 ```json

--- a/src/run/flows/asset/summary-attempts.ts
+++ b/src/run/flows/asset/summary-attempts.ts
@@ -6,6 +6,31 @@ import { buildPathSummaryPrompt } from "../../../prompts/index.js";
 import { ensureCliAttachmentPath } from "../../attachments.js";
 import type { AssetSummaryContext, SummarizeAssetArgs } from "./types.js";
 
+function isPathBasedAttachment(args: SummarizeAssetArgs): boolean {
+  return args.attachment.kind === "image" || args.attachment.kind === "file";
+}
+
+function isRemoteCliAttachmentProviderSafe(
+  attempt: ModelAttempt,
+  args: SummarizeAssetArgs,
+): boolean {
+  if (attempt.transport !== "cli") return true;
+  if (!attempt.cliProvider) return false;
+  if (attempt.cliProvider === "opencode") return true;
+  return attempt.cliProvider === "codex" && args.attachment.kind === "image";
+}
+
+export function filterUnsafeRemoteAssetCliAttempts({
+  attempts,
+  args,
+}: {
+  attempts: ModelAttempt[];
+  args: SummarizeAssetArgs;
+}): ModelAttempt[] {
+  if (args.sourceKind !== "asset-url" || !isPathBasedAttachment(args)) return attempts;
+  return attempts.filter((attempt) => isRemoteCliAttachmentProviderSafe(attempt, args));
+}
+
 export async function buildAssetModelAttempts({
   ctx,
   kind,
@@ -73,7 +98,7 @@ export async function buildAssetCliContext({
 }) {
   if (!attempts.some((attempt) => attempt.transport === "cli")) return null;
   if (attachmentsCount === 0) return null;
-  const needsPathPrompt = args.attachment.kind === "image" || args.attachment.kind === "file";
+  const needsPathPrompt = isPathBasedAttachment(args);
   if (!needsPathPrompt) return null;
 
   const filePath = await ensureCliAttachmentPath({
@@ -82,8 +107,9 @@ export async function buildAssetCliContext({
     attachment: args.attachment,
   });
   const dir = path.dirname(filePath);
+  const isRemoteAsset = args.sourceKind === "asset-url";
   const extraArgsByProvider: Partial<Record<CliProvider, string[]>> = {
-    gemini: ["--include-directories", dir],
+    gemini: isRemoteAsset ? undefined : ["--include-directories", dir],
     codex: args.attachment.kind === "image" ? ["-i", filePath] : undefined,
     opencode: ["--file", filePath],
   };
@@ -100,8 +126,8 @@ export async function buildAssetCliContext({
       lengthInstruction: ctx.lengthInstruction ?? null,
       languageInstruction: ctx.languageInstruction ?? null,
     }),
-    allowTools: true,
-    cwd: dir,
+    allowTools: !isRemoteAsset,
+    cwd: isRemoteAsset ? undefined : dir,
     extraArgsByProvider,
   };
 }

--- a/src/run/flows/asset/summary.ts
+++ b/src/run/flows/asset/summary.ts
@@ -25,7 +25,11 @@ import { writeVerbose } from "../../logging.js";
 import { prepareMarkdownForTerminal } from "../../markdown.js";
 import { isRichTty, markdownRenderWidth, supportsColor } from "../../terminal.js";
 import { prepareAssetPrompt } from "./preprocess.js";
-import { buildAssetCliContext, buildAssetModelAttempts } from "./summary-attempts.js";
+import {
+  buildAssetCliContext,
+  buildAssetModelAttempts,
+  filterUnsafeRemoteAssetCliAttempts,
+} from "./summary-attempts.js";
 import type {
   AssetSummaryContext,
   AssetSummaryContextInput,
@@ -289,11 +293,17 @@ export async function executeAssetSummary(
     requiresVideoUnderstanding,
     lastSuccessfulCliProvider,
   });
+  const executableAttempts = filterUnsafeRemoteAssetCliAttempts({ attempts, args });
+  if (attempts.length > 0 && executableAttempts.length === 0) {
+    throw new Error(
+      "Remote image and binary file summaries cannot use CLI providers that require broad local tools. Choose a native model or summarize a local file instead.",
+    );
+  }
 
   const cliContext = await buildAssetCliContext({
     ctx,
     args,
-    attempts,
+    attempts: executableAttempts,
     attachmentsCount: attachments.length,
     summaryLengthTarget,
   });
@@ -312,7 +322,7 @@ export async function executeAssetSummary(
     : null;
 
   const execution = await executeSummaryAttempts({
-    attempts,
+    attempts: executableAttempts,
     isFallbackModel: ctx.isFallbackModel,
     isNamedModelSelection: ctx.isNamedModelSelection,
     wantsFreeNamedModel: ctx.wantsFreeNamedModel,

--- a/tests/asset.summary-attempts.test.ts
+++ b/tests/asset.summary-attempts.test.ts
@@ -18,6 +18,7 @@ vi.mock("../src/run/attachments.js", () => ({
 import {
   buildAssetCliContext,
   buildAssetModelAttempts,
+  filterUnsafeRemoteAssetCliAttempts,
 } from "../src/run/flows/asset/summary-attempts.js";
 
 function createContext(overrides: Record<string, unknown> = {}) {
@@ -307,6 +308,95 @@ describe("asset summary attempts", () => {
       cwd: "/tmp/assets",
       extraArgsByProvider: {
         gemini: ["--include-directories", "/tmp/assets"],
+        codex: ["-i", "/tmp/assets/file.png"],
+        opencode: ["--file", "/tmp/assets/file.png"],
+      },
+    });
+  });
+
+  it("removes unsafe CLI providers and tool approval for remote binary attachments", async () => {
+    const attempts = filterUnsafeRemoteAssetCliAttempts({
+      attempts: [
+        {
+          transport: "native",
+          userModelId: "openai/gpt-5.4",
+          llmModelId: "gpt-5.4",
+          openrouterProviders: null,
+          forceOpenRouter: false,
+          requiredEnv: "OPENAI_API_KEY",
+        },
+        {
+          transport: "cli",
+          userModelId: "cli/claude/sonnet",
+          llmModelId: null,
+          cliProvider: "claude",
+          cliModel: "sonnet",
+          openrouterProviders: null,
+          forceOpenRouter: false,
+          requiredEnv: "CLI_CLAUDE",
+        },
+        {
+          transport: "cli",
+          userModelId: "cli/codex/gpt-5.5",
+          llmModelId: null,
+          cliProvider: "codex",
+          cliModel: "gpt-5.5",
+          openrouterProviders: null,
+          forceOpenRouter: false,
+          requiredEnv: "CLI_CODEX",
+        },
+        {
+          transport: "cli",
+          userModelId: "cli/opencode",
+          llmModelId: null,
+          cliProvider: "opencode",
+          cliModel: null,
+          openrouterProviders: null,
+          forceOpenRouter: false,
+          requiredEnv: "CLI_OPENCODE",
+        },
+      ] as never,
+      args: {
+        sourceKind: "asset-url",
+        sourceLabel: "https://example.com/file.png",
+        attachment: {
+          kind: "image",
+          filename: "file.png",
+          mediaType: "image/png",
+          bytes: new Uint8Array([1]),
+        },
+      } as never,
+    });
+
+    expect(attempts.map((attempt) => attempt.userModelId)).toEqual([
+      "openai/gpt-5.4",
+      "cli/codex/gpt-5.5",
+      "cli/opencode",
+    ]);
+
+    const result = await buildAssetCliContext({
+      ctx: createContext() as never,
+      args: {
+        sourceKind: "asset-url",
+        sourceLabel: "https://example.com/file.png",
+        attachment: {
+          kind: "image",
+          filename: "file.png",
+          mediaType: "image/png",
+          bytes: new Uint8Array([1]),
+        },
+      } as never,
+      attempts,
+      attachmentsCount: 1,
+      summaryLengthTarget: { maxCharacters: 900 },
+    });
+
+    expect(result).toEqual({
+      promptOverride: "prompt",
+      allowTools: false,
+      cwd: undefined,
+      extraArgsByProvider: {
+        gemini: undefined,
         codex: ["-i", "/tmp/assets/file.png"],
         opencode: ["--file", "/tmp/assets/file.png"],
       },

--- a/tests/chrome.browser-media.test.ts
+++ b/tests/chrome.browser-media.test.ts
@@ -22,6 +22,8 @@ describe("chrome browser media decoding", () => {
   it("accepts only fetchable HTTP media URLs", async () => {
     expect(isBrowserMediaUrl("https://example.com/video.mp4")).toBe(true);
     expect(isBrowserMediaUrl("http://example.com/video.mp4")).toBe(true);
+    expect(isBrowserMediaUrl("http://127.0.0.1/video.mp4")).toBe(false);
+    expect(isBrowserMediaUrl("http://10.0.0.1/video.mp4")).toBe(false);
     expect(isBrowserMediaUrl("blob:https://example.com/id")).toBe(false);
     expect(isBrowserMediaUrl("not a URL")).toBe(false);
 


### PR DESCRIPTION
## Summary

- block loopback and private-network browser media URLs before offscreen decode
- keep remote image and binary-file summaries from auto-enabling broad CLI tool approval
- add focused regression coverage and document the remote-asset CLI restriction

## Security Review

Deep scan results:
- fixed a browser-media SSRF path from page-selected media URLs into credentialed extension fetches
- fixed a remote-attachment confused-deputy path that could expand one staged file into broad provider tool access
- left the browser URL extraction DNS-bypass candidate as a follow-up item pending a shipped-browser reproduction

## Verification

- `./node_modules/.bin/vitest run tests/chrome.browser-media.test.ts tests/asset.summary-attempts.test.ts tests/llm.cli.test.ts tests/llm.cli.copilot.test.ts`
- `./node_modules/.bin/vitest run tests/asset.summary-branches.test.ts`
- `./node_modules/.bin/oxfmt --check CHANGELOG.md docs/cli.md apps/chrome-extension/src/entrypoints/background/browser-media.ts src/run/flows/asset/summary-attempts.ts src/run/flows/asset/summary.ts tests/asset.summary-attempts.test.ts tests/chrome.browser-media.test.ts`
- `./node_modules/.bin/oxlint --type-aware --tsconfig tsconfig.build.json --config .oxlintrc.json .`
- `./node_modules/.bin/tsgo -p tsconfig.build.json --noEmit`
- `./node_modules/.bin/tsgo -p tsconfig.build.json`
- `node scripts/build-cli.mjs`
- `./node_modules/.bin/wxt build` from `apps/chrome-extension`
