### PR TITLE
fix(agy): pass print prompt as flag argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Antigravity CLI: pass prompts through the required print argument with platform-safe size limits and prompt-safe errors (#357, thanks @mvance).
 - Security: block private browser-media URLs in the extension and stop remote binary attachments from auto-enabling broad CLI tool permissions.
 
 ## 0.21.3 - 2026-07-06

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -173,7 +173,7 @@ Notes:
 - If a CLI call fails, auto mode falls back to the next candidate.
 - Cursor Agent CLI uses the `agent` binary and relies on Cursor CLI auth (login or `CURSOR_API_KEY`).
 - Antigravity CLI uses the active agy session model; `cli.agy.model` is ignored by runtime selection.
-- Antigravity normal text summaries run `agy --print` with no prompt argument in a temporary cwd with `--sandbox`, streaming the prompt over stdin so extracted content is not exposed in argv. Attachment prompts keep the caller cwd so agy can inspect the requested path but do not auto-approve tools.
+- Antigravity normal text summaries run `agy --print <prompt>` in a temporary cwd with `--sandbox`. Because current agy print mode requires the prompt in argv, large prompts are rejected before launch using platform-specific argv limits; use another CLI/provider for large or sensitive extracted content. Attachment prompts keep the caller cwd so agy can inspect the requested path but do not auto-approve tools.
 - pi runs in JSON mode (`--print --mode json`) with `--no-tools`, `--no-context-files`, `--no-extensions`, `--no-skills`, `--no-session` for isolated summarization. It receives the summarize system prompt via `--system-prompt`, the summarize prompt over stdin, and reports usage/cost via JSONL events. Use `PI_PATH` to override the binary path.
 - Codex CLI normal text summaries run isolated by default: `codex exec --ephemeral --ignore-user-config --ignore-rules -C <temp-dir> ...` with a sanitized temporary `CODEX_HOME` that carries auth only. Set `cli.codex.isolated` to `false` only when you intentionally need Codex to inherit local config/rules.
 - Gemini CLI is invoked in headless mode with `--prompt` for compatibility with current Gemini CLI releases.

--- a/src/llm/cli-exec.ts
+++ b/src/llm/cli-exec.ts
@@ -34,6 +34,11 @@ function formatErrorMessageWithStderr(
   return `${message}${separator}${trimmedStderr}`;
 }
 
+function redactSensitiveText(text: string, sensitiveText?: string): string {
+  if (!sensitiveText) return text;
+  return text.split(sensitiveText).join("[prompt redacted]");
+}
+
 function formatTimeoutLabel(timeoutMs: number): string {
   if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
     if (timeoutMs % 60_000 === 0) return `${Math.floor(timeoutMs / 60_000)}m`;
@@ -61,7 +66,17 @@ function getExecErrorMessage(error: CliExecError): string {
     : "CLI command failed";
 }
 
-function getExecCommand(error: CliExecError, cmd: string, args: string[]): string {
+function getExecCommand(
+  error: CliExecError,
+  cmd: string,
+  args: string[],
+  redactedCommand?: string,
+  shouldRedact = false,
+): string {
+  if (typeof redactedCommand === "string" && redactedCommand.trim().length > 0) {
+    return redactedCommand.trim();
+  }
+  if (shouldRedact) return `${cmd} [arguments redacted]`;
   return typeof error.cmd === "string" && error.cmd.trim().length > 0
     ? error.cmd.trim()
     : [cmd, ...args].join(" ");
@@ -73,6 +88,14 @@ function abortReason(signal: AbortSignal): Error {
     : new DOMException("This operation was aborted", "AbortError");
 }
 
+function errorOptions(
+  error: CliExecError,
+  redactedCommand?: string,
+  redactText?: string,
+): ErrorOptions | undefined {
+  return redactedCommand || redactText ? undefined : { cause: error };
+}
+
 export async function execCliWithInput({
   execFileImpl,
   cmd,
@@ -82,6 +105,8 @@ export async function execCliWithInput({
   env,
   cwd,
   signal,
+  redactedCommand,
+  redactText,
 }: {
   execFileImpl: ExecFileFn;
   cmd: string;
@@ -91,6 +116,8 @@ export async function execCliWithInput({
   env: Record<string, string | undefined>;
   cwd?: string;
   signal?: AbortSignal;
+  redactedCommand?: string;
+  redactText?: string;
 }): Promise<{ stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
     let interruptedSignal: NodeJS.Signals | null = null;
@@ -143,7 +170,8 @@ export async function execCliWithInput({
       },
       (error, stdout, stderr) => {
         cleanupSignalHandlers();
-        const stderrText = toUtf8String(stderr);
+        const shouldRedact = Boolean(redactedCommand || redactText);
+        const stderrText = redactSensitiveText(toUtf8String(stderr), redactText);
         if (aborted && signal) {
           reject(abortReason(signal));
           return;
@@ -155,19 +183,29 @@ export async function execCliWithInput({
         if (error) {
           if (isExecTimeoutError(error)) {
             const timeoutMessage =
-              `CLI command timed out after ${formatTimeoutLabel(timeoutMs)}: ${getExecCommand(error, cmd, args)}. ` +
+              `CLI command timed out after ${formatTimeoutLabel(timeoutMs)}: ${getExecCommand(error, cmd, args, redactedCommand, shouldRedact)}. ` +
               "Increase --timeout (e.g. 5m).";
             reject(
               new Error(formatErrorMessageWithStderr(timeoutMessage, stderrText, "\n"), {
-                cause: error,
+                ...errorOptions(error, redactedCommand, redactText),
               }),
             );
             return;
           }
+          const errorMessage =
+            shouldRedact && redactedCommand
+              ? `CLI command failed: ${redactedCommand}`
+              : shouldRedact
+                ? "CLI command failed"
+                : getExecErrorMessage(error);
           reject(
-            new Error(formatErrorMessageWithStderr(getExecErrorMessage(error), stderrText), {
-              cause: error,
-            }),
+            new Error(
+              formatErrorMessageWithStderr(
+                redactSensitiveText(errorMessage, redactText),
+                stderrText,
+              ),
+              errorOptions(error, redactedCommand, redactText),
+            ),
           );
           return;
         }

--- a/src/llm/cli-exec.ts
+++ b/src/llm/cli-exec.ts
@@ -34,11 +34,6 @@ function formatErrorMessageWithStderr(
   return `${message}${separator}${trimmedStderr}`;
 }
 
-function redactSensitiveText(text: string, sensitiveText?: string): string {
-  if (!sensitiveText) return text;
-  return text.split(sensitiveText).join("[prompt redacted]");
-}
-
 function formatTimeoutLabel(timeoutMs: number): string {
   if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
     if (timeoutMs % 60_000 === 0) return `${Math.floor(timeoutMs / 60_000)}m`;
@@ -71,12 +66,10 @@ function getExecCommand(
   cmd: string,
   args: string[],
   redactedCommand?: string,
-  shouldRedact = false,
 ): string {
   if (typeof redactedCommand === "string" && redactedCommand.trim().length > 0) {
     return redactedCommand.trim();
   }
-  if (shouldRedact) return `${cmd} [arguments redacted]`;
   return typeof error.cmd === "string" && error.cmd.trim().length > 0
     ? error.cmd.trim()
     : [cmd, ...args].join(" ");
@@ -88,12 +81,8 @@ function abortReason(signal: AbortSignal): Error {
     : new DOMException("This operation was aborted", "AbortError");
 }
 
-function errorOptions(
-  error: CliExecError,
-  redactedCommand?: string,
-  redactText?: string,
-): ErrorOptions | undefined {
-  return redactedCommand || redactText ? undefined : { cause: error };
+function errorOptions(error: CliExecError, redactedCommand?: string): ErrorOptions | undefined {
+  return redactedCommand ? undefined : { cause: error };
 }
 
 export async function execCliWithInput({
@@ -106,7 +95,6 @@ export async function execCliWithInput({
   cwd,
   signal,
   redactedCommand,
-  redactText,
 }: {
   execFileImpl: ExecFileFn;
   cmd: string;
@@ -117,7 +105,6 @@ export async function execCliWithInput({
   cwd?: string;
   signal?: AbortSignal;
   redactedCommand?: string;
-  redactText?: string;
 }): Promise<{ stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
     let interruptedSignal: NodeJS.Signals | null = null;
@@ -159,59 +146,61 @@ export async function execCliWithInput({
     process.prependOnceListener("SIGTERM", handleSigterm);
     signal?.addEventListener("abort", handleAbort, { once: true });
 
-    child = execFileImpl(
-      cmd,
-      args,
-      {
-        timeout: timeoutMs,
-        env: { ...process.env, ...env },
-        cwd,
-        maxBuffer: 50 * 1024 * 1024,
-      },
-      (error, stdout, stderr) => {
-        cleanupSignalHandlers();
-        const shouldRedact = Boolean(redactedCommand || redactText);
-        const stderrText = redactSensitiveText(toUtf8String(stderr), redactText);
-        if (aborted && signal) {
-          reject(abortReason(signal));
-          return;
-        }
-        if (interruptedSignal) {
-          reject(new CliInterruptedError(interruptedSignal));
-          return;
-        }
-        if (error) {
-          if (isExecTimeoutError(error)) {
-            const timeoutMessage =
-              `CLI command timed out after ${formatTimeoutLabel(timeoutMs)}: ${getExecCommand(error, cmd, args, redactedCommand, shouldRedact)}. ` +
-              "Increase --timeout (e.g. 5m).";
+    try {
+      child = execFileImpl(
+        cmd,
+        args,
+        {
+          timeout: timeoutMs,
+          env: { ...process.env, ...env },
+          cwd,
+          maxBuffer: 50 * 1024 * 1024,
+        },
+        (error, stdout, stderr) => {
+          cleanupSignalHandlers();
+          // A sensitive argv value may be transformed or truncated before a CLI echoes it.
+          // Suppress all child diagnostics instead of attempting unsafe substring redaction.
+          const stderrText = redactedCommand ? "" : toUtf8String(stderr);
+          if (aborted && signal) {
+            reject(abortReason(signal));
+            return;
+          }
+          if (interruptedSignal) {
+            reject(new CliInterruptedError(interruptedSignal));
+            return;
+          }
+          if (error) {
+            if (isExecTimeoutError(error)) {
+              const timeoutMessage =
+                `CLI command timed out after ${formatTimeoutLabel(timeoutMs)}: ${getExecCommand(error, cmd, args, redactedCommand)}. ` +
+                "Increase --timeout (e.g. 5m).";
+              reject(
+                new Error(
+                  formatErrorMessageWithStderr(timeoutMessage, stderrText, "\n"),
+                  errorOptions(error, redactedCommand),
+                ),
+              );
+              return;
+            }
+            const errorMessage = redactedCommand
+              ? `CLI command failed: ${redactedCommand}`
+              : getExecErrorMessage(error);
             reject(
-              new Error(formatErrorMessageWithStderr(timeoutMessage, stderrText, "\n"), {
-                ...errorOptions(error, redactedCommand, redactText),
-              }),
+              new Error(
+                formatErrorMessageWithStderr(errorMessage, stderrText),
+                errorOptions(error, redactedCommand),
+              ),
             );
             return;
           }
-          const errorMessage =
-            shouldRedact && redactedCommand
-              ? `CLI command failed: ${redactedCommand}`
-              : shouldRedact
-                ? "CLI command failed"
-                : getExecErrorMessage(error);
-          reject(
-            new Error(
-              formatErrorMessageWithStderr(
-                redactSensitiveText(errorMessage, redactText),
-                stderrText,
-              ),
-              errorOptions(error, redactedCommand, redactText),
-            ),
-          );
-          return;
-        }
-        resolve({ stdout: toUtf8String(stdout), stderr: stderrText });
-      },
-    );
+          resolve({ stdout: toUtf8String(stdout), stderr: stderrText });
+        },
+      );
+    } catch (error) {
+      cleanupSignalHandlers();
+      reject(redactedCommand ? new Error(`CLI command failed: ${redactedCommand}`) : error);
+      return;
+    }
 
     if (aborted) {
       try {

--- a/src/llm/cli-runners/plain.ts
+++ b/src/llm/cli-runners/plain.ts
@@ -1,11 +1,50 @@
 import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { Buffer } from "node:buffer";
 import { execCliWithInput } from "../cli-exec.js";
 import type { CliRunResult, ResolvedCliRunOptions } from "./types.js";
 
 function hasAnyFlag(args: string[], flags: string[]): boolean {
   return args.some((arg) => flags.some((flag) => arg === flag || arg.startsWith(`${flag}=`)));
+}
+
+const AGY_MAX_PRINT_ARG_BYTES = 120 * 1024;
+const AGY_WINDOWS_MAX_COMMAND_CHARS = 30_000;
+
+export type AgyPrintArgLimit = { limit: number; type: "bytes" | "chars" };
+
+export function resolveAgyMaxPrintArgLimit(
+  platform: NodeJS.Platform = typeof process !== "undefined" ? process.platform : "linux",
+): AgyPrintArgLimit {
+  return platform === "win32"
+    ? { limit: AGY_WINDOWS_MAX_COMMAND_CHARS, type: "chars" }
+    : { limit: AGY_MAX_PRINT_ARG_BYTES, type: "bytes" };
+}
+
+function estimateWindowsCommandArgChars(arg: string): number {
+  if (arg.length === 0) return 2;
+  if (!/[\s"]/u.test(arg)) return arg.length;
+  let length = 2;
+  let backslashes = 0;
+  for (let index = 0; index < arg.length; index += 1) {
+    const char = arg[index];
+    if (char === "\\") {
+      backslashes += 1;
+      length += 1;
+      continue;
+    }
+    if (char === '"') length += backslashes + 1;
+    backslashes = 0;
+    length += 1;
+  }
+  return length + backslashes;
+}
+
+export function estimateWindowsCommandChars(args: string[]): number {
+  return args.reduce((total, arg, index) => {
+    return total + (index === 0 ? 0 : 1) + estimateWindowsCommandArgChars(arg);
+  }, 0);
 }
 
 export async function runCopilotCli(options: ResolvedCliRunOptions): Promise<CliRunResult> {
@@ -28,13 +67,22 @@ export async function runCopilotCli(options: ResolvedCliRunOptions): Promise<Cli
 }
 
 export async function runAgyCli(options: ResolvedCliRunOptions): Promise<CliRunResult> {
+  const platform = typeof process !== "undefined" ? process.platform : "linux";
   const isolatedCwd = !options.allowTools
     ? await fs.mkdtemp(path.join(tmpdir(), "summarize-agy-"))
     : null;
   try {
     const args = [...options.providerExtraArgs];
     if (!options.allowTools && !hasAnyFlag(args, ["--sandbox"])) args.push("--sandbox");
-    args.push("--print");
+    const { limit, type } = resolveAgyMaxPrintArgLimit(platform);
+    const promptSize =
+      type === "chars" ? options.prompt.length : Buffer.byteLength(options.prompt, "utf8");
+    if (promptSize > limit) {
+      throw new Error(
+        `Antigravity CLI requires --print <prompt> and cannot safely receive large prompts over argv (${promptSize} ${type}). ` +
+          "Use a different CLI provider for this input, reduce extracted content, or update agy to support stdin/file input.",
+      );
+    }
     if (
       Number.isFinite(options.timeoutMs) &&
       options.timeoutMs > 0 &&
@@ -42,15 +90,31 @@ export async function runAgyCli(options: ResolvedCliRunOptions): Promise<CliRunR
     ) {
       args.push("--print-timeout", `${Math.max(1, Math.ceil(options.timeoutMs / 1000))}s`);
     }
+    args.push("--print", options.prompt);
+    if (platform === "win32") {
+      const commandChars = estimateWindowsCommandChars([options.binary, ...args]);
+      if (commandChars > limit) {
+        throw new Error(
+          `Antigravity CLI requires --print <prompt> and cannot safely receive large prompts over argv (${commandChars} escaped chars). ` +
+            "Use a different CLI provider for this input, reduce extracted content, or update agy to support stdin/file input.",
+        );
+      }
+    }
+    const redactedCommand = [
+      options.binary,
+      ...args.map((arg, index) => (args[index - 1] === "--print" ? "[prompt redacted]" : arg)),
+    ].join(" ");
     const { stdout } = await execCliWithInput({
       execFileImpl: options.execFileImpl,
       cmd: options.binary,
       args,
-      input: options.prompt,
+      input: "",
       timeoutMs: options.timeoutMs,
       env: options.env,
       cwd: isolatedCwd ?? options.cwd,
       signal: options.signal,
+      redactedCommand,
+      redactText: options.prompt,
     });
     const text = stdout.trim();
     if (!text) throw new Error("CLI returned empty output");

--- a/src/llm/cli-runners/plain.ts
+++ b/src/llm/cli-runners/plain.ts
@@ -1,7 +1,7 @@
+import { Buffer } from "node:buffer";
 import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { Buffer } from "node:buffer";
 import { execCliWithInput } from "../cli-exec.js";
 import type { CliRunResult, ResolvedCliRunOptions } from "./types.js";
 
@@ -74,6 +74,12 @@ export async function runAgyCli(options: ResolvedCliRunOptions): Promise<CliRunR
   try {
     const args = [...options.providerExtraArgs];
     if (!options.allowTools && !hasAnyFlag(args, ["--sandbox"])) args.push("--sandbox");
+    if (options.prompt.includes("\0")) {
+      throw new Error(
+        "Antigravity CLI cannot receive prompts containing NUL characters over argv. " +
+          "Use a different CLI provider for this input or remove the NUL characters.",
+      );
+    }
     const { limit, type } = resolveAgyMaxPrintArgLimit(platform);
     const promptSize =
       type === "chars" ? options.prompt.length : Buffer.byteLength(options.prompt, "utf8");
@@ -114,7 +120,6 @@ export async function runAgyCli(options: ResolvedCliRunOptions): Promise<CliRunR
       cwd: isolatedCwd ?? options.cwd,
       signal: options.signal,
       redactedCommand,
-      redactText: options.prompt,
     });
     const text = stdout.trim();
     if (!text) throw new Error("CLI returned empty output");

--- a/tests/llm.cli-exec-signals.test.ts
+++ b/tests/llm.cli-exec-signals.test.ts
@@ -129,4 +129,124 @@ describe("execCliWithInput signals", () => {
     });
     expect(kill).toHaveBeenCalledWith("SIGTERM");
   });
+
+  it("keeps the child-process cause when no redaction is requested", async () => {
+    const execError = Object.assign(new Error("boom"), { code: 1 });
+    const execFileImpl: ExecFileFn = ((_cmd, _args, _options, cb) => {
+      cb?.(execError, "", "");
+      return {
+        stdin: {
+          write: vi.fn(),
+          end: vi.fn(),
+        },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    const error = await execCliWithInput({
+      execFileImpl,
+      cmd: "cli",
+      args: ["--flag"],
+      input: "",
+      timeoutMs: 10_000,
+      env: {},
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("boom");
+    expect((error as Error & { cause?: unknown }).cause).toBe(execError);
+  });
+
+  it("uses a caller-provided redacted command for timeout errors", async () => {
+    const secret = "raw secret";
+    const execError = Object.assign(new Error("timed out"), {
+      code: "ETIMEDOUT",
+      cmd: `cli --secret ${secret}`,
+    });
+    const execFileImpl: ExecFileFn = ((_cmd, _args, _options, cb) => {
+      cb?.(execError, "", `stderr ${secret}`);
+      return {
+        stdin: {
+          write: vi.fn(),
+          end: vi.fn(),
+        },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    const error = await execCliWithInput({
+      execFileImpl,
+      cmd: "cli",
+      args: ["--secret", secret],
+      input: "",
+      timeoutMs: 2_000,
+      env: {},
+      redactedCommand: "cli --secret [redacted]",
+      redactText: secret,
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("cli --secret [redacted]");
+    expect((error as Error).message).toContain("stderr [prompt redacted]");
+    expect((error as Error).message).not.toContain(secret);
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  it("uses a generic timeout command when only redact text is provided", async () => {
+    const secret = "x";
+    const execError = Object.assign(new Error("timed out"), {
+      code: "ETIMEDOUT",
+      cmd: `cli --secret ${secret}`,
+    });
+    const execFileImpl: ExecFileFn = ((_cmd, _args, _options, cb) => {
+      cb?.(execError, "", "");
+      return {
+        stdin: {
+          write: vi.fn(),
+          end: vi.fn(),
+        },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    const error = await execCliWithInput({
+      execFileImpl,
+      cmd: "cli",
+      args: ["--secret", secret],
+      input: "",
+      timeoutMs: 2_000,
+      env: {},
+      redactText: secret,
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("cli [arguments redacted]");
+    expect((error as Error).message).not.toContain(secret);
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  it("omits the child-process cause when only a redacted command is provided", async () => {
+    const execError = Object.assign(new Error("Command failed: cli --secret raw"), { code: 1 });
+    const execFileImpl: ExecFileFn = ((_cmd, _args, _options, cb) => {
+      cb?.(execError, "", "");
+      return {
+        stdin: {
+          write: vi.fn(),
+          end: vi.fn(),
+        },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    const error = await execCliWithInput({
+      execFileImpl,
+      cmd: "cli",
+      args: ["--secret", "raw"],
+      input: "",
+      timeoutMs: 2_000,
+      env: {},
+      redactedCommand: "cli --secret [redacted]",
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("cli --secret [redacted]");
+    expect((error as Error).message).not.toContain("raw");
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
 });

--- a/tests/llm.cli-exec-signals.test.ts
+++ b/tests/llm.cli-exec-signals.test.ts
@@ -180,44 +180,11 @@ describe("execCliWithInput signals", () => {
       timeoutMs: 2_000,
       env: {},
       redactedCommand: "cli --secret [redacted]",
-      redactText: secret,
     }).catch((value: unknown) => value);
 
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain("cli --secret [redacted]");
-    expect((error as Error).message).toContain("stderr [prompt redacted]");
-    expect((error as Error).message).not.toContain(secret);
-    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
-  });
-
-  it("uses a generic timeout command when only redact text is provided", async () => {
-    const secret = "x";
-    const execError = Object.assign(new Error("timed out"), {
-      code: "ETIMEDOUT",
-      cmd: `cli --secret ${secret}`,
-    });
-    const execFileImpl: ExecFileFn = ((_cmd, _args, _options, cb) => {
-      cb?.(execError, "", "");
-      return {
-        stdin: {
-          write: vi.fn(),
-          end: vi.fn(),
-        },
-      } as unknown as ReturnType<ExecFileFn>;
-    }) as ExecFileFn;
-
-    const error = await execCliWithInput({
-      execFileImpl,
-      cmd: "cli",
-      args: ["--secret", secret],
-      input: "",
-      timeoutMs: 2_000,
-      env: {},
-      redactText: secret,
-    }).catch((value: unknown) => value);
-
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain("cli [arguments redacted]");
+    expect((error as Error).message).not.toContain("stderr");
     expect((error as Error).message).not.toContain(secret);
     expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
   });
@@ -247,6 +214,28 @@ describe("execCliWithInput signals", () => {
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain("cli --secret [redacted]");
     expect((error as Error).message).not.toContain("raw");
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  it("sanitizes synchronous launch errors for redacted commands", async () => {
+    const secret = "raw secret";
+    const execFileImpl: ExecFileFn = (() => {
+      throw new TypeError(`The argument contains a null byte: ${secret}`);
+    }) as ExecFileFn;
+
+    const error = await execCliWithInput({
+      execFileImpl,
+      cmd: "cli",
+      args: ["--secret", secret],
+      input: "",
+      timeoutMs: 2_000,
+      env: {},
+      redactedCommand: "cli --secret [redacted]",
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("CLI command failed: cli --secret [redacted]");
+    expect((error as Error).message).not.toContain(secret);
     expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
   });
 });

--- a/tests/llm.cli.agy.test.ts
+++ b/tests/llm.cli.agy.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+  estimateWindowsCommandChars,
+  resolveAgyMaxPrintArgLimit,
+} from "../src/llm/cli-runners/plain.js";
 import { resolveCliBinary, runCliModel } from "../src/llm/cli.js";
 import type { ExecFileFn } from "../src/markitdown.js";
 
@@ -16,7 +20,33 @@ const makeStub = (
 };
 
 describe("runCliModel - agy provider", () => {
-  it("invokes agy with --print, passes prompt via stdin, returns plain text", async () => {
+  it("uses a lower agy prompt argv limit on Windows", () => {
+    expect(resolveAgyMaxPrintArgLimit("win32")).toEqual({ limit: 30_000, type: "chars" });
+    expect(resolveAgyMaxPrintArgLimit("darwin")).toEqual({ limit: 120 * 1024, type: "bytes" });
+    expect(resolveAgyMaxPrintArgLimit("linux")).toEqual({ limit: 120 * 1024, type: "bytes" });
+  });
+
+  it("accounts for Windows argv escaping overhead", () => {
+    const plainPrompt = "x".repeat(20_000);
+    const quoteHeavyPrompt = '"'.repeat(20_000);
+
+    expect(estimateWindowsCommandChars(["agy", "--print", plainPrompt])).toBeLessThan(30_000);
+    expect(estimateWindowsCommandChars(["agy", "--print", quoteHeavyPrompt])).toBeGreaterThan(
+      30_000,
+    );
+    expect(estimateWindowsCommandChars(["agy", ""])).toBe("agy".length + 1 + 2);
+    expect(estimateWindowsCommandChars(["agy", "C:\\Program Files\\agy\\"])).toBeGreaterThan(
+      "agy C:\\Program Files\\agy\\".length,
+    );
+    expect(estimateWindowsCommandChars(["agy", 'say \\"hello"'])).toBeGreaterThan(
+      'agy say \\"hello"'.length,
+    );
+    expect(estimateWindowsCommandChars(["agy", "--print", "😀 "])).toBe(
+      "agy".length + 1 + "--print".length + 1 + 2 + "😀 ".length,
+    );
+  });
+
+  it("invokes agy with --print prompt argument, returns plain text", async () => {
     let seenCmd = "";
     let seenCwd = "";
     let seenInput = "";
@@ -52,14 +82,16 @@ describe("runCliModel - agy provider", () => {
     expect(result.usage).toBeNull();
     expect(result.costUsd).toBeNull();
     expect(seenCmd).toBe("agy");
-    expect(seen[0]).toContain("--print");
+    const printIdx = seen[0].indexOf("--print");
+    expect(printIdx).toBeGreaterThanOrEqual(0);
+    expect(seen[0][printIdx + 1]).toBe("Summarize this.");
     expect(seen[0]).toContain("--sandbox");
     expect(seen[0]).toContain("--print-timeout");
     expect(seen[0]).toContain("1s");
     expect(seen[0]).not.toContain("--output-format");
     expect(seenCwd).toContain("summarize-agy-");
     expect(seenCwd).not.toBe("/tmp/agy-original-cwd");
-    expect(seenInput).toContain("Summarize this.");
+    expect(seenInput).toBe("");
   });
 
   it("uses the active agy session model instead of passing --model", async () => {
@@ -160,6 +192,126 @@ describe("runCliModel - agy provider", () => {
       config: { agy: { extraArgs: ["-print-timeout=10m"] } },
     });
     expect(seen[2]?.filter((arg) => arg.includes("print-timeout"))).toEqual(["-print-timeout=10m"]);
+  });
+
+  it("does not treat prompt text as an agy timeout override", async () => {
+    const seen: string[][] = [];
+    const execFileImpl = makeStub((args) => {
+      seen.push(args);
+      return { stdout: "ok" };
+    });
+
+    await runCliModel({
+      provider: "agy",
+      prompt: "--print-timeout should be summarized",
+      model: null,
+      allowTools: false,
+      timeoutMs: 90_000,
+      env: {},
+      execFileImpl,
+      config: null,
+    });
+
+    const args = seen[0];
+    expect(args).toContain("--print-timeout");
+    expect(args).toContain("90s");
+    const timeoutIdx = args.indexOf("--print-timeout");
+    const printIdx = args.indexOf("--print");
+    expect(timeoutIdx).toBeGreaterThanOrEqual(0);
+    expect(printIdx).toBeGreaterThan(timeoutIdx);
+    expect(args[printIdx + 1]).toBe("--print-timeout should be summarized");
+  });
+
+  it("redacts the agy prompt from timeout errors", async () => {
+    const prompt = "super secret page content";
+    const execFileImpl: ExecFileFn = ((cmd, args, _options, cb) => {
+      cb?.(
+        Object.assign(new Error("timed out"), {
+          code: "ETIMEDOUT",
+          cmd: [cmd, ...args].join(" "),
+        }),
+        "",
+        "",
+      );
+      return {
+        stdin: { write: () => {}, end: () => {} },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    const promise = runCliModel({
+      provider: "agy",
+      prompt,
+      model: null,
+      allowTools: false,
+      timeoutMs: 1000,
+      env: {},
+      execFileImpl,
+      config: null,
+    });
+
+    const error = await promise.catch((value: unknown) => value);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/agy .*--print \[prompt redacted\]/);
+    expect((error as Error).message).not.toContain(prompt);
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  it("redacts the agy prompt from non-timeout errors", async () => {
+    const prompt = "super secret page content";
+    const execFileImpl: ExecFileFn = ((cmd, args, _options, cb) => {
+      cb?.(
+        Object.assign(new Error(`Command failed: ${[cmd, ...args].join(" ")}`), {
+          code: 1,
+        }),
+        "",
+        `stderr includes ${prompt}`,
+      );
+      return {
+        stdin: { write: () => {}, end: () => {} },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    const promise = runCliModel({
+      provider: "agy",
+      prompt,
+      model: null,
+      allowTools: false,
+      timeoutMs: 1000,
+      env: {},
+      execFileImpl,
+      config: null,
+    });
+
+    const error = await promise.catch((value: unknown) => value);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/CLI command failed: agy .*--print \[prompt redacted\]/);
+    expect((error as Error).message).not.toContain(prompt);
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  it("rejects oversized agy prompts before passing them through argv", async () => {
+    let called = false;
+    const execFileImpl: ExecFileFn = ((_cmd, _args, _options, cb) => {
+      called = true;
+      cb?.(null, "ok", "");
+      return {
+        stdin: { write: () => {}, end: () => {} },
+      } as unknown as ReturnType<ExecFileFn>;
+    }) as ExecFileFn;
+
+    await expect(
+      runCliModel({
+        provider: "agy",
+        prompt: "x".repeat(resolveAgyMaxPrintArgLimit().limit + 1),
+        model: null,
+        allowTools: false,
+        timeoutMs: 1000,
+        env: {},
+        execFileImpl,
+        config: null,
+      }),
+    ).rejects.toThrow(/cannot safely receive large prompts over argv/);
+    expect(called).toBe(false);
   });
 
   it("throws when agy returns empty output", async () => {

--- a/tests/llm.cli.agy.test.ts
+++ b/tests/llm.cli.agy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   estimateWindowsCommandChars,
   resolveAgyMaxPrintArgLimit,
@@ -258,13 +258,14 @@ describe("runCliModel - agy provider", () => {
 
   it("redacts the agy prompt from non-timeout errors", async () => {
     const prompt = "super secret page content";
+    const transformedPromptExcerpt = "super\\nsecret";
     const execFileImpl: ExecFileFn = ((cmd, args, _options, cb) => {
       cb?.(
         Object.assign(new Error(`Command failed: ${[cmd, ...args].join(" ")}`), {
           code: 1,
         }),
         "",
-        `stderr includes ${prompt}`,
+        `stderr includes transformed prompt text: ${transformedPromptExcerpt}`,
       );
       return {
         stdin: { write: () => {}, end: () => {} },
@@ -284,8 +285,11 @@ describe("runCliModel - agy provider", () => {
 
     const error = await promise.catch((value: unknown) => value);
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toMatch(/CLI command failed: agy .*--print \[prompt redacted\]/);
+    expect((error as Error).message).toMatch(
+      /CLI command failed: agy .*--print \[prompt redacted\]/,
+    );
     expect((error as Error).message).not.toContain(prompt);
+    expect((error as Error).message).not.toContain(transformedPromptExcerpt);
     expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
   });
 
@@ -312,6 +316,24 @@ describe("runCliModel - agy provider", () => {
       }),
     ).rejects.toThrow(/cannot safely receive large prompts over argv/);
     expect(called).toBe(false);
+  });
+
+  it("rejects NUL-containing agy prompts before passing them through argv", async () => {
+    const execFileImpl = vi.fn() as unknown as ExecFileFn;
+
+    await expect(
+      runCliModel({
+        provider: "agy",
+        prompt: "private\0content",
+        model: null,
+        allowTools: false,
+        timeoutMs: 1000,
+        env: {},
+        execFileImpl,
+        config: null,
+      }),
+    ).rejects.toThrow(/cannot receive prompts containing NUL characters/);
+    expect(execFileImpl).not.toHaveBeenCalled();
   });
 
   it("throws when agy returns empty output", async () => {


### PR DESCRIPTION
## Issue

A nightly summarization run started producing summaries about the `--print-timeout` flag itself instead of the webpage content. The failure was exposed after `agy` 1.1.1 changed print-mode stdin handling: when a prompt is supplied via the print flag, `agy` no longer reads the piped stdin prompt that had previously masked `summarize`'s invocation bug.

## Root Cause

`summarize` invoked Antigravity print mode as a standalone flag and sent the prompt on stdin:

```ts
args.push("--print");
```

When a timeout was configured, the generated command looked like this:

```sh
agy --sandbox --print --print-timeout 90s
```

Because `agy --print` / `agy -p` is a string flag that requires the prompt as its direct argument, `agy` parsed `--print-timeout` as the prompt value. With newer `agy` behavior, stdin was ignored and the webpage content was never summarized.

## Changes

- Pass the prompt as `agy --print <prompt>` and clear stdin.
- Add platform-specific argv safety checks because current `agy` print mode requires prompt content in argv:
  - non-Windows platforms reject prompts over `120 KiB` by UTF-8 byte length;
  - Windows rejects prompts over `30,000` characters and also checks estimated escaped command-line length.
- Redact prompt-bearing command/error output and omit raw error causes when redaction is active, so argv-based prompts do not leak through application errors.
- Update focused unit tests for argument ordering, empty stdin, timeout handling, argv limits, Windows command estimation, and redacted errors.
- Update `docs/cli.md` to document `agy --print <prompt>` and the argv-size/sensitivity tradeoff.

## Verification

- `pnpm test tests/llm.cli.agy.test.ts tests/llm.cli-exec-signals.test.ts`
- `pnpm build`

### Behavior Evidence

#### Successful Webpage Summary
Using the patched build, running `summarize` with the `agy` backend successfully extracts and summarizes the page content:
```bash
$ node dist/cli.js --cli agy "https://example.com"
This domain is for documentation examples. *Avoid use in operations.*

9.0s · 15 words · cli/agy
```

#### Timeout/Error Handling
With a 1-second timeout and cache bypass, the CLI command times out correctly and throws a clean error with the prompt safely redacted:
```bash
$ node dist/cli.js --cli agy --timeout 1s --no-cache "https://example.com"
CLI command failed: agy --sandbox --print-timeout 1s --print [prompt redacted]
```
