### PR TITLE
fix(chrome): diagnose stale daemon extension contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Dependencies: update the policy-eligible type-aware Oxlint release.
 - Chrome extension: keep MiniMax Direct reasoning separate from visible streamed summaries (#354, thanks @vincent-peng).
-- Chrome extension: route daemon Connect to actionable Runtime diagnostics for permissions, native-host failures, ports, and reload state (#356, thanks @vincent-peng).
+- Chrome extension: route daemon Connect to actionable Runtime diagnostics for permissions, native-host failures, ports, and stale extension state (#352, #356; thanks @buhusa and @vincent-peng).
 - Antigravity CLI: pass prompts through the required print argument with platform-safe size limits and prompt-safe errors (#357, thanks @mvance).
 - Security: block private browser-media URLs in the extension and stop remote binary attachments from auto-enabling broad CLI tool permissions.
 - Chrome extension: make User Scripts optional, omit debugger access from summary builds, and provide a separate debugger-enabled automation build.

--- a/apps/chrome-extension/src/entrypoints/options/daemon-status.ts
+++ b/apps/chrome-extension/src/entrypoints/options/daemon-status.ts
@@ -17,6 +17,13 @@ function formatDaemonConnectionError(err: unknown) {
   const message = err instanceof Error ? err.message.trim() : "";
   const lower = message.toLowerCase();
   if (
+    lower.includes("receiving end does not exist") ||
+    lower.includes("extension context invalidated") ||
+    lower.includes("message port closed")
+  ) {
+    return "Extension context stale — reload the extension, then reopen the side panel";
+  }
+  if (
     lower.includes("host exited") ||
     lower.includes("host has exited") ||
     lower.includes("connection closed unexpectedly")

--- a/tests/options.daemon-status.test.ts
+++ b/tests/options.daemon-status.test.ts
@@ -107,6 +107,24 @@ describe("options daemon status", () => {
     expect(statusEl.dataset.state).toBe("error");
   });
 
+  it("maps a disconnected extension context to targeted reload guidance", async () => {
+    const statusEl = document.createElement("div");
+    const checker = createDaemonStatusChecker({
+      statusEl,
+      fetchImpl: async () => {
+        throw new Error("Could not establish connection. Receiving end does not exist.");
+      },
+      getExtensionVersion: () => "0.21.3",
+    });
+
+    await checker.checkDaemonStatus("token");
+
+    expect(statusEl.textContent).toBe(
+      "Extension context stale — reload the extension, then reopen the side panel",
+    );
+    expect(statusEl.dataset.state).toBe("error");
+  });
+
   it("preserves installed native host exit diagnostics instead of reinstall guidance", async () => {
     const statusEl = document.createElement("div");
     const checker = createDaemonStatusChecker({


### PR DESCRIPTION
## Summary

- classify stale Chrome extension messaging contexts separately from daemon, token, port, and native-host failures
- tell users to reload the extension and reopen the side panel
- preserve issue reporter and prior diagnostic contributor credit in the changelog

Reported by @buhusa. Builds on the Runtime diagnostics from #356 by @vincent-peng.

Closes #352.

## Root cause

The recovered failure exposed a stale Chrome extension context: the reported `Receiving end does not exist` error and a Direct/Browser-only banner remaining visible after Daemon settings were selected are both consistent with an invalidated panel/service-worker messaging context. The daemon and native-host transport itself passes end to end, so this change avoids misdiagnosing that state as a daemon, token, or port failure.

## Exact candidate

Head: `80edc1bce56ff1f12af387e6109005cab4b40dd6`

## Proof

- `pnpm -s vitest run tests/options.daemon-status.test.ts`: 10 passed
- `pnpm -C apps/chrome-extension test:chrome`: production native-host E2E passed; complete Chrome suite 111 passed, 6 explicitly live-gated skips
- `pnpm -s check`: formatting, lint, typecheck, 549 test files and 2,981 tests passed
- behavior contract C1-C4: Connect routing, permission visibility, stale-context guidance, native-host streaming, and safe defaults passed
- built daemon: health, authenticated ping, and native-host manifest passed
- `pnpm audit --audit-level high`: no known vulnerabilities
- autoreview: clean, no actionable findings, exact commit `80edc1bc`
- Public Model Identifier Gate: PASS; the exact diff adds no model-bearing identifiers or artifacts

## Risk

Low. The runtime change only specializes existing user-facing error classification and has focused regression coverage.
