### PR TITLE
fix: harden CLI input classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- URL routing: classify YouTube inputs by hostname so lookalike domains use normal website extraction and labels.
+- CLI arguments: preserve `--` so dash-prefixed local paths remain valid positional inputs.
 - Dependencies: update the policy-eligible type-aware Oxlint release.
 - Chrome extension: keep MiniMax Direct reasoning separate from visible streamed summaries (#354, thanks @vincent-peng).
 - Chrome extension: route daemon Connect to actionable Runtime diagnostics for permissions, native-host failures, ports, and stale extension state (#352, #356; thanks @buhusa and @vincent-peng).

--- a/packages/core/src/content/transcript/providers/youtube.ts
+++ b/packages/core/src/content/transcript/providers/youtube.ts
@@ -1,3 +1,4 @@
+import { isYouTubeUrl } from "../../url.js";
 import { resolveTranscriptionConfig } from "../transcription-config.js";
 import type { ProviderContext, ProviderFetchOptions, ProviderResult } from "../types.js";
 import { resolveTranscriptProviderCapabilities } from "./transcription-capability.js";
@@ -13,9 +14,7 @@ import {
   tryYtDlpTranscript,
 } from "./youtube/provider-flow.js";
 
-const YOUTUBE_URL_PATTERN = /youtube\.com|youtu\.be/i;
-
-export const canHandle = ({ url }: ProviderContext): boolean => YOUTUBE_URL_PATTERN.test(url);
+export const canHandle = ({ url }: ProviderContext): boolean => isYouTubeUrl(url);
 
 export const fetchTranscript = async (
   context: ProviderContext,

--- a/src/run/finish-line-lengths.ts
+++ b/src/run/finish-line-lengths.ts
@@ -1,3 +1,4 @@
+import { isYouTubeUrl } from "@steipete/summarize-core/content/url";
 import {
   formatCompactCount,
   formatDurationSecondsSmart,
@@ -23,7 +24,7 @@ export type ExtractedForLengths = {
 function inferMediaKindLabelForFinishLine(
   extracted: ExtractedForLengths,
 ): "audio" | "video" | null {
-  if (extracted.siteName === "YouTube" || /youtube\.com|youtu\.be/i.test(extracted.url)) {
+  if (extracted.siteName === "YouTube" || isYouTubeUrl(extracted.url)) {
     return "video";
   }
   if (extracted.isVideoOnly || extracted.video) {
@@ -37,8 +38,7 @@ function inferMediaKindLabelForFinishLine(
 }
 
 function buildCompactTranscriptPart(extracted: ExtractedForLengths): string | null {
-  const isYouTube =
-    extracted.siteName === "YouTube" || /youtube\.com|youtu\.be/i.test(extracted.url);
+  const isYouTube = extracted.siteName === "YouTube" || isYouTubeUrl(extracted.url);
   if (!isYouTube && !extracted.transcriptCharacters) return null;
 
   const transcriptChars = extracted.transcriptCharacters;
@@ -71,8 +71,7 @@ function buildCompactTranscriptPart(extracted: ExtractedForLengths): string | nu
 
 function buildDetailedLengthPartsForExtracted(extracted: ExtractedForLengths): string[] {
   const parts: string[] = [];
-  const isYouTube =
-    extracted.siteName === "YouTube" || /youtube\.com|youtu\.be/i.test(extracted.url);
+  const isYouTube = extracted.siteName === "YouTube" || isYouTubeUrl(extracted.url);
   if (!isYouTube && !extracted.transcriptCharacters) return parts;
 
   const transcriptChars = extracted.transcriptCharacters;

--- a/src/run/runner-flags.ts
+++ b/src/run/runner-flags.ts
@@ -1,3 +1,4 @@
+import { isYouTubeUrl } from "@steipete/summarize-core/content/url";
 import {
   type FirecrawlMode,
   type DiarizationMode,
@@ -135,7 +136,7 @@ export function resolveRunnerFlags({
         : undefined,
   );
 
-  const isYoutubeUrl = typeof url === "string" ? /youtube\.com|youtu\.be/i.test(url) : false;
+  const isYoutubeUrl = typeof url === "string" ? isYouTubeUrl(url) : false;
   const formatExplicitlySet = hasFlag(normalizedArgv, "--format");
   const rawFormatOpt = typeof programOpts.format === "string" ? programOpts.format : null;
   const format = parseExtractFormat(

--- a/src/run/runner-setup.ts
+++ b/src/run/runner-setup.ts
@@ -8,18 +8,26 @@ export function prepareRunEnvironment(
   argv: string[],
   inputEnv: Record<string, string | undefined>,
 ) {
-  const normalizedArgv = normalizeDiarizeArgv(argv.filter((arg) => arg !== "--"));
-  const noColorFlag = normalizedArgv.includes("--no-color");
+  const normalizedArgv = normalizeDiarizeArgv(argv);
+  const preSeparatorArgv = argvBeforeSeparator(normalizedArgv);
+  const noColorFlag = preSeparatorArgv.includes("--no-color");
   let envForRun: Record<string, string | undefined> = noColorFlag
     ? { ...inputEnv, NO_COLOR: "1", FORCE_COLOR: "0" }
     : { ...inputEnv };
   const { config: bootstrapConfig } = loadSummarizeConfig({ env: envForRun });
   envForRun = mergeConfigEnv({ env: envForRun, config: bootstrapConfig });
-  return { normalizedArgv, envForRun };
+  return { normalizedArgv, preSeparatorArgv, envForRun };
+}
+
+export function argvBeforeSeparator(argv: readonly string[]): string[] {
+  const separatorIndex = argv.indexOf("--");
+  return separatorIndex === -1 ? [...argv] : argv.slice(0, separatorIndex);
 }
 
 export function normalizeDiarizeArgv(argv: string[]): string[] {
+  const separatorIndex = argv.indexOf("--");
   return argv.map((arg, index) => {
+    if (separatorIndex !== -1 && index > separatorIndex) return arg;
     if (arg !== "--diarize") return arg;
     const next = argv[index + 1];
     if (!next || next.startsWith("-")) return arg;

--- a/src/run/runner.ts
+++ b/src/run/runner.ts
@@ -38,13 +38,14 @@ export async function runCli(
   const runStdout = perfTrace?.wrapStdout(stdout) ?? stdout;
 
   try {
-    const { normalizedArgv, envForRun } = prepareRunEnvironment(argv, inputEnv);
+    const { normalizedArgv, preSeparatorArgv, envForRun } = prepareRunEnvironment(argv, inputEnv);
     perfTrace?.mark("cli:environment");
     const env = envForRun;
 
     if (
       await handleImmediateCliRequests({
         normalizedArgv,
+        preSeparatorArgv,
         envForRun,
         fetchImpl: fetch,
         stdout: runStdout,
@@ -78,7 +79,7 @@ export async function runCli(
 
     if (
       await handleCacheUtilityFlags({
-        normalizedArgv,
+        normalizedArgv: preSeparatorArgv,
         envForRun,
         stdout: runStdout,
       })
@@ -86,7 +87,7 @@ export async function runCli(
       return;
     }
     await executeCliSummarizeCommand({
-      normalizedArgv,
+      normalizedArgv: preSeparatorArgv,
       program,
       env,
       envForRun,
@@ -105,28 +106,59 @@ export async function runCli(
 
 async function handleImmediateCliRequests(options: {
   normalizedArgv: string[];
+  preSeparatorArgv: string[];
   envForRun: Record<string, string | undefined>;
   fetchImpl: typeof fetch;
   stdout: NodeJS.WritableStream;
   stderr: NodeJS.WritableStream;
 }) {
-  const { normalizedArgv, envForRun, fetchImpl, stdout, stderr } = options;
-  if (handleHelpRequest({ normalizedArgv, envForRun, stdout, stderr })) {
+  const { normalizedArgv, preSeparatorArgv, envForRun, fetchImpl, stdout, stderr } = options;
+  if (handleHelpRequest({ normalizedArgv: preSeparatorArgv, envForRun, stdout, stderr })) {
     return true;
   }
-  if (await handleRefreshFreeRequest({ normalizedArgv, envForRun, fetchImpl, stdout, stderr })) {
+  if (
+    await handleRefreshFreeRequest({
+      normalizedArgv: preSeparatorArgv,
+      envForRun,
+      fetchImpl,
+      stdout,
+      stderr,
+    })
+  ) {
     return true;
   }
-  if (await handleStatusCliRequest({ normalizedArgv, envForRun, fetchImpl, stdout })) {
+  if (
+    await handleStatusCliRequest({
+      normalizedArgv: preSeparatorArgv,
+      envForRun,
+      fetchImpl,
+      stdout,
+    })
+  ) {
     return true;
   }
-  if (await handleDaemonCliRequest({ normalizedArgv, envForRun, fetchImpl, stdout, stderr })) {
+  if (
+    await handleDaemonCliRequest({
+      normalizedArgv: preSeparatorArgv,
+      envForRun,
+      fetchImpl,
+      stdout,
+      stderr,
+    })
+  ) {
     return true;
   }
   if (await handleSlidesCliRequest({ normalizedArgv, envForRun, fetchImpl, stdout, stderr })) {
     return true;
   }
-  if (await handleTranscriberCliRequest({ normalizedArgv, envForRun, stdout, stderr })) {
+  if (
+    await handleTranscriberCliRequest({
+      normalizedArgv: preSeparatorArgv,
+      envForRun,
+      stdout,
+      stderr,
+    })
+  ) {
     return true;
   }
   return false;

--- a/src/run/slides-cli.ts
+++ b/src/run/slides-cli.ts
@@ -19,6 +19,7 @@ import { formatVersionLine } from "../version.js";
 import { applyHelpStyle, buildSlidesProgram } from "./help.js";
 import { writeVerbose } from "./logging.js";
 import { createMediaCacheFromConfig } from "./media-cache-state.js";
+import { argvBeforeSeparator } from "./runner-setup.js";
 import { renderSlidesInline, type SlidesRenderMode } from "./slides-render.js";
 import { isRichTty, supportsColor } from "./terminal.js";
 
@@ -103,6 +104,7 @@ export async function handleSlidesCliRequest({
     verbose?: boolean;
     debug?: boolean;
   };
+  const preSeparatorArgv = argvBeforeSeparator(normalizedArgv);
 
   const renderMode = parseRenderMode(opts.render);
   if (opts.json && renderMode !== "none") {
@@ -114,7 +116,7 @@ export async function handleSlidesCliRequest({
     slidesOcr: opts.slidesOcr ?? false,
     slidesDir: opts.output ?? opts.slidesDir,
     slidesSceneThreshold: opts.slidesSceneThreshold,
-    slidesSceneThresholdExplicit: normalizedArgv.some(
+    slidesSceneThresholdExplicit: preSeparatorArgv.some(
       (arg) => arg === "--slides-scene-threshold" || arg.startsWith("--slides-scene-threshold="),
     ),
     slidesMax: opts.slidesMax,

--- a/tests/cli.flags.test.ts
+++ b/tests/cli.flags.test.ts
@@ -16,7 +16,8 @@ import {
   parseYoutubeMode,
 } from "../src/flags.js";
 import { buildProgram } from "../src/run/help.js";
-import { normalizeDiarizeArgv } from "../src/run/runner-setup.js";
+import { resolveRunnerFlags } from "../src/run/runner-flags.js";
+import { normalizeDiarizeArgv, prepareRunEnvironment } from "../src/run/runner-setup.js";
 
 describe("cli flag parsing", () => {
   it("defaults summary length to long", () => {
@@ -216,5 +217,41 @@ describe("cli flag parsing", () => {
     expect(() => parseRetriesArg("0x2")).toThrow(/Unsupported --retries/);
     expect(() => parseRetriesArg("2.0")).toThrow(/Unsupported --retries/);
     expect(() => parseRetriesArg("-1")).toThrow(/Unsupported --retries/);
+  });
+
+  it("does not apply YouTube defaults to lookalike hostnames", () => {
+    const url = "https://notyoutube.com/watch?v=abcdefghijk";
+    const normalizedArgv = ["--extract", url];
+    const program = buildProgram();
+    program.parse(normalizedArgv, { from: "user" });
+
+    const flags = resolveRunnerFlags({
+      normalizedArgv,
+      programOpts: program.opts() as Record<string, unknown>,
+      envForRun: {},
+      url,
+    });
+
+    expect(flags.isYoutubeUrl).toBe(false);
+    expect(flags.format).toBe("markdown");
+  });
+
+  it("accepts dash-prefixed inputs after the end-of-options separator", () => {
+    const { normalizedArgv, preSeparatorArgv } = prepareRunEnvironment(
+      ["--extract", "--", "--format=.pdf"],
+      {},
+    );
+    const program = buildProgram();
+    program.parse(normalizedArgv, { from: "user" });
+
+    expect(program.args).toEqual(["--format=.pdf"]);
+    expect(
+      resolveRunnerFlags({
+        normalizedArgv: preSeparatorArgv,
+        programOpts: program.opts() as Record<string, unknown>,
+        envForRun: {},
+        url: null,
+      }).format,
+    ).toBe("markdown");
   });
 });

--- a/tests/finish-line.lengths.test.ts
+++ b/tests/finish-line.lengths.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLengthPartsForFinishLine,
+  type ExtractedForLengths,
+} from "../src/run/finish-line-lengths.js";
+
+const extracted = (url: string): ExtractedForLengths => ({
+  url,
+  siteName: "Example",
+  totalCharacters: 1_000,
+  wordCount: 160,
+  transcriptCharacters: 960,
+  transcriptLines: 10,
+  transcriptWordCount: 160,
+  transcriptSource: "generic",
+  transcriptionProvider: null,
+  mediaDurationSeconds: 60,
+  video: null,
+  isVideoOnly: false,
+  diagnostics: { transcript: { cacheStatus: "miss" } },
+});
+
+describe("finish line transcript lengths", () => {
+  it("does not label lookalike hostnames as YouTube", () => {
+    expect(
+      buildLengthPartsForFinishLine(extracted("https://notyoutube.com/watch?v=abcdefghijk"), false),
+    ).toEqual(["txc=1m podcast · 160 words"]);
+  });
+});

--- a/tests/runner-setup.test.ts
+++ b/tests/runner-setup.test.ts
@@ -23,8 +23,8 @@ function collectStream() {
 
 describe("runner setup", () => {
   it("normalizes bare diarize URLs and honors --no-color", () => {
-    const { normalizedArgv, envForRun } = prepareRunEnvironment(
-      ["--", "--diarize", "https://www.youtube.com/watch?v=abcdefghijk", "--no-color"],
+    const { normalizedArgv, preSeparatorArgv, envForRun } = prepareRunEnvironment(
+      ["--diarize", "https://www.youtube.com/watch?v=abcdefghijk", "--no-color"],
       { HOME: mkdtempSync(join(tmpdir(), "summarize-runner-setup-")) },
     );
 
@@ -33,8 +33,23 @@ describe("runner setup", () => {
       "https://www.youtube.com/watch?v=abcdefghijk",
       "--no-color",
     ]);
+    expect(preSeparatorArgv).toEqual(normalizedArgv);
     expect(envForRun.NO_COLOR).toBe("1");
     expect(envForRun.FORCE_COLOR).toBe("0");
+  });
+
+  it("preserves the end-of-options separator and positional values after it", () => {
+    const { normalizedArgv, preSeparatorArgv, envForRun } = prepareRunEnvironment(
+      ["--", "--diarize", "--no-color"],
+      {
+        HOME: mkdtempSync(join(tmpdir(), "summarize-runner-setup-")),
+      },
+    );
+
+    expect(normalizedArgv).toEqual(["--", "--diarize", "--no-color"]);
+    expect(preSeparatorArgv).toEqual([]);
+    expect(envForRun.NO_COLOR).toBeUndefined();
+    expect(envForRun.FORCE_COLOR).toBeUndefined();
   });
 
   it("leaves color env untouched when --no-color is absent", () => {

--- a/tests/transcript.providers.placeholder.test.ts
+++ b/tests/transcript.providers.placeholder.test.ts
@@ -41,6 +41,16 @@ describe("placeholder transcript providers", () => {
     expect(generic.canHandle(contextFor("https://example.com/article"))).toBe(true);
   });
 
+  it("matches YouTube by hostname instead of a lookalike substring", async () => {
+    const youtube = await import("../packages/core/src/content/transcript/providers/youtube.js");
+    expect(youtube.canHandle(contextFor("https://www.youtube.com/watch?v=abcdefghijk"))).toBe(true);
+    expect(youtube.canHandle(contextFor("https://youtu.be/abcdefghijk"))).toBe(true);
+    expect(youtube.canHandle(contextFor("https://notyoutube.com/watch?v=abcdefghijk"))).toBe(false);
+    expect(youtube.canHandle(contextFor("https://youtube.com.example/watch?v=abcdefghijk"))).toBe(
+      false,
+    );
+  });
+
   it("returns not_implemented provider metadata", async () => {
     const podcast = await import("../packages/core/src/content/transcript/providers/podcast.js");
     const generic = await import("../packages/core/src/content/transcript/providers/generic.js");


### PR DESCRIPTION
## Summary

- classify YouTube inputs through the canonical hostname-aware helper across transcript routing, CLI defaults, and finish-line labels
- preserve the standard `--` end-of-options separator while limiting manual flag scans to the arguments before it
- add regression coverage for lookalike domains and flag-shaped local filenames

## Root cause

Several CLI/runtime paths used substring matching for YouTube URLs, so lookalike hosts could enter YouTube-specific routing. Argument normalization also removed `--`, and the first fix needed a shared pre-separator boundary so downstream manual flag scans could not reinterpret positional filenames as options.

## User impact

Normal websites whose hostnames contain `youtube.com` or `youtu.be` now use website extraction and correct labels. Dash-prefixed and flag-shaped local paths remain positional when passed after `--`.

## Validation

- `pnpm -s check` — 579 test files; 2,986 passed, 43 skipped
- focused CLI/provider/finish-line tests — 63 passed
- built CLI black-box validation for lookalike hosts, real YouTube hosts, dash-prefixed paths, and a `--format=.pdf` positional filename
- commit-mode AutoReview — clean, no accepted/actionable findings