### PR TITLE
fix: prevent whisper.cpp repetition loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.21.5 - Unreleased
 
+### Fixes
+
+- whisper.cpp: disable cross-window text context to prevent cascading repetition and truncated long-form transcripts (#363, thanks @Owengogogo).
+
 ## 0.21.4 - 2026-07-16
 
 ### Fixes

--- a/packages/core/src/transcription/whisper/whisper-cpp.ts
+++ b/packages/core/src/transcription/whisper/whisper-cpp.ts
@@ -111,6 +111,9 @@ export async function transcribeWithWhisperCppFile({
       modelPath,
       "--language",
       "auto",
+      // Prevent one bad long-form window from seeding cascading repetition in later windows.
+      "-mc",
+      "0",
       "--no-timestamps",
       "--no-prints",
       "--print-progress",

--- a/tests/transcription.whisper-cpp.test.ts
+++ b/tests/transcription.whisper-cpp.test.ts
@@ -57,6 +57,10 @@ describe("transcription/whisper local whisper.cpp", () => {
           return proc;
         }
 
+        const maxContextIdx = args.indexOf("-mc");
+        expect(maxContextIdx).toBeGreaterThanOrEqual(0);
+        expect(args[maxContextIdx + 1]).toBe("0");
+
         // transcription run: create output file and close 0
         const outIdx = args.indexOf("--output-file");
         const base = outIdx >= 0 ? args[outIdx + 1] : null;


### PR DESCRIPTION
## Summary

- pass `-mc 0` to whisper.cpp so one bad long-form window cannot seed repetition across later windows
- cover the decoder argument in the existing local whisper.cpp integration test
- document the user-visible fix in the Unreleased changelog

Fixes #363.

## Root cause

whisper.cpp retains decoded text as context across audio windows by default. On long-form multilingual audio, a hallucinated window can recursively condition later windows, producing loops and silently skipping content.

## Proof

Live comparison used whisper.cpp 1.9.1, the official large-v3-turbo model, and the public 46m12s Chinese episode linked from #364.

- default decoder: 2,910 characters; 53 `hula` repetitions; 146.95s
- `-mc 0`: 10,631 characters; zero `hula` repetitions; 139.90s
- output gain: 3.65x, with a coherent ending restored
- real built CLI after the patch: 31,183 output bytes; zero stderr; 164.20s

Artifact hashes:

- model SHA-256: `1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69`
- audio SHA-256: `ff664698f80b6bec2a2e96b16b8bc9f1b9b8456ab566ea5072ab190a950faf3e`

Commands:

```bash
pnpm -s exec vitest run tests/transcription.whisper-cpp.test.ts
pnpm -s check
pnpm -s build

whisper-cli --model ggml-large-v3-turbo.bin --language auto --no-timestamps --no-prints --print-progress --output-txt --output-file default episode.wav
whisper-cli --model ggml-large-v3-turbo.bin --language auto --no-timestamps --no-prints --print-progress --output-txt --output-file no-context -mc 0 episode.wav

env -u GROQ_API_KEY SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP=0 SUMMARIZE_WHISPER_CPP_MODEL_PATH=ggml-large-v3-turbo.bin node dist/cli.js episode.wav --extract --json --metrics off --transcriber whisper --no-cache
```

Observed results:

- focused test: 20 passed
- full check: 550 files passed, 29 skipped; 2,986 tests passed, 43 skipped
- build: passed
- AutoReview: clean, no accepted/actionable findings
