### PR TITLE
feat: add Xiaoyuzhou podcast resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.21.6 - Unreleased
 
+### Features
+
+- Podcasts: resolve Xiaoyuzhou episode pages through validated audio metadata (#364, thanks @Owengogogo).
+
 ## 0.21.5 - 2026-07-16
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -610,12 +610,13 @@ tries Groq first when configured, then ONNX before `whisper.cpp` and the remaini
 - Select the local transcription stage: `--transcriber parakeet|canary|whisper|auto`
 - Docs: `docs/nvidia-onnx-transcription.md`
 
-### Verified podcast services (2025-12-25)
+### Verified podcast services (2026-07-17)
 
 Run: `summarize <url>`
 
 - Apple Podcasts
 - Spotify
+- Xiaoyuzhou
 - Amazon Music / Audible podcast pages
 - Podbean
 - Podchaser

--- a/docs/website.md
+++ b/docs/website.md
@@ -24,7 +24,7 @@ Use this for non-YouTube URLs.
   - Use `--firecrawl always` to try Firecrawl first for non-YouTube URLs.
 - With `--format md`, `--markdown-mode auto|llm|readability` can also convert HTML → Markdown via an LLM using the configured `--model` (no provider fallback).
 - With `--format md`, `--markdown-mode auto` may fall back to `uvx markitdown` when available (disable with `--preprocess off`).
-- For podcast URLs (Apple Podcasts, RSS, Spotify episodes), it downloads the episode audio and transcribes via Whisper (Groq first when configured, then local ONNX/`whisper.cpp`, then cloud fallbacks); progress shows “Downloading audio …” then “Transcribing …” (duration uses RSS hints or `ffprobe` when available).
+- For podcast URLs (Apple Podcasts, RSS, Spotify, and Xiaoyuzhou episodes), it downloads the episode audio and transcribes via Whisper (Groq first when configured, then local ONNX/`whisper.cpp`, then cloud fallbacks); progress shows “Downloading audio …” then “Transcribing …” (duration uses RSS hints or `ffprobe` when available).
 
 Daemon note:
 

--- a/packages/core/src/content/link-preview/content/podcast-utils.ts
+++ b/packages/core/src/content/link-preview/content/podcast-utils.ts
@@ -52,6 +52,10 @@ export function extractApplePodcastIds(
   }
 }
 
+export function extractXiaoyuzhouEpisodeId(url: string): string | null {
+  return url.match(/^https:\/\/www\.xiaoyuzhoufm\.com\/episode\/([a-f0-9]{24})$/)?.[1] ?? null;
+}
+
 export function isPodcastLikeJsonLdType(type: string | null | undefined): boolean {
   if (!type) return false;
   const normalized = type.toLowerCase();
@@ -66,6 +70,7 @@ export function isPodcastLikeJsonLdType(type: string | null | undefined): boolea
 
 export function isPodcastHost(url: string): boolean {
   try {
+    if (extractXiaoyuzhouEpisodeId(url)) return true;
     const parsed = new URL(url);
     const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
     if (host.startsWith("music.amazon.") && parsed.pathname.includes("/podcasts/")) {

--- a/packages/core/src/content/link-preview/content/transcript-only-strategies.ts
+++ b/packages/core/src/content/link-preview/content/transcript-only-strategies.ts
@@ -4,7 +4,11 @@ import type { resolveTranscriptionConfig } from "../../transcript/transcription-
 import { isDirectMediaUrl, isLoomVideoUrl } from "../../url.js";
 import type { LinkPreviewDeps } from "../deps.js";
 import type { CacheMode } from "../types.js";
-import { extractApplePodcastIds, extractSpotifyEpisodeId } from "./podcast-utils.js";
+import {
+  extractApplePodcastIds,
+  extractSpotifyEpisodeId,
+  extractXiaoyuzhouEpisodeId,
+} from "./podcast-utils.js";
 import { isTwitterBroadcastUrl } from "./twitter-utils.js";
 import type { ExtractedLinkContent, MediaTranscriptMode, YoutubeTranscriptMode } from "./types.js";
 import {
@@ -29,6 +33,20 @@ type TranscriptOnlyStrategy = {
 };
 
 const TRANSCRIPT_ONLY_STRATEGIES: readonly TranscriptOnlyStrategy[] = [
+  {
+    matches: (url) => Boolean(extractXiaoyuzhouEpisodeId(url)),
+    requiresTranscriptionProvider: true,
+    availabilityError:
+      "Xiaoyuzhou episode transcription requires a transcription provider (install whisper-cpp or set GROQ_API_KEY, ASSEMBLYAI_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, FAL_KEY, or DEEPGRAM_API_KEY).",
+    transcriptMode: (mode) => mode,
+    failureLabel: "Xiaoyuzhou episode",
+    transcriptNote: "Xiaoyuzhou episode: resolved guarded og:audio media",
+    firecrawlNote: "Xiaoyuzhou short-circuit skipped generic HTML/Firecrawl extraction",
+    markdownNote: "Xiaoyuzhou short-circuit uses transcript content",
+    siteName: "Xiaoyuzhou",
+    video: () => null,
+    isVideoOnly: false,
+  },
   {
     matches: (url) => Boolean(extractSpotifyEpisodeId(url)),
     requiresTranscriptionProvider: true,

--- a/packages/core/src/content/transcript/providers/podcast.ts
+++ b/packages/core/src/content/transcript/providers/podcast.ts
@@ -1,3 +1,4 @@
+import { extractXiaoyuzhouEpisodeId } from "../../link-preview/content/podcast-utils.js";
 import { isDirectMediaUrl } from "../../url.js";
 import { resolveTranscriptionConfig } from "../transcription-config.js";
 import type { ProviderContext, ProviderFetchOptions, ProviderResult } from "../types.js";
@@ -35,6 +36,7 @@ import {
 } from "./podcast/rss.js";
 import { fetchSpotifyTranscript } from "./podcast/spotify-flow.js";
 import { looksLikeBlockedHtml } from "./podcast/spotify.js";
+import { fetchXiaoyuzhouTranscript } from "./podcast/xiaoyuzhou.js";
 import {
   buildMissingTranscriptionProviderResult,
   resolveTranscriptProviderCapabilities,
@@ -45,6 +47,7 @@ export const canHandle = ({ url, html }: ProviderContext): boolean => {
   // even if the URL contains "podcast" in the path (like "rt_podcast996.mp3")
   if (isDirectMediaUrl(url)) return false;
   if (typeof html === "string" && looksLikeRssOrAtomFeed(html)) return true;
+  if (extractXiaoyuzhouEpisodeId(url)) return true;
   if (PODCAST_PLATFORM_HOST_PATTERN.test(url)) return true;
   return FEED_HINT_URL_PATTERN.test(url);
 };
@@ -81,9 +84,12 @@ export const fetchTranscript = async (
     onProgress: options.onProgress ?? null,
   };
 
-  const transcribe = (request: TranscribeRequest): Promise<TranscriptionResult> =>
+  const transcribe = ({
+    fetchImpl = options.fetch,
+    ...request
+  }: TranscribeRequest): Promise<TranscriptionResult> =>
     transcribeMediaUrl({
-      fetchImpl: options.fetch,
+      fetchImpl,
       transcription,
       notes,
       progress,
@@ -104,6 +110,9 @@ export const fetchTranscript = async (
 
   const directResult = await tryPodcastTranscriptFromFeed(flow);
   if (directResult) return directResult;
+
+  const xiaoyuzhouResult = await fetchXiaoyuzhouTranscript(flow);
+  if (xiaoyuzhouResult) return xiaoyuzhouResult;
 
   const spotifyResult = await fetchSpotifyTranscript(flow);
   if (spotifyResult) return spotifyResult;

--- a/packages/core/src/content/transcript/providers/podcast/media.ts
+++ b/packages/core/src/content/transcript/providers/podcast/media.ts
@@ -41,6 +41,7 @@ export {
 } from "./media-download.js";
 
 export type TranscribeRequest = {
+  fetchImpl?: typeof fetch;
   url: string;
   filenameHint: string;
   durationSecondsHint: number | null;

--- a/packages/core/src/content/transcript/providers/podcast/xiaoyuzhou.ts
+++ b/packages/core/src/content/transcript/providers/podcast/xiaoyuzhou.ts
@@ -1,0 +1,184 @@
+import { parseHtmlDocument } from "../../../html-document.js";
+import { fetchHtmlDocument } from "../../../link-preview/content/fetcher.js";
+import { extractXiaoyuzhouEpisodeId } from "../../../link-preview/content/podcast-utils.js";
+import type { ProviderResult } from "../../types.js";
+import { MAX_REMOTE_MEDIA_BYTES, TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
+import type { PodcastFlowContext } from "./flow-context.js";
+import {
+  filenameFromUrl,
+  normalizeHeaderType,
+  parseContentLength,
+  remoteMediaTooLargeError,
+} from "./media-download.js";
+import { buildWhisperResult } from "./results.js";
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const MAX_AUDIO_REDIRECTS = 10;
+const XIAOYUZHOU_AUDIO_HOST = "media.xyzcdn.net";
+
+export async function fetchXiaoyuzhouTranscript(
+  flow: PodcastFlowContext,
+): Promise<ProviderResult | null> {
+  const episodeId = extractXiaoyuzhouEpisodeId(flow.context.url);
+  if (!episodeId) return null;
+
+  const missing = flow.ensureTranscriptionProvider();
+  if (missing) return missing;
+
+  let audioUrl: string | null = null;
+  try {
+    const page = await fetchHtmlDocument(flow.options.fetch, flow.context.url, {
+      timeoutMs: flow.options.timeoutMs,
+      onProgress: flow.options.onProgress,
+      rejectNonHtmlText: true,
+    });
+    if (extractXiaoyuzhouEpisodeId(page.finalUrl) !== episodeId) {
+      throw new Error("Xiaoyuzhou episode page redirected outside its canonical URL");
+    }
+
+    audioUrl = extractXiaoyuzhouOgAudioUrl(page.html);
+    if (!audioUrl) {
+      throw new Error("Xiaoyuzhou episode page is missing a valid HTTPS og:audio URL");
+    }
+
+    const audioFetch = createSameHostAudioFetch(flow.options.fetch, audioUrl);
+    await validateAudioResponse({
+      fetchImpl: audioFetch,
+      url: audioUrl,
+      maxBytes: flow.transcription.remoteMediaMaxBytes ?? MAX_REMOTE_MEDIA_BYTES,
+    });
+
+    flow.pushOnce("whisper");
+    const result = await flow.transcribe({
+      fetchImpl: audioFetch,
+      url: audioUrl,
+      filenameHint: filenameFromUrl(audioUrl) ?? "episode.m4a",
+      durationSecondsHint: null,
+    });
+    if (result.text) flow.notes.push("Resolved Xiaoyuzhou episode via validated og:audio");
+
+    return buildWhisperResult({
+      attemptedProviders: flow.attemptedProviders,
+      notes: flow.notes,
+      outcome: result,
+      includeProviderOnFailure: true,
+      metadata: {
+        provider: "podcast",
+        kind: "xiaoyuzhou_og_audio",
+        episodeId,
+        audioUrl,
+      },
+    });
+  } catch (error) {
+    return {
+      text: null,
+      source: null,
+      attemptedProviders: flow.attemptedProviders,
+      notes: `Xiaoyuzhou episode resolution failed: ${error instanceof Error ? error.message : String(error)}`,
+      metadata: {
+        provider: "podcast",
+        kind: "xiaoyuzhou_og_audio",
+        episodeId,
+        ...(audioUrl ? { audioUrl } : {}),
+      },
+    };
+  }
+}
+
+export function extractXiaoyuzhouOgAudioUrl(html: string): string | null {
+  const parsed = parseHtmlDocument(html);
+  try {
+    const meta = parsed.document.querySelector('meta[property="og:audio"]');
+    const candidate = (meta?.getAttribute("content") ?? "").trim();
+    if (!candidate) return null;
+    const url = new URL(candidate);
+    if (
+      url.protocol !== "https:" ||
+      url.hostname.toLowerCase() !== XIAOYUZHOU_AUDIO_HOST ||
+      url.port !== "" ||
+      url.username !== "" ||
+      url.password !== ""
+    ) {
+      return null;
+    }
+    return url.href;
+  } catch {
+    return null;
+  } finally {
+    parsed.close();
+  }
+}
+
+function createSameHostAudioFetch(fetchImpl: typeof fetch, audioUrl: string): typeof fetch {
+  const allowedHost = new URL(audioUrl).host.toLowerCase();
+
+  const sameHostFetch = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ): Promise<Response> => {
+    let currentInput = input;
+    let currentInit = { ...init, redirect: "manual" as const };
+
+    for (let redirects = 0; redirects <= MAX_AUDIO_REDIRECTS; redirects += 1) {
+      const currentUrl = inputUrl(currentInput);
+      const currentParsed = new URL(currentUrl);
+      if (currentParsed.protocol !== "https:" || currentParsed.host.toLowerCase() !== allowedHost) {
+        throw new Error("Xiaoyuzhou audio request changed host");
+      }
+      const response = await fetchImpl(currentInput, currentInit);
+      if (!REDIRECT_STATUSES.has(response.status)) return response;
+
+      const location = response.headers.get("location");
+      if (!location) return response;
+      if (redirects === MAX_AUDIO_REDIRECTS) {
+        throw new Error("Xiaoyuzhou audio redirected too many times");
+      }
+
+      const nextUrl = new URL(location, response.url || currentUrl);
+      if (nextUrl.protocol !== "https:" || nextUrl.host.toLowerCase() !== allowedHost) {
+        throw new Error("Xiaoyuzhou audio redirected to another host");
+      }
+
+      await response.body?.cancel().catch(() => {});
+      currentInput = nextUrl.href;
+      currentInit = { ...currentInit, body: null };
+    }
+
+    throw new Error("Xiaoyuzhou audio redirected too many times");
+  };
+
+  return sameHostFetch as typeof fetch;
+}
+
+async function validateAudioResponse({
+  fetchImpl,
+  url,
+  maxBytes,
+}: {
+  fetchImpl: typeof fetch;
+  url: string;
+  maxBytes: number;
+}): Promise<void> {
+  const response = await fetchImpl(url, {
+    method: "HEAD",
+    redirect: "follow",
+    signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`Xiaoyuzhou audio probe failed (${response.status})`);
+
+  const mediaType = normalizeHeaderType(response.headers.get("content-type"));
+  if (!mediaType?.startsWith("audio/")) {
+    throw new Error(`Xiaoyuzhou og:audio returned non-audio content (${mediaType ?? "missing"})`);
+  }
+
+  const contentLength = parseContentLength(response.headers.get("content-length"));
+  if (contentLength !== null && contentLength > maxBytes) {
+    throw remoteMediaTooLargeError(contentLength, maxBytes);
+  }
+}
+
+function inputUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}

--- a/tests/content.podcast-utils.test.ts
+++ b/tests/content.podcast-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractApplePodcastIds,
   extractSpotifyEpisodeId,
+  extractXiaoyuzhouEpisodeId,
   isPodcastHost,
   isPodcastLikeJsonLdType,
 } from "../packages/core/src/content/link-preview/content/podcast-utils.js";
@@ -27,6 +28,25 @@ describe("podcast utils", () => {
     expect(extractApplePodcastIds("https://example.com/us/podcast/foo/id12345?i=678")).toBeNull();
   });
 
+  it("matches only canonical Xiaoyuzhou episode URLs", () => {
+    const id = "6a55a96dca0de6c44ae6bb29";
+    expect(extractXiaoyuzhouEpisodeId(`https://www.xiaoyuzhoufm.com/episode/${id}`)).toBe(id);
+
+    for (const url of [
+      `http://www.xiaoyuzhoufm.com/episode/${id}`,
+      `https://xiaoyuzhoufm.com/episode/${id}`,
+      `https://www.xiaoyuzhoufm.com:443/episode/${id}`,
+      `https://www.xiaoyuzhoufm.com/episode/${id}/`,
+      `https://www.xiaoyuzhoufm.com/episode/${id}?from=share`,
+      `https://www.xiaoyuzhoufm.com/episode/${id}#player`,
+      `https://www.xiaoyuzhoufm.com/episode/${id}/extra`,
+      "https://www.xiaoyuzhoufm.com/episode/not-an-id",
+      `https://www.xiaoyuzhoufm.com.evil.example/episode/${id}`,
+    ]) {
+      expect(extractXiaoyuzhouEpisodeId(url), url).toBeNull();
+    }
+  });
+
   it("recognizes podcast-like json ld types and hostnames", () => {
     expect(isPodcastLikeJsonLdType("PodcastEpisode")).toBe(true);
     expect(isPodcastLikeJsonLdType("AudioObject")).toBe(true);
@@ -36,6 +56,10 @@ describe("podcast utils", () => {
     expect(isPodcastHost("https://subdomain.simplecast.com/episodes/foo")).toBe(true);
     expect(isPodcastHost("https://music.amazon.co.uk/podcasts/foo")).toBe(true);
     expect(isPodcastHost("https://music.amazon.co.uk/music/foo")).toBe(false);
+    expect(isPodcastHost("https://www.xiaoyuzhoufm.com/episode/6a55a96dca0de6c44ae6bb29")).toBe(
+      true,
+    );
+    expect(isPodcastHost("https://www.xiaoyuzhoufm.com/podcast/foo")).toBe(false);
     expect(isPodcastHost("bad url")).toBe(false);
   });
 });

--- a/tests/fixtures/xiaoyuzhou-episode.html
+++ b/tests/fixtures/xiaoyuzhou-episode.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta content="Fixture episode" property="og:title" />
+    <meta content="https://media.xyzcdn.net/fixture/episode.m4a" property="og:audio" />
+  </head>
+  <body>
+    <main>Fixture episode page.</main>
+  </body>
+</html>

--- a/tests/link-preview.xiaoyuzhou-episode.test.ts
+++ b/tests/link-preview.xiaoyuzhou-episode.test.ts
@@ -1,0 +1,203 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import { fetchLinkContent } from "../packages/core/src/content/link-preview/content/index.js";
+import { extractXiaoyuzhouOgAudioUrl } from "../packages/core/src/content/transcript/providers/podcast/xiaoyuzhou.js";
+
+const EPISODE_URL = "https://www.xiaoyuzhoufm.com/episode/6a55a96dca0de6c44ae6bb29";
+const AUDIO_URL = "https://media.xyzcdn.net/fixture/episode.m4a";
+const FIXTURE_HTML = await readFile(
+  new URL("./fixtures/xiaoyuzhou-episode.html", import.meta.url),
+  "utf8",
+);
+
+function deps(fetchImpl: typeof fetch, remoteMediaMaxBytes = "1024") {
+  return {
+    fetch: fetchImpl,
+    env: {
+      SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP: "1",
+      SUMMARIZE_REMOTE_MEDIA_MAX_BYTES: remoteMediaMaxBytes,
+      ASSEMBLYAI_API_KEY: "",
+      DEEPGRAM_API_KEY: "",
+      FAL_KEY: "",
+      GEMINI_API_KEY: "",
+      GOOGLE_API_KEY: "",
+      GOOGLE_GENERATIVE_AI_API_KEY: "",
+      GROQ_API_KEY: "",
+      OPENAI_API_KEY: "",
+    },
+    scrapeWithFirecrawl: null,
+    apifyApiToken: null,
+    ytDlpPath: null,
+    groqApiKey: null,
+    assemblyaiApiKey: null,
+    deepgramApiKey: null,
+    falApiKey: null,
+    geminiApiKey: null,
+    openaiApiKey: "OPENAI",
+    convertHtmlToMarkdown: null,
+    transcriptCache: null,
+  };
+}
+
+function inputUrl(input: RequestInfo | URL): string {
+  return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+}
+
+describe("Xiaoyuzhou episode resolver", () => {
+  it("accepts only credential-free HTTPS media.xyzcdn.net metadata", () => {
+    expect(extractXiaoyuzhouOgAudioUrl(FIXTURE_HTML)).toBe(AUDIO_URL);
+    for (const candidate of [
+      "http://media.xyzcdn.net/fixture/episode.m4a",
+      "https://other.example/fixture/episode.m4a",
+      "https://user@media.xyzcdn.net/fixture/episode.m4a",
+      "https://media.xyzcdn.net:8443/fixture/episode.m4a",
+      "not a URL",
+      "",
+    ]) {
+      const html = `<meta property="og:audio" content="${candidate}">`;
+      expect(extractXiaoyuzhouOgAudioUrl(html), candidate).toBeNull();
+    }
+    expect(extractXiaoyuzhouOgAudioUrl("<html><head></head></html>")).toBeNull();
+  });
+
+  it("extracts fixture og:audio and hands it to guarded media transcription", async () => {
+    const mediaFetches: RequestInit[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = inputUrl(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === EPISODE_URL) {
+        return new Response(FIXTURE_HTML, {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      }
+      if (url === AUDIO_URL) {
+        mediaFetches.push(init ?? {});
+        if (method === "HEAD") {
+          return new Response(null, {
+            status: 200,
+            headers: { "content-type": "audio/mp4", "content-length": "4" },
+          });
+        }
+        return new Response(new Uint8Array([0, 1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "audio/mp4", "content-length": "4" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${url}`);
+    });
+    const openaiFetch = vi.fn(async (input: RequestInfo | URL) => {
+      expect(inputUrl(input)).toContain("api.openai.com/v1/audio/transcriptions");
+      return new Response(JSON.stringify({ text: "hello from Xiaoyuzhou" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    try {
+      vi.stubGlobal("fetch", openaiFetch as unknown as typeof fetch);
+      const result = await fetchLinkContent(
+        EPISODE_URL,
+        { cacheMode: "bypass", timeoutMs: 60_000 },
+        deps(fetchImpl as unknown as typeof fetch),
+      );
+
+      expect(result.transcriptSource).toBe("whisper");
+      expect(result.content).toContain("hello from Xiaoyuzhou");
+      expect(result.siteName).toBe("Xiaoyuzhou");
+      expect(result.diagnostics.transcript.notes).toContain("validated og:audio");
+      expect(mediaFetches).toHaveLength(3);
+      expect(mediaFetches.every((init) => init.redirect === "manual")).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it.each([
+    {
+      name: "non-audio response",
+      head: () =>
+        new Response(null, {
+          status: 200,
+          headers: { "content-type": "text/html", "content-length": "4" },
+        }),
+      limit: "1024",
+      message: /non-audio content/,
+    },
+    {
+      name: "oversized response",
+      head: () =>
+        new Response(null, {
+          status: 200,
+          headers: { "content-type": "audio/mp4", "content-length": "5" },
+        }),
+      limit: "4",
+      message: /Remote media too large/,
+    },
+    {
+      name: "cross-host redirect",
+      head: () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "https://other.example/episode.m4a" },
+        }),
+      limit: "1024",
+      message: /redirected to another host/,
+    },
+  ])("rejects $name", async ({ head, limit, message }) => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = inputUrl(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === EPISODE_URL) {
+        return new Response(FIXTURE_HTML, {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      }
+      if (url === AUDIO_URL && method === "HEAD") return head();
+      throw new Error(`Unexpected fetch: ${method} ${url}`);
+    });
+
+    await expect(
+      fetchLinkContent(
+        EPISODE_URL,
+        { cacheMode: "bypass", timeoutMs: 60_000 },
+        deps(fetchImpl as unknown as typeof fetch, limit),
+      ),
+    ).rejects.toThrow(message);
+  });
+
+  it("rejects a cross-host redirect that appears only during download", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = inputUrl(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === EPISODE_URL) {
+        return new Response(FIXTURE_HTML, {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      }
+      if (url === AUDIO_URL && method === "HEAD") {
+        return new Response(null, {
+          status: 200,
+          headers: { "content-type": "audio/mp4", "content-length": "4" },
+        });
+      }
+      if (url === AUDIO_URL) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://other.example/episode.m4a" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${url}`);
+    });
+
+    await expect(
+      fetchLinkContent(
+        EPISODE_URL,
+        { cacheMode: "bypass", timeoutMs: 60_000 },
+        deps(fetchImpl as unknown as typeof fetch),
+      ),
+    ).rejects.toThrow(/redirected to another host/);
+  });
+});

--- a/tests/transcript.podcast-provider.can-handle.test.ts
+++ b/tests/transcript.podcast-provider.can-handle.test.ts
@@ -45,6 +45,20 @@ describe("podcast transcript provider - canHandle + RSS detection branches", () 
         resourceKey: null,
       }),
     ).toBe(true);
+    expect(
+      canHandle({
+        url: "https://www.xiaoyuzhoufm.com/episode/6a55a96dca0de6c44ae6bb29",
+        html: null,
+        resourceKey: null,
+      }),
+    ).toBe(true);
+    expect(
+      canHandle({
+        url: "https://www.xiaoyuzhoufm.com/episode/not-an-id",
+        html: null,
+        resourceKey: null,
+      }),
+    ).toBe(false);
 
     expect(canHandle({ url: "https://example.com/podcast", html: null, resourceKey: null })).toBe(
       true,


### PR DESCRIPTION
## Summary

- recognize only canonical `https://www.xiaoyuzhoufm.com/episode/<24-hex-id>` URLs
- fetch the episode page through the existing link fetcher, accept only HTTPS `og:audio` media from `media.xyzcdn.net`, and reject non-audio, oversized, or cross-host-redirecting responses
- pass validated media into the existing capped media download and transcription flow
- add fixture coverage, user documentation, and changelog credit for @Owengogogo

## Root cause

Xiaoyuzhou was not recognized by podcast routing, so its episode pages fell through to generic HTML extraction even though the page exposes the full episode media through Open Graph metadata.

## Proof

```text
pnpm exec vitest run tests/content.podcast-utils.test.ts tests/transcript.podcast-provider.can-handle.test.ts tests/link-preview.xiaoyuzhou-episode.test.ts
3 files passed; 11 tests passed

pnpm -s check
551 files passed; 2993 tests passed; branch coverage 85.00%

/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode local --parallel-tests "pnpm -s check"
autoreview clean: no accepted/actionable findings reported

pnpm -s build
exit 0
```

Built CLI live proof against the public episode from #364, using local whisper.cpp with caches bypassed:

```text
exit 0
siteName=Xiaoyuzhou
transcriptSource=whisper
characters=10626
transcriptCharacters=10614
notes include: Resolved Xiaoyuzhou episode via validated og:audio
```

Fixes #364.
