### PR TITLE
ci: sign and notarize macOS release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: macOS release contract
+        run: scripts/test-macos-release.sh
+
       - name: Pack
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,323 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  validate:
+    name: Validate frozen release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      target-sha: ${{ steps.release.outputs.target-sha }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Checkout frozen tag
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag, source, npm, and CI
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version=${RELEASE_TAG#v}
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "release tag must be v-prefixed SemVer" >&2
+            exit 1
+          fi
+          if [[ "$(git cat-file -t "refs/tags/$RELEASE_TAG")" != tag ]]; then
+            echo "release tag must be annotated" >&2
+            exit 1
+          fi
+          tag_object=$(git rev-parse "refs/tags/$RELEASE_TAG")
+          target_sha=$(git rev-parse "refs/tags/$RELEASE_TAG^{}")
+          if [[ "$RELEASE_SHA" != "$tag_object" && "$RELEASE_SHA" != "$target_sha" ]]; then
+            echo "release event does not match the annotated tag object or its commit" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$target_sha" origin/main || {
+            echo "release commit is not reachable from main" >&2
+            exit 1
+          }
+          root_version=$(node -p 'require("./package.json").version')
+          core_version=$(node -p 'require("./packages/core/package.json").version')
+          fallback_version=$(sed -nE 's/^export const FALLBACK_VERSION = "([^"]+)";.*/\1/p' src/version.ts)
+          if [[ "$root_version" != "$version" || "$core_version" != "$version" || "$fallback_version" != "$version" ]]; then
+            echo "release version metadata does not match $version" >&2
+            exit 1
+          fi
+          grep -Eq "^## ${version} - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md || {
+            echo "CHANGELOG.md lacks a dated $version section" >&2
+            exit 1
+          }
+          [[ "$(npm view "@steipete/summarize@$version" version)" == "$version" ]]
+          [[ "$(npm view "@steipete/summarize-core@$version" version)" == "$version" ]]
+          successful_ci=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$target_sha&status=completed&per_page=100" \
+            --jq '[.workflow_runs[] | select(.event == "push" and .conclusion == "success")] | length')
+          if [[ "$successful_ci" -lt 1 ]]; then
+            echo "release commit has no successful push CI run" >&2
+            exit 1
+          fi
+          if gh release view "$RELEASE_TAG" --json tagName >/dev/null 2>&1; then
+            echo "GitHub Release $RELEASE_TAG already exists" >&2
+            exit 1
+          fi
+          echo "target-sha=$target_sha" >>"$GITHUB_OUTPUT"
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+
+  build:
+    name: Build, sign, and notarize
+    needs: validate
+    runs-on: macos-15
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout frozen tag
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.validate.outputs.target-sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.34.5 --activate
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build signed and notarized macOS archives
+        env:
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_PRIVATE_KEY_P8: ${{ secrets.ASC_PRIVATE_KEY_P8 }}
+          MACOS_SIGNING_P12: ${{ secrets.MACOS_SIGNING_P12 }}
+          MACOS_SIGNING_P12_PASSWORD: ${{ secrets.MACOS_SIGNING_P12_PASSWORD }}
+        run: |
+          set -euo pipefail
+          expected_identity='Developer ID Application: Peter Steinberger (Y5PE65HELJ)'
+          keychain="$RUNNER_TEMP/summarize-release.keychain-db"
+          keychain_phrase=$(openssl rand -hex 24)
+          p12="$RUNNER_TEMP/summarize-release.p12"
+          p8="$RUNNER_TEMP/AuthKey_${ASC_KEY_ID}.p8"
+          original_keychains="$RUNNER_TEMP/original-keychains.txt"
+          security list-keychains -d user >"$original_keychains"
+          cleanup() {
+            set +e
+            restored=()
+            while IFS= read -r entry; do
+              entry=${entry#"${entry%%[![:space:]]*}"}
+              entry=${entry#\"}
+              entry=${entry%\"}
+              [[ -n "$entry" ]] && restored+=("$entry")
+            done <"$original_keychains"
+            [[ ${#restored[@]} -eq 0 ]] || security list-keychains -d user -s "${restored[@]}"
+            security delete-keychain "$keychain" >/dev/null 2>&1 || true
+            rm -f "$p12" "$p8" "$original_keychains"
+          }
+          trap cleanup EXIT
+
+          printf %s "$MACOS_SIGNING_P12" | base64 -D >"$p12"
+          printf %s "$ASC_PRIVATE_KEY_P8" >"$p8"
+          chmod 600 "$p12" "$p8"
+          security create-keychain -p "$keychain_phrase" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_phrase" "$keychain"
+          security import "$p12" \
+            -k "$keychain" \
+            -P "$MACOS_SIGNING_P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$keychain_phrase" \
+            "$keychain" >/dev/null
+          current=()
+          while IFS= read -r entry; do
+            entry=${entry#"${entry%%[![:space:]]*}"}
+            entry=${entry#\"}
+            entry=${entry%\"}
+            [[ -n "$entry" ]] && current+=("$entry")
+          done <"$original_keychains"
+          security list-keychains -d user -s "$keychain" "${current[@]}"
+          identities=$(security find-identity -v -p codesigning "$keychain")
+          [[ "$(grep -F -c "$expected_identity" <<<"$identities")" == 1 ]] || {
+            echo "CI keychain does not contain exactly one policy identity" >&2
+            exit 1
+          }
+
+          env \
+            SUMMARIZE_OFFICIAL_RELEASE=1 \
+            CODESIGN_IDENTITY="$expected_identity" \
+            CODESIGN_KEYCHAIN="$keychain" \
+            ASC_KEY_ID="$ASC_KEY_ID" \
+            ASC_ISSUER_ID="$ASC_ISSUER_ID" \
+            ASC_PRIVATE_KEY_PATH="$p8" \
+            pnpm -s build:bun:test
+
+      - name: Build browser extension archives
+        run: |
+          scripts/release.sh chrome
+          scripts/release.sh firefox
+
+      - name: Freeze release payload
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-payload/assets
+          cp \
+            "dist-bun/summarize-macos-arm64-v${VERSION}.tar.gz" \
+            "dist-bun/summarize-macos-x64-v${VERSION}.tar.gz" \
+            "dist-chrome/summarize-chrome-extension-v${VERSION}.zip" \
+            "dist-firefox/summarize-firefox-extension-v${VERSION}.zip" \
+            release-payload/assets/
+          awk -v start="$VERSION" '
+            BEGIN { p=0 }
+            $0 ~ ("^## " start "([ -]|$)") { p=1; next }
+            p && $0 ~ /^## / { exit }
+            p { print }
+          ' CHANGELOG.md >release-payload/RELEASE-NOTES.md
+          grep -q '[^[:space:]]' release-payload/RELEASE-NOTES.md
+          cd release-payload/assets
+          shasum -a 256 summarize-* >SHA256SUMS
+          shasum -a 256 -c SHA256SUMS
+
+      - name: Upload immutable release payload
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: release-${{ needs.validate.outputs.target-sha }}
+          path: release-payload
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+  verify:
+    name: Verify notarized macOS archive (${{ matrix.arch }})
+    needs: [validate, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-15
+            archive_arch: arm64
+          - arch: x86_64
+            runner: macos-15-intel
+            archive_arch: x64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout frozen tag
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ needs.validate.outputs.target-sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Download immutable release payload
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: release-${{ needs.validate.outputs.target-sha }}
+          path: release-payload
+
+      - name: Verify checksums, signature, notarization, and execution
+        env:
+          ARCH: ${{ matrix.arch }}
+          ARCHIVE_ARCH: ${{ matrix.archive_arch }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd release-payload/assets
+          shasum -a 256 -c SHA256SUMS
+          cd ../..
+          scripts/verify-macos-release.sh \
+            "release-payload/assets/summarize-macos-${ARCHIVE_ARCH}-v${VERSION}.tar.gz" \
+            "$ARCH" \
+            "$VERSION"
+
+  publish:
+    name: Publish verified GitHub Release
+    needs: [validate, build, verify]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download verified release payload
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: release-${{ needs.validate.outputs.target-sha }}
+          path: release-payload
+
+      - name: Publish exact verified bytes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          TARGET_SHA: ${{ needs.validate.outputs.target-sha }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd release-payload/assets
+          sha256sum -c SHA256SUMS
+          cd ../..
+
+          object=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq '"\(.object.type) \(.object.sha)"')
+          object_type=
+          object_sha=
+          for _ in {1..8}; do
+            read -r object_type object_sha <<<"$object"
+            [[ "$object_type" == tag ]] || break
+            object=$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$object_sha" --jq '"\(.object.type) \(.object.sha)"')
+          done
+          if [[ "$object_type" != commit || "$object_sha" != "$TARGET_SHA" ]]; then
+            echo "release tag moved away from the validated commit" >&2
+            exit 1
+          fi
+
+          release_flags=()
+          if [[ "$VERSION" == *-* ]]; then
+            release_flags+=(--prerelease --latest=false)
+          fi
+          gh release create "$RELEASE_TAG" \
+            release-payload/assets/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "$RELEASE_TAG" \
+            --notes-file release-payload/RELEASE-NOTES.md \
+            "${release_flags[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.21.7 - Unreleased
 
+- Release pipeline: sign the Bun macOS executables with the personal Developer ID, notarize them with Apple, verify both architectures without signing credentials, and publish only the verified artifacts.
+
 ## 0.21.6 - 2026-07-18
 
 ### Highlights

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,9 +3,10 @@
 Ship is **not done** until:
 
 - npm is published
-- GitHub Release has the Bun tarball asset
+- GitHub Release has both Developer ID-signed and Apple-notarized Bun tarball assets
 - GitHub Release has the Chrome extension zip
 - GitHub Release has the Firefox extension zip
+- GitHub Release has `SHA256SUMS` for the exact CI-verified assets
 - Homebrew/core formula is updated + `brew install summarize` verifies
 
 ## Version sources (keep in sync)
@@ -33,9 +34,10 @@ Ship is **not done** until:
    - `pnpm -s check`
    - `pnpm -s build`
 
-3. Build Bun artifact (prints sha256 + creates tarball)
+3. Build Bun artifact locally (unsigned smoke proof only)
    - `pnpm -s build:bun:test`
    - Artifacts: `dist-bun/summarize-macos-arm64-v<ver>.tar.gz`, `dist-bun/summarize-macos-x64-v<ver>.tar.gz`
+   - Local artifacts are not releasable. The tag-triggered Release workflow rebuilds the frozen source, signs and notarizes both Mach-O executables, and packages those CI-produced bytes.
 
 4. Build Chrome extension artifact
    - `pnpm -C apps/chrome-extension build`
@@ -68,33 +70,18 @@ Ship is **not done** until:
    git push --tags
    ```
 
+   - The tag must be annotated, match all three version sources, point to a commit reachable from `main`, and already have successful push CI.
+   - Pushing the tag triggers `.github/workflows/release.yml`. Do not upload local `dist-bun` artifacts.
+
 8. GitHub Release + assets
 
    ```bash
-   ver="$(node -p 'require(\"./package.json\").version')"
-
-   # Notes = full changelog section(s), but without a duplicated version header.
-   # If you skipped GitHub Releases for some versions, set prev to the last released version
-   # and include all sections since then.
-   prev="0.6.1"
-
-   awk -v start="$ver" -v stop="$prev" '
-     BEGIN { p=0 }
-     $0 ~ ("^## " start " ") { p=1; next }
-     $0 ~ ("^## " stop " ") { p=0 }
-     p { print }
-   ' CHANGELOG.md >"/tmp/summarize-v${ver}-notes.md"
-
-   gh release create "v${ver}" \
-     "dist-bun/summarize-macos-arm64-v${ver}.tar.gz" \
-     "dist-bun/summarize-macos-x64-v${ver}.tar.gz" \
-     "dist-chrome/summarize-chrome-extension-v${ver}.zip" \
-     "dist-firefox/summarize-firefox-extension-v${ver}.zip" \
-     --title "v${ver}" \
-     --notes-file "/tmp/summarize-v${ver}-notes.md"
+   scripts/release.sh github
    ```
 
-   - Verify notes render (real newlines): `gh release view v<ver> --json body --jq .body`
+   - The Release workflow imports the personal Developer ID p12 into an ephemeral keychain, builds and notarizes both Bun executables, freezes all four archives plus checksums into one Actions artifact, and verifies each macOS archive on its native architecture without signing credentials.
+   - A separate publisher creates the GitHub Release only after both verifiers pass. `scripts/release.sh github` is verification-only and refuses a missing or incomplete CI-published release.
+   - Verify notes render with real newlines: `gh release view v<ver> --json body --jq .body`.
 
 9. Homebrew/core verify
    - Homebrew/core is autobumped from the GitHub Release; this can lag the npm/GitHub release.
@@ -111,7 +98,7 @@ Notes:
 
 - npm may prompt for browser auth when `npm config get auth-type` is `web`. For scripted publishes, create auth in the `$npm` tmux/1Password workflow and pass OTP as `NPM_OTP` only when needed.
 - Publishing with raw `npm publish` is forbidden here. Use `pnpm publish` only; it rewrites `workspace:*` dependencies in the packed CLI metadata.
-- `scripts/release.sh publish` uses `next` first, then exact-version smoke, then `latest`. Tag/GitHub release come after that smoke passes.
+- `scripts/release.sh publish` uses `next` first, then exact-version smoke, then `latest`. The annotated tag comes after that smoke passes; CI owns the GitHub Release.
 - `prepare` runs `pnpm build` automatically during publish.
 
 Helper: `scripts/release.sh` (phases: `gates|build|bun|chrome|firefox|verify|publish|smoke|promote|tag|github|homebrew|deprecate|all`).
@@ -128,7 +115,7 @@ Goal:
 
 1. Build the Bun artifact
    - `pnpm build:bun:test`
-   - This uses `bun build --compile --bytecode`, prints tarball sha256s, and smokes the host binary.
+   - This uses `bun build --compile --bytecode`, prints tarball sha256s, and smokes the host binary. Without `SUMMARIZE_OFFICIAL_RELEASE=1`, these are local proof artifacts only.
 
 2. Smoke test locally (before uploading)
    - `dist-bun/summarize --version`
@@ -136,13 +123,11 @@ Goal:
    - Optional: run one real file/link summary.
 
 3. GitHub Release (when approved)
-   - Create a release for tag `v<ver>` with clean notes (no duplicated version header inside the notes body):
-     - Prefer `--title "v<ver>"` and `--notes-file …` (avoid pasting text with escaped `\\n`)
-     - Notes should start with sections like `### Changes`, not `## v<ver>` (the release already has a title)
-   - Upload `dist-bun/summarize-macos-arm64-v<ver>.tar.gz`
-   - Upload `dist-bun/summarize-macos-x64-v<ver>.tar.gz`
-   - Verify notes render correctly:
-     - `gh release view v<ver> --json body --jq .body` (should show real newlines, not literal `\\n`)
+   - Push the annotated `v<ver>` tag. The Release workflow is the only supported publisher.
+   - Each Bun executable is signed after compilation with `Developer ID Application: Peter Steinberger (Y5PE65HELJ)`, identifier `com.steipete.summarize.cli`, hardened runtime, a trusted timestamp, and the two Bun JIT entitlements in `scripts/macos-release.entitlements`.
+   - Apple notarization is submitted for each signed executable. Raw Mach-O files cannot carry stapled tickets, so both CI verifiers require `codesign --check-notarization -R=notarized` online.
+   - The browser extension zips and npm tarballs contain no Mach-O and stay outside Apple signing.
+   - Repository secrets are `MACOS_SIGNING_P12`, `MACOS_SIGNING_P12_PASSWORD`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, and `ASC_PRIVATE_KEY_P8`. Never pass them to verifier jobs.
 
 4. Homebrew/core verification (after autobump)
    ```bash

--- a/scripts/build-bun.js
+++ b/scripts/build-bun.js
@@ -79,7 +79,7 @@ function chmodX(path) {
   run("chmod", ["+x", path]);
 }
 
-function buildOne({ target, outName, version, gitSha }) {
+function buildOne({ arch, target, outName, version, gitSha }) {
   const outPath = join(distDir, outName);
   console.log(`\n🔨 Building ${outName} (target=${target}, bytecode)…`);
   const env = { ...process.env };
@@ -102,6 +102,7 @@ function buildOne({ target, outName, version, gitSha }) {
     { env },
   );
   chmodX(outPath);
+  run(join(projectRoot, "scripts", "codesign-macos.sh"), [outPath, arch]);
 
   try {
     const st = statSync(outPath);
@@ -151,7 +152,7 @@ function buildMacosTargets({ version }) {
   buildFfmpegWasmRunner();
 
   for (const { arch, target, outName } of MAC_TARGETS) {
-    const binary = buildOne({ target, outName, version, gitSha });
+    const binary = buildOne({ arch, target, outName, version, gitSha });
     const tarPath = packageTarball({ binaryPath: binary, version, arch });
     builds[arch] = { binary, tarPath };
   }

--- a/scripts/codesign-macos.sh
+++ b/scripts/codesign-macos.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BINARY=${1:-}
+ARCH=${2:-}
+OFFICIAL_RELEASE=${SUMMARIZE_OFFICIAL_RELEASE:-0}
+IDENTIFIER=com.steipete.summarize.cli
+TEAM_ID=Y5PE65HELJ
+EXPECTED_AUTHORITY="Developer ID Application: Peter Steinberger ($TEAM_ID)"
+ENTITLEMENTS="$ROOT/scripts/macos-release.entitlements"
+REQUIREMENT="identifier \"$IDENTIFIER\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = \"$TEAM_ID\""
+
+[[ "$OFFICIAL_RELEASE" == 0 || "$OFFICIAL_RELEASE" == 1 ]] || {
+  echo "SUMMARIZE_OFFICIAL_RELEASE must be 0 or 1" >&2
+  exit 2
+}
+[[ "$OFFICIAL_RELEASE" == 1 ]] || exit 0
+[[ -f "$BINARY" && ! -L "$BINARY" && "$ARCH" =~ ^(arm64|x64)$ ]] || {
+  echo "usage: SUMMARIZE_OFFICIAL_RELEASE=1 $0 binary arm64|x64" >&2
+  exit 2
+}
+[[ "$(uname -s)" == Darwin ]] || {
+  echo "official macOS release signing must run on macOS" >&2
+  exit 1
+}
+[[ "${CODESIGN_IDENTITY:-}" == "$EXPECTED_AUTHORITY" ]] || {
+  echo "official macOS releases require $EXPECTED_AUTHORITY" >&2
+  exit 1
+}
+[[ -n "${CODESIGN_KEYCHAIN:-}" && -f "$CODESIGN_KEYCHAIN" ]] || {
+  echo "CODESIGN_KEYCHAIN must name the CI release keychain" >&2
+  exit 1
+}
+[[ -n "${ASC_KEY_ID:-}" && -n "${ASC_ISSUER_ID:-}" ]] || {
+  echo "ASC_KEY_ID and ASC_ISSUER_ID are required" >&2
+  exit 1
+}
+[[ -n "${ASC_PRIVATE_KEY_PATH:-}" && -f "$ASC_PRIVATE_KEY_PATH" ]] || {
+  echo "ASC_PRIVATE_KEY_PATH must name the App Store Connect private key" >&2
+  exit 1
+}
+
+for tool in codesign csreq ditto lipo mktemp plutil xcrun; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "missing required command: $tool" >&2
+    exit 1
+  }
+done
+plutil -lint "$ENTITLEMENTS" >/dev/null
+
+EXPECTED_ARCH=$ARCH
+[[ "$EXPECTED_ARCH" == x64 ]] && EXPECTED_ARCH=x86_64
+WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/summarize-notary.XXXXXX")
+NOTARY_ARCHIVE="$WORK_DIR/summarize-$ARCH.zip"
+NOTARY_RESULT="$WORK_DIR/notary-result.json"
+EMBEDDED_ENTITLEMENTS="$WORK_DIR/embedded-entitlements.plist"
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+codesign \
+  --force \
+  --keychain "$CODESIGN_KEYCHAIN" \
+  --options runtime \
+  --timestamp \
+  --identifier "$IDENTIFIER" \
+  --requirements "=designated => $REQUIREMENT" \
+  --entitlements "$ENTITLEMENTS" \
+  --sign "$CODESIGN_IDENTITY" \
+  "$BINARY"
+
+codesign --verify --strict -R="$REQUIREMENT" --verbose=2 "$BINARY"
+signature=$(codesign -dvvv "$BINARY" 2>&1)
+grep -Fqx "Identifier=$IDENTIFIER" <<<"$signature"
+grep -Fqx "Authority=$EXPECTED_AUTHORITY" <<<"$signature"
+grep -Fqx "TeamIdentifier=$TEAM_ID" <<<"$signature"
+grep -Eq '^CodeDirectory .*flags=.*\([^)]*runtime[^)]*\)' <<<"$signature"
+grep -Eq '^Timestamp=.+$' <<<"$signature"
+
+embedded_requirement=$(codesign -d -r- "$BINARY" 2>&1)
+embedded_source=$(sed -n 's/^designated => //p' <<<"$embedded_requirement")
+[[ -n "$embedded_source" && "$embedded_source" != *$'\n'* ]] || {
+  echo "signed binary does not contain exactly one designated requirement" >&2
+  exit 1
+}
+expected_canonical=$(csreq -r "=$REQUIREMENT" -t)
+embedded_canonical=$(csreq -r "=$embedded_source" -t)
+[[ "$embedded_canonical" == "$expected_canonical" ]] || {
+  echo "embedded designated requirement does not match the release policy" >&2
+  exit 1
+}
+
+codesign -d --entitlements :- "$BINARY" >"$EMBEDDED_ENTITLEMENTS" 2>/dev/null
+plutil -lint "$EMBEDDED_ENTITLEMENTS" >/dev/null
+node - "$EMBEDDED_ENTITLEMENTS" <<'NODE'
+const { execFileSync } = require("node:child_process");
+const file = process.argv[2];
+const json = execFileSync("plutil", ["-convert", "json", "-o", "-", file], {
+  encoding: "utf8",
+});
+const entitlements = JSON.parse(json);
+const expected = [
+  "com.apple.security.cs.allow-jit",
+  "com.apple.security.cs.allow-unsigned-executable-memory",
+];
+const actual = Object.keys(entitlements).sort();
+if (
+  JSON.stringify(actual) !== JSON.stringify(expected) ||
+  expected.some((key) => entitlements[key] !== true)
+) {
+  throw new Error(`unexpected embedded entitlements: ${actual.join(", ")}`);
+}
+NODE
+
+actual_arch=$(lipo -archs "$BINARY" | tr -d '[:space:]')
+[[ "$actual_arch" == "$EXPECTED_ARCH" ]] || {
+  echo "signed binary architecture is $actual_arch, expected $EXPECTED_ARCH" >&2
+  exit 1
+}
+
+ditto -c -k --sequesterRsrc --keepParent "$BINARY" "$NOTARY_ARCHIVE"
+xcrun notarytool submit "$NOTARY_ARCHIVE" \
+  --key "$ASC_PRIVATE_KEY_PATH" \
+  --key-id "$ASC_KEY_ID" \
+  --issuer "$ASC_ISSUER_ID" \
+  --no-s3-acceleration \
+  --wait \
+  --output-format json >"$NOTARY_RESULT"
+node - "$NOTARY_RESULT" <<'NODE'
+const fs = require("node:fs");
+const result = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+if (result.status !== "Accepted") {
+  throw new Error(`notarization failed: ${result.status ?? "unknown status"}`);
+}
+console.log(`Notarization accepted: ${result.id ?? "submission id unavailable"}`);
+NODE
+
+notarization_ready=0
+for _ in {1..12}; do
+  if codesign --verify --strict --check-notarization -R=notarized --verbose=2 "$BINARY"; then
+    notarization_ready=1
+    break
+  fi
+  sleep 5
+done
+[[ "$notarization_ready" == 1 ]] || {
+  echo "accepted notarization ticket did not become available online" >&2
+  exit 1
+}

--- a/scripts/macos-release.entitlements
+++ b/scripts/macos-release.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+</dict>
+</plist>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -320,32 +320,34 @@ phase_tag() {
 }
 
 phase_github() {
-  banner "GitHub release"
+  banner "Verify CI-published GitHub release"
   require_clean_git
   require_lockstep_versions
-  local version root_dir notes_file
+  local version asset_names expected_asset
   version="$(node -p 'require("./package.json").version')"
-  root_dir="$(pwd)"
-  local assets=(
-    "${root_dir}/dist-bun/summarize-macos-arm64-v${version}.tar.gz"
-    "${root_dir}/dist-bun/summarize-macos-x64-v${version}.tar.gz"
-    "${root_dir}/dist-chrome/summarize-chrome-extension-v${version}.zip"
-    "${root_dir}/dist-firefox/summarize-firefox-extension-v${version}.zip"
-  )
-  for asset in "${assets[@]}"; do
-    if [ ! -f "${asset}" ]; then
-      echo "Missing release asset: ${asset}"
-      exit 1
-    fi
-  done
   if ! git rev-parse -q --verify "refs/tags/v${version}" >/dev/null; then
     echo "Missing tag v${version}. Run: scripts/release.sh tag"
     exit 1
   fi
-  notes_file="$(mktemp)"
-  write_release_notes "${version}" "${notes_file}"
-  run gh release create "v${version}" "${assets[@]}" --verify-tag --title "v${version}" --notes-file "${notes_file}"
+  if ! asset_names="$(gh release view "v${version}" --json assets --jq '.assets[].name')"; then
+    echo "GitHub Release v${version} is not published yet. The tag-triggered Release workflow owns signing, notarization, verification, and publication."
+    exit 1
+  fi
+  local expected_assets=(
+    "summarize-macos-arm64-v${version}.tar.gz"
+    "summarize-macos-x64-v${version}.tar.gz"
+    "summarize-chrome-extension-v${version}.zip"
+    "summarize-firefox-extension-v${version}.zip"
+    "SHA256SUMS"
+  )
+  for expected_asset in "${expected_assets[@]}"; do
+    if ! grep -Fxq "$expected_asset" <<<"$asset_names"; then
+      echo "GitHub Release v${version} is missing ${expected_asset}"
+      exit 1
+    fi
+  done
   run gh release view "v${version}" --json body --jq .body >/dev/null
+  echo "ok"
 }
 
 phase_homebrew() {
@@ -399,7 +401,7 @@ case "$PHASE" in
     phase_build
     phase_publish
     phase_tag
-    phase_github
+    echo "Tag pushed. The Release workflow now builds, signs, notarizes, verifies, and publishes the GitHub Release."
     ;;
   *)
     echo "Usage: scripts/release.sh [phase]"
@@ -414,11 +416,11 @@ case "$PHASE" in
     echo "  promote   npm dist-tag add current version as latest"
     echo "  deprecate deprecate @steipete/summarize@BAD_VERSION"
     echo "  tag       git tag vX.Y.Z + push tags"
-    echo "  github    create GitHub Release + upload release assets"
+    echo "  github    verify the CI-published GitHub Release and required assets"
     echo "  homebrew  verify Homebrew/core formula has current version"
     echo "  chrome    build + zip Chrome extension"
     echo "  firefox   build + zip Firefox extension"
-    echo "  all       gates + build + verify + publish + tag + github"
+    echo "  all       gates + build + verify + publish + tag (CI publishes GitHub Release)"
     exit 2
     ;;
 esac

--- a/scripts/test-macos-release.sh
+++ b/scripts/test-macos-release.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/summarize-release-test.XXXXXX")
+MOCK_BIN="$TEST_DIR/bin"
+LOG="$TEST_DIR/commands.log"
+mkdir -p "$MOCK_BIN" "$TEST_DIR/stage/ffmpeg-wasm/node"
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cat >"$MOCK_BIN/uname" <<'EOF'
+#!/bin/sh
+echo Darwin
+EOF
+
+cat >"$MOCK_BIN/lipo" <<'EOF'
+#!/bin/sh
+echo "${MOCK_ARCH:-arm64}"
+EOF
+
+cat >"$MOCK_BIN/codesign" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'codesign %s\n' "$*" >>"$MOCK_LOG"
+authority=${MOCK_AUTHORITY:-Developer ID Application: Peter Steinberger (Y5PE65HELJ)}
+requirement=${MOCK_REQUIREMENT:-'identifier "com.steipete.summarize.cli" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Y5PE65HELJ'}
+case " $* " in
+  *' -dvvv '*)
+    cat <<META
+Executable=test
+Identifier=com.steipete.summarize.cli
+CodeDirectory v=20500 size=1 flags=0x10000(runtime) hashes=1+7 location=embedded
+Authority=$authority
+Timestamp=Jul 18, 2026 at 4:00:00 PM
+TeamIdentifier=Y5PE65HELJ
+Runtime Version=15.0.0
+META
+    ;;
+  *' -d -r- '*)
+    echo "Executable=test"
+    echo "designated => $requirement"
+    ;;
+  *' -d --entitlements :- '*)
+    cat <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>com.apple.security.cs.allow-jit</key><true/>
+<key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+</dict></plist>
+PLIST
+    ;;
+esac
+EOF
+
+cat >"$MOCK_BIN/csreq" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" != -r==* ]] || exit 2
+case "$*" in
+  *com.steipete.summarize.cli*Y5PE65HELJ*) echo 'canonical release requirement' ;;
+  *) echo 'canonical non-policy requirement' ;;
+esac
+EOF
+
+cat >"$MOCK_BIN/ditto" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'ditto %s\n' "$*" >>"$MOCK_LOG"
+output=${!#}
+: >"$output"
+EOF
+
+cat >"$MOCK_BIN/xcrun" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'xcrun %s\n' "$*" >>"$MOCK_LOG"
+printf '{"status":"%s","id":"11111111-2222-3333-4444-555555555555"}\n' "${MOCK_NOTARY_STATUS:-Accepted}"
+EOF
+
+cat >"$MOCK_BIN/plutil" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == -lint ]]; then
+  exit 0
+fi
+if [[ "$1" == -convert && "$2" == json ]]; then
+  printf '%s\n' '{"com.apple.security.cs.allow-jit":true,"com.apple.security.cs.allow-unsigned-executable-memory":true}'
+  exit 0
+fi
+exit 1
+EOF
+
+chmod +x "$MOCK_BIN"/*
+
+cat >"$TEST_DIR/stage/summarize" <<'EOF'
+#!/bin/sh
+echo '0.21.6 (844664f3)'
+EOF
+chmod +x "$TEST_DIR/stage/summarize"
+printf 'runner\n' >"$TEST_DIR/stage/ffmpeg-wasm/run-generated.js"
+printf 'wasm\n' >"$TEST_DIR/stage/ffmpeg-wasm/node/ffmpeg_g.wasm"
+tar -czf "$TEST_DIR/release.tar.gz" -C "$TEST_DIR/stage" summarize ffmpeg-wasm
+: >"$TEST_DIR/release.keychain-db"
+: >"$TEST_DIR/AuthKey_TEST.p8"
+
+COMMON_ENV=(
+  PATH="$MOCK_BIN:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+  MOCK_LOG="$LOG"
+  SUMMARIZE_OFFICIAL_RELEASE=1
+  CODESIGN_IDENTITY="Developer ID Application: Peter Steinberger (Y5PE65HELJ)"
+  CODESIGN_KEYCHAIN="$TEST_DIR/release.keychain-db"
+  ASC_KEY_ID=ABCDEFGHIJ
+  ASC_ISSUER_ID=11111111-2222-3333-4444-555555555555
+  ASC_PRIVATE_KEY_PATH="$TEST_DIR/AuthKey_TEST.p8"
+)
+
+env "${COMMON_ENV[@]}" "$ROOT/scripts/codesign-macos.sh" "$TEST_DIR/stage/summarize" arm64
+grep -F -- '--options runtime' "$LOG" >/dev/null || fail "codesign skipped hardened runtime"
+grep -F -- '--identifier com.steipete.summarize.cli' "$LOG" >/dev/null || fail "codesign skipped stable identifier"
+grep -F -- '--entitlements' "$LOG" >/dev/null || fail "codesign skipped Bun entitlements"
+grep -F -- 'notarytool submit' "$LOG" >/dev/null || fail "notarytool was not invoked"
+grep -F -- '--check-notarization -R=notarized' "$LOG" >/dev/null || fail "online notarization was not verified"
+
+if env "${COMMON_ENV[@]}" CODESIGN_IDENTITY='Developer ID Application: Wrong (AAAAAAAAAA)' \
+  "$ROOT/scripts/codesign-macos.sh" "$TEST_DIR/stage/summarize" arm64 >/dev/null 2>&1; then
+  fail "wrong signing authority was accepted"
+fi
+
+if env "${COMMON_ENV[@]}" MOCK_NOTARY_STATUS=Invalid \
+  "$ROOT/scripts/codesign-macos.sh" "$TEST_DIR/stage/summarize" arm64 >/dev/null 2>&1; then
+  fail "rejected notarization was accepted"
+fi
+
+if env "${COMMON_ENV[@]}" MOCK_REQUIREMENT='identifier "com.wrong"' \
+  "$ROOT/scripts/codesign-macos.sh" "$TEST_DIR/stage/summarize" arm64 >/dev/null 2>&1; then
+  fail "wrong embedded requirement was accepted while signing"
+fi
+
+env \
+  -u MACOS_SIGNING_P12 \
+  -u MACOS_SIGNING_P12_PASSWORD \
+  -u ASC_KEY_ID \
+  -u ASC_ISSUER_ID \
+  -u ASC_PRIVATE_KEY_P8 \
+  -u CODESIGN_IDENTITY \
+  -u CODESIGN_KEYCHAIN \
+  -u ASC_PRIVATE_KEY_PATH \
+  PATH="$MOCK_BIN:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+  MOCK_LOG="$LOG" \
+  "$ROOT/scripts/verify-macos-release.sh" "$TEST_DIR/release.tar.gz" arm64 0.21.6
+
+if env \
+  -u MACOS_SIGNING_P12 \
+  -u MACOS_SIGNING_P12_PASSWORD \
+  -u ASC_KEY_ID \
+  -u ASC_ISSUER_ID \
+  -u ASC_PRIVATE_KEY_P8 \
+  -u CODESIGN_IDENTITY \
+  -u CODESIGN_KEYCHAIN \
+  -u ASC_PRIVATE_KEY_PATH \
+  PATH="$MOCK_BIN:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+  MOCK_LOG="$LOG" \
+  MOCK_AUTHORITY='Developer ID Application: Wrong (AAAAAAAAAA)' \
+  "$ROOT/scripts/verify-macos-release.sh" "$TEST_DIR/release.tar.gz" arm64 0.21.6 >/dev/null 2>&1; then
+  fail "verifier accepted the wrong signing authority"
+fi
+
+if env \
+  -u MACOS_SIGNING_P12 \
+  -u MACOS_SIGNING_P12_PASSWORD \
+  -u ASC_KEY_ID \
+  -u ASC_ISSUER_ID \
+  -u ASC_PRIVATE_KEY_P8 \
+  -u CODESIGN_IDENTITY \
+  -u CODESIGN_KEYCHAIN \
+  -u ASC_PRIVATE_KEY_PATH \
+  PATH="$MOCK_BIN:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+  MOCK_LOG="$LOG" \
+  MOCK_REQUIREMENT='identifier "com.wrong"' \
+  "$ROOT/scripts/verify-macos-release.sh" "$TEST_DIR/release.tar.gz" arm64 0.21.6 >/dev/null 2>&1; then
+  fail "verifier accepted the wrong embedded requirement"
+fi
+
+echo "macOS release contract tests passed"

--- a/scripts/verify-macos-release.sh
+++ b/scripts/verify-macos-release.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCHIVE=${1:-}
+EXPECTED_ARCH=${2:-}
+EXPECTED_VERSION=${3:-}
+IDENTIFIER=com.steipete.summarize.cli
+TEAM_ID=Y5PE65HELJ
+EXPECTED_AUTHORITY="Developer ID Application: Peter Steinberger ($TEAM_ID)"
+REQUIREMENT="identifier \"$IDENTIFIER\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = \"$TEAM_ID\""
+
+if [[ ! -f "$ARCHIVE" || ! "$EXPECTED_ARCH" =~ ^(arm64|x86_64)$ ||
+  ! "$EXPECTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "usage: $0 archive.tar.gz arm64|x86_64 version" >&2
+  exit 2
+fi
+[[ "$(uname -s)" == Darwin ]] || {
+  echo "macOS release verification requires a native macOS host" >&2
+  exit 1
+}
+for secret_name in MACOS_SIGNING_P12 MACOS_SIGNING_P12_PASSWORD ASC_KEY_ID ASC_ISSUER_ID ASC_PRIVATE_KEY_P8 CODESIGN_IDENTITY CODESIGN_KEYCHAIN ASC_PRIVATE_KEY_PATH; do
+  [[ -z "${!secret_name+x}" ]] || {
+    echo "release verification must not receive signing secret $secret_name" >&2
+    exit 1
+  }
+done
+for tool in codesign csreq lipo mktemp plutil tar; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "missing required command: $tool" >&2
+    exit 1
+  }
+done
+
+WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/summarize-verify.XXXXXX")
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+entries=$(tar -tzf "$ARCHIVE")
+grep -Fxq summarize <<<"$entries" || {
+  echo "release archive does not contain summarize at its root" >&2
+  exit 1
+}
+if grep -Eq '(^/|(^|/)\.\.(/|$))' <<<"$entries"; then
+  echo "release archive contains an unsafe path" >&2
+  exit 1
+fi
+if tar -tvzf "$ARCHIVE" | awk '$1 !~ /^[-d]/ { exit 1 }'; then
+  :
+else
+  echo "release archive contains a link or unsupported entry type" >&2
+  exit 1
+fi
+tar -xzf "$ARCHIVE" -C "$WORK_DIR"
+BINARY="$WORK_DIR/summarize"
+[[ -f "$BINARY" && ! -L "$BINARY" && -x "$BINARY" ]] || {
+  echo "release archive summarize is not a regular executable" >&2
+  exit 1
+}
+
+actual_arch=$(lipo -archs "$BINARY" | tr -d '[:space:]')
+[[ "$actual_arch" == "$EXPECTED_ARCH" ]] || {
+  echo "release binary architecture is $actual_arch, expected $EXPECTED_ARCH" >&2
+  exit 1
+}
+
+signature=$(codesign -dvvv "$BINARY" 2>&1)
+grep -Fqx "Identifier=$IDENTIFIER" <<<"$signature"
+grep -Fqx "Authority=$EXPECTED_AUTHORITY" <<<"$signature"
+grep -Fqx "TeamIdentifier=$TEAM_ID" <<<"$signature"
+grep -Eq '^CodeDirectory .*flags=.*\([^)]*runtime[^)]*\)' <<<"$signature"
+grep -Eq '^Timestamp=.+$' <<<"$signature"
+
+embedded_requirement=$(codesign -d -r- "$BINARY" 2>&1)
+embedded_source=$(sed -n 's/^designated => //p' <<<"$embedded_requirement")
+[[ -n "$embedded_source" && "$embedded_source" != *$'\n'* ]] || {
+  echo "release binary does not contain exactly one designated requirement" >&2
+  exit 1
+}
+expected_canonical=$(csreq -r "=$REQUIREMENT" -t)
+embedded_canonical=$(csreq -r "=$embedded_source" -t)
+[[ "$embedded_canonical" == "$expected_canonical" ]] || {
+  echo "release binary designated requirement does not match policy" >&2
+  exit 1
+}
+codesign --verify --strict -R="$REQUIREMENT" --verbose=2 "$BINARY"
+codesign --verify --strict --check-notarization -R=notarized --verbose=2 "$BINARY"
+
+embedded_entitlements="$WORK_DIR/embedded-entitlements.plist"
+codesign -d --entitlements :- "$BINARY" >"$embedded_entitlements" 2>/dev/null
+plutil -lint "$embedded_entitlements" >/dev/null
+node - "$embedded_entitlements" <<'NODE'
+const { execFileSync } = require("node:child_process");
+const file = process.argv[2];
+const json = execFileSync("plutil", ["-convert", "json", "-o", "-", file], {
+  encoding: "utf8",
+});
+const entitlements = JSON.parse(json);
+const expected = [
+  "com.apple.security.cs.allow-jit",
+  "com.apple.security.cs.allow-unsigned-executable-memory",
+];
+const actual = Object.keys(entitlements).sort();
+if (
+  JSON.stringify(actual) !== JSON.stringify(expected) ||
+  expected.some((key) => entitlements[key] !== true)
+) {
+  throw new Error(`unexpected embedded entitlements: ${actual.join(", ")}`);
+}
+NODE
+
+version_output=$(env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin "$BINARY" --version)
+if [[ "$version_output" != "$EXPECTED_VERSION" &&
+  ! "$version_output" =~ ^${EXPECTED_VERSION//./\.}[[:space:]]+\([0-9a-f]{8}\)$ ]]; then
+  echo "release binary reports $version_output, expected $EXPECTED_VERSION" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add a tag-triggered release workflow that freezes the validated commit, imports the personal Developer ID into an ephemeral keychain, signs and notarizes both Bun macOS executables, and packages the browser extensions
- verify checksums, exact signer/team/identifier, hardened runtime, timestamp, designated requirement, Bun entitlements, notarization, architecture, and native execution on credential-free arm64 and Intel jobs before publication
- make CI the sole GitHub Release publisher, preserve prerelease semantics, re-check the tag-to-commit binding immediately before publication, and document the new release contract

## Artifact audit

- the v0.21.6 arm64 and x64 release tarballs each contain one Mach-O executable; both current binaries fail strict signature validation
- the Chrome and Firefox archives contain no Mach-O files
- the npm CLI/core packages contain JavaScript/WASM rather than Mach-O files

## Proof

- `actionlint .github/workflows/release.yml .github/workflows/ci.yml`
- `scripts/test-macos-release.sh`
- `bash -n scripts/codesign-macos.sh scripts/verify-macos-release.sh scripts/test-macos-release.sh scripts/release.sh`
- `pnpm -s format:check`
- real local Bun build/smoke for arm64 and x64, including version/help, HTTP, FFmpeg WASM ffprobe, and slide extraction
- structured pre-commit review: clean after release-integrity fixes

No tag or release is created by this PR.
