### PR TITLE
fix(chrome): restore persisted options tabs safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Release pipeline: sign the Bun macOS executables with the personal Developer ID, notarize them with Apple, verify both architectures without signing credentials, and publish only the verified artifacts.
 - Dependencies: refresh the policy-eligible CLI, browser-media, test, formatting, and lint toolchain, including patched protobufjs and sharp transitive releases.
+- Chrome extension: restore persisted Logs and Processes tabs without aborting options-page startup (#370, #371; thanks @ostehost).
 
 ## 0.21.6 - 2026-07-18
 

--- a/apps/chrome-extension/src/entrypoints/options/main.ts
+++ b/apps/chrome-extension/src/entrypoints/options/main.ts
@@ -20,7 +20,7 @@ import {
   createAutomationPermissionsController,
   createStatusController,
 } from "./support";
-import { createOptionsTabs } from "./tab-controller";
+import { createOptionsTabs, resolveActiveOptionsTab } from "./tab-controller";
 
 declare const __SUMMARIZE_GIT_HASH__: string;
 declare const __SUMMARIZE_VERSION__: string;
@@ -106,6 +106,8 @@ const {
   tabPanels,
   logsLevelInputs,
 } = getOptionsElements();
+
+const resolveActiveTab = () => resolveActiveOptionsTab(tabButtons);
 
 let isInitializing = true;
 const { setStatus, flashStatus } = createStatusController(statusEl);
@@ -197,7 +199,7 @@ const processesViewer = createProcessesViewer({
 
 let refreshBrowserCacheStatus = () => {};
 
-const { resolveActiveTab } = createOptionsTabs({
+createOptionsTabs({
   root: tabsRoot,
   buttons: tabButtons,
   panels: tabPanels,

--- a/apps/chrome-extension/src/entrypoints/options/tab-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/options/tab-controller.ts
@@ -22,6 +22,11 @@ function clearRequestedTab(tabIds: Set<string>) {
   window.history.replaceState(window.history.state, "", `${url.pathname}${url.search}${url.hash}`);
 }
 
+export function resolveActiveOptionsTab(buttons: readonly HTMLButtonElement[]): string | null {
+  const active = buttons.find((button) => button.getAttribute("aria-selected") === "true");
+  return active?.dataset.tab ?? null;
+}
+
 export function createOptionsTabs({
   root,
   buttons,
@@ -46,10 +51,7 @@ export function createOptionsTabs({
   const requestedTab = getRequestedTab(tabIds);
   let consumedRequestedTab = requestedTab;
 
-  const resolveActiveTab = (): string | null => {
-    const active = buttons.find((button) => button.getAttribute("aria-selected") === "true");
-    return active?.dataset.tab ?? null;
-  };
+  const resolveActiveTab = () => resolveActiveOptionsTab(buttons);
 
   const setActiveTab = (tabId: string, options: { initial?: boolean } = {}) => {
     if (!tabIds.has(tabId)) return;

--- a/apps/chrome-extension/tests/options.spec.ts
+++ b/apps/chrome-extension/tests/options.spec.ts
@@ -73,6 +73,26 @@ test("options restores the active tab from browser local storage", async ({
   }
 });
 
+test("options restores the Logs tab without aborting startup", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+
+  try {
+    const page = await openExtensionPage(harness, "options.html", "#tabs");
+    await page.click("#tab-logs");
+    await expect(page.locator("#panel-logs")).toBeVisible();
+
+    await page.reload();
+    await expect(page.locator("#tab-logs")).toHaveAttribute("aria-selected", "true");
+    await expect(page.locator("#panel-logs")).toBeVisible();
+
+    assertNoErrors(harness);
+  } finally {
+    await closeExtension(harness.context, harness.userDataDir);
+  }
+});
+
 test("options themes password and URL fields like the provider control", async ({
   browserName: _browserName,
 }, testInfo) => {

--- a/tests/options.tab-controller.test.ts
+++ b/tests/options.tab-controller.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createOptionsTabs } from "../apps/chrome-extension/src/entrypoints/options/tab-controller.js";
+import {
+  createOptionsTabs,
+  resolveActiveOptionsTab,
+} from "../apps/chrome-extension/src/entrypoints/options/tab-controller.js";
 
 const storageKey = "summarize:options-tab";
 
@@ -91,6 +94,22 @@ describe("options tab controller", () => {
     storage.setItem(storageKey, "logs");
     window.history.replaceState(null, "", "/options.html?tab=missing");
     const harness = createHarness();
+
+    const tabs = createOptionsTabs({
+      ...harness,
+      storageKey,
+    });
+
+    expect(tabs.resolveActiveTab()).toBe("logs");
+    expect(harness.onLogsActiveChange).toHaveBeenCalledWith(true);
+  });
+
+  it("lets initial callbacks resolve the active tab during controller creation", () => {
+    storage.setItem(storageKey, "logs");
+    const harness = createHarness();
+    harness.onLogsActiveChange.mockImplementation((active) => {
+      if (active) expect(resolveActiveOptionsTab(harness.buttons)).toBe("logs");
+    });
 
     const tabs = createOptionsTabs({
       ...harness,


### PR DESCRIPTION
Fixes #370.

## Problem

Restoring a persisted Logs or Processes tab invoked its activation callback while `main.ts` was still assigning the controller returned by `createOptionsTabs`. The viewer then called the not-yet-assigned `resolveActiveTab`, aborting options-page startup and leaving misleading daemon state behind.

## Fix

Keep the tab controller's synchronous activation contract, but expose its DOM-backed active-tab resolver independently. The options entrypoint now creates that resolver before the Logs and Processes viewers, so initial callbacks can safely query the selected tab without depending on the factory's return assignment.

The rewrite also adds controller-level coverage for resolving the active tab during initial callbacks and a built-extension regression that persists Logs, reloads, verifies the restored tab and panel, and checks for page or console errors.

## Proof

- `pnpm -s exec vitest run tests/options.tab-controller.test.ts --reporter=verbose` — 4/4 passed.
- Focused built-extension Runtime and Logs persistence tests — 2/2 passed.
- `pnpm -s check` — 2,994 passed, 43 skipped.
- `pnpm -C apps/chrome-extension test:chrome` — native-host E2E passed; full suite 113 passed, 5 intentional live skips.
- `pnpm -C apps/chrome-extension test:firefox` — Firefox build and smoke passed.
- Codex autoreview — clean, no accepted/actionable findings.

Existing-profile Chrome attachment remained unavailable because this session received `EPERM` reading Chrome's profile state. The repository's supported built-extension browser tests provide the runtime proof above.

Thanks @ostehost for the precise report, reproduction, and root-cause analysis.
