### PR TITLE
fix: recover stale native messaging workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.21.8 - Unreleased
 
+### Fixes
+
+- Chrome extension: reload stale service workers after granting Native Messaging so daemon requests recover on retry (#372, thanks @materemias).
+
 ## 0.21.7 - 2026-07-27
 
 ### Highlights

--- a/apps/chrome-extension/src/lib/daemon-fetch.ts
+++ b/apps/chrome-extension/src/lib/daemon-fetch.ts
@@ -21,6 +21,22 @@ type NativeResponseMessage =
   | { type: "end" }
   | { type: "error"; message: string };
 
+type NativeMessagingRuntime = {
+  connectNative?: typeof chrome.runtime.connectNative;
+  reload: typeof chrome.runtime.reload;
+};
+
+export function connectNativeOrReload(
+  runtime: NativeMessagingRuntime,
+  hostName: string,
+): chrome.runtime.Port {
+  if (typeof runtime.connectNative !== "function") {
+    runtime.reload();
+    throw new Error("Local companion enabled — extension reloaded; reopen it and retry");
+  }
+  return runtime.connectNative(hostName);
+}
+
 function bytesToBase64(bytes: Uint8Array): string {
   let binary = "";
   const chunkSize = 32_768;
@@ -184,7 +200,7 @@ export async function daemonFetch(input: RequestInfo | URL, init?: RequestInit):
     const permitted = await chrome.permissions.contains({ permissions: ["nativeMessaging"] });
     if (!permitted) throw new Error("Local companion permission is not enabled");
     return await nativeDaemonFetch(input, init, () =>
-      chrome.runtime.connectNative(NATIVE_MESSAGING_HOST_NAME),
+      connectNativeOrReload(chrome.runtime, NATIVE_MESSAGING_HOST_NAME),
     );
   }
   return await nativeDaemonFetch(input, init);
@@ -238,7 +254,7 @@ export function bindNativeDaemonBridge(): void {
           return;
         }
         try {
-          nativePort = chrome.runtime.connectNative(NATIVE_MESSAGING_HOST_NAME);
+          nativePort = connectNativeOrReload(chrome.runtime, NATIVE_MESSAGING_HOST_NAME);
         } catch (error) {
           sendError(error instanceof Error ? error.message : String(error));
           return;

--- a/tests/daemon-fetch.test.ts
+++ b/tests/daemon-fetch.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  connectNativeOrReload,
+  NATIVE_MESSAGING_HOST_NAME,
+} from "../apps/chrome-extension/src/lib/daemon-fetch";
+
+describe("connectNativeOrReload", () => {
+  it("reloads a stale extension context and asks the caller to retry", () => {
+    const reload = vi.fn();
+
+    expect(() =>
+      connectNativeOrReload({ connectNative: undefined, reload }, NATIVE_MESSAGING_HOST_NAME),
+    ).toThrow("Local companion enabled — extension reloaded; reopen it and retry");
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("opens the native host when the API is available", () => {
+    const port = {} as chrome.runtime.Port;
+    const connectNative = vi.fn(() => port);
+    const reload = vi.fn();
+
+    expect(connectNativeOrReload({ connectNative, reload }, NATIVE_MESSAGING_HOST_NAME)).toBe(port);
+    expect(connectNative).toHaveBeenCalledWith(NATIVE_MESSAGING_HOST_NAME);
+    expect(reload).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- guard both Chrome Native Messaging connection paths when an already-running worker lacks `chrome.runtime.connectNative`
- reload the stale extension context and return an actionable reopen-and-retry error
- cover both the stale recovery and normal connection branches

Fixes #372.

## Proof

- `vitest run tests/daemon-fetch.test.ts`: 2 passed
- `pnpm typecheck`: passed
- `pnpm format:check`: passed across 1,333 files
- `pnpm lint`: passed
- `pnpm -C apps/chrome-extension build`: production Chrome MV3 build passed
- Native Messaging Playwright E2E: 1 passed; real installed native host served status, models, summary request, and streamed response
- Source-blind built-artifact stale-worker probe: began with callable `connectNative`, forced it unavailable, observed one reload and `Local companion enabled — extension reloaded; reopen it and retry`
- `autoreview --mode local`: clean, no accepted/actionable findings
