### PR TITLE
fix: improve summary Markdown structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.21.9 - Unreleased
 
+### Fixes
+
+- Summaries: structure multi-point pages and discussion threads as scannable Markdown blocks instead of dense prose.
+
 ### Documentation
 
 - Rewrite the README as a concise front door to the CLI, browser extension, and task-focused guides.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -80,7 +80,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
 - `--model <preset>`
   - Uses a built-in or config-defined preset (see `docs/config.md` → “Presets”).
 - `--prompt <text>` / `--prompt-file <path>`
-  - Overrides the built-in summary instructions (prompt becomes the instruction prefix).
+  - Replaces the built-in summary instructions, including the default structure and formatting guidance.
   - Prompts are wrapped in `<instructions>`, `<context>`, `<content>` tags.
   - When `--length` is numeric, we add `Output is X characters.` When `--language` is explicitly set, we add `Output should be <language>.`
 - `--no-cache`
@@ -96,7 +96,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
   - Minimum numeric value: 50 chars.
   - Built-in default: `long`.
   - Config default: `output.length` in `~/.summarize/config.json`.
-  - Output format is Markdown; use short paragraphs and only add bullets when they improve scanability.
+  - Output format is Markdown. Default URL summaries separate paragraphs, headings, and lists with blank lines; multi-point material uses descriptive headings or short bullets when they improve scanability.
 - `--force-summary`
   - Always run the LLM even when extracted content is shorter than the requested length.
 - `--max-output-tokens <count>`
@@ -117,6 +117,8 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
 
 ## Prompt rules
 
+- Default URL summaries lead with a concise overview and organize multi-point material by theme, chronology, or viewpoint. Short or simple sources stay compact instead of forcing headings or lists.
+- Discussion and comment threads are synthesized around the main viewpoints, agreement, disagreement, evidence, and caveats rather than recapped comment by comment.
 - Video and podcast summaries omit sponsor/ads/promotional segments; do not include them in the summary.
 - Do not mention or acknowledge sponsors/ads, and do not say you skipped or ignored anything.
 - If a standout line is present, include 1-2 short exact excerpts formatted as Markdown italics with single asterisks. Do not use quotation marks of any kind (straight or curly). If a title or excerpt would normally use quotes, remove them and optionally italicize the text instead. Apostrophes in contractions are OK. Never include ad/sponsor/boilerplate excerpts and do not mention them. Avoid sponsor/ad/promo language, brand names like Squarespace, or CTA phrases like discount code.

--- a/packages/core/src/prompts/link-summary.ts
+++ b/packages/core/src/prompts/link-summary.ts
@@ -102,8 +102,8 @@ export function buildLinkSummaryPrompt({
   const contextHeader = contextLines.join("\n");
 
   const audienceLine = hasTranscript
-    ? "You summarize online videos for curious Twitter users who want to know whether the clip is worth watching."
-    : "You summarize online articles for curious Twitter users who want the gist before deciding to dive in.";
+    ? "You summarize online videos and transcripts for curious readers who want the key ideas before deciding whether to watch."
+    : "You summarize web pages, including articles, posts, and discussion threads, for curious readers who want the gist before deciding to dive in.";
 
   const effectiveSummaryLength: SummaryLengthTarget =
     typeof summaryLength === "string"
@@ -202,8 +202,18 @@ export function buildLinkSummaryPrompt({
           `Required markers (use each exactly once, in order): ${slideMarkers}`,
         ].join("\n")
       : "";
-  const listGuidanceLine =
-    "Use short paragraphs; use bullet lists only when they improve scanability; avoid rigid templates.";
+  const sourceStructureInstruction =
+    slides && slides.count > 0
+      ? ""
+      : "Adapt the structure to the source. For an article or transcript, lead with the central claim or takeaway and group supporting details by theme or chronology. For a discussion or comment thread, synthesize the main viewpoints and, when present, areas of agreement, disagreement, evidence, and caveats. Do not recap comments one by one or organize the summary around usernames.";
+  const structureGuidanceLine =
+    slides && slides.count > 0
+      ? ""
+      : 'Make multi-point summaries easy to scan. Lead with a concise overview, then separate distinct themes or viewpoints with descriptive Markdown headings using the "### " prefix and/or short bullet lists. Keep paragraphs short and never put a multi-point summary in one uninterrupted paragraph. For a short or simple source, do not force headings or lists.';
+  const markdownSpacingInstruction =
+    slides && slides.count > 0
+      ? "Keep the response compact by avoiding blank lines between sentences or list items; use only the single newlines required by the formatting instructions."
+      : "Use one blank line between Markdown blocks such as paragraphs, headings, and lists. Keep list items on consecutive lines with no blank lines between them.";
   const quoteGuidanceLine =
     "Include 1-2 short exact excerpts (max 25 words each) formatted as Markdown italics using single asterisks when there is a strong, non-sponsor line. Use straight quotation marks (no curly) as needed. If no suitable line exists, omit excerpts. Never include ad/sponsor/boilerplate excerpts and do not mention them.";
   const sponsorInstruction =
@@ -216,7 +226,7 @@ export function buildLinkSummaryPrompt({
           sponsorInstruction,
           formattingLine,
           headingInstruction,
-          "Keep the response compact by avoiding blank lines between sentences or list items; use only the single newlines required by the formatting instructions.",
+          markdownSpacingInstruction,
           "Do not use emojis, disclaimers, or speculation.",
           "Write in direct, factual language.",
           "Format the answer in Markdown.",
@@ -230,6 +240,7 @@ export function buildLinkSummaryPrompt({
     "Hard rules: never mention sponsor/ads; use straight quotation marks only (no curly quotes).",
     "Apostrophes in contractions are OK.",
     audienceLine,
+    sourceStructureInstruction,
     sponsorInstruction,
     directive.guidance,
     formattingLine,
@@ -238,11 +249,11 @@ export function buildLinkSummaryPrompt({
     maxCharactersLine,
     contentLengthLine,
     formatOutputLanguageInstruction(outputLanguage ?? { kind: "auto" }),
-    "Keep the response compact by avoiding blank lines between sentences or list items; use only the single newlines required by the formatting instructions.",
+    markdownSpacingInstruction,
     "Do not use emojis, disclaimers, or speculation.",
     "Write in direct, factual language.",
     "Format the answer in Markdown and obey the length-specific formatting above.",
-    listGuidanceLine,
+    structureGuidanceLine,
     quoteGuidanceLine,
     "Base everything strictly on the provided content and never invent details.",
     "Final check: remove any sponsor/ad references or mentions of skipping/ignoring content. Ensure excerpts (if any) are italicized and use only straight quotes.",

--- a/tests/prompts.link-summary.more-branches.test.ts
+++ b/tests/prompts.link-summary.more-branches.test.ts
@@ -75,7 +75,7 @@ describe("prompts/link-summary - more branches", () => {
       shares: [],
     });
     expect(prompt).toContain("You are not given any quotes");
-    expect(prompt).toContain("online articles");
+    expect(prompt).toContain("web pages");
   });
 
   it("respects explicit maxCharacters when below content length", () => {

--- a/tests/prompts.link-summary.slides.test.ts
+++ b/tests/prompts.link-summary.slides.test.ts
@@ -29,6 +29,10 @@ describe("buildLinkSummaryPrompt (slides)", () => {
     expect(prompt).toContain('add exactly "## Interlude" with no body');
     expect(prompt).not.toContain("leave that slide marker with no text");
     expect(prompt).toContain("Do not create a dedicated Slides section or list");
+    expect(prompt).toContain("Keep the response compact by avoiding blank lines");
+    expect(prompt).not.toContain("For a discussion or comment thread");
+    expect(prompt).not.toContain("Make multi-point summaries easy to scan");
+    expect(prompt).not.toContain("Use one blank line between Markdown blocks");
     expect(prompt).not.toContain("Include at least 3 headings");
   });
 });

--- a/tests/prompts.link-summary.test.ts
+++ b/tests/prompts.link-summary.test.ts
@@ -33,6 +33,42 @@ describe("buildLinkSummaryPrompt", () => {
     expect(prompt).not.toContain("Tweets from sharers:");
   });
 
+  it("adds source-aware, scannable Markdown guidance", () => {
+    const prompt = buildLinkSummaryPrompt({
+      url: "https://news.ycombinator.com/item?id=123",
+      title: "Discussion",
+      siteName: "Hacker News",
+      description: null,
+      content: "Article and comments",
+      truncated: false,
+      hasTranscript: false,
+      outputLanguage: { kind: "fixed", tag: "en", label: "English" },
+      summaryLength: "long",
+      shares: [],
+    });
+
+    expect(prompt).toContain(
+      "You summarize web pages, including articles, posts, and discussion threads",
+    );
+    expect(prompt).toContain("For an article or transcript, lead with the central claim");
+    expect(prompt).toContain("For a discussion or comment thread, synthesize the main viewpoints");
+    expect(prompt).toContain("areas of agreement, disagreement, evidence, and caveats");
+    expect(prompt).toContain(
+      "Do not recap comments one by one or organize the summary around usernames",
+    );
+    expect(prompt).toContain("Lead with a concise overview");
+    expect(prompt).toContain(
+      'descriptive Markdown headings using the "### " prefix and/or short bullet lists',
+    );
+    expect(prompt).toContain("never put a multi-point summary in one uninterrupted paragraph");
+    expect(prompt).toContain("For a short or simple source, do not force headings or lists");
+    expect(prompt).toContain("Use one blank line between Markdown blocks");
+    expect(prompt).toContain(
+      "Keep list items on consecutive lines with no blank lines between them",
+    );
+    expect(prompt).not.toContain("Keep the response compact by avoiding blank lines");
+  });
+
   it("adds a soft target when summary length is specified in characters", () => {
     const prompt = buildLinkSummaryPrompt({
       url: "https://example.com",
@@ -85,9 +121,7 @@ describe("buildLinkSummaryPrompt", () => {
     );
     expect(prompt).toContain('append a brief subsection titled "What sharers are saying"');
     expect(prompt).toContain("Use 2-5 short paragraphs.");
-    expect(prompt).toContain(
-      "Use short paragraphs; use bullet lists only when they improve scanability; avoid rigid templates.",
-    );
+    expect(prompt).toContain("Make multi-point summaries easy to scan");
   });
 
   it("keeps token map stable", () => {

--- a/tests/prompts.override.test.ts
+++ b/tests/prompts.override.test.ts
@@ -32,7 +32,10 @@ describe("prompt overrides", () => {
     expect(prompt).toContain("Source URL: https://example.com");
     expect(prompt).toContain("<content>");
     expect(prompt).toContain("Body");
-    expect(prompt).not.toContain("You summarize online articles");
+    expect(prompt).not.toContain("You summarize web pages");
+    expect(prompt).not.toContain("For a discussion or comment thread");
+    expect(prompt).not.toContain("Make multi-point summaries easy to scan");
+    expect(prompt).not.toContain("Use one blank line between Markdown blocks");
   });
 
   it("replaces file-text instructions and keeps inline content", () => {
@@ -144,10 +147,13 @@ describe("prompt overrides", () => {
     );
     expect(prompt).toContain('Every slide must include a headline line that starts with "## ".');
     expect(prompt).toContain('add exactly "## Interlude" with no body');
+    expect(prompt).toContain("Keep the response compact by avoiding blank lines");
     expect(prompt).toContain(
       'Final check for slides: every [slide:N] must be immediately followed by a line that starts with "## ".',
     );
-    expect(prompt).not.toContain("You summarize online videos");
+    expect(prompt).not.toContain("You summarize online videos and transcripts");
+    expect(prompt).not.toContain("For a discussion or comment thread");
+    expect(prompt).not.toContain("Use one blank line between Markdown blocks");
   });
 
   it("escapes untrusted content and context inside prompt tags", () => {


### PR DESCRIPTION
## Summary

- make default URL summaries use real Markdown block spacing instead of collapsing dense prose
- organize multi-point pages by theme, chronology, or viewpoint, with source-aware guidance for discussion threads
- preserve compact short summaries, custom prompt replacement, timestamp sections, and strict slide formatting

## Root cause

The shared prompt told models to avoid blank lines, while the Chrome side panel renders Markdown with soft line breaks disabled. Long discussion summaries could therefore collapse into a wall of text even when the model attempted light formatting.

This stays prompt-only and cross-provider: no renderer workaround, content-type protocol, or structured-output schema.

## Verification

- `pnpm exec vitest run tests/prompts.link-summary.test.ts tests/prompts.link-summary.more-branches.test.ts tests/prompts.link-summary.slides.test.ts tests/prompts.override.test.ts tests/prompts.file.test.ts tests/prompts.cli.test.ts`
- `pnpm -s check`
- `pnpm -s build`
- `pnpm -s docs:build`
- live Chrome side-panel run on the reported Hacker News thread with `cli/codex/gpt-5.6-sol`; the revised prompt produced descriptive sections and separated blocks
- short Wikipedia smoke test remained two compact paragraphs without forced headings
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings

Live proof used the same Hacker News thread and model before and after the prompt change: the baseline rendered as dense prose, while the revised prompt produced descriptive sections and separated Markdown blocks.
