### PR TITLE
fix(extension): restore Chrome side-panel slide capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,8 @@ jobs:
       - name: Extension E2E (Chromium)
         run: |
           xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
-            pnpm -C apps/chrome-extension exec playwright test -c playwright.config.ts --project=chromium tests/native-messaging.e2e.spec.ts
+            pnpm -C apps/chrome-extension exec playwright test -c playwright.config.ts --project=chromium \
+              tests/native-messaging.e2e.spec.ts tests/sidepanel.browser-slides.spec.ts
           SUMMARIZE_E2E_HTTP_TRANSPORT=1 pnpm -C apps/chrome-extension build
           xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
             env SUMMARIZE_E2E_HTTP_TRANSPORT=1 pnpm -C apps/chrome-extension exec playwright test -c playwright.config.ts --project=chromium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Chrome extension: restore Video + Slides capture from toolbar-opened side panels by granting production builds the visible-tab access Chrome requires.
 - Summaries: structure multi-point pages and discussion threads as scannable Markdown blocks instead of dense prose.
 
 ### Documentation

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -13,7 +13,7 @@
     "dev:firefox": "BROWSER=firefox wxt dev",
     "lint": "oxlint --type-aware --tsconfig tsconfig.json --config ../../.oxlintrc.json .",
     "test": "pnpm test:e2e",
-    "test:chrome": "env -u NO_COLOR pnpm build && env -u NO_COLOR playwright test -c playwright.config.ts --project=chromium tests/native-messaging.e2e.spec.ts && env -u NO_COLOR SUMMARIZE_E2E_HTTP_TRANSPORT=1 pnpm build && env -u NO_COLOR SUMMARIZE_E2E_HTTP_TRANSPORT=1 playwright test -c playwright.config.ts --project=chromium",
+    "test:chrome": "env -u NO_COLOR pnpm build && env -u NO_COLOR playwright test -c playwright.config.ts --project=chromium tests/native-messaging.e2e.spec.ts tests/sidepanel.browser-slides.spec.ts && env -u NO_COLOR SUMMARIZE_E2E_HTTP_TRANSPORT=1 pnpm build && env -u NO_COLOR SUMMARIZE_E2E_HTTP_TRANSPORT=1 playwright test -c playwright.config.ts --project=chromium",
     "test:e2e": "pnpm test:chrome",
     "test:firefox": "env -u NO_COLOR pnpm build:firefox && env -u NO_COLOR node scripts/firefox-smoke.mjs",
     "test:firefox:force": "env -u NO_COLOR ALLOW_FIREFOX_EXTENSION_TESTS=1 pnpm build:firefox && env -u NO_COLOR ALLOW_FIREFOX_EXTENSION_TESTS=1 playwright test -c playwright.config.ts --project=firefox",

--- a/apps/chrome-extension/tests/extension.spec.ts
+++ b/apps/chrome-extension/tests/extension.spec.ts
@@ -90,7 +90,7 @@ test("manifest excludes Meta sites and the local companion from always-on conten
   }
 });
 
-test("Chromium manifest scopes broad host access to the HTTP E2E build", () => {
+test("Chromium manifest grants visible-tab capture and keeps companion access optional", () => {
   const manifestPath = path.resolve(__dirname, "..", ".output", "chrome-mv3", "manifest.json");
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
     host_permissions?: string[];
@@ -102,11 +102,7 @@ test("Chromium manifest scopes broad host access to the HTTP E2E build", () => {
 
   expect(manifest.permissions ?? []).not.toContain("nativeMessaging");
   expect(manifest.optional_permissions ?? []).toContain("nativeMessaging");
-  if (process.env.SUMMARIZE_E2E_HTTP_TRANSPORT === "1") {
-    expect(manifest.host_permissions ?? []).toContain("<all_urls>");
-  } else {
-    expect(manifest.host_permissions ?? []).not.toContain("<all_urls>");
-  }
+  expect(manifest.host_permissions ?? []).toContain("<all_urls>");
   expect(manifest.host_permissions ?? []).toContain("http://127.0.0.1/*");
   expect(manifest.optional_host_permissions ?? []).toEqual([]);
   expect(manifest.storage?.managed_schema).toBe("managed-storage-schema.json");

--- a/apps/chrome-extension/tests/sidepanel.browser-slides.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.browser-slides.spec.ts
@@ -26,6 +26,10 @@ test("sidepanel captures local video slides through the visible-tab fallback", a
   browserName: _browserName,
 }, testInfo) => {
   test.setTimeout(90_000);
+  test.skip(
+    process.env.SUMMARIZE_E2E_HTTP_TRANSPORT === "1",
+    "Browser slide capture is validated against the production manifest.",
+  );
 
   if (testInfo.project.name === "firefox") {
     test.skip(true, "Browser slide capture is validated in Chromium.");

--- a/apps/chrome-extension/wxt.config.ts
+++ b/apps/chrome-extension/wxt.config.ts
@@ -6,18 +6,8 @@ import { resolveTransformersRuntimeAssets } from "./scripts/transformers-runtime
 const targetBrowser = process.env.BROWSER === "firefox" ? "firefox" : "chrome";
 const e2eHttpTransport = process.env.SUMMARIZE_E2E_HTTP_TRANSPORT === "1";
 
-export function resolveExtensionHostPermissions({
-  browser,
-  e2eHttpTransport: enableE2eHttpTransport,
-}: {
-  browser: "chrome" | "firefox";
-  e2eHttpTransport: boolean;
-}): string[] {
-  if (browser === "firefox" || enableE2eHttpTransport) {
-    return ["<all_urls>", "http://127.0.0.1/*"];
-  }
-  return ["https://*/*", "http://localhost/*", "http://127.0.0.1/*"];
-}
+// `captureVisibleTab()` needs literal `<all_urls>` because side-panel action toggles do not grant `activeTab`.
+const extensionHostPermissions = ["<all_urls>", "http://127.0.0.1/*"];
 
 const extensionVersion = (() => {
   try {
@@ -117,10 +107,7 @@ export default defineConfig({
       ],
       optional_permissions:
         browser === "firefox" ? ["userScripts"] : ["nativeMessaging", "userScripts"],
-      host_permissions: resolveExtensionHostPermissions({
-        browser,
-        e2eHttpTransport,
-      }),
+      host_permissions: extensionHostPermissions,
       ...(browser === "firefox"
         ? {}
         : {

--- a/tests/extension.firefox.manifest.test.ts
+++ b/tests/extension.firefox.manifest.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
-import extensionConfig, {
-  resolveExtensionHostPermissions,
-} from "../apps/chrome-extension/wxt.config.js";
+import extensionConfig from "../apps/chrome-extension/wxt.config.js";
 
 describe("firefox extension manifest", () => {
   it("uses Firefox-compatible permissions and metadata", () => {
@@ -67,15 +65,16 @@ describe("firefox extension manifest", () => {
     }
   });
 
-  it("grants broad capture permission only to Firefox and HTTP E2E builds", () => {
-    expect(
-      resolveExtensionHostPermissions({ browser: "chrome", e2eHttpTransport: false }),
-    ).not.toContain("<all_urls>");
-    expect(
-      resolveExtensionHostPermissions({ browser: "chrome", e2eHttpTransport: true }),
-    ).toContain("<all_urls>");
-    expect(
-      resolveExtensionHostPermissions({ browser: "firefox", e2eHttpTransport: false }),
-    ).toContain("<all_urls>");
+  it("grants visible-tab capture access in Chrome and Firefox builds", () => {
+    const manifestFactory = (extensionConfig as { manifest?: unknown }).manifest;
+    if (typeof manifestFactory !== "function") {
+      throw new Error("Missing manifest factory in WXT config");
+    }
+
+    const chromeManifest = manifestFactory({ browser: "chrome" }) as Record<string, unknown>;
+    const firefoxManifest = manifestFactory({ browser: "firefox" }) as Record<string, unknown>;
+
+    expect(chromeManifest.host_permissions).toEqual(["<all_urls>", "http://127.0.0.1/*"]);
+    expect(firefoxManifest.host_permissions).toEqual(["<all_urls>", "http://127.0.0.1/*"]);
   });
 });


### PR DESCRIPTION
## Summary

- restore literal `<all_urls>` host access in production Chrome extension builds so Browser-mode Video + Slides can call `captureVisibleTab()` from a persistent side panel
- remove the production/E2E permission mismatch that hid the regression
- run the visible-tab slide-capture E2E against the production manifest and lock the generated manifest contract

## Root cause

Chrome intentionally toggles an `openPanelOnActionClick` side panel without granting `activeTab`, and interactions inside the persistent panel do not create that grant. The slide fallback therefore reached `chrome.tabs.captureVisibleTab()` without either permission Chrome accepts: a live `activeTab` grant or literal `<all_urls>`.

Production Chrome had only `https://*/*`, while the HTTP E2E build received `<all_urls>`. The browser-slides E2E passed under the broader test manifest even though the shipped manifest failed.

## Permission impact

Production Chrome now uses the same `<all_urls>` host permission already used by Firefox and the HTTP E2E build. The extension's static content scripts already match `<all_urls>`; this change makes the host-permission contract explicit for visible-tab capture rather than relying on a transient side-panel grant Chrome does not provide.

## Verification

- `pnpm exec vitest run tests/extension.firefox.manifest.test.ts`
- production build with `SUMMARIZE_E2E_HTTP_TRANSPORT` unset
- production-build `tests/sidepanel.browser-slides.spec.ts`: 1 passed
- `pnpm -C apps/chrome-extension lint`
- `pnpm -C apps/chrome-extension test:chrome`: production permission-sensitive tests 2 passed; full suite 111 passed, 7 skipped
- `pnpm -C apps/chrome-extension test:firefox`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:coverage`: 3,001 passed, 43 skipped
- `pnpm -s build`
- tracked-file formatting and `git diff --check`
- source-blind behavior validation: all 5 contract clauses passed
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings
