### PR TITLE
fix(extension): stop cancelled native bridge setup

### DIFF
--- a/apps/chrome-extension/src/lib/daemon-fetch.ts
+++ b/apps/chrome-extension/src/lib/daemon-fetch.ts
@@ -212,10 +212,10 @@ export function bindNativeDaemonBridge(): void {
     if (clientPort.name !== DAEMON_BRIDGE_PORT_NAME) return;
     let nativePort: chrome.runtime.Port | null = null;
     let started = false;
-    let disconnected = false;
+    let stopped = false;
 
     const sendError = (message: string) => {
-      if (disconnected) return;
+      if (stopped) return;
       try {
         clientPort.postMessage({ type: "error", message });
       } catch {
@@ -236,19 +236,22 @@ export function bindNativeDaemonBridge(): void {
       if (!raw || typeof raw !== "object") return;
       const message = raw as NativeRequestMessage | { type?: string };
       if (message.type === "cancel") {
+        stopped = true;
         nativePort?.postMessage({ type: "cancel" });
         disconnectNative();
         return;
       }
-      if (message.type !== "request" || started) return;
+      if (message.type !== "request" || started || stopped) return;
       started = true;
       void (async () => {
         const policy = await readDaemonPolicy();
+        if (stopped) return;
         if (!policy.daemonAllowed) {
           sendError("Local companion disabled by administrator");
           return;
         }
         const permitted = await chrome.permissions.contains({ permissions: ["nativeMessaging"] });
+        if (stopped) return;
         if (!permitted) {
           sendError("Local companion permission is not enabled");
           return;
@@ -260,7 +263,7 @@ export function bindNativeDaemonBridge(): void {
           return;
         }
         nativePort.onMessage.addListener((nativeMessage: unknown) => {
-          if (disconnected) return;
+          if (stopped) return;
           try {
             clientPort.postMessage(nativeMessage);
           } catch {
@@ -276,7 +279,7 @@ export function bindNativeDaemonBridge(): void {
       })();
     });
     clientPort.onDisconnect.addListener(() => {
-      disconnected = true;
+      stopped = true;
       disconnectNative();
     });
   });

--- a/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
+++ b/apps/chrome-extension/tests/native-messaging.e2e.spec.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { chromium, expect, test } from "@playwright/test";
 import { NATIVE_MESSAGING_HOST_NAME } from "../../../src/daemon/constants.js";
 import { buildNativeMessagingManifest } from "../../../src/daemon/native-messaging-install.js";
+import { DAEMON_BRIDGE_PORT_NAME } from "../src/lib/daemon-fetch.js";
 import {
   activateTabByUrlInPanelWindow,
   buildUiState,
@@ -51,7 +52,10 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
-type NativeMessagingHarness = ExtensionHarness & { nativeManifestPaths: string[] };
+type NativeMessagingHarness = ExtensionHarness & {
+  nativeLaunchMarkerPath: string;
+  nativeManifestPaths: string[];
+};
 
 async function launchNativeMessagingHarness(port: number): Promise<NativeMessagingHarness> {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "summarize-native-home-"));
@@ -87,6 +91,7 @@ async function launchNativeMessagingHarness(port: number): Promise<NativeMessagi
   );
 
   const launcherPath = path.join(configDir, "native-host-e2e");
+  const nativeLaunchMarkerPath = path.join(configDir, "native-host-launches.log");
   const userDataDir = path.join(home, "profile");
   const registerPath = path.join(repoRoot, "scripts", "register-typescript.mjs");
   const cliPath = path.join(repoRoot, "src", "cli.ts");
@@ -104,7 +109,11 @@ async function launchNativeMessagingHarness(port: number): Promise<NativeMessagi
   ]
     .map(shellQuote)
     .join(" ");
-  fs.writeFileSync(launcherPath, `#!/bin/sh\nexec ${command} "$@"\n`, { mode: 0o700 });
+  fs.writeFileSync(
+    launcherPath,
+    `#!/bin/sh\nprintf 'launch\\n' >> ${shellQuote(nativeLaunchMarkerPath)}\nexec ${command} "$@"\n`,
+    { mode: 0o700 },
+  );
 
   const nativeManifestDirs = [path.join(userDataDir, "NativeMessagingHosts")];
   const nativeManifestPaths = nativeManifestDirs.map((directory) => {
@@ -136,9 +145,111 @@ async function launchNativeMessagingHarness(port: number): Promise<NativeMessagi
     consoleErrors: [],
     userDataDir: home,
     browser: "chromium",
+    nativeLaunchMarkerPath,
     nativeManifestPaths,
   };
 }
+
+test("disconnected bridge does not start the native host after delayed permission", async () => {
+  const seen: string[] = [];
+  const server = createServer((request, response) => {
+    seen.push(request.url ?? "/");
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ ok: true }));
+  });
+  const port = await listen(server);
+  const harness = await launchNativeMessagingHarness(port);
+
+  try {
+    await seedSettings(harness, {
+      token: "native-e2e-token",
+      daemonPort: String(port),
+      summaryRuntime: "daemon",
+    });
+    const background = harness.context.serviceWorkers()[0];
+    if (!background) throw new Error("Missing extension service worker");
+    await background.evaluate(() => {
+      const proof = globalThis as typeof globalThis & {
+        __summarizePermissionCompleted?: boolean;
+        __summarizePermissionReached?: boolean;
+        __summarizeReleasePermission?: () => void;
+      };
+      const contains = chrome.permissions.contains.bind(chrome.permissions);
+      chrome.permissions.contains = async (permissions) => {
+        if (permissions.permissions?.includes("nativeMessaging")) {
+          proof.__summarizePermissionReached = true;
+          await new Promise<void>((resolve) => {
+            proof.__summarizeReleasePermission = resolve;
+          });
+        }
+        const permitted = await contains(permissions);
+        proof.__summarizePermissionCompleted = true;
+        return permitted;
+      };
+    });
+
+    const extensionPage = await harness.context.newPage();
+    await extensionPage.goto(getExtensionUrl(harness, "offscreen.html"));
+    await extensionPage.evaluate(
+      ({ bridgeName, daemonPort }) => {
+        const bridge = chrome.runtime.connect({ name: bridgeName });
+        bridge.postMessage({
+          type: "request",
+          method: "GET",
+          path: "/health",
+          port: daemonPort,
+          headers: {},
+        });
+      },
+      { bridgeName: DAEMON_BRIDGE_PORT_NAME, daemonPort: port },
+    );
+    await expect
+      .poll(() =>
+        background.evaluate(() =>
+          Boolean(
+            (
+              globalThis as typeof globalThis & {
+                __summarizePermissionReached?: boolean;
+              }
+            ).__summarizePermissionReached,
+          ),
+        ),
+      )
+      .toBe(true);
+
+    await extensionPage.close();
+    await background.evaluate(() => {
+      (
+        globalThis as typeof globalThis & {
+          __summarizeReleasePermission?: () => void;
+        }
+      ).__summarizeReleasePermission?.();
+    });
+    await expect
+      .poll(() =>
+        background.evaluate(() =>
+          Boolean(
+            (
+              globalThis as typeof globalThis & {
+                __summarizePermissionCompleted?: boolean;
+              }
+            ).__summarizePermissionCompleted,
+          ),
+        ),
+      )
+      .toBe(true);
+    await background.evaluate(() => new Promise((resolve) => setTimeout(resolve, 500)));
+
+    expect(fs.existsSync(harness.nativeLaunchMarkerPath)).toBe(false);
+    expect(seen).toEqual([]);
+  } finally {
+    for (const manifestPath of harness.nativeManifestPaths) {
+      fs.rmSync(manifestPath, { force: true });
+    }
+    await closeExtension(harness.context, harness.userDataDir);
+    await closeServer(server);
+  }
+});
 
 test("installed native host carries status, models, and summary streaming end to end", async () => {
   const seen: Array<{ method: string; url: string; authorization?: string }> = [];

--- a/tests/daemon-fetch.test.ts
+++ b/tests/daemon-fetch.test.ts
@@ -1,8 +1,82 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { readDaemonPolicy } = vi.hoisted(() => ({
+  readDaemonPolicy: vi.fn(),
+}));
+
+vi.mock("../apps/chrome-extension/src/lib/daemon-policy", () => ({ readDaemonPolicy }));
+
 import {
+  bindNativeDaemonBridge,
   connectNativeOrReload,
+  DAEMON_BRIDGE_PORT_NAME,
   NATIVE_MESSAGING_HOST_NAME,
 } from "../apps/chrome-extension/src/lib/daemon-fetch";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function createEvent<TArgs extends unknown[]>() {
+  const listeners: Array<(...args: TArgs) => void> = [];
+  return {
+    addListener: vi.fn((listener: (...args: TArgs) => void) => listeners.push(listener)),
+    emit: (...args: TArgs) => {
+      for (const listener of listeners) listener(...args);
+    },
+  };
+}
+
+function createPort(name: string) {
+  const onMessage = createEvent<[unknown]>();
+  const onDisconnect = createEvent<[]>();
+  const postMessage = vi.fn();
+  const disconnect = vi.fn();
+  const port = {
+    name,
+    onMessage,
+    onDisconnect,
+    postMessage,
+    disconnect,
+  } as unknown as chrome.runtime.Port;
+  return { port, onMessage, onDisconnect, postMessage, disconnect };
+}
+
+function createBridgeHarness({
+  permission = vi.fn(async () => true),
+}: {
+  permission?: ReturnType<typeof vi.fn>;
+} = {}) {
+  const onConnect = createEvent<[chrome.runtime.Port]>();
+  const native = createPort("");
+  const connectNative = vi.fn(() => native.port);
+  const reload = vi.fn();
+  vi.stubEnv("BROWSER", "chrome");
+  vi.stubGlobal("chrome", {
+    permissions: { contains: permission },
+    runtime: { connectNative, lastError: undefined, onConnect, reload },
+  });
+  bindNativeDaemonBridge();
+
+  const client = createPort(DAEMON_BRIDGE_PORT_NAME);
+  onConnect.emit(client.port);
+  return { client, connectNative, native, permission };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
 
 describe("connectNativeOrReload", () => {
   it("reloads a stale extension context and asks the caller to retry", () => {
@@ -22,5 +96,70 @@ describe("connectNativeOrReload", () => {
     expect(connectNativeOrReload({ connectNative, reload }, NATIVE_MESSAGING_HOST_NAME)).toBe(port);
     expect(connectNative).toHaveBeenCalledWith(NATIVE_MESSAGING_HOST_NAME);
     expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe("bindNativeDaemonBridge", () => {
+  it("does not request permission after cancellation during the policy check", async () => {
+    const policy = deferred<{ daemonAllowed: boolean; managed: boolean }>();
+    readDaemonPolicy.mockReturnValueOnce(policy.promise);
+    const harness = createBridgeHarness();
+
+    harness.client.onMessage.emit({ type: "request" });
+    expect(readDaemonPolicy).toHaveBeenCalledOnce();
+    harness.client.onMessage.emit({ type: "cancel" });
+    policy.resolve({ daemonAllowed: true, managed: false });
+    await flushMicrotasks();
+
+    expect(harness.permission).not.toHaveBeenCalled();
+    expect(harness.connectNative).not.toHaveBeenCalled();
+  });
+
+  it("does not connect after cancellation during the permission check", async () => {
+    readDaemonPolicy.mockResolvedValueOnce({ daemonAllowed: true, managed: false });
+    const permission = deferred<boolean>();
+    const harness = createBridgeHarness({
+      permission: vi.fn(() => permission.promise),
+    });
+
+    harness.client.onMessage.emit({ type: "request" });
+    await vi.waitFor(() => expect(harness.permission).toHaveBeenCalledOnce());
+    harness.client.onMessage.emit({ type: "cancel" });
+    permission.resolve(true);
+    await flushMicrotasks();
+
+    expect(harness.connectNative).not.toHaveBeenCalled();
+    expect(harness.native.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not connect after the client disconnects during the permission check", async () => {
+    readDaemonPolicy.mockResolvedValueOnce({ daemonAllowed: true, managed: false });
+    const permission = deferred<boolean>();
+    const harness = createBridgeHarness({
+      permission: vi.fn(() => permission.promise),
+    });
+
+    harness.client.onMessage.emit({ type: "request" });
+    await vi.waitFor(() => expect(harness.permission).toHaveBeenCalledOnce());
+    harness.client.onDisconnect.emit();
+    permission.resolve(true);
+    await flushMicrotasks();
+
+    expect(harness.connectNative).not.toHaveBeenCalled();
+    expect(harness.native.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("forwards cancellation after the native host is connected", async () => {
+    readDaemonPolicy.mockResolvedValueOnce({ daemonAllowed: true, managed: false });
+    const harness = createBridgeHarness();
+    const request = { type: "request", method: "GET", path: "/health" };
+
+    harness.client.onMessage.emit(request);
+    await vi.waitFor(() => expect(harness.connectNative).toHaveBeenCalledOnce());
+    harness.client.onMessage.emit({ type: "cancel" });
+
+    expect(harness.native.postMessage).toHaveBeenNthCalledWith(1, request);
+    expect(harness.native.postMessage).toHaveBeenNthCalledWith(2, { type: "cancel" });
+    expect(harness.native.disconnect).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- make the Chrome native-daemon bridge terminal after an explicit cancellation or client disconnect
- stop cancelled requests from opening a native host after asynchronous policy or permission checks complete
- preserve cancellation forwarding and cleanup for an already-connected native host
- add deterministic coverage for cancellation at both preflight boundaries and after connection

## Root cause

The extension-page bridge performs managed-policy and `nativeMessaging` permission checks before opening the native host. If its client cancelled or disconnected while either promise was pending, the continuation did not consult that terminal state before connecting and forwarding the stale request.

## Real Chrome behavior proof

The production MV3 extension now has a persisted Playwright regression using real Chromium and a registered native-host launcher:

1. The service worker deliberately pauses the real `chrome.permissions.contains({ permissions: ["nativeMessaging"] })` preflight.
2. An extension page opens the real runtime bridge, sends a `/health` request, reaches the delayed preflight, and then closes.
3. The permission call is released and observed completing, followed by a 500 ms process-start grace interval.
4. The native-host launch marker remains absent and the local daemon observes zero requests.

Focused production-transport trace:

```text
✓ disconnected bridge does not start the native host after delayed permission
✓ installed native host carries status, models, and summary streaming end to end
✓ sidepanel captures local video slides through the visible-tab fallback
3 passed
```

## Validation

- `pnpm exec vitest run tests/daemon-fetch.test.ts` — 6 passed
- `pnpm -s check` — 553 test files passed, 3,005 tests passed
- `pnpm -C apps/chrome-extension test:chrome` — production native-messaging/slide E2E: 3 passed; Chromium suite: 111 passed, 8 skipped
