### PR TITLE
fix(security): route remote asset fetch through the SSRF network guard

### DIFF
--- a/src/application/url-routing.ts
+++ b/src/application/url-routing.ts
@@ -55,7 +55,7 @@ export async function resolveInitialUrlInput({
   const route = await resolveUrlAssetRoute({
     url: input.url,
     isYoutubeUrl,
-    fetchImpl: ctx.io.fetch,
+    fetchImpl: ctx.io.urlFetch ?? ctx.io.fetch,
     timeoutMs: ctx.flags.timeoutMs,
     detectUnknownAssetUrls: false,
   });
@@ -71,7 +71,7 @@ export async function resolveInitialUrlInput({
     emitLoading(input, emit);
     const acquired = await acquireRemoteAssetInput({
       url: input.url,
-      fetchImpl: ctx.io.fetch,
+      fetchImpl: ctx.io.urlFetch ?? ctx.io.fetch,
       timeoutMs: ctx.flags.timeoutMs,
     });
     if (acquired) {
@@ -119,7 +119,7 @@ export async function executeUrlWithAssetFallback({
     const fallbackRoute = await resolveUrlAssetRoute({
       url: rawUrlInput.url,
       isYoutubeUrl,
-      fetchImpl: ctx.io.fetch,
+      fetchImpl: ctx.io.urlFetch ?? ctx.io.fetch,
       timeoutMs: ctx.flags.timeoutMs,
       detectUnknownAssetUrls: true,
       assumeAsset: true,
@@ -135,7 +135,7 @@ export async function executeUrlWithAssetFallback({
     if (fallbackRoute === "asset" || (fallbackRoute === "video" && request.slides)) {
       const acquired = await acquireRemoteAssetInput({
         url: rawUrlInput.url,
-        fetchImpl: ctx.io.fetch,
+        fetchImpl: ctx.io.urlFetch ?? ctx.io.fetch,
         timeoutMs: ctx.flags.timeoutMs,
       });
       if (acquired) {

--- a/tests/application.url-routing.ssrf-guard.test.ts
+++ b/tests/application.url-routing.ssrf-guard.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AcquiredAssetExecutor } from "../src/application/asset-execution.js";
+import type {
+  SummarizeEventSink,
+  SummarizeRequest,
+} from "../src/application/summarize-contracts.js";
+import { resolveInitialUrlInput } from "../src/application/url-routing.js";
+import type { UrlFlowContext } from "../src/run/flows/url/types.js";
+
+// Regression guard for an SSRF-filter bypass: remote asset classification and
+// download must go through the SSRF-guarded `io.urlFetch` (the daemon's
+// network-guarded fetch that blocks private/link-local targets and
+// re-validates redirects) rather than the raw `io.fetch`, matching every
+// other user-URL flow (extraction-session, video-only, slides-session).
+describe("url-routing remote asset SSRF guard", () => {
+  function pdfResponse(): Response {
+    return new Response("%PDF-1.4\n", {
+      status: 200,
+      headers: { "content-type": "application/pdf" },
+    });
+  }
+
+  function buildContext(guardedFetch: typeof fetch, rawFetch: typeof fetch): UrlFlowContext {
+    return {
+      io: { fetch: rawFetch, urlFetch: guardedFetch },
+      flags: { timeoutMs: 1000 },
+    } as unknown as UrlFlowContext;
+  }
+
+  it("downloads remote assets through the guarded urlFetch, never the raw fetch", async () => {
+    const guardedFetch = vi.fn(async () => pdfResponse()) as unknown as typeof fetch;
+    const rawFetch = vi.fn(async () => {
+      throw new Error("raw io.fetch must not be used for user-URL asset downloads");
+    }) as unknown as typeof fetch;
+
+    const assetExecutor = {
+      execute: vi.fn(),
+      emitProgress: vi.fn(),
+    } as unknown as AcquiredAssetExecutor;
+    const emit: SummarizeEventSink = vi.fn();
+
+    const result = await resolveInitialUrlInput({
+      input: {
+        kind: "input-url",
+        url: "https://example.com/report.pdf",
+        title: null,
+        maxCharacters: null,
+      },
+      request: { slides: false } as unknown as SummarizeRequest,
+      isYoutubeUrl: false,
+      ctx: buildContext(guardedFetch, rawFetch),
+      assetExecutor,
+      emit,
+    });
+
+    expect(guardedFetch).toHaveBeenCalledTimes(1);
+    expect(rawFetch).not.toHaveBeenCalled();
+    expect(result.input).toMatchObject({ kind: "resolved-asset" });
+  });
+});


### PR DESCRIPTION
## Summary

The URL flow's remote-asset **classification** and **download** fetch user-supplied URLs with the raw `ctx.io.fetch` instead of the SSRF-guarded `ctx.io.urlFetch`. This bypasses the daemon's network guard for the asset sub-path.

In the daemon, `urlFetch` is built by `createDaemonUrlFetchGuard` (`src/daemon/url-fetch-guard.ts` -> `createNetworkGuardedFetch` in `packages/core/src/content/network-guard.ts`). That guard:

- blocks private / link-local / loopback / CGNAT / ULA targets (IPv4 + IPv6, incl. mapped/NAT64), via `isBlockedNetworkAddress`,
- pins DNS to the validated address (anti-rebinding),
- **re-validates every redirect hop**.

`ctx.io.fetch` is `metrics.trackedFetch` (`src/application/metrics.ts`) which only records metrics and calls the raw global `fetch` - no address blocking, and it follows redirects by default.

## Where

`src/application/url-routing.ts` - `resolveInitialUrlInput` and `executeUrlWithAssetFallback` call `resolveUrlAssetRoute` (classify: HEAD/GET) and `acquireRemoteAssetInput` (download) with `fetchImpl: ctx.io.fetch` at 4 sites (lines 58, 74, 122, 138 before this change).

Every other user-URL flow already routes through the guard with `io.urlFetch ?? io.fetch`:

- `src/run/flows/url/extraction-session.ts:68`
- `src/run/flows/url/video-only.ts:93`
- `src/run/flows/url/slides-session.ts:260`

The asset path is the outlier.

## Impact

The daemon calls `assertDaemonUrlFetchAllowed(pageUrl)` once up front, but that validates only the initial hostname (no pinning, no redirect coverage). Because the asset classify/download then uses the unguarded, redirect-following `io.fetch`:

- a summarized URL that **redirects** to an internal target (e.g. `302 -> http://169.254.169.254/latest/meta-data/` cloud metadata, or a `http://127.0.0.1:PORT/` service) is followed and fetched, and
- a hostname that **DNS-rebinds** after the upfront check resolves to a private address at download time.

The primary text-extraction path was already guarded; only the asset sub-path leaked. Scope is the loopback, token-authenticated daemon, so this is a hardening / defense-in-depth consistency fix rather than a critical unauthenticated issue - but it restores the SSRF control the guard was written to provide.

## Fix

Use `ctx.io.urlFetch ?? ctx.io.fetch` at the 4 asset fetch call sites, matching the existing pattern. Minimal, behavior-preserving when no guard is installed (CLI: `urlFetch` is undefined, falls back to `io.fetch`).

## Test

`tests/application.url-routing.ssrf-guard.test.ts` drives `resolveInitialUrlInput` with a `.pdf` URL, a guarded `urlFetch` spy, and a raw `fetch` spy, and asserts the download goes through the guarded fetch and never the raw one.

- Fails on `main` (raw `io.fetch` is invoked).
- Passes with this change.

Verification:

```
pnpm exec vitest run tests/application.url-routing.ssrf-guard.test.ts   # 1 passed
pnpm exec oxfmt --check <changed files>                                 # clean
pnpm exec oxlint --type-aware ...                                       # clean
pnpm exec tsgo -p tsconfig.build.json --noEmit                          # exit 0
```