### PR TITLE
chore: prepare 0.21.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.21.9 - Unreleased
+## 0.21.9 - 2026-08-08
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/summarize",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "description": "Link → clean text → summary.",
   "bin": {
     "summarize": "./dist/cli.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/summarize-core",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "description": "Summarize core library (content extraction + prompts).",
   "files": [
     "dist",

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 declare const __dirname: string | undefined;
 
-export const FALLBACK_VERSION = "0.21.8";
+export const FALLBACK_VERSION = "0.21.9";
 
 export function resolvePackageVersion(importMetaUrl?: string): string {
   const injected =


### PR DESCRIPTION
## Summary

- prepare the lockstep CLI/core 0.21.9 patch release
- date the reconciled changelog entry
- update the standalone Bun binary fallback version

## Validation

- `scripts/release.sh gates` — 554 files / 3,006 active tests passed with coverage
- `scripts/release.sh build` — CLI/core build passed; local arm64/x64 Bun artifacts built; arm64 version/help, HTTP extraction, and FFmpeg WebAssembly slide E2E passed; Chrome and Firefox packages built
- structured autoreview — no actionable findings

The pre-release collision check found no 0.21.9 tag, GitHub Release, or npm versions for either lockstep package.
