### PR TITLE
fix: respect custom Google base URL during model resolution

### DIFF
--- a/src/engine/model-call.ts
+++ b/src/engine/model-call.ts
@@ -8,6 +8,7 @@ import type { Prompt } from "../llm/prompt.js";
 export async function resolveModelIdForLlmCall({
   parsedModel,
   apiKeys,
+  googleBaseUrlOverride,
   fetchImpl,
   timeoutMs,
 }: {
@@ -15,6 +16,7 @@ export async function resolveModelIdForLlmCall({
   apiKeys: {
     googleApiKey: string | null;
   };
+  googleBaseUrlOverride?: string | null;
   fetchImpl: typeof fetch;
   timeoutMs: number;
 }): Promise<{ modelId: string; note: string | null; forceStreamOff: boolean }> {
@@ -24,6 +26,10 @@ export async function resolveModelIdForLlmCall({
 
   const key = apiKeys.googleApiKey;
   if (!key) {
+    return { modelId: parsedModel.canonical, note: null, forceStreamOff: false };
+  }
+
+  if (googleBaseUrlOverride?.trim()) {
     return { modelId: parsedModel.canonical, note: null, forceStreamOff: false };
   }
 

--- a/src/engine/model-call.ts
+++ b/src/engine/model-call.ts
@@ -5,6 +5,13 @@ import type { parseGatewayStyleModelId } from "../llm/model-id.js";
 import type { ModelRequestOptions } from "../llm/model-options.js";
 import type { Prompt } from "../llm/prompt.js";
 
+const GOOGLE_DEVELOPER_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+
+function isCustomGoogleBaseUrl(raw: string | null | undefined): boolean {
+  const normalized = raw?.trim().replace(/\/+$/, "");
+  return Boolean(normalized && normalized !== GOOGLE_DEVELOPER_API_BASE_URL);
+}
+
 export async function resolveModelIdForLlmCall({
   parsedModel,
   apiKeys,
@@ -29,7 +36,7 @@ export async function resolveModelIdForLlmCall({
     return { modelId: parsedModel.canonical, note: null, forceStreamOff: false };
   }
 
-  if (googleBaseUrlOverride?.trim()) {
+  if (isCustomGoogleBaseUrl(googleBaseUrlOverride)) {
     return { modelId: parsedModel.canonical, note: null, forceStreamOff: false };
   }
 

--- a/src/engine/model-executor.ts
+++ b/src/engine/model-executor.ts
@@ -207,6 +207,7 @@ export function createModelExecutor(deps: ModelExecutorDeps) {
     const modelResolution = await resolveModelIdForLlmCall({
       parsedModel,
       apiKeys: { googleApiKey: apiKeysForLlm.googleApiKey },
+      googleBaseUrlOverride: providerRuntime.baseUrls.google,
       fetchImpl: deps.trackedFetch,
       timeoutMs: deps.timeoutMs,
     });

--- a/tests/engine.model-call.test.ts
+++ b/tests/engine.model-call.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveModelIdForLlmCall } from "../src/engine/model-call.js";
+import { parseGatewayStyleModelId } from "../src/llm/model-id.js";
+
+describe("model call resolution", () => {
+  it("skips Developer API model discovery for a custom Google base URL", async () => {
+    const fetchMock = vi.fn();
+
+    const result = await resolveModelIdForLlmCall({
+      parsedModel: parseGatewayStyleModelId("google/gemini-custom-preview"),
+      apiKeys: { googleApiKey: "test" },
+      googleBaseUrlOverride: "https://google-proxy.example.com",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      timeoutMs: 2000,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      modelId: "google/gemini-custom-preview",
+      note: null,
+      forceStreamOff: false,
+    });
+  });
+
+  it("keeps Developer API model discovery for the default Google endpoint", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          models: [{ name: "models/gemini-custom" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const result = await resolveModelIdForLlmCall({
+      parsedModel: parseGatewayStyleModelId("google/gemini-custom-preview"),
+      apiKeys: { googleApiKey: "test" },
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      timeoutMs: 2000,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(result.modelId).toBe("google/gemini-custom");
+  });
+});

--- a/tests/engine.model-call.test.ts
+++ b/tests/engine.model-call.test.ts
@@ -22,7 +22,14 @@ describe("model call resolution", () => {
     });
   });
 
-  it("keeps Developer API model discovery for the default Google endpoint", async () => {
+  it.each([
+    ["an unset base URL", undefined],
+    ["the explicit Developer API base URL", "https://generativelanguage.googleapis.com/v1beta"],
+    [
+      "the explicit Developer API base URL with a trailing slash",
+      "https://generativelanguage.googleapis.com/v1beta/",
+    ],
+  ])("keeps Developer API model discovery for %s", async (_description, googleBaseUrlOverride) => {
     const fetchMock = vi.fn(async () => {
       return new Response(
         JSON.stringify({
@@ -35,6 +42,7 @@ describe("model call resolution", () => {
     const result = await resolveModelIdForLlmCall({
       parsedModel: parseGatewayStyleModelId("google/gemini-custom-preview"),
       apiKeys: { googleApiKey: "test" },
+      googleBaseUrlOverride,
       fetchImpl: fetchMock as unknown as typeof fetch,
       timeoutMs: 2000,
     });

--- a/tests/engine.model-executor.test.ts
+++ b/tests/engine.model-executor.test.ts
@@ -191,6 +191,27 @@ describe("model executor OpenAI chat-completions routing", () => {
   });
 });
 
+describe("model executor Google routing", () => {
+  it("passes the configured Google base URL to model resolution", async () => {
+    const engine = createTestModelExecutor(undefined);
+    engine.providerRuntime.apiKeys.google = "google-key";
+    engine.providerRuntime.baseUrls.google = "https://google-proxy.example.com";
+    const attempt = resolveTestFixedAttempt(engine, "google/gemini-custom-preview");
+
+    await engine.runSummaryAttempt({
+      attempt,
+      prompt: { userText: "Summarize this." } as Prompt,
+      allowStreaming: false,
+    });
+
+    expect(mocks.resolveModelIdForLlmCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        googleBaseUrlOverride: "https://google-proxy.example.com",
+      }),
+    );
+  });
+});
+
 describe("model executor credential availability", () => {
   it("reads gateway, OpenRouter, Ollama, and CLI availability from resolved runtime inputs", () => {
     const engine = createTestModelExecutor(undefined);


### PR DESCRIPTION
## Summary

- skip Gemini Developer API model discovery for genuinely custom `GOOGLE_BASE_URL` endpoints
- pass the resolved Google base URL into model resolution
- preserve ListModels behavior when the default endpoint is unset or explicitly configured

## Why

Google model resolution currently calls `generativelanguage.googleapis.com` before inference, even when inference is configured for another endpoint such as Vertex AI. If the API key is restricted to Vertex AI, that preflight fails with `403 Forbidden` before the configured endpoint is reached.

## Reproduction

Configure a Google model with a Vertex AI `GOOGLE_BASE_URL` and a key restricted to `aiplatform.googleapis.com`, then run a summary. The current release calls the Gemini Developer API ListModels endpoint and exits before inference.

## Compatibility

Default Google endpoint behavior is unchanged. This includes explicit `https://generativelanguage.googleapis.com/v1beta` values with or without a trailing slash. With a genuinely custom base URL, the configured model ID is passed through without Developer API discovery.

## Live proof

Same Vertex-restricted key and endpoint, with secrets and project ID redacted:

```text
GOOGLE_BASE_URL=https://aiplatform.googleapis.com/v1/projects/<redacted>/locations/global/publishers/google
GEMINI_API_KEY=<redacted Vertex-scoped key>
model=google/gemini-3.6-flash
```

Before this patch on v0.21.9:

```text
Cannot verify Google model availability for gemini-3.6-flash.
Google ListModels failed (403 Forbidden): Requests to this API
generativelanguage.googleapis.com method
google.ai.generativelanguage.v1beta.ModelService.ListModels are blocked.
exit: 1
```

After this patch, run directly from the PR source:

```text
$ pnpm dev:cli package.json --model google/gemini-3.6-flash --length short \
    --force-summary --no-cache --stream off --plain --metrics off

## Package Overview
This file contains the configuration and metadata for @steipete/summarize...
via model google/gemini-3.6-flash
exit: 0
```

The same installed-package smoke test also passed on a second macOS host.

## Tests

- `pnpm exec vitest run tests/engine.model-call.test.ts tests/engine.model-executor.test.ts`
- focused result: 21 passed
- `pnpm -s check` (3,011 passed, 43 skipped)
- live Vertex AI smoke test with `google/gemini-3.6-flash`

Closes #383
