### PR TITLE
fix(content): stop content truncation from splitting a surrogate pair

### DIFF
--- a/packages/core/src/content/link-preview/content/cleaner.ts
+++ b/packages/core/src/content/link-preview/content/cleaner.ts
@@ -65,6 +65,10 @@ export function clipAtSentenceBoundary(input: string, maxLength: number): string
   if (lastSentenceBreak > maxLength * 0.5) {
     return slice.slice(0, lastSentenceBreak + 1);
   }
+  const lastCodeUnit = slice.charCodeAt(slice.length - 1);
+  if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) {
+    return slice.slice(0, -1);
+  }
   return slice;
 }
 

--- a/tests/cleaner.test.ts
+++ b/tests/cleaner.test.ts
@@ -40,6 +40,18 @@ describe("content cleaner utilities", () => {
     expect(clipAtSentenceBoundary(input, 200)).toBe(input);
   });
 
+  it("keeps clipped content well-formed at a surrogate pair", () => {
+    const input = `${"x".repeat(80)}\u{1F600} and more trailing text here`;
+    const result = clipAtSentenceBoundary(input, 81);
+    expect(result.isWellFormed()).toBe(true);
+    expect(result).toBe("x".repeat(80));
+    expect(clipAtSentenceBoundary(input, 82)).toBe(`${"x".repeat(80)}\u{1F600}`);
+  });
+
+  it("preserves plain BMP truncation", () => {
+    expect(clipAtSentenceBoundary("abcdefgh", 5)).toBe("abcde");
+  });
+
   it("applies a content budget and counts words", () => {
     const content = "Hello world. This is a test.";
     const result = applyContentBudget(content, 10);
@@ -47,6 +59,11 @@ describe("content cleaner utilities", () => {
     expect(result.totalCharacters).toBe(content.length);
     expect(result.content.length).toBeLessThanOrEqual(10);
     expect(result.wordCount).toBeGreaterThan(0);
+  });
+
+  it("keeps budgeted content well-formed at a surrogate pair", () => {
+    const input = `${"x".repeat(80)}\u{1F600} and more trailing text here`;
+    expect(applyContentBudget(input, 81).content.isWellFormed()).toBe(true);
   });
 
   it("keeps content when under budget and reports empty word count", () => {


### PR DESCRIPTION
## Problem

`clipAtSentenceBoundary` in `packages/core/src/content/link-preview/content/cleaner.ts` cuts with `input.slice(0, maxLength)`. That is a UTF-16 code unit index.

Every non-BMP character is a surrogate pair of two code units. Emoji are the common case. When the cut lands between the two units, and no sentence break sits past `maxLength * 0.5`, the rescue branch does not run and the function returns a string that ends in a lone high surrogate.

`applyContentBudget` then calls `.trim()`, which does not remove a lone surrogate. Nothing later repairs it.

Measured with the function as it is on `main`, using `"x".repeat(80) + "\u{1F600}" + " and more trailing text here"` and `maxLength` 81:

```
output length   81
last code unit  0xd83d
isWellFormed()  false
UTF-8 tail      "xxxxx" followed by U+FFFD
```

The text is written to stdout, to `--json` output, and into the model request body. Each of those is a UTF-8 encode, so the reader sees a replacement character where the text should end cleanly.

`applyContentBudget` is exported from `packages/core/src/content/index.ts` and is called from:

- `packages/core/src/content/browser-html.ts:33`
- `packages/core/src/content/link-preview/content/utils.ts:249,335,358,362`
- `src/run/flows/asset/extract.ts:55,117`
- `src/speaker-identification/identify.ts:194`

So any page or transcript that carries an emoji near the budget boundary can hit this.

## Change

Four lines. When the clipped text ends in an unpaired high surrogate, drop that one code unit.

The guard sits after the sentence-break return, so it only affects the plain truncation path. A cut at `. `, `! `, `? ` or a blank line is already safe, because those characters are all BMP.

A trailing high surrogate is unpaired by definition, since its low half would follow it. A trailing low surrogate means the pair is complete, so it is left alone.

## Scope

This fixes lone surrogates only. It does not add grapheme cluster handling.

A cut inside a ZWJ emoji sequence or before a combining mark still produces well-formed text, so it is a different question. A lone surrogate is invalid text. I kept the two separate to keep this change small. Say the word if you want the grapheme case handled too.

I did not use `String.prototype.toWellFormed()`. It replaces the lone surrogate with U+FFFD, which keeps the visible corruption instead of removing it.

## Proof

`cleaner.ts` reverted, tests kept:

```
FAIL  tests/cleaner.test.ts > content cleaner utilities > keeps clipped content well-formed at a surrogate pair
FAIL  tests/cleaner.test.ts > content cleaner utilities > keeps budgeted content well-formed at a surrogate pair
Tests  2 failed | 8 passed (10)
```

With the change:

```
Tests  10 passed (10)
```

Full suite after the change: 3018 passed, 43 skipped, 0 failed, across 585 test files.

`oxfmt --check` reports the correct format. `oxlint` exits 0. `tsc -p packages/core/tsconfig.build.json --noEmit` exits 0.

The new tests also assert the opposite case. When the budget is 82 and both code units fit, the emoji is kept. The existing expectations for `clipAtSentenceBoundary` are unchanged, and a plain BMP truncation still returns the same result as before.


### Runtime check on the real helper

The results above come from Vitest. This is a direct terminal run of the exported helper, on this branch and on `main`.

Command:

```
node --import ./scripts/register-typescript.mjs --input-type=module \
  -e 'import { applyContentBudget } from "./packages/core/src/content/link-preview/content/cleaner.ts"; const value = applyContentBudget("x".repeat(80) + "\u{1F600} and more", 81).content; console.log(`well-formed=${value.isWellFormed()} length=${value.length}`);'
```

`main` at `861fa4a9`:

```
well-formed=false length=81
```

This branch at `d88c576`:

```
well-formed=true length=80
```

The input is 80 `x` characters plus one emoji. The budget is 81 UTF-16 code units. `main` returns the raw slice, which ends in a lone high surrogate. This branch drops that one code unit and returns 80 well-formed units.
