### PR TITLE
fix(core): stop FAL polling after timeout

### DIFF
--- a/packages/core/src/transcription/whisper/fal-client.ts
+++ b/packages/core/src/transcription/whisper/fal-client.ts
@@ -29,6 +29,7 @@ type FalClientOptions = {
 
 type FalSubscribeOptions = {
   input: Record<string, unknown>;
+  signal?: AbortSignal;
 };
 
 type FalQueueStatus = {
@@ -78,6 +79,23 @@ function isRetryableNetworkError(error: unknown): boolean {
   return error instanceof TypeError && /fetch failed/i.test(error.message);
 }
 
+function abortableDelay(ms: number, signal?: AbortSignal | null): Promise<void> {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
+  if (signal.aborted) return Promise.reject(signal.reason);
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 async function fetchWithRetry(
   fetchImpl: typeof fetch,
   input: string,
@@ -97,7 +115,7 @@ async function fetchWithRetry(
     } catch (error) {
       if (attempt >= FAL_MAX_RETRIES || !isRetryableNetworkError(error)) throw error;
     }
-    await new Promise((resolve) => setTimeout(resolve, FAL_RETRY_BASE_DELAY_MS * 2 ** attempt));
+    await abortableDelay(FAL_RETRY_BASE_DELAY_MS * 2 ** attempt, init.signal);
   }
 }
 
@@ -254,16 +272,19 @@ async function waitForQueueResult({
   credentials,
   statusUrl,
   responseUrl,
+  signal,
 }: {
   fetchImpl: typeof fetch;
   credentials: string;
   statusUrl: string;
   responseUrl: string;
+  signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
   while (true) {
     const status = (await fetchJson(fetchImpl, statusUrl, {
       method: "GET",
       headers: authHeaders(credentials),
+      signal,
     })) as FalQueueStatus;
     if (status.status === "COMPLETED") {
       if (status.error) {
@@ -272,12 +293,13 @@ async function waitForQueueResult({
       return await fetchJson(fetchImpl, responseUrl, {
         method: "GET",
         headers: authHeaders(credentials),
+        signal,
       });
     }
     if (status.status !== "IN_QUEUE" && status.status !== "IN_PROGRESS") {
       throw new Error(`FAL returned an unknown queue status: ${String(status.status)}`);
     }
-    await new Promise((resolve) => setTimeout(resolve, FAL_POLL_INTERVAL_MS));
+    await abortableDelay(FAL_POLL_INTERVAL_MS, signal);
   }
 }
 
@@ -310,6 +332,7 @@ export function createFalClient({
           "X-Fal-Queue-Priority": "normal",
         },
         body: JSON.stringify(options.input),
+        signal: options.signal,
       });
       const requestId = typeof submitted.request_id === "string" ? submitted.request_id.trim() : "";
       if (!requestId) throw new Error("FAL queue submission returned no request ID");
@@ -322,6 +345,7 @@ export function createFalClient({
         credentials,
         statusUrl: `${requestBase}/status`,
         responseUrl: requestBase,
+        signal: options.signal,
       });
       return { data, requestId };
     },

--- a/packages/core/src/transcription/whisper/fal.ts
+++ b/packages/core/src/transcription/whisper/fal.ts
@@ -11,14 +11,26 @@ export async function transcribeWithFal(
   const blob = new Blob([toArrayBuffer(bytes)], { type: mediaType });
   const audioUrl = await fal.storage.upload(blob);
 
-  const result = await Promise.race([
-    fal.subscribe("fal-ai/wizper", {
-      input: { audio_url: audioUrl, language: "en" },
-    }),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("FAL transcription timeout")), TRANSCRIPTION_TIMEOUT_MS),
-    ),
-  ]);
+  const controller = new AbortController();
+  const timeoutError = new Error("FAL transcription timeout");
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  let result: unknown;
+  try {
+    result = await Promise.race([
+      fal.subscribe("fal-ai/wizper", {
+        input: { audio_url: audioUrl, language: "en" },
+        signal: controller.signal,
+      }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(timeoutError);
+          controller.abort(timeoutError);
+        }, TRANSCRIPTION_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeout !== null) clearTimeout(timeout);
+  }
 
   return extractText(result);
 }

--- a/tests/transcription.fal-client.test.ts
+++ b/tests/transcription.fal-client.test.ts
@@ -222,6 +222,78 @@ describe("FAL REST client", () => {
     }
   });
 
+  it("stops polling when the subscription is aborted", async () => {
+    vi.useFakeTimers();
+    let statusChecks = 0;
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      expect(init?.signal).toBe(controller.signal);
+      if (url === "https://queue.fal.run/fal-ai/wizper") {
+        return jsonResponse({ request_id: "request-abort" });
+      }
+      if (url.endsWith("/requests/request-abort/status")) {
+        statusChecks += 1;
+        return jsonResponse({ status: "IN_PROGRESS" });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const fal = createFalClient({ credentials: "FAL", fetchImpl: fetchMock });
+      const pending = fal.subscribe("fal-ai/wizper", {
+        input: {},
+        signal: controller.signal,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(statusChecks).toBe(1);
+
+      const abortError = new Error("subscription cancelled");
+      controller.abort(abortError);
+      await expect(pending).rejects.toBe(abortError);
+      expect(vi.getTimerCount()).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(statusChecks).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry after aborting during backoff", async () => {
+    vi.useFakeTimers();
+    let submissions = 0;
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://queue.fal.run/fal-ai/wizper") {
+        submissions += 1;
+        return jsonResponse({ detail: "try again" }, 503);
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const fal = createFalClient({ credentials: "FAL", fetchImpl: fetchMock });
+      const pending = fal.subscribe("fal-ai/wizper", {
+        input: {},
+        signal: controller.signal,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(submissions).toBe(1);
+
+      const abortError = new Error("subscription cancelled");
+      controller.abort(abortError);
+      await expect(pending).rejects.toBe(abortError);
+      expect(vi.getTimerCount()).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(submissions).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reports malformed and failed queue responses", async () => {
     const missingRequestId = createFalClient({
       credentials: "FAL",

--- a/tests/transcription.whisper.test.ts
+++ b/tests/transcription.whisper.test.ts
@@ -874,52 +874,99 @@ describe("transcription/whisper", () => {
   });
 
   it("extracts FAL text from data.text", async () => {
+    vi.useFakeTimers();
     falMocks.createFalClient.mockReset().mockReturnValue({
       storage: { upload: vi.fn(async () => "https://fal.example/audio") },
       subscribe: vi.fn(async () => ({ data: { text: "  hello fal  " } })),
     });
 
-    const { transcribeMediaWithWhisper } =
-      await import("../packages/core/src/transcription/whisper.js");
-    const result = await transcribeMediaWithWhisper({
-      bytes: new Uint8Array([1, 2, 3]),
-      mediaType: "audio/mpeg",
-      filename: "audio.mp3",
-      groqApiKey: null,
-      openaiApiKey: null,
-      falApiKey: "FAL",
+    try {
+      const { transcribeMediaWithWhisper } =
+        await import("../packages/core/src/transcription/whisper.js");
+      const result = await transcribeMediaWithWhisper({
+        bytes: new Uint8Array([1, 2, 3]),
+        mediaType: "audio/mpeg",
+        filename: "audio.mp3",
+        groqApiKey: null,
+        openaiApiKey: null,
+        falApiKey: "FAL",
+      });
+
+      expect(result.text).toBe("hello fal");
+      expect(result.provider).toBe("fal");
+      expect(result.error).toBeNull();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the FAL timeout when the subscription fails", async () => {
+    vi.useFakeTimers();
+    falMocks.createFalClient.mockReset().mockReturnValue({
+      storage: { upload: vi.fn(async () => "https://fal.example/audio") },
+      subscribe: vi.fn(async () => {
+        throw new Error("subscription failed");
+      }),
     });
 
-    expect(result.text).toBe("hello fal");
-    expect(result.provider).toBe("fal");
-    expect(result.error).toBeNull();
+    try {
+      const { transcribeMediaWithWhisper } =
+        await import("../packages/core/src/transcription/whisper.js");
+      const result = await transcribeMediaWithWhisper({
+        bytes: new Uint8Array([1, 2, 3]),
+        mediaType: "audio/mpeg",
+        filename: "audio.mp3",
+        groqApiKey: null,
+        openaiApiKey: null,
+        falApiKey: "FAL",
+      });
+
+      expect(result.error?.message).toContain("subscription failed");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("times out FAL subscriptions", async () => {
     vi.useFakeTimers();
+    const subscribe = vi.fn(
+      async (_endpoint: string, options: { signal?: AbortSignal }) =>
+        await new Promise((_, reject) => {
+          options.signal?.addEventListener("abort", () => reject(options.signal?.reason), {
+            once: true,
+          });
+        }),
+    );
     falMocks.createFalClient.mockReset().mockReturnValue({
       storage: { upload: vi.fn(async () => "https://fal.example/audio") },
-      subscribe: vi.fn(async () => new Promise(() => {})),
+      subscribe,
     });
 
-    const { transcribeMediaWithWhisper } =
-      await import("../packages/core/src/transcription/whisper.js");
-    const promise = transcribeMediaWithWhisper({
-      bytes: new Uint8Array([1, 2, 3]),
-      mediaType: "audio/mpeg",
-      filename: "audio.mp3",
-      groqApiKey: null,
-      openaiApiKey: null,
-      falApiKey: "FAL",
-    });
+    try {
+      const { transcribeMediaWithWhisper } =
+        await import("../packages/core/src/transcription/whisper.js");
+      const promise = transcribeMediaWithWhisper({
+        bytes: new Uint8Array([1, 2, 3]),
+        mediaType: "audio/mpeg",
+        filename: "audio.mp3",
+        groqApiKey: null,
+        openaiApiKey: null,
+        falApiKey: "FAL",
+      });
 
-    await vi.advanceTimersByTimeAsync(600_000);
-    const result = await promise;
+      await vi.advanceTimersByTimeAsync(600_000);
+      const result = await promise;
 
-    expect(result.text).toBeNull();
-    expect(result.provider).toBe("fal");
-    expect(result.error?.message.toLowerCase()).toContain("timeout");
-    vi.useRealTimers();
+      expect(result.text).toBeNull();
+      expect(result.provider).toBe("fal");
+      expect(result.error?.message).toContain("FAL transcription timeout");
+      expect(subscribe.mock.calls[0]?.[1].signal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("prefers Groq over OpenAI when groqApiKey is provided", async () => {


### PR DESCRIPTION
## Summary

- clear the FAL transcription deadline after the subscription settles
- abort local queue requests, status polling, and retry delays when the deadline expires
- add deterministic regression coverage for successful, failed, timed-out, polling, and retry paths

## Root cause

`transcribeWithFal` raced `fal.subscribe()` against a 10-minute timer without clearing the losing timer. A successful one-shot CLI invocation could therefore remain alive until that timer fired.

When the timer won, `Promise.race` rejected the caller but did not cancel the losing subscription. The internal FAL client could continue polling while the provider chain moved on to Deepgram.

The deadline still begins after upload, matching the existing behavior. Aborting stops local fetches and timers; it does not cancel an already-submitted remote FAL job.

## Verification

- `pnpm -s vitest run tests/transcription.fal-client.test.ts tests/transcription.whisper.test.ts` — 2 files, 52 tests passed
- `pnpm -s check` — 556 files passed, 29 skipped; 3,018 tests passed, 43 skipped
- `pnpm -s build` — passed
- built-module smoke with mocked FAL HTTP — returned `done`, reported zero active `Timeout` resources, and exited in 0.07 seconds
- parallel review swarm — no material regression, security/privacy, performance/reliability, or contract findings
