### PR TITLE
fix(content): decode HTML entities in one pass

### DIFF
--- a/packages/core/src/content/link-preview/content/cleaner.ts
+++ b/packages/core/src/content/link-preview/content/cleaner.ts
@@ -24,16 +24,24 @@ export function normalizeWhitespace(input: string): string {
     .trim();
 }
 
+const HTML_ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&#x27;": "'",
+  "&#x2F;": "/",
+  "&nbsp;": " ",
+};
+
+// Decode in a single pass. Chained replaceAll calls decoded "&amp;" first, so a
+// single-escaped "&amp;lt;" became "&lt;" and the next call decoded it again to "<".
 export function decodeHtmlEntities(input: string): string {
-  return input
-    .replaceAll("&amp;", "&")
-    .replaceAll("&lt;", "<")
-    .replaceAll("&gt;", ">")
-    .replaceAll("&quot;", '"')
-    .replaceAll("&#39;", "'")
-    .replaceAll("&#x27;", "'")
-    .replaceAll("&#x2F;", "/")
-    .replaceAll("&nbsp;", " ");
+  return input.replaceAll(
+    /&(?:amp|lt|gt|quot|nbsp|#39|#x27|#x2F);/g,
+    (entity) => HTML_ENTITIES[entity] ?? entity,
+  );
 }
 
 export function stripInvisibleUnicode(input: string): string {

--- a/tests/cleaner.test.ts
+++ b/tests/cleaner.test.ts
@@ -27,6 +27,17 @@ describe("content cleaner utilities", () => {
     expect(decodeHtmlEntities("&lt;tag&gt; &amp; &#39;x&#39;")).toBe("<tag> & 'x'");
   });
 
+  it("decodes each entity once, so an escaped entity stays escaped", () => {
+    expect(decodeHtmlEntities("&amp;lt;div&amp;gt;")).toBe("&lt;div&gt;");
+    expect(decodeHtmlEntities("&amp;quot;x&amp;quot;")).toBe("&quot;x&quot;");
+    expect(decodeHtmlEntities("&amp;nbsp;")).toBe("&nbsp;");
+    expect(decodeHtmlEntities("&amp;amp;")).toBe("&amp;");
+  });
+
+  it("leaves unknown entities untouched", () => {
+    expect(decodeHtmlEntities("&copy; &unknown; 5 &lt; 6")).toBe("&copy; &unknown; 5 < 6");
+  });
+
   it("normalizes candidates", () => {
     expect(normalizeCandidate(null)).toBeNull();
     expect(normalizeCandidate("   ")).toBeNull();


### PR DESCRIPTION
## Problem

`decodeHtmlEntities` decodes with a chain of `replaceAll` calls, and `&amp;` is decoded first:

```ts
return input
  .replaceAll("&amp;", "&")
  .replaceAll("&lt;", "<")
  ...
```

Each call runs over the output of the previous one, so a single-escaped `&amp;lt;` becomes `&lt;` at step one and step two decodes it again into `<`. One level of escaping is unwrapped twice.

Measured on the helper:

| input | before | correct |
|---|---|---|
| `&amp;lt;div&amp;gt;` | `<div>` | `&lt;div&gt;` |
| `&amp;quot;x&amp;quot;` | `"x"` | `&quot;x&quot;` |
| `&amp;amp;` | `&amp;` | `&amp;` |
| `&lt;p&gt;` | `<p>` | `<p>` |

Only entities after `&amp;` in the chain are affected. The last two rows show ordinary input is unaffected, so this is specific to the chain order.

## Which callers this actually affects

This matters only where the helper is handed RAW html, meaning entities are still in their source form. Callers that regex-strip tags and then decode:

| caller | affected |
|---|---|
| `content/browser-html.ts:61` `decodeHtmlEntities(withBreaks.replace(/<[^>]+>/g, " ")...)` | yes |
| `content/browser-html.ts:88` `decodeHtmlEntities(value.replace(/<[^>]+>/g, " "))` | yes |
| `link-preview/content/article.ts:161` inside `extractPlainText` | yes |
| `link-preview/content/firecrawl.ts:30` calls `extractPlainText(html)` directly | yes |
| `article.ts:48` and `:106`, inside the sanitize-html `textFilter` | no |
| `parsers.ts:75` and `:90`, on `element.textContent` | no |

The last four are not affected because sanitize-html and the DOM have already decoded one level before the helper runs, so it only ever sees single-escaped text there.

I checked this by running the real extraction paths rather than reasoning about them:

```
input: <p>To escape a tag write &amp;lt;div&amp;gt; here.</p>

                          before                                  after
extractArticleContent     To escape a tag write <div> here.       To escape a tag write <div> here.
extractPlainText          To escape a tag write <div> here.       To escape a tag write &lt;div&gt; here.
```

`extractArticleContent` is unchanged, because it goes through sanitize-html. `extractPlainText` is fixed. An earlier version of this description claimed the sanitize-html path was affected; that was wrong and the table above replaces it.

## Change

One regex pass with a lookup table, so each entity is decoded exactly once. The set of entities and their replacements is unchanged, including the case-sensitive `&#x27;` and `&#x2F;`. Unknown entities are still left untouched.

## Proof

```
vitest run tests/cleaner.test.ts
Tests  9 passed (9)
```

Source change reverted, tests kept:

```
FAIL  tests/cleaner.test.ts > decodes each entity once, so an escaped entity stays escaped
AssertionError: expected '<div>' to be '&lt;div&gt;'
```

Full suite, unchanged from before this commit:

```
vitest run
Test Files  556 passed | 29 skipped (585)
     Tests  3017 passed | 43 skipped (3060)
```

`oxlint` and `oxfmt --check` on both changed files: exit 0.

The existing test at `tests/cleaner.test.ts:27` still passes. It did not catch this because its `&amp;` is standalone and surrounded by spaces, so decoding it never produces a new entity for a later call to consume.
