### PR TITLE
test: signal disconnect readiness after handler setup

### DIFF
--- a/tests/daemon.agent-disconnect.test.ts
+++ b/tests/daemon.agent-disconnect.test.ts
@@ -38,11 +38,11 @@ describe("daemon agent disconnect", () => {
       `#!/usr/bin/env node
 const fs = require("node:fs");
 const marker = process.env.CANCEL_MARKER;
-fs.writeFileSync(marker, "started");
 process.on("SIGTERM", () => {
   fs.writeFileSync(marker, "interrupted");
   process.exit(0);
 });
+fs.writeFileSync(marker, "started");
 setTimeout(() => {
   fs.writeFileSync(marker, "completed");
   process.stdout.write('{"result":{"payloads":[{"text":"late"}]}}\\n');


### PR DESCRIPTION
The daemon disconnect fixture could advertise readiness before it had installed its SIGTERM handler. A client abort in that interval terminates the fake CLI without writing the expected `interrupted` marker, producing the timeout seen in [postmerge CI job 100979867921](https://github.com/steipete/summarize/actions/runs/33859323380/job/100979867921).

Move the `started` write after handler registration. Both SSE and JSON cancellation assertions and all timeouts remain unchanged; production code is untouched.

Validation:

- A controlled scheduling pause immediately after the readiness write reproduces the original fixture exiting on SIGTERM with the marker still `started`; the corrected fixture exits normally with `interrupted`.
- Full `pnpm -s check`: passed, 3,025 tests passed / 43 skipped; all coverage thresholds met. This includes real HTTP SSE/JSON disconnects and child-process cancellation. Frozen install and build also passed on Node 24/pnpm 11.24.0.
- Full-candidate isolated Codex P0–P2 review: scoped-clean, no actionable findings.

The controlled reproduction proves the ordering race consistent with the hosted failure; it does not reconstruct the hosted scheduler's exact timing. This follow-up is prepared for maintainer review.
