### PR TITLE
refactor(llm): share request options and SDK stream lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Dependencies and maintenance
 
+- Consolidate LLM request options and SDK stream handling while preserving provider-specific configuration, errors, and fallback behavior.
 - Refresh stabilized DOM, Markdown, browser media, image, protobuf, and pnpm dependencies; repair the Node 24 test container's workspace build and preserve local security patches (#403, thanks @dependabot).
 - Refresh Pi AI and Oxc tooling while keeping Node typings aligned with the supported Node 24 runtime (#399, thanks @dependabot).
 - Align Dependabot's npm cooldown with pnpm's seven-day stabilization window so automated updates do not select versions the install gate rejects.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -90,6 +90,8 @@ The engine owns:
 - timestamp validation
 - retry/fallback outcomes
 
+Provider transport lives in `src/llm`. Generation and streaming share `LlmRequestOptions`, so prompt conversion and fallback attempts retain the original request settings. SDK-backed streaming providers share delta collection, deadlines, usage, and final-text handling; provider branches own model configuration and error normalization. OpenAI's HTTP transport keeps its separate response handling.
+
 ## Tests
 
 Key coverage:

--- a/src/llm/generate-text-stream.ts
+++ b/src/llm/generate-text-stream.ts
@@ -6,10 +6,9 @@ import {
   streamUsageWithTimeout,
   withTimeoutFallback,
 } from "./generate-text-shared.js";
-import type { LlmApiKeys } from "./generate-text-types.js";
+import type { LlmRequestOptions } from "./generate-text-types.js";
 import { parseGatewayStyleModelId } from "./model-id.js";
 import type { LlmProvider } from "./model-id.js";
-import type { ModelRequestOptions } from "./model-options.js";
 import {
   getGatewayProviderProfile,
   isOpenAiCompatibleProvider,
@@ -34,22 +33,8 @@ import { extractText } from "./providers/shared.js";
 import type { OpenAiClientConfig } from "./providers/types.js";
 import type { LlmTokenUsage } from "./types.js";
 
-export type StreamTextWithContextArgs = {
-  modelId: string;
-  apiKeys: LlmApiKeys;
+export type StreamTextWithContextArgs = LlmRequestOptions & {
   context: Context;
-  temperature?: number;
-  maxOutputTokens?: number;
-  timeoutMs: number;
-  fetchImpl: typeof fetch;
-  forceOpenRouter?: boolean;
-  openaiBaseUrlOverride?: string | null;
-  anthropicBaseUrlOverride?: string | null;
-  googleBaseUrlOverride?: string | null;
-  xaiBaseUrlOverride?: string | null;
-  ollamaBaseUrlOverride?: string | null;
-  forceChatCompletions?: boolean;
-  requestOptions?: ModelRequestOptions;
 };
 
 export type StreamTextResult = {
@@ -269,13 +254,41 @@ export async function streamTextWithContext({
     model: parsed.model,
     temperature,
   });
-  void fetchImpl;
-
   const controller = new AbortController();
   let lastError: unknown = null;
   const setLastError = (error: unknown) => {
     if ((lastError as Error | null)?.message === "LLM request timed out") return;
     lastError = error;
+  };
+
+  const streamSimpleText = (
+    model: Parameters<typeof streamSimple>[0],
+    options: Parameters<typeof streamSimple>[2],
+    normalizeError: (error: unknown) => unknown = (error) => error,
+  ): StreamTextResult => {
+    const stream = streamSimple(model, context, {
+      ...(typeof effectiveTemperature === "number" ? { temperature: effectiveTemperature } : {}),
+      ...(typeof maxOutputTokens === "number" ? { maxTokens: maxOutputTokens } : {}),
+      ...options,
+      signal: controller.signal,
+    });
+    return {
+      textStream: createTimedTextStream({
+        textStream: collectTextDeltas({
+          stream,
+          onError: (error) => {
+            lastError = normalizeError(error);
+          },
+        }),
+        timeoutMs,
+        controller,
+        setLastError,
+      }),
+      canonicalModelId: parsed.canonical,
+      provider: parsed.provider,
+      ...resolveStreamCompletion(stream, timeoutMs),
+      lastError: () => lastError,
+    };
   };
 
   try {
@@ -287,30 +300,7 @@ export async function streamTextWithContext({
         context,
         xaiBaseUrlOverride,
       });
-      const stream = streamSimple(model, context, {
-        ...(typeof effectiveTemperature === "number" ? { temperature: effectiveTemperature } : {}),
-        ...(typeof maxOutputTokens === "number" ? { maxTokens: maxOutputTokens } : {}),
-        apiKey,
-        signal: controller.signal,
-      });
-      const textDeltas = collectTextDeltas({
-        stream,
-        onError: (error) => {
-          lastError = error;
-        },
-      });
-      return {
-        textStream: createTimedTextStream({
-          textStream: textDeltas,
-          timeoutMs,
-          controller,
-          setLastError,
-        }),
-        canonicalModelId: parsed.canonical,
-        provider: parsed.provider,
-        ...resolveStreamCompletion(stream, timeoutMs),
-        lastError: () => lastError,
-      };
+      return streamSimpleText(model, { apiKey });
     }
 
     if (providerProfile.execution === "google") {
@@ -325,34 +315,15 @@ export async function streamTextWithContext({
         context,
         googleBaseUrlOverride,
       });
-      const stream = streamSimple(model, context, {
-        ...(typeof effectiveTemperature === "number" ? { temperature: effectiveTemperature } : {}),
-        ...(typeof maxOutputTokens === "number" ? { maxTokens: maxOutputTokens } : {}),
-        apiKey,
-        signal: controller.signal,
-      });
-      const textDeltas = collectTextDeltas({
-        stream,
-        onError: (error) => {
-          lastError =
-            normalizeGoogleAssistantError(
-              error as { stopReason?: string; errorMessage?: string },
-              parsed.model,
-            ) ?? error;
-        },
-      });
-      return {
-        textStream: createTimedTextStream({
-          textStream: textDeltas,
-          timeoutMs,
-          controller,
-          setLastError,
-        }),
-        canonicalModelId: parsed.canonical,
-        provider: parsed.provider,
-        ...resolveStreamCompletion(stream, timeoutMs),
-        lastError: () => lastError,
-      };
+      return streamSimpleText(
+        model,
+        { apiKey },
+        (error) =>
+          normalizeGoogleAssistantError(
+            error as { stopReason?: string; errorMessage?: string },
+            parsed.model,
+          ) ?? error,
+      );
     }
 
     if (providerProfile.execution === "anthropic") {
@@ -368,30 +339,11 @@ export async function streamTextWithContext({
         isSyntheticCustomGateway,
         reasoningEffort: requestOptions?.reasoningEffort,
       });
-      const stream = streamSimple(model, context, {
-        ...(typeof effectiveTemperature === "number" ? { temperature: effectiveTemperature } : {}),
-        ...(typeof maxOutputTokens === "number" ? { maxTokens: maxOutputTokens } : {}),
-        ...(reasoning ? { reasoning } : {}),
-        apiKey,
-        signal: controller.signal,
-      });
-      return {
-        textStream: createTimedTextStream({
-          textStream: collectTextDeltas({
-            stream,
-            onError: (error) => {
-              lastError = normalizeAnthropicModelAccessError(error, parsed.model) ?? error;
-            },
-          }),
-          timeoutMs,
-          controller,
-          setLastError,
-        }),
-        canonicalModelId: parsed.canonical,
-        provider: parsed.provider,
-        ...resolveStreamCompletion(stream, timeoutMs),
-        lastError: () => lastError,
-      };
+      return streamSimpleText(
+        model,
+        { apiKey, ...(reasoning ? { reasoning } : {}) },
+        (error) => normalizeAnthropicModelAccessError(error, parsed.model) ?? error,
+      );
     }
 
     if (
@@ -492,31 +444,10 @@ export async function streamTextWithContext({
             openaiConfig,
           })
         : resolveOpenAiModel({ modelId: parsed.model, context, openaiConfig });
-      const stream = streamSimple(model, context, {
-        ...(typeof effectiveTemperature === "number" ? { temperature: effectiveTemperature } : {}),
-        ...(typeof maxOutputTokens === "number" ? { maxTokens: maxOutputTokens } : {}),
+      return streamSimpleText(model, {
         ...(parsed.provider === "minimax" ? { onPayload: enableMinimaxReasoningSplit } : {}),
         apiKey: openaiConfig.apiKey,
-        signal: controller.signal,
       });
-      const textDeltas = collectTextDeltas({
-        stream,
-        onError: (error) => {
-          lastError = error;
-        },
-      });
-      return {
-        textStream: createTimedTextStream({
-          textStream: textDeltas,
-          timeoutMs,
-          controller,
-          setLastError,
-        }),
-        canonicalModelId: parsed.canonical,
-        provider: parsed.provider,
-        ...resolveStreamCompletion(stream, timeoutMs),
-        lastError: () => lastError,
-      };
     }
 
     throw new Error(`Unknown provider ${parsed.provider}`);

--- a/src/llm/generate-text-types.ts
+++ b/src/llm/generate-text-types.ts
@@ -1,7 +1,26 @@
+import type { ModelRequestOptions } from "./model-options.js";
+
 export type LlmApiKeys = {
   xaiApiKey: string | null;
   openaiApiKey: string | null;
   googleApiKey: string | null;
   anthropicApiKey: string | null;
   openrouterApiKey: string | null;
+};
+
+export type LlmRequestOptions = {
+  modelId: string;
+  apiKeys: LlmApiKeys;
+  temperature?: number;
+  maxOutputTokens?: number;
+  timeoutMs: number;
+  fetchImpl: typeof fetch;
+  forceOpenRouter?: boolean;
+  openaiBaseUrlOverride?: string | null;
+  anthropicBaseUrlOverride?: string | null;
+  googleBaseUrlOverride?: string | null;
+  xaiBaseUrlOverride?: string | null;
+  ollamaBaseUrlOverride?: string | null;
+  forceChatCompletions?: boolean;
+  requestOptions?: ModelRequestOptions;
 };

--- a/src/llm/generate-text.ts
+++ b/src/llm/generate-text.ts
@@ -1,4 +1,3 @@
-import type { Context } from "@earendil-works/pi-ai";
 import { completeSimple } from "@earendil-works/pi-ai/compat";
 import { maybeGenerateDocumentText } from "./generate-text-document.js";
 import {
@@ -11,11 +10,10 @@ import {
   shouldRetryGpt5WithoutTokenCap,
   sleep,
 } from "./generate-text-shared.js";
-import { streamTextWithContext } from "./generate-text-stream.js";
-import type { LlmApiKeys } from "./generate-text-types.js";
+import { streamTextWithContext, type StreamTextResult } from "./generate-text-stream.js";
+import type { LlmRequestOptions } from "./generate-text-types.js";
 import { parseGatewayStyleModelId } from "./model-id.js";
 import type { LlmProvider } from "./model-id.js";
-import type { ModelRequestOptions } from "./model-options.js";
 import type { Prompt } from "./prompt.js";
 import {
   getGatewayProviderProfile,
@@ -28,12 +26,7 @@ import {
 } from "./providers/anthropic.js";
 import { completeGoogleText } from "./providers/google.js";
 import { enableMinimaxReasoningSplit } from "./providers/minimax.js";
-import {
-  resolveAnthropicModel,
-  resolveGoogleModel,
-  resolveOpenAiCompatibleGatewayModel,
-  resolveXaiModel,
-} from "./providers/models.js";
+import { resolveOpenAiCompatibleGatewayModel, resolveXaiModel } from "./providers/models.js";
 import { completeOpenAiText } from "./providers/openai.js";
 import { extractText, throwIfAssistantMessageFailed } from "./providers/shared.js";
 import type { OpenAiClientConfig } from "./providers/types.js";
@@ -66,50 +59,39 @@ class DocumentFallbackError extends Error {
   }
 }
 
-export async function generateTextWithModelId({
-  modelId,
-  apiKeys,
-  prompt,
-  temperature,
-  maxOutputTokens,
-  timeoutMs,
-  fetchImpl,
-  forceOpenRouter,
-  openaiBaseUrlOverride,
-  anthropicBaseUrlOverride,
-  googleBaseUrlOverride,
-  xaiBaseUrlOverride,
-  zaiBaseUrlOverride,
-  ollamaBaseUrlOverride,
-  forceChatCompletions,
-  requestOptions,
-  retries = 0,
-  onRetry,
-}: {
-  modelId: string;
-  apiKeys: LlmApiKeys;
+type GenerateTextArgs = LlmRequestOptions & {
   prompt: Prompt;
-  temperature?: number;
-  maxOutputTokens?: number;
-  timeoutMs: number;
-  fetchImpl: typeof fetch;
-  forceOpenRouter?: boolean;
-  openaiBaseUrlOverride?: string | null;
-  anthropicBaseUrlOverride?: string | null;
-  googleBaseUrlOverride?: string | null;
-  xaiBaseUrlOverride?: string | null;
   zaiBaseUrlOverride?: string | null;
-  ollamaBaseUrlOverride?: string | null;
-  forceChatCompletions?: boolean;
-  requestOptions?: ModelRequestOptions;
   retries?: number;
   onRetry?: (notice: RetryNotice) => void;
-}): Promise<{
+};
+
+export async function generateTextWithModelId(args: GenerateTextArgs): Promise<{
   text: string;
   canonicalModelId: string;
   provider: LlmProvider;
   usage: LlmTokenUsage | null;
 }> {
+  const {
+    modelId,
+    apiKeys,
+    prompt,
+    temperature,
+    maxOutputTokens,
+    timeoutMs,
+    fetchImpl,
+    forceOpenRouter,
+    openaiBaseUrlOverride,
+    anthropicBaseUrlOverride,
+    googleBaseUrlOverride,
+    xaiBaseUrlOverride,
+    zaiBaseUrlOverride,
+    ollamaBaseUrlOverride,
+    forceChatCompletions,
+    requestOptions,
+    retries = 0,
+    onRetry,
+  } = args;
   const parsed = parseGatewayStyleModelId(modelId);
   const providerProfile = getGatewayProviderProfile(parsed.provider);
   const effectiveTemperature = resolveEffectiveTemperature({
@@ -139,24 +121,9 @@ export async function generateTextWithModelId({
         retryWithModelId: async (fallbackModelId) => {
           try {
             return await generateTextWithModelId({
+              ...args,
               modelId: fallbackModelId,
-              apiKeys,
-              prompt,
-              temperature,
-              maxOutputTokens,
-              timeoutMs,
-              fetchImpl,
-              forceOpenRouter,
-              openaiBaseUrlOverride,
-              anthropicBaseUrlOverride,
-              googleBaseUrlOverride,
-              xaiBaseUrlOverride,
-              zaiBaseUrlOverride,
-              ollamaBaseUrlOverride,
-              forceChatCompletions,
-              requestOptions,
               retries: Math.max(0, maxRetries - documentAttempt),
-              onRetry,
             });
           } catch (error) {
             throw new DocumentFallbackError(error);
@@ -239,22 +206,15 @@ export async function generateTextWithModelId({
           context,
           xaiBaseUrlOverride,
         });
-        const result = await completeSimple(model, context, {
-          ...(typeof effectiveTemperature === "number"
-            ? { temperature: effectiveTemperature }
-            : {}),
-          ...(typeof maxOutputTokens === "number" ? { maxTokens: maxOutputTokens } : {}),
+        const result = await completeSimpleText({
+          model,
           apiKey,
           signal: controller.signal,
         });
-        throwIfAssistantMessageFailed(result, parsed.canonical);
-        const text = extractText(result);
-        if (!text) throw new Error(`LLM returned an empty summary (model ${parsed.canonical}).`);
         return {
-          text,
+          ...result,
           canonicalModelId: parsed.canonical,
           provider: parsed.provider,
-          usage: normalizeTokenUsage(result.usage),
         };
       }
 
@@ -378,45 +338,17 @@ export async function generateTextWithModelId({
         })
       ) {
         return generateTextWithModelId({
+          ...args,
           modelId: parsed.canonical,
-          apiKeys,
-          prompt,
-          temperature,
-          timeoutMs,
-          fetchImpl,
-          forceOpenRouter,
-          openaiBaseUrlOverride,
-          anthropicBaseUrlOverride,
-          googleBaseUrlOverride,
-          xaiBaseUrlOverride,
-          zaiBaseUrlOverride,
-          ollamaBaseUrlOverride,
-          forceChatCompletions,
-          requestOptions,
+          maxOutputTokens: undefined,
           retries: Math.max(0, maxRetries - attempt),
-          onRetry,
         });
       }
       if (googleFallbackModelId) {
         return generateTextWithModelId({
+          ...args,
           modelId: googleFallbackModelId,
-          apiKeys,
-          prompt,
-          temperature,
-          maxOutputTokens,
-          timeoutMs,
-          fetchImpl,
-          forceOpenRouter,
-          openaiBaseUrlOverride,
-          anthropicBaseUrlOverride,
-          googleBaseUrlOverride,
-          xaiBaseUrlOverride,
-          zaiBaseUrlOverride,
-          ollamaBaseUrlOverride,
-          forceChatCompletions,
-          requestOptions,
           retries: Math.max(0, maxRetries - attempt),
-          onRetry,
         });
       }
       if (parsed.provider === "anthropic") {
@@ -440,61 +372,10 @@ export async function generateTextWithModelId({
 }
 
 export async function streamTextWithModelId({
-  modelId,
-  apiKeys,
   prompt,
-  temperature,
-  maxOutputTokens,
-  timeoutMs,
-  fetchImpl,
-  forceOpenRouter,
-  openaiBaseUrlOverride,
-  anthropicBaseUrlOverride,
-  googleBaseUrlOverride,
-  xaiBaseUrlOverride,
-  ollamaBaseUrlOverride,
-  forceChatCompletions,
-  requestOptions,
-}: {
-  modelId: string;
-  apiKeys: LlmApiKeys;
+  ...options
+}: LlmRequestOptions & {
   prompt: Prompt;
-  temperature?: number;
-  maxOutputTokens?: number;
-  timeoutMs: number;
-  fetchImpl: typeof fetch;
-  forceOpenRouter?: boolean;
-  openaiBaseUrlOverride?: string | null;
-  anthropicBaseUrlOverride?: string | null;
-  googleBaseUrlOverride?: string | null;
-  xaiBaseUrlOverride?: string | null;
-  ollamaBaseUrlOverride?: string | null;
-  forceChatCompletions?: boolean;
-  requestOptions?: ModelRequestOptions;
-}): Promise<{
-  textStream: AsyncIterable<string>;
-  canonicalModelId: string;
-  provider: LlmProvider;
-  usage: Promise<LlmTokenUsage | null>;
-  finalText: Promise<string | null>;
-  lastError: () => unknown;
-}> {
-  const context = promptToContext(prompt);
-  return streamTextWithContext({
-    modelId,
-    apiKeys,
-    context,
-    temperature,
-    maxOutputTokens,
-    timeoutMs,
-    fetchImpl,
-    forceOpenRouter,
-    openaiBaseUrlOverride,
-    anthropicBaseUrlOverride,
-    googleBaseUrlOverride,
-    xaiBaseUrlOverride,
-    ollamaBaseUrlOverride,
-    forceChatCompletions,
-    requestOptions,
-  });
+}): Promise<StreamTextResult> {
+  return streamTextWithContext({ ...options, context: promptToContext(prompt) });
 }


### PR DESCRIPTION
SDK-backed streaming providers repeated the same request setup, delta collection, deadline wrapping, usage extraction, and final-text handling. Generation and streaming also maintained separate copies of the request-option contract, and fallback calls manually recopied every option.

Share the request-option type and SDK stream lifecycle. Keep provider model configuration, reasoning options, error normalization, and the OpenAI HTTP transport explicit. Fallbacks retain the original request and override only the model, retry budget, or token cap. This removes 166 net lines, including the architecture note and changelog entry.

Validation: `pnpm build` and `pnpm check` pass (3,025 tests passed; 43 skipped). The 48 focused provider/generation/streaming tests pass before and after. Independent Codex autoreview reports no actionable P0–P2 findings. No public API or behavior change is intended.
