### PR TITLE
refactor(transcription): share Gemini lifecycle and provider error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Consolidate LLM request options and SDK stream handling while preserving provider-specific configuration, errors, and fallback behavior.
 - Build asset summary contexts directly from shared application state, removing redundant context wrappers and narrowing the asset-only format override.
+- Share Gemini file/byte transcription and bounded cloud-provider error handling, with coverage for the inline-upload boundary and uploaded-file cleanup after failures.
 - Refresh stabilized DOM, Markdown, browser media, image, protobuf, and pnpm dependencies; repair the Node 24 test container's workspace build and preserve local security patches (#403, thanks @dependabot).
 - Refresh Pi AI and Oxc tooling while keeping Node typings aligned with the supported Node 24 runtime (#399, thanks @dependabot).
 - Align Dependabot's npm cooldown with pnpm's seven-day stabilization window so automated updates do not select versions the install gate rejects.

--- a/packages/core/src/transcription/whisper/deepgram.ts
+++ b/packages/core/src/transcription/whisper/deepgram.ts
@@ -1,8 +1,8 @@
 import { openAsBlob } from "node:fs";
-import { MAX_ERROR_DETAIL_CHARS, TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
+import { TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
 import { resolveDeepgramTranscriptionModel } from "./provider-setup.js";
 import type { TranscriptionSegment } from "./types.js";
-import { toArrayBuffer } from "./utils.js";
+import { readErrorDetail, toArrayBuffer } from "./utils.js";
 
 type Env = Record<string, string | undefined>;
 
@@ -140,16 +140,4 @@ function secondsToMs(value: unknown): number | null {
 
 function normalizeMediaType(value: string): string {
   return value.trim() || "application/octet-stream";
-}
-
-async function readErrorDetail(response: Response): Promise<string | null> {
-  try {
-    const text = (await response.text()).trim();
-    if (!text) return null;
-    return text.length > MAX_ERROR_DETAIL_CHARS
-      ? `${text.slice(0, MAX_ERROR_DETAIL_CHARS)}…`
-      : text;
-  } catch {
-    return null;
-  }
 }

--- a/packages/core/src/transcription/whisper/elevenlabs.ts
+++ b/packages/core/src/transcription/whisper/elevenlabs.ts
@@ -1,8 +1,9 @@
 import { openAsBlob } from "node:fs";
 import { basename } from "node:path";
-import { MAX_ERROR_DETAIL_CHARS, TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
+import { TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
 import { appendTranscriptToken, formatDiarizedTranscript } from "./diarization-format.js";
 import type { TranscriptionSegment, WhisperTranscriptionResult } from "./types.js";
+import { readErrorDetail } from "./utils.js";
 
 const ELEVENLABS_TRANSCRIPTION_URL = "https://api.elevenlabs.io/v1/speech-to-text";
 export const ELEVENLABS_DIARIZATION_MODEL = "scribe_v2";
@@ -144,16 +145,4 @@ function resolveSpeakerLabel(labels: Map<string, string>, rawSpeaker: string): s
 function parseSecondsToMs(value: unknown): number | null {
   const numeric = typeof value === "number" ? value : Number.NaN;
   return Number.isFinite(numeric) && numeric >= 0 ? Math.round(numeric * 1000) : null;
-}
-
-async function readErrorDetail(response: Response): Promise<string | null> {
-  try {
-    const text = (await response.text()).trim();
-    if (!text) return null;
-    return text.length > MAX_ERROR_DETAIL_CHARS
-      ? `${text.slice(0, MAX_ERROR_DETAIL_CHARS)}…`
-      : text;
-  } catch {
-    return null;
-  }
 }

--- a/packages/core/src/transcription/whisper/gemini.ts
+++ b/packages/core/src/transcription/whisper/gemini.ts
@@ -1,9 +1,23 @@
 import { promises as fs } from "node:fs";
 import { MAX_ERROR_DETAIL_CHARS, TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
 import { resolveGeminiTranscriptionModel } from "./provider-setup.js";
-import { ensureWhisperFilenameExtension, toArrayBuffer, wrapError } from "./utils.js";
+import {
+  ensureWhisperFilenameExtension,
+  readErrorDetail,
+  toArrayBuffer,
+  wrapError,
+} from "./utils.js";
 
 type Env = Record<string, string | undefined>;
+
+type GeminiTranscriptionOptions = {
+  env?: Env;
+  model?: string | null;
+};
+
+type GeminiMediaPart =
+  | { inline_data: { mime_type: string; data: string } }
+  | { file_data: { mime_type: string; file_uri: string } };
 
 const GEMINI_INLINE_UPLOAD_BYTES = 20 * 1024 * 1024;
 const DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com";
@@ -23,18 +37,18 @@ export async function transcribeWithGemini(
   mediaType: string,
   filename: string | null,
   apiKey: string,
-  options?: {
-    env?: Env;
-    model?: string | null;
-  },
+  options?: GeminiTranscriptionOptions,
 ): Promise<string | null> {
   if (bytes.byteLength <= GEMINI_INLINE_UPLOAD_BYTES) {
-    return await generateInlineTranscript({
-      bytes,
-      mediaType,
+    return await generateTranscript({
+      media: {
+        inline_data: {
+          mime_type: mediaType,
+          data: Buffer.from(toArrayBuffer(bytes)).toString("base64"),
+        },
+      },
       apiKey,
-      env: options?.env,
-      model: options?.model ?? null,
+      ...options,
     });
   }
 
@@ -46,12 +60,20 @@ export async function transcribeWithGemini(
     env: options?.env,
   });
   try {
-    return await generateFileTranscript({
-      file: upload,
+    const ready = await waitForGeminiFileActive(upload, apiKey, options?.env);
+    const fileUri = typeof ready.uri === "string" ? ready.uri.trim() : "";
+    if (!fileUri) {
+      throw new Error("Gemini Files API did not return a file uri");
+    }
+    return await generateTranscript({
+      media: {
+        file_data: {
+          mime_type: resolveGeminiMimeType(ready, mediaType),
+          file_uri: fileUri,
+        },
+      },
       apiKey,
-      env: options?.env,
-      model: options?.model ?? null,
-      mediaType,
+      ...options,
     });
   } finally {
     await deleteGeminiFile(upload, apiKey, options?.env).catch(() => {});
@@ -63,61 +85,25 @@ export async function transcribeFileWithGemini({
   mediaType,
   filename,
   apiKey,
-  env,
-  model,
+  ...options
 }: {
   filePath: string;
   mediaType: string;
   filename: string | null;
   apiKey: string;
-  env?: Env;
-  model?: string | null;
-}): Promise<string | null> {
-  const stat = await fs.stat(filePath);
-  if (stat.size <= GEMINI_INLINE_UPLOAD_BYTES) {
-    const bytes = new Uint8Array(await fs.readFile(filePath));
-    return await generateInlineTranscript({
-      bytes,
-      mediaType,
-      apiKey,
-      env,
-      model,
-    });
-  }
-
-  const upload = await uploadGeminiFile({
-    filePath,
-    mediaType,
-    filename,
-    apiKey,
-    env,
-  });
-  try {
-    return await generateFileTranscript({
-      file: upload,
-      apiKey,
-      env,
-      model,
-      mediaType,
-    });
-  } finally {
-    await deleteGeminiFile(upload, apiKey, env).catch(() => {});
-  }
+} & GeminiTranscriptionOptions): Promise<string | null> {
+  return transcribeWithGemini(await fs.readFile(filePath), mediaType, filename, apiKey, options);
 }
 
-async function generateInlineTranscript({
-  bytes,
-  mediaType,
+async function generateTranscript({
+  media,
   apiKey,
   env,
   model,
 }: {
-  bytes: Uint8Array;
-  mediaType: string;
+  media: GeminiMediaPart;
   apiKey: string;
-  env?: Env;
-  model?: string | null;
-}): Promise<string | null> {
+} & GeminiTranscriptionOptions): Promise<string | null> {
   const response = await geminiJsonRequest({
     path: `v1beta/models/${resolveModelId(model, env)}:generateContent`,
     apiKey,
@@ -126,87 +112,13 @@ async function generateInlineTranscript({
       generationConfig: { temperature: 0 },
       contents: [
         {
-          parts: [
-            { text: TRANSCRIPTION_PROMPT },
-            {
-              inline_data: {
-                mime_type: mediaType,
-                data: Buffer.from(toArrayBuffer(bytes)).toString("base64"),
-              },
-            },
-          ],
+          parts: [{ text: TRANSCRIPTION_PROMPT }, media],
         },
       ],
     },
   });
 
   return extractGeminiTranscript(response, resolveModelId(model, env));
-}
-
-async function generateFileTranscript({
-  file,
-  apiKey,
-  env,
-  model,
-  mediaType,
-}: {
-  file: GeminiFileResource;
-  apiKey: string;
-  env?: Env;
-  model?: string | null;
-  mediaType: string;
-}): Promise<string | null> {
-  const ready = await waitForGeminiFileActive(file, apiKey, env);
-  const fileUri = typeof ready.uri === "string" ? ready.uri.trim() : "";
-  if (!fileUri) {
-    throw new Error("Gemini Files API did not return a file uri");
-  }
-  const response = await geminiJsonRequest({
-    path: `v1beta/models/${resolveModelId(model, env)}:generateContent`,
-    apiKey,
-    env,
-    body: {
-      generationConfig: { temperature: 0 },
-      contents: [
-        {
-          parts: [
-            { text: TRANSCRIPTION_PROMPT },
-            {
-              file_data: {
-                mime_type: resolveGeminiMimeType(ready, mediaType),
-                file_uri: fileUri,
-              },
-            },
-          ],
-        },
-      ],
-    },
-  });
-
-  return extractGeminiTranscript(response, resolveModelId(model, env));
-}
-
-async function uploadGeminiFile({
-  filePath,
-  mediaType,
-  filename,
-  apiKey,
-  env,
-}: {
-  filePath: string;
-  mediaType: string;
-  filename: string | null;
-  apiKey: string;
-  env?: Env;
-}): Promise<GeminiFileResource> {
-  const bytes = await fs.readFile(filePath);
-  return await uploadGeminiBytes({
-    bytes: new Uint8Array(bytes),
-    mediaType,
-    filename,
-    apiKey,
-    env,
-  });
 }
 
 async function uploadGeminiBytes({
@@ -430,14 +342,4 @@ function truncate(value: string): string {
   return trimmed.length > MAX_ERROR_DETAIL_CHARS
     ? `${trimmed.slice(0, MAX_ERROR_DETAIL_CHARS)}…`
     : trimmed;
-}
-
-async function readErrorDetail(response: Response): Promise<string | null> {
-  try {
-    const text = await response.text();
-    const trimmed = text.trim();
-    return trimmed.length > 0 ? truncate(trimmed) : null;
-  } catch {
-    return null;
-  }
 }

--- a/packages/core/src/transcription/whisper/groq.ts
+++ b/packages/core/src/transcription/whisper/groq.ts
@@ -1,8 +1,8 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { MAX_ERROR_DETAIL_CHARS, TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
-import { ensureWhisperFilenameExtension, toArrayBuffer } from "./utils.js";
+import { TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
+import { ensureWhisperFilenameExtension, readErrorDetail, toArrayBuffer } from "./utils.js";
 
 const GROQ_TRANSCRIPT_URL = "https://api.groq.com/openai/v1/audio/transcriptions";
 
@@ -48,19 +48,6 @@ export function shouldRetryGroqViaFfmpeg(error: Error): boolean {
     msg.includes("could not be decoded") ||
     msg.includes("format is not supported")
   );
-}
-
-async function readErrorDetail(response: Response): Promise<string | null> {
-  try {
-    const text = await response.text();
-    const trimmed = text.trim();
-    if (!trimmed) return null;
-    return trimmed.length > MAX_ERROR_DETAIL_CHARS
-      ? `${trimmed.slice(0, MAX_ERROR_DETAIL_CHARS)}…`
-      : trimmed;
-  } catch {
-    return null;
-  }
 }
 
 async function tryGroqCurlFallback({

--- a/packages/core/src/transcription/whisper/openai.ts
+++ b/packages/core/src/transcription/whisper/openai.ts
@@ -1,10 +1,10 @@
 import { openAsBlob } from "node:fs";
 import { basename } from "node:path";
 import { resolveOpenAiWhisperBaseUrl } from "../../openai/base-url.js";
-import { MAX_ERROR_DETAIL_CHARS, TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
+import { TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
 import { formatDiarizedTranscript, formatSpeakerLabel } from "./diarization-format.js";
 import type { TranscriptionSegment, WhisperTranscriptionResult } from "./types.js";
-import { ensureWhisperFilenameExtension, toArrayBuffer } from "./utils.js";
+import { ensureWhisperFilenameExtension, readErrorDetail, toArrayBuffer } from "./utils.js";
 
 type Env = Record<string, string | undefined>;
 export const OPENAI_DIARIZATION_MODEL = "gpt-4o-transcribe-diarize";
@@ -244,17 +244,4 @@ function parseRateLimitDurationMs(value: string | null): number | null {
       amount * (unit === "ms" ? 1 : unit === "s" ? 1_000 : unit === "m" ? 60_000 : 3_600_000);
   }
   return consumed === trimmed && total >= 0 ? total : null;
-}
-
-async function readErrorDetail(response: Response): Promise<string | null> {
-  try {
-    const text = await response.text();
-    const trimmed = text.trim();
-    if (!trimmed) return null;
-    return trimmed.length > MAX_ERROR_DETAIL_CHARS
-      ? `${trimmed.slice(0, MAX_ERROR_DETAIL_CHARS)}…`
-      : trimmed;
-  } catch {
-    return null;
-  }
 }

--- a/packages/core/src/transcription/whisper/utils.ts
+++ b/packages/core/src/transcription/whisper/utils.ts
@@ -1,4 +1,17 @@
 import { promises as fs } from "node:fs";
+import { MAX_ERROR_DETAIL_CHARS } from "./constants.js";
+
+export async function readErrorDetail(response: Response): Promise<string | null> {
+  try {
+    const text = (await response.text()).trim();
+    if (!text) return null;
+    return text.length > MAX_ERROR_DETAIL_CHARS
+      ? `${text.slice(0, MAX_ERROR_DETAIL_CHARS)}…`
+      : text;
+  } catch {
+    return null;
+  }
+}
 
 export function wrapError(prefix: string, error: unknown): Error {
   if (error instanceof Error) {

--- a/tests/transcription.whisper.gemini.test.ts
+++ b/tests/transcription.whisper.gemini.test.ts
@@ -90,84 +90,136 @@ describe("transcription/whisper gemini", () => {
     expect(result.notes.join(" ")).toContain("Gemini transcription failed");
   });
 
-  it("uses the Gemini Files API for oversized local files", async () => {
-    vi.stubEnv("SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP", "1");
-    const root = await mkdtemp(join(tmpdir(), "summarize-gemini-file-"));
-    const audioPath = join(root, "audio.mp3");
-    await writeFile(audioPath, new Uint8Array([1, 2, 3]));
-    await truncate(audioPath, 21 * 1024 * 1024);
-
+  it.each([3, 20 * 1024 * 1024])("uses inline data for a %i-byte local file", async (size) => {
+    const root = await mkdtemp(join(tmpdir(), "summarize-gemini-inline-"));
+    const filePath = join(root, "audio.mp3");
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      if (url.endsWith("/upload/v1beta/files")) {
-        return new Response(JSON.stringify({}), {
-          status: 200,
-          headers: {
-            "x-goog-upload-url": "https://upload.example/files/123",
-          },
-        });
-      }
-      if (url === "https://upload.example/files/123") {
-        return new Response(
-          JSON.stringify({
-            file: {
-              name: "files/123",
-              uri: "https://files.example/audio",
-              state: "ACTIVE",
-              mimeType: "audio/mpeg",
-            },
-          }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        );
-      }
-      if (url.includes("/models/gemini-2.5-flash:generateContent")) {
-        const body = JSON.parse(String(init?.body)) as {
-          contents?: Array<{ parts?: Array<{ file_data?: { file_uri?: string } }> }>;
-        };
-        expect(body.contents?.[0]?.parts?.[1]?.file_data?.file_uri).toBe(
-          "https://files.example/audio",
-        );
-        return new Response(
-          JSON.stringify({
-            candidates: [
-              {
-                content: {
-                  parts: [{ text: "uploaded transcript" }],
-                },
-              },
-            ],
-          }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        );
-      }
-      if (url.endsWith("/v1beta/files/123")) {
-        return new Response("", { status: 204 });
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-
-    try {
-      vi.stubGlobal("fetch", fetchMock);
-      const { transcribeMediaFileWithWhisper } =
-        await import("../packages/core/src/transcription/whisper.js");
-      const result = await transcribeMediaFileWithWhisper({
-        filePath: audioPath,
-        mediaType: "audio/mpeg",
-        filename: "audio.mp3",
-        groqApiKey: null,
-        geminiApiKey: "GEMINI",
-        openaiApiKey: null,
-        falApiKey: null,
-        env: { SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP: "1" },
+      expect(String(input)).toBe(
+        "https://gemini.example/proxy/v1beta/models/custom:generateContent",
+      );
+      expect(new Headers(init?.headers).get("x-goog-api-key")).toBe("GEMINI");
+      const body = JSON.parse(String(init?.body));
+      const data = body.contents[0].parts[1].inline_data;
+      expect(data.mime_type).toBe("audio/mpeg");
+      expect(Buffer.from(data.data, "base64").byteLength).toBe(size);
+      return Response.json({
+        candidates: [{ content: { parts: [{ text: "inline transcript" }] } }],
       });
-
-      expect(result.text).toBe("uploaded transcript");
-      expect(result.provider).toBe("gemini");
-      expect(
-        fetchMock.mock.calls.some(([input]) => String(input).includes("/upload/v1beta/files")),
-      ).toBe(true);
+    });
+    try {
+      await writeFile(filePath, new Uint8Array([1, 2, 3]));
+      await truncate(filePath, size);
+      vi.stubGlobal("fetch", fetchMock);
+      const { transcribeFileWithGemini } =
+        await import("../packages/core/src/transcription/whisper/gemini.js");
+      await expect(
+        transcribeFileWithGemini({
+          filePath,
+          mediaType: "audio/mpeg",
+          filename: "audio.mp3",
+          apiKey: "GEMINI",
+          env: { GOOGLE_BASE_URL: "https://gemini.example/proxy/" },
+          model: "custom",
+        }),
+      ).resolves.toBe("inline transcript");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     } finally {
-      await rm(root, { recursive: true, force: true }).catch(() => {});
+      await rm(root, { recursive: true, force: true });
     }
   });
+
+  it.each([false, true])(
+    "cleans up oversized local files with generation failure=%s",
+    async (failGeneration) => {
+      vi.stubEnv("SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP", "1");
+      const root = await mkdtemp(join(tmpdir(), "summarize-gemini-file-"));
+      const audioPath = join(root, "audio.mp3");
+      await writeFile(audioPath, new Uint8Array([1, 2, 3]));
+      await truncate(audioPath, 20 * 1024 * 1024 + 1);
+
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.endsWith("/upload/v1beta/files")) {
+          return new Response(JSON.stringify({}), {
+            status: 200,
+            headers: {
+              "x-goog-upload-url": "https://upload.example/files/123",
+            },
+          });
+        }
+        if (url === "https://upload.example/files/123") {
+          return new Response(
+            JSON.stringify({
+              file: {
+                name: "files/123",
+                uri: "https://files.example/audio",
+                state: "ACTIVE",
+                mimeType: "audio/mpeg",
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.includes("/models/gemini-2.5-flash:generateContent")) {
+          if (failGeneration) return new Response("unavailable", { status: 503 });
+          const body = JSON.parse(String(init?.body)) as {
+            contents?: Array<{ parts?: Array<{ file_data?: { file_uri?: string } }> }>;
+          };
+          expect(body.contents?.[0]?.parts?.[1]?.file_data?.file_uri).toBe(
+            "https://files.example/audio",
+          );
+          return new Response(
+            JSON.stringify({
+              candidates: [
+                {
+                  content: {
+                    parts: [{ text: "uploaded transcript" }],
+                  },
+                },
+              ],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.endsWith("/v1beta/files/123")) {
+          expect(init?.method).toBe("DELETE");
+          return new Response(null, { status: 204 });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      });
+
+      try {
+        vi.stubGlobal("fetch", fetchMock);
+        const { transcribeMediaFileWithWhisper } =
+          await import("../packages/core/src/transcription/whisper.js");
+        const result = await transcribeMediaFileWithWhisper({
+          filePath: audioPath,
+          mediaType: "audio/mpeg",
+          filename: "audio.mp3",
+          groqApiKey: null,
+          geminiApiKey: "GEMINI",
+          openaiApiKey: null,
+          falApiKey: null,
+          env: { SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP: "1" },
+        });
+
+        if (failGeneration) {
+          expect(result.text).toBeNull();
+          expect(result.error?.message).toContain("Gemini request failed (503)");
+        } else {
+          expect(result.text).toBe("uploaded transcript");
+          expect(result.provider).toBe("gemini");
+        }
+        expect(
+          fetchMock.mock.calls.some(([input]) => String(input).includes("/upload/v1beta/files")),
+        ).toBe(true);
+        expect(fetchMock).toHaveBeenCalledWith(
+          new URL("https://generativelanguage.googleapis.com/v1beta/files/123"),
+          expect.objectContaining({ method: "DELETE" }),
+        );
+      } finally {
+        await rm(root, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  );
 });


### PR DESCRIPTION
Gemini's file and byte entry points separately selected inline versus uploaded transcription, generated matching requests, and managed uploaded-file cleanup. The file path already read the whole file for either route. Five cloud-provider modules also repeated the same bounded HTTP error-body reader.

Delegate local files to the shared byte lifecycle, share the generateContent payload builder, and use one error reader. Preserve the inclusive 20 MiB inline threshold, endpoint/model overrides, polling, cleanup, provider errors, and exported input signatures. This removes 134 production lines and 81 net lines after test and changelog additions.

Expand characterization coverage for small files, exactly 20 MiB, one byte above the threshold, and deletion after failed generation. Correct the cleanup fixture to return a bodyless 204 response so it proves successful deletion rather than silently swallowing a mock error.

Validation: `pnpm build` and `pnpm check` pass (3,029 tests passed; 43 skipped), with 63 focused transcription tests passing. The six Gemini characterization cases pass before and after the implementation change. Independent Codex autoreview reports no actionable P0–P2 findings.
