### PR TITLE
refactor(engine): unify completion and stream fallback execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Dependencies and maintenance
 
+- Unify model execution around one resolved request and completion path; centralize stream consumption while preserving output-failure and retry boundaries.
 - Consolidate LLM request options and SDK stream handling while preserving provider-specific configuration, errors, and fallback behavior.
 - Build asset summary contexts directly from shared application state, removing redundant context wrappers and narrowing the asset-only format override.
 - Share Gemini file/byte transcription and bounded cloud-provider error handling, with coverage for the inline-upload boundary and uploaded-file cleanup after failures.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -25,7 +25,7 @@ CLI and daemon code remain adapters:
 | `events.ts`             | Adapter-neutral summary stream contract                             |
 | `errors.ts`             | Stable engine error-code guards                                     |
 | `types.ts`              | Model attempts and typed execution results                          |
-| `model-call.ts`         | Provider model resolution and non-streaming calls                   |
+| `model-call.ts`         | Provider model resolution                                           |
 | `streaming.ts`          | Stream capability and chunk normalization                           |
 
 ## Dependency rules
@@ -43,6 +43,8 @@ Engine modules may depend on portable domain/config modules, provider clients, c
 ## Streaming
 
 The engine never writes summary text to stdout.
+
+Each provider attempt resolves one request shared by streaming, direct completion, and fallback completion. Stream consumption owns output-handler lifecycle and marks visible or handler failures as interrupted; only an uncommitted provider failure can fall back to completion. Usage collection happens after successful stream consumption and does not trigger another model call.
 
 `SummaryStreamHandler` receives normalized chunks:
 

--- a/src/engine/model-call.ts
+++ b/src/engine/model-call.ts
@@ -1,9 +1,5 @@
-import { generateTextWithModelId } from "../llm/generate-text.js";
 import { resolveGoogleModelForUsage } from "../llm/google-models.js";
-import type { LlmProvider } from "../llm/model-id.js";
 import type { parseGatewayStyleModelId } from "../llm/model-id.js";
-import type { ModelRequestOptions } from "../llm/model-options.js";
-import type { Prompt } from "../llm/prompt.js";
 
 const GOOGLE_DEVELOPER_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 
@@ -26,18 +22,10 @@ export async function resolveModelIdForLlmCall({
   googleBaseUrlOverride?: string | null;
   fetchImpl: typeof fetch;
   timeoutMs: number;
-}): Promise<{ modelId: string; note: string | null; forceStreamOff: boolean }> {
-  if (parsedModel.provider !== "google") {
-    return { modelId: parsedModel.canonical, note: null, forceStreamOff: false };
-  }
-
+}): Promise<{ modelId: string; note: string | null }> {
   const key = apiKeys.googleApiKey;
-  if (!key) {
-    return { modelId: parsedModel.canonical, note: null, forceStreamOff: false };
-  }
-
-  if (isCustomGoogleBaseUrl(googleBaseUrlOverride)) {
-    return { modelId: parsedModel.canonical, note: null, forceStreamOff: false };
+  if (parsedModel.provider !== "google" || !key || isCustomGoogleBaseUrl(googleBaseUrlOverride)) {
+    return { modelId: parsedModel.canonical, note: null };
   }
 
   const resolved = await resolveGoogleModelForUsage({
@@ -50,87 +38,5 @@ export async function resolveModelIdForLlmCall({
   return {
     modelId: `google/${resolved.resolvedModelId}`,
     note: resolved.note,
-    forceStreamOff: false,
-  };
-}
-
-export async function summarizeWithModelId({
-  modelId,
-  prompt,
-  maxOutputTokens,
-  timeoutMs,
-  fetchImpl,
-  apiKeys,
-  forceOpenRouter,
-  openaiBaseUrlOverride,
-  anthropicBaseUrlOverride,
-  googleBaseUrlOverride,
-  xaiBaseUrlOverride,
-  zaiBaseUrlOverride,
-  ollamaBaseUrlOverride,
-  forceChatCompletions,
-  requestOptions,
-  retries,
-  onRetry,
-}: {
-  modelId: string;
-  prompt: Prompt;
-  maxOutputTokens?: number;
-  timeoutMs: number;
-  fetchImpl: typeof fetch;
-  apiKeys: {
-    xaiApiKey: string | null;
-    openaiApiKey: string | null;
-    googleApiKey: string | null;
-    anthropicApiKey: string | null;
-    openrouterApiKey: string | null;
-  };
-  forceOpenRouter?: boolean;
-  openaiBaseUrlOverride?: string | null;
-  anthropicBaseUrlOverride?: string | null;
-  googleBaseUrlOverride?: string | null;
-  xaiBaseUrlOverride?: string | null;
-  zaiBaseUrlOverride?: string | null;
-  ollamaBaseUrlOverride?: string | null;
-  forceChatCompletions?: boolean;
-  requestOptions?: ModelRequestOptions;
-  retries: number;
-  onRetry?: (notice: {
-    attempt: number;
-    maxRetries: number;
-    delayMs: number;
-    error: unknown;
-  }) => void;
-}): Promise<{
-  text: string;
-  provider: LlmProvider;
-  canonicalModelId: string;
-  usage: Awaited<ReturnType<typeof generateTextWithModelId>>["usage"];
-}> {
-  const result = await generateTextWithModelId({
-    modelId,
-    apiKeys,
-    forceOpenRouter,
-    openaiBaseUrlOverride,
-    anthropicBaseUrlOverride,
-    googleBaseUrlOverride,
-    xaiBaseUrlOverride,
-    zaiBaseUrlOverride,
-    ollamaBaseUrlOverride,
-    forceChatCompletions,
-    requestOptions,
-    prompt,
-    temperature: 0,
-    maxOutputTokens,
-    timeoutMs,
-    fetchImpl,
-    retries,
-    onRetry,
-  });
-  return {
-    text: result.text,
-    provider: result.provider,
-    canonicalModelId: result.canonicalModelId,
-    usage: result.usage,
   };
 }

--- a/src/engine/model-executor.ts
+++ b/src/engine/model-executor.ts
@@ -1,7 +1,8 @@
 import type { CliProvider } from "../config.js";
+import type { LlmCall } from "../costs.js";
 import { isCliDisabled, runCliModel } from "../llm/cli.js";
 import { isRetryableLlmError, resolveLlmErrorMessage } from "../llm/generate-text-shared.js";
-import { streamTextWithModelId } from "../llm/generate-text.js";
+import { generateTextWithModelId, streamTextWithModelId } from "../llm/generate-text.js";
 import { parseGatewayStyleModelId } from "../llm/model-id.js";
 import { mergeRequestOptionsForProvider } from "../llm/model-options.js";
 import type { ModelRequestOptions, OpenAiReasoningEffort } from "../llm/model-options.js";
@@ -14,9 +15,9 @@ import {
 import type { ProviderRuntimeBindings } from "../llm/provider-profile.js";
 import { formatCompactCount } from "../shared/format-count.js";
 import { countTokens } from "../tokenizer.js";
-import { EngineError } from "./errors.js";
+import { EngineError, hasEngineErrorCode } from "./errors.js";
 import type { SummaryStreamHandler } from "./events.js";
-import { resolveModelIdForLlmCall, summarizeWithModelId } from "./model-call.js";
+import { resolveModelIdForLlmCall } from "./model-call.js";
 import {
   canStream,
   isGoogleStreamingUnsupportedError,
@@ -40,23 +41,7 @@ export type ModelExecutorDeps = {
   trackedFetch: typeof fetch;
   resolveMaxOutputTokensForCall: (modelId: string) => Promise<number | null>;
   resolveMaxInputTokensForCall: (modelId: string) => Promise<number | null>;
-  llmCalls: Array<{
-    provider:
-      | "xai"
-      | "openai"
-      | "google"
-      | "anthropic"
-      | "zai"
-      | "nvidia"
-      | "minimax"
-      | "github-copilot"
-      | "ollama"
-      | "cli";
-    model: string;
-    usage: Awaited<ReturnType<typeof summarizeWithModelId>>["usage"] | null;
-    costUsd?: number | null;
-    purpose: "summary" | "markdown" | "speaker-identification";
-  }>;
+  llmCalls: LlmCall[];
   log?: ((message: string) => void) | null;
   trace?: ((name: string, detail?: string | null) => void) | null;
   providerRuntime: ProviderRuntimeBindings;
@@ -77,6 +62,85 @@ class StreamHandlerError extends Error {
     this.name = "StreamHandlerError";
     this.handlerError = normalized;
   }
+}
+
+function normalizeStreamError(error: unknown): Error {
+  return error instanceof Error
+    ? error
+    : new Error(resolveLlmErrorMessage(error) || "LLM stream failed", { cause: error });
+}
+
+function streamInterrupted(error: unknown): EngineError {
+  const cause = normalizeStreamError(error);
+  return new EngineError("SUMMARY_STREAM_INTERRUPTED", cause.message, { cause });
+}
+
+async function consumeSummaryStream(
+  result: Awaited<ReturnType<typeof streamTextWithModelId>>,
+  handler: SummaryStreamHandler | null | undefined,
+  trace: ModelExecutorDeps["trace"],
+): Promise<Pick<SummaryAttemptResult, "summary" | "summaryEmitted">> {
+  let streamed = "";
+  let handlerStarted = false;
+  let outputEmitted = false;
+  const emitChunk = async (next: string, appended: string) => {
+    const previous = streamed;
+    streamed = next;
+    if (!handler || (!handlerStarted && !streamed.trim())) return;
+    const firstChunk = !handlerStarted;
+    handlerStarted = true;
+    try {
+      outputEmitted =
+        (await handler.onChunk({
+          streamed,
+          prevStreamed: firstChunk ? "" : previous,
+          appended: firstChunk ? streamed : appended,
+        })) || outputEmitted;
+    } catch (error) {
+      throw new StreamHandlerError(error);
+    }
+  };
+  const throwIfFailed = () => {
+    const error = result.lastError();
+    if (error) throw normalizeStreamError(error);
+  };
+  try {
+    let sawFirstDelta = false;
+    for await (const delta of result.textStream) {
+      if (!sawFirstDelta) {
+        sawFirstDelta = true;
+        trace?.("summary:first-delta");
+      }
+      const merged = mergeStreamingChunk(streamed, delta);
+      await emitChunk(merged.next, merged.appended);
+    }
+    throwIfFailed();
+    const finalText = (await result.finalText)?.trim() ?? "";
+    throwIfFailed();
+    if (finalText.length > streamed.length && finalText.startsWith(streamed)) {
+      await emitChunk(finalText, finalText.slice(streamed.length));
+    }
+    if (!streamed.trim()) throw new Error("LLM returned an empty summary");
+  } catch (error) {
+    if (handler && handlerStarted && !outputEmitted) {
+      try {
+        await handler.onReset();
+      } catch (resetError) {
+        throw streamInterrupted(new StreamHandlerError(resetError).handlerError);
+      }
+    }
+    if (error instanceof StreamHandlerError) throw streamInterrupted(error.handlerError);
+    throw outputEmitted ? streamInterrupted(error) : error;
+  }
+  let finalOutputEmitted = false;
+  if (handler && handlerStarted) {
+    try {
+      finalOutputEmitted = (await handler.onDone?.(streamed)) ?? false;
+    } catch (error) {
+      throw streamInterrupted(error);
+    }
+  }
+  return { summary: streamed.trim(), summaryEmitted: outputEmitted || finalOutputEmitted };
 }
 
 export function createModelExecutor(deps: ModelExecutorDeps) {
@@ -223,7 +287,6 @@ export function createModelExecutor(deps: ModelExecutorDeps) {
     const streamingEnabledForCall =
       allowStreaming &&
       deps.streamingEnabled &&
-      !modelResolution.forceStreamOff &&
       canStream({
         provider: parsedModelEffective.provider,
         prompt,
@@ -260,24 +323,39 @@ export function createModelExecutor(deps: ModelExecutorDeps) {
       }
     }
 
-    if (!streamingEnabledForCall) {
-      const result = await summarizeWithModelId({
-        modelId: parsedModelEffective.canonical,
-        prompt,
-        maxOutputTokens: maxOutputTokensForCall ?? undefined,
-        timeoutMs: deps.timeoutMs,
-        fetchImpl: deps.trackedFetch,
-        apiKeys: apiKeysForLlm,
-        forceOpenRouter: attempt.forceOpenRouter,
-        openaiBaseUrlOverride: attempt.openaiBaseUrlOverride ?? providerRuntime.baseUrls.openai,
-        anthropicBaseUrlOverride: providerRuntime.baseUrls.anthropic,
-        googleBaseUrlOverride: providerRuntime.baseUrls.google,
-        xaiBaseUrlOverride: providerRuntime.baseUrls.xai,
+    const request = {
+      modelId: parsedModelEffective.canonical,
+      prompt,
+      temperature: 0,
+      maxOutputTokens: maxOutputTokensForCall ?? undefined,
+      timeoutMs: deps.timeoutMs,
+      fetchImpl: deps.trackedFetch,
+      apiKeys: apiKeysForLlm,
+      forceOpenRouter: attempt.forceOpenRouter,
+      openaiBaseUrlOverride: attempt.openaiBaseUrlOverride ?? providerRuntime.baseUrls.openai,
+      anthropicBaseUrlOverride: providerRuntime.baseUrls.anthropic,
+      googleBaseUrlOverride: providerRuntime.baseUrls.google,
+      xaiBaseUrlOverride: providerRuntime.baseUrls.xai,
+      ollamaBaseUrlOverride: providerRuntime.baseUrls.ollama,
+      forceChatCompletions,
+      requestOptions,
+    };
+    const toResult = (summary: string, summaryEmitted = false): SummaryAttemptResult => ({
+      summary,
+      summaryEmitted,
+      modelMeta: {
+        provider: parsedModelEffective.provider,
+        canonical: attempt.userModelId.toLowerCase().startsWith("openrouter/")
+          ? attempt.userModelId
+          : parsedModelEffective.canonical,
+      },
+      maxOutputTokensForCall: maxOutputTokensForCall ?? null,
+    });
+    const complete = async (retries = deps.retries) => {
+      const result = await generateTextWithModelId({
+        ...request,
         zaiBaseUrlOverride: providerRuntime.baseUrls.zai,
-        ollamaBaseUrlOverride: providerRuntime.baseUrls.ollama,
-        forceChatCompletions,
-        requestOptions,
-        retries: deps.retries,
+        retries,
         onRetry: createRetryLogger(parsedModelEffective.canonical),
       });
       deps.llmCalls.push({
@@ -288,264 +366,52 @@ export function createModelExecutor(deps: ModelExecutorDeps) {
       });
       const summary = result.text.trim();
       if (!summary) throw new Error("LLM returned an empty summary");
-      const displayCanonical = attempt.userModelId.toLowerCase().startsWith("openrouter/")
-        ? attempt.userModelId
-        : parsedModelEffective.canonical;
-      return {
-        summary,
-        summaryEmitted: false,
-        modelMeta: {
-          provider: parsedModelEffective.provider,
-          canonical: displayCanonical,
-        },
-        maxOutputTokensForCall: maxOutputTokensForCall ?? null,
-      };
-    }
+      return summary;
+    };
+    if (!streamingEnabledForCall) return toResult(await complete());
 
-    let summaryEmitted = false;
-    let summary = "";
-    let getLastStreamError: (() => unknown) | null = null;
-
-    let streamResult: Awaited<ReturnType<typeof streamTextWithModelId>> | null = null;
-    const summarizeWithoutStreaming = async (retries = deps.retries) => {
-      const result = await summarizeWithModelId({
-        modelId: parsedModelEffective.canonical,
-        prompt,
-        maxOutputTokens: maxOutputTokensForCall ?? undefined,
-        timeoutMs: deps.timeoutMs,
-        fetchImpl: deps.trackedFetch,
-        apiKeys: apiKeysForLlm,
-        forceOpenRouter: attempt.forceOpenRouter,
-        openaiBaseUrlOverride: attempt.openaiBaseUrlOverride ?? providerRuntime.baseUrls.openai,
-        anthropicBaseUrlOverride: providerRuntime.baseUrls.anthropic,
-        googleBaseUrlOverride: providerRuntime.baseUrls.google,
-        xaiBaseUrlOverride: providerRuntime.baseUrls.xai,
-        zaiBaseUrlOverride: providerRuntime.baseUrls.zai,
-        ollamaBaseUrlOverride: providerRuntime.baseUrls.ollama,
-        forceChatCompletions,
-        requestOptions,
-        retries,
-        onRetry: createRetryLogger(parsedModelEffective.canonical),
-      });
-      deps.llmCalls.push({
-        provider: result.provider,
-        model: result.canonicalModelId,
-        usage: result.usage,
-        purpose: "summary",
-      });
-      return result.text;
-    };
-    const canFallbackFromStreamError = (error: unknown): boolean =>
-      isStreamingTimeoutError(error) ||
-      (deps.retries > 0 && isRetryableLlmError(error)) ||
-      (parsedModelEffective.provider === "google" && isGoogleStreamingUnsupportedError(error));
-    const remainingRetriesAfterStreamFallback = (error: unknown): number =>
-      isRetryableLlmError(error) ? Math.max(0, deps.retries - 1) : deps.retries;
-    const normalizeStreamError = (error: unknown): Error =>
-      error instanceof Error
-        ? error
-        : new Error(resolveLlmErrorMessage(error) || "LLM stream failed", { cause: error });
-    const throwIfStreamFailed = () => {
-      const error = getLastStreamError?.();
-      if (error) throw normalizeStreamError(error);
-    };
-    const writeStreamFallbackNotice = (error: unknown) => {
-      if (isStreamingTimeoutError(error)) {
-        deps.log?.(
-          `Streaming timed out for ${parsedModelEffective.canonical}; falling back to non-streaming.`,
-        );
-        return;
-      }
-      if (isRetryableLlmError(error)) {
-        deps.log?.(
-          `Transient streaming failure for ${parsedModelEffective.canonical}; retrying non-streaming.`,
-        );
-        return;
-      }
-      deps.log?.(
-        `Google model ${parsedModelEffective.canonical} rejected streamGenerateContent; falling back to non-streaming.`,
-      );
-    };
-    const createStreamInterruptedError = (error: unknown) => {
-      const normalized = normalizeStreamError(error);
-      return new EngineError("SUMMARY_STREAM_INTERRUPTED", normalized.message, {
-        cause: normalized,
-      });
-    };
-    const callStreamHandler = async <T>(operation: () => T | Promise<T>): Promise<T> => {
-      try {
-        return await operation();
-      } catch (error) {
-        throw new StreamHandlerError(error);
-      }
-    };
+    let stream: Awaited<ReturnType<typeof streamTextWithModelId>>;
+    let consumed: Pick<SummaryAttemptResult, "summary" | "summaryEmitted">;
     try {
       deps.trace?.("summary:stream-open");
-      streamResult = await streamTextWithModelId({
-        modelId: parsedModelEffective.canonical,
-        apiKeys: apiKeysForLlm,
-        forceOpenRouter: attempt.forceOpenRouter,
-        openaiBaseUrlOverride: attempt.openaiBaseUrlOverride ?? providerRuntime.baseUrls.openai,
-        anthropicBaseUrlOverride: providerRuntime.baseUrls.anthropic,
-        googleBaseUrlOverride: providerRuntime.baseUrls.google,
-        xaiBaseUrlOverride: providerRuntime.baseUrls.xai,
-        ollamaBaseUrlOverride: providerRuntime.baseUrls.ollama,
-        forceChatCompletions,
-        requestOptions,
-        prompt,
-        temperature: 0,
-        maxOutputTokens: maxOutputTokensForCall ?? undefined,
-        timeoutMs: deps.timeoutMs,
-        fetchImpl: deps.trackedFetch,
-      });
+      stream = await streamTextWithModelId(request);
+      consumed = await consumeSummaryStream(stream, streamHandler, deps.trace);
     } catch (error) {
-      if (canFallbackFromStreamError(error)) {
-        writeStreamFallbackNotice(error);
-        summary = await summarizeWithoutStreaming(remainingRetriesAfterStreamFallback(error));
-        streamResult = null;
-      } else {
-        throw error;
-      }
-    }
-
-    if (streamResult) {
-      getLastStreamError = streamResult.lastError;
-      let streamed = "";
-      let streamedRaw = "";
-      let streamCompleted = false;
-      let streamHandlerStarted = false;
-      let streamOutputEmitted = false;
-
-      try {
-        let sawFirstDelta = false;
-        for await (const delta of streamResult.textStream) {
-          if (!sawFirstDelta) {
-            sawFirstDelta = true;
-            deps.trace?.("summary:first-delta");
-          }
-          const prevStreamed = streamed;
-          const merged = mergeStreamingChunk(streamed, delta);
-          streamed = merged.next;
-          if (streamHandler) {
-            if (!streamHandlerStarted && !streamed.trim()) continue;
-            const firstChunk = !streamHandlerStarted;
-            streamHandlerStarted = true;
-            streamOutputEmitted =
-              (await callStreamHandler(() =>
-                streamHandler.onChunk({
-                  streamed: merged.next,
-                  prevStreamed: firstChunk ? "" : prevStreamed,
-                  appended: firstChunk ? merged.next : merged.appended,
-                }),
-              )) || streamOutputEmitted;
-          }
-        }
-
-        throwIfStreamFailed();
-
-        const finalText = (await streamResult.finalText)?.trim() ?? "";
-        throwIfStreamFailed();
-        if (finalText.length > streamed.length && finalText.startsWith(streamed)) {
-          const prevStreamed = streamed;
-          const firstChunk = !streamHandlerStarted;
-          streamed = finalText;
-          if (streamHandler) {
-            streamHandlerStarted = true;
-            streamOutputEmitted =
-              (await callStreamHandler(() =>
-                streamHandler.onChunk({
-                  streamed,
-                  prevStreamed: firstChunk ? "" : prevStreamed,
-                  appended: firstChunk ? streamed : streamed.slice(prevStreamed.length),
-                }),
-              )) || streamOutputEmitted;
-          }
-        }
-
-        streamedRaw = streamed;
-        const trimmed = streamed.trim();
-        streamed = trimmed;
-        if (!streamed) throw new Error("LLM returned an empty summary");
-        streamCompleted = true;
-      } catch (error) {
-        if (streamHandler && streamHandlerStarted && !streamOutputEmitted) {
-          try {
-            await callStreamHandler(() => streamHandler.onReset());
-          } catch (resetError) {
-            const cause =
-              resetError instanceof StreamHandlerError ? resetError.handlerError : resetError;
-            throw createStreamInterruptedError(cause);
-          }
-          streamHandlerStarted = false;
-        }
-        if (error instanceof StreamHandlerError) {
-          throw createStreamInterruptedError(error.handlerError);
-        }
-        if (canFallbackFromStreamError(error) && !streamOutputEmitted) {
-          writeStreamFallbackNotice(error);
-          summary = await summarizeWithoutStreaming(remainingRetriesAfterStreamFallback(error));
-          streamResult = null;
-        } else {
-          throw streamOutputEmitted ? createStreamInterruptedError(error) : error;
-        }
-      } finally {
-        if (streamCompleted && streamHandler && streamHandlerStarted) {
-          try {
-            const finalOutputEmitted =
-              (await streamHandler.onDone?.(streamedRaw || streamed)) ?? false;
-            summaryEmitted = streamOutputEmitted || finalOutputEmitted;
-          } catch (error) {
-            throw createStreamInterruptedError(error);
-          }
-        }
-      }
-      if (streamResult) {
-        const usage = await streamResult.usage;
-        deps.llmCalls.push({
-          provider: streamResult.provider,
-          model: streamResult.canonicalModelId,
-          usage,
-          purpose: "summary",
-        });
-        summary = streamed;
-      }
-    }
-
-    summary = summary.trim();
-    if (summary.length === 0) {
-      const last = getLastStreamError?.();
-      if (last instanceof Error) {
-        throw new Error(last.message, { cause: last });
-      }
-      throw new Error("LLM returned an empty summary");
-    }
-
-    if (!streamResult && streamHandler) {
-      const cleaned = summary.trim();
+      if (hasEngineErrorCode(error, "SUMMARY_STREAM_INTERRUPTED")) throw error;
+      const timedOut = isStreamingTimeoutError(error);
+      const retryable = isRetryableLlmError(error);
+      const unsupported =
+        parsedModelEffective.provider === "google" && isGoogleStreamingUnsupportedError(error);
+      if (!timedOut && !(deps.retries > 0 && retryable) && !unsupported) throw error;
+      deps.log?.(
+        timedOut
+          ? `Streaming timed out for ${request.modelId}; falling back to non-streaming.`
+          : retryable
+            ? `Transient streaming failure for ${request.modelId}; retrying non-streaming.`
+            : `Google model ${request.modelId} rejected streamGenerateContent; falling back to non-streaming.`,
+      );
+      const summary = await complete(retryable ? Math.max(0, deps.retries - 1) : deps.retries);
+      if (!streamHandler) return toResult(summary);
       try {
         const chunkEmitted = await streamHandler.onChunk({
-          streamed: cleaned,
+          streamed: summary,
           prevStreamed: "",
-          appended: cleaned,
+          appended: summary,
         });
-        const finalOutputEmitted = (await streamHandler.onDone?.(cleaned)) ?? false;
-        summaryEmitted = chunkEmitted || finalOutputEmitted;
-      } catch (error) {
-        throw createStreamInterruptedError(error);
+        const finalEmitted = (await streamHandler.onDone?.(summary)) ?? false;
+        return toResult(summary, chunkEmitted || finalEmitted);
+      } catch (outputError) {
+        throw streamInterrupted(outputError);
       }
     }
-
-    return {
-      summary,
-      summaryEmitted,
-      modelMeta: {
-        provider: parsedModelEffective.provider,
-        canonical: attempt.userModelId.toLowerCase().startsWith("openrouter/")
-          ? attempt.userModelId
-          : parsedModelEffective.canonical,
-      },
-      maxOutputTokensForCall: maxOutputTokensForCall ?? null,
-    };
+    const usage = await stream.usage;
+    deps.llmCalls.push({
+      provider: stream.provider,
+      model: stream.canonicalModelId,
+      usage,
+      purpose: "summary",
+    });
+    return toResult(consumed.summary, consumed.summaryEmitted);
   };
 
   return {

--- a/tests/engine.model-call.test.ts
+++ b/tests/engine.model-call.test.ts
@@ -18,7 +18,6 @@ describe("model call resolution", () => {
     expect(result).toEqual({
       modelId: "google/gemini-custom-preview",
       note: null,
-      forceStreamOff: false,
     });
   });
 

--- a/tests/engine.model-executor.test.ts
+++ b/tests/engine.model-executor.test.ts
@@ -8,17 +8,17 @@ import { parseRequestedModelId } from "../src/model-spec.js";
 
 const mocks = vi.hoisted(() => ({
   resolveModelIdForLlmCall: vi.fn(),
-  summarizeWithModelId: vi.fn(),
+  generateTextWithModelId: vi.fn(),
   streamTextWithModelId: vi.fn(),
 }));
 
 vi.mock("../src/llm/generate-text.js", () => ({
+  generateTextWithModelId: mocks.generateTextWithModelId,
   streamTextWithModelId: mocks.streamTextWithModelId,
 }));
 
 vi.mock("../src/engine/model-call.js", () => ({
   resolveModelIdForLlmCall: mocks.resolveModelIdForLlmCall,
-  summarizeWithModelId: mocks.summarizeWithModelId,
 }));
 
 function createTestModelExecutor(
@@ -93,16 +93,15 @@ function resolveTestFixedAttempt(
 
 beforeEach(() => {
   mocks.resolveModelIdForLlmCall.mockReset();
-  mocks.summarizeWithModelId.mockReset();
+  mocks.generateTextWithModelId.mockReset();
   mocks.streamTextWithModelId.mockReset();
   mocks.resolveModelIdForLlmCall.mockImplementation(
     async ({ parsedModel }: { parsedModel: { canonical: string } }) => ({
       modelId: parsedModel.canonical,
       note: null,
-      forceStreamOff: false,
     }),
   );
-  mocks.summarizeWithModelId.mockResolvedValue({
+  mocks.generateTextWithModelId.mockResolvedValue({
     text: "Summary.",
     provider: "openai",
     canonicalModelId: "openai/gpt-5.4",
@@ -125,7 +124,7 @@ describe("model executor OpenAI chat-completions routing", () => {
       false,
     );
 
-    const call = mocks.summarizeWithModelId.mock.calls[0]?.[0] as {
+    const call = mocks.generateTextWithModelId.mock.calls[0]?.[0] as {
       forceChatCompletions?: boolean;
       openaiBaseUrlOverride?: string | null;
     };
@@ -146,7 +145,7 @@ describe("model executor OpenAI chat-completions routing", () => {
       false,
     );
 
-    const call = mocks.summarizeWithModelId.mock.calls[0]?.[0] as {
+    const call = mocks.generateTextWithModelId.mock.calls[0]?.[0] as {
       forceChatCompletions?: boolean;
       forceOpenRouter?: boolean;
     };
@@ -163,7 +162,7 @@ describe("model executor OpenAI chat-completions routing", () => {
       allowStreaming: false,
     });
 
-    const call = mocks.summarizeWithModelId.mock.calls[0]?.[0] as {
+    const call = mocks.generateTextWithModelId.mock.calls[0]?.[0] as {
       apiKeys?: { openaiApiKey?: string | null };
       forceChatCompletions?: boolean;
       openaiBaseUrlOverride?: string | null;
@@ -182,7 +181,7 @@ describe("model executor OpenAI chat-completions routing", () => {
       allowStreaming: false,
     });
 
-    const call = mocks.summarizeWithModelId.mock.calls[0]?.[0] as {
+    const call = mocks.generateTextWithModelId.mock.calls[0]?.[0] as {
       apiKeys?: { openaiApiKey?: string | null };
       openaiBaseUrlOverride?: string | null;
     };
@@ -226,6 +225,62 @@ describe("model executor credential availability", () => {
 });
 
 describe("model executor streaming", () => {
+  it.each(["opening", "consuming"])("preserves request settings after %s fails", async (phase) => {
+    const failure = Object.assign(new Error("connection reset"), { code: "ECONNRESET" });
+    if (phase === "opening") {
+      mocks.streamTextWithModelId.mockRejectedValue(failure);
+    } else {
+      mocks.streamTextWithModelId.mockResolvedValue({
+        textStream: (async function* () {
+          throw failure;
+        })(),
+        usage: Promise.resolve(null),
+        finalText: Promise.resolve(null),
+        lastError: () => null,
+      });
+    }
+    const engine = createTestModelExecutor(false, true, 2);
+    const attempt = resolveTestFixedAttempt(engine, "openai/gpt-5.4");
+    attempt.openaiBaseUrlOverride = "https://gateway.example/v1";
+    attempt.requestOptions = { reasoningEffort: "high" };
+    await engine.runSummaryAttempt({
+      attempt,
+      prompt: { system: "Summarize faithfully.", userText: "Document." },
+      allowStreaming: true,
+    });
+    const request = mocks.streamTextWithModelId.mock.calls[0]?.[0];
+    expect(request).toMatchObject({
+      temperature: 0,
+      openaiBaseUrlOverride: "https://gateway.example/v1",
+    });
+    expect(mocks.generateTextWithModelId).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ ...request, retries: 1 }),
+    );
+  });
+
+  it("does not repeat a completed model call when usage collection fails", async () => {
+    const failure = new Error("usage connection reset");
+    const usage = Promise.reject(failure);
+    void usage.catch(() => {});
+    mocks.streamTextWithModelId.mockResolvedValue({
+      textStream: (async function* () {
+        yield "Summary.";
+      })(),
+      finalText: Promise.resolve("Summary."),
+      usage,
+      lastError: () => null,
+    });
+    const engine = createTestModelExecutor(undefined, true, 2);
+    await expect(
+      engine.runSummaryAttempt({
+        attempt: resolveTestFixedAttempt(engine, "openai/gpt-5.4"),
+        prompt: { userText: "Document." },
+        allowStreaming: true,
+      }),
+    ).rejects.toBe(failure);
+    expect(mocks.generateTextWithModelId).not.toHaveBeenCalled();
+  });
+
   it("emits structured chunks without owning output", async () => {
     async function* textStream() {
       yield "Hello";
@@ -377,7 +432,7 @@ describe("model executor streaming", () => {
       canonicalModelId: "openai/gpt-5.4",
       lastError: () => null,
     });
-    mocks.summarizeWithModelId.mockResolvedValue({
+    mocks.generateTextWithModelId.mockResolvedValue({
       text: "Fallback summary.",
       provider: "openai",
       canonicalModelId: "openai/gpt-5.4",
@@ -485,7 +540,7 @@ describe("model executor streaming", () => {
     expect(hasEngineErrorCode(error, "SUMMARY_STREAM_INTERRUPTED")).toBe(true);
     expect(error).toMatchObject({ message: "output connection closed" });
     expect(onReset).toHaveBeenCalledOnce();
-    expect(mocks.summarizeWithModelId).not.toHaveBeenCalled();
+    expect(mocks.generateTextWithModelId).not.toHaveBeenCalled();
   });
 
   it("retries a clean empty stream before output starts", async () => {
@@ -515,7 +570,7 @@ describe("model executor streaming", () => {
       }),
     ).resolves.toMatchObject({ summary: "Summary." });
 
-    expect(mocks.summarizeWithModelId).toHaveBeenCalledWith(
+    expect(mocks.generateTextWithModelId).toHaveBeenCalledWith(
       expect.objectContaining({ retries: 0 }),
     );
   });


### PR DESCRIPTION
Model execution separately constructed direct, streaming, and fallback requests, duplicated completion bookkeeping, and routed ordinary completion through a forwarding-only wrapper. Stream opening and stream consumption also had separate fallback branches.

Resolve the provider request once, use one completion path, and give stream consumption a single output lifecycle boundary. Preserve buffered-output resets, authoritative final-text correction, provider-specific request options, retry budgets, usage accounting, and canonical display IDs. Remove the forwarding wrapper and the model-resolution flag that was always false.

Stream or output-handler failures after visible output remain terminal. Usage collection stays outside the model retry path, so a completed model call is never repeated merely because usage reporting fails. New regression cases cover request preservation after both stream-opening and stream-consumption failures, plus usage failure isolation.

Validation: `pnpm build` and `pnpm check` pass, including 30 focused engine tests and independent Codex autoreview with no actionable P0–P2 findings.
