### PR TITLE
refactor(transcription): share source-aware provider execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Dependencies and maintenance
 
+- Replace duplicated file/byte transcription orchestration with one source-aware runner, shared local/provider handling, and common decode retries while preserving lazy file uploads and full-input fallback.
 - Unify model execution around one resolved request and completion path; centralize stream consumption while preserving output-failure and retry boundaries.
 - Consolidate LLM request options and SDK stream handling while preserving provider-specific configuration, errors, and fallback behavior.
 - Build asset summary contexts directly from shared application state, removing redundant context wrappers and narrowing the asset-only format override.

--- a/docs/media.md
+++ b/docs/media.md
@@ -37,6 +37,7 @@ read_when:
 
 ## Shared helpers
 
+- Transcription normalizes file and byte inputs into one run with shared settings and accumulated notes. Local and remote providers share dispatch and result handling; native-file providers keep lazy file access. Groq/OpenAI share decode retries, while upload limits, chunking, and preservation of full input for later providers remain explicit source-specific policies.
 - Direct media classification lives in `packages/core/src/content/direct-media.ts`.
 - Local path/`file://` normalization + mtime lookup lives in `packages/core/src/content/local-file.ts`.
 - Slides, URL extraction, and transcription should reuse those helpers instead of re-parsing extensions separately.

--- a/packages/core/src/transcription/whisper/cloud-providers.ts
+++ b/packages/core/src/transcription/whisper/cloud-providers.ts
@@ -76,7 +76,7 @@ function resolveCloudProviderOrderFromAvailability(
   });
 }
 
-export function resolveCloudProviderOrder(state: CloudProviderKeyState): CloudProvider[] {
+export function resolveCloudProviderOrder(state: Partial<CloudProviderKeyState>): CloudProvider[] {
   const order: CloudProvider[] = [];
   if (state.assemblyaiApiKey) order.push("assemblyai");
   if (state.geminiApiKey) order.push("gemini");

--- a/packages/core/src/transcription/whisper/core.ts
+++ b/packages/core/src/transcription/whisper/core.ts
@@ -1,389 +1,164 @@
+import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { transcribeChunkedFile } from "./chunking.js";
 import { DEFAULT_SEGMENT_SECONDS, MAX_OPENAI_UPLOAD_BYTES } from "./constants.js";
+import { transcribeWithDecodeRetry } from "./decode-retry.js";
 import {
   transcribeMediaBytesWithDiarization,
   transcribeMediaFileWithDiarization,
 } from "./diarization.js";
-import { isFfmpegAvailable, transcodeBytesToMp3 } from "./ffmpeg.js";
+import { isFfmpegAvailable } from "./ffmpeg.js";
 import { shouldRetryGroqViaFfmpeg, transcribeWithGroq } from "./groq.js";
+import { transcribeWithLocalOnnx, transcribeWithLocalWhisper } from "./local.js";
+import { transcribeWithRemoteFallbacks } from "./remote.js";
 import {
-  transcribeWithLocalOnnx,
-  transcribeWithLocalOnnxFile,
-  transcribeWithLocalWhisperBytes,
-  transcribeWithLocalWhisperFile,
-} from "./local.js";
-import {
-  transcribeBytesWithRemoteFallbacks,
-  transcribeFileWithRemoteFallbacks,
-  transcribeOversizedBytesViaTempFile,
-} from "./remote.js";
-import type {
-  DiarizationPreference,
-  WhisperProgressEvent,
-  WhisperTranscriptionResult,
-} from "./types.js";
+  createTranscriptionRun,
+  type TranscriptionChunking,
+  type TranscriptionFile,
+  type TranscriptionOptions,
+  type TranscriptionRun,
+  type TranscriptionSource,
+} from "./request.js";
+import type { WhisperTranscriptionResult } from "./types.js";
 import { formatBytes, wrapError } from "./utils.js";
 
-type Env = Record<string, string | undefined>;
-
-type MediaRequest = {
-  groqApiKey: string | null;
-  assemblyaiApiKey?: string | null;
-  elevenlabsApiKey?: string | null;
-  geminiApiKey?: string | null;
-  openaiApiKey: string | null;
-  falApiKey: string | null;
-  deepgramApiKey?: string | null;
-  diarization?: DiarizationPreference | null;
-  totalDurationSeconds?: number | null;
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  env?: Env;
-};
-
-export async function transcribeMediaWithWhisper({
+export function transcribeMediaWithWhisper({
   bytes,
   mediaType,
   filename,
-  groqApiKey,
   skipGroq = false,
-  assemblyaiApiKey = null,
-  elevenlabsApiKey = null,
-  geminiApiKey = null,
-  openaiApiKey,
-  falApiKey,
-  deepgramApiKey = null,
-  diarization = null,
-  totalDurationSeconds = null,
-  onProgress,
-  env = process.env,
+  ...options
 }: {
   bytes: Uint8Array;
   mediaType: string;
   filename: string | null;
   skipGroq?: boolean;
-} & MediaRequest): Promise<WhisperTranscriptionResult> {
-  if (diarization) {
-    return await transcribeMediaBytesWithDiarization({
-      bytes,
-      mediaType,
-      filename,
-      preference: diarization,
-      elevenlabsApiKey,
-      openaiApiKey,
-      env,
-      totalDurationSeconds,
-      onProgress,
-    });
-  }
-
-  const notes: string[] = [];
-
-  let groqError: Error | null = null;
-  if (groqApiKey && !skipGroq) {
-    const groqResult = await transcribeWithGroqFirst({
-      bytes,
-      mediaType,
-      filename,
-      groqApiKey,
-      notes,
-    });
-    bytes = groqResult.bytes;
-    mediaType = groqResult.mediaType;
-    filename = groqResult.filename;
-    if (groqResult.text) {
-      return { text: groqResult.text, provider: "groq", error: null, notes };
-    }
-    groqError = groqResult.error;
-  }
-
-  if (groqError) {
-    notes.push(
-      `Groq transcription failed; falling back to local/AssemblyAI/Gemini/OpenAI/FAL/Deepgram: ${groqError.message}`,
-    );
-  }
-
-  const onnx = await transcribeWithLocalOnnx({
-    bytes,
-    mediaType,
-    filename,
-    totalDurationSeconds,
-    onProgress,
-    env,
-    notes,
-  });
-  if (onnx) return onnx;
-
-  const local = await transcribeWithLocalWhisperBytes({
-    bytes,
-    mediaType,
-    filename,
-    totalDurationSeconds,
-    onProgress,
-    env,
-    notes,
-  });
-  if (local) return local;
-
-  return await transcribeBytesWithRemoteFallbacks({
-    bytes,
-    mediaType,
-    filename,
-    notes,
-    groqApiKey,
-    groqError,
-    assemblyaiApiKey,
-    geminiApiKey,
-    openaiApiKey,
-    falApiKey,
-    deepgramApiKey,
-    env,
-    onProgress,
-    transcribeOversizedBytesWithChunking: ({ bytes, mediaType, filename, onProgress }) =>
-      transcribeOversizedBytesViaTempFile({
-        bytes,
-        mediaType,
-        filename,
-        onProgress,
-        transcribeFile: ({ filePath, mediaType, filename, onProgress }) =>
-          transcribeMediaFileWithWhisper({
-            filePath,
-            mediaType,
-            filename,
-            groqApiKey,
-            assemblyaiApiKey,
-            geminiApiKey,
-            openaiApiKey,
-            falApiKey,
-            deepgramApiKey,
-            segmentSeconds: DEFAULT_SEGMENT_SECONDS,
-            onProgress,
-            env,
-          }),
-      }),
-  });
+} & TranscriptionOptions): Promise<WhisperTranscriptionResult> {
+  return transcribe({ kind: "bytes", bytes, mediaType, filename }, options, skipGroq);
 }
 
-export async function transcribeMediaFileWithWhisper({
+export function transcribeMediaFileWithWhisper({
   filePath,
   mediaType,
   filename,
-  groqApiKey,
-  assemblyaiApiKey = null,
-  elevenlabsApiKey = null,
-  geminiApiKey = null,
-  openaiApiKey,
-  falApiKey,
-  deepgramApiKey = null,
-  diarization = null,
-  segmentSeconds = DEFAULT_SEGMENT_SECONDS,
-  totalDurationSeconds = null,
   onProgress = null,
-  env = process.env,
+  ...options
 }: {
   filePath: string;
   mediaType: string;
   filename: string | null;
-  segmentSeconds?: number;
-} & MediaRequest): Promise<WhisperTranscriptionResult> {
-  if (diarization) {
-    return await transcribeMediaFileWithDiarization({
-      filePath,
-      mediaType,
-      filename,
-      preference: diarization,
-      elevenlabsApiKey,
-      openaiApiKey,
-      env,
-      totalDurationSeconds,
-      onProgress,
-    });
+} & TranscriptionOptions): Promise<WhisperTranscriptionResult> {
+  return transcribe({ kind: "file", filePath, mediaType, filename }, { ...options, onProgress });
+}
+
+async function transcribe(
+  source: TranscriptionSource,
+  options: TranscriptionOptions,
+  skipGroq = false,
+): Promise<WhisperTranscriptionResult> {
+  const run = createTranscriptionRun(source, options);
+  const settings = run.options;
+  if (settings.diarization) {
+    const request = {
+      mediaType: source.mediaType,
+      filename: source.filename,
+      preference: settings.diarization,
+      elevenlabsApiKey: settings.elevenlabsApiKey ?? null,
+      openaiApiKey: settings.openaiApiKey,
+      env: settings.env,
+      totalDurationSeconds: settings.totalDurationSeconds,
+      onProgress: settings.onProgress,
+    };
+    return source.kind === "bytes"
+      ? transcribeMediaBytesWithDiarization({ ...request, bytes: source.bytes })
+      : transcribeMediaFileWithDiarization({ ...request, filePath: source.filePath });
   }
 
-  const notes: string[] = [];
-
-  let skipGroqInNestedCalls = false;
-  let groqError: Error | null = null;
-  if (groqApiKey) {
-    skipGroqInNestedCalls = true;
-    const groqResult = await transcribeGroqFileFirst({
-      filePath,
-      mediaType,
-      filename,
-      groqApiKey,
-      assemblyaiApiKey,
-      geminiApiKey,
-      openaiApiKey,
-      falApiKey,
-      deepgramApiKey,
-      segmentSeconds,
-      totalDurationSeconds,
-      onProgress,
-      env,
-      notes,
-    });
-    if (groqResult.text) return groqResult;
-    groqError = groqResult.error;
-  }
-
-  const onnx = await transcribeWithLocalOnnxFile({
-    filePath,
-    mediaType,
-    totalDurationSeconds,
-    onProgress,
-    env,
-    notes,
-  });
-  if (onnx) return onnx;
-
-  const local = await transcribeWithLocalWhisperFile({
-    filePath,
-    mediaType,
-    totalDurationSeconds,
-    onProgress,
-    env,
-    notes,
-  });
-  if (local) return local;
-
-  return await transcribeFileWithRemoteFallbacks({
-    filePath,
-    mediaType,
-    filename,
-    notes,
-    groqApiKey,
-    groqError,
-    assemblyaiApiKey,
-    geminiApiKey,
-    openaiApiKey,
-    falApiKey,
-    deepgramApiKey,
-    env,
-    totalDurationSeconds,
-    onProgress,
-    transcribeChunkedFile: ({ filePath, segmentSeconds, totalDurationSeconds, onProgress }) =>
+  const chunking: TranscriptionChunking = {
+    file: (filePath, segmentSeconds, skipGroq) =>
       transcribeChunkedFile({
         filePath,
         segmentSeconds,
-        totalDurationSeconds,
-        onProgress,
+        totalDurationSeconds: settings.totalDurationSeconds,
+        onProgress: settings.onProgress,
         transcribeSegment: ({ bytes, filename }) =>
           transcribeMediaWithWhisper({
+            ...settings,
             bytes,
             mediaType: "audio/mpeg",
             filename,
-            groqApiKey,
-            skipGroq: skipGroqInNestedCalls,
-            assemblyaiApiKey,
-            geminiApiKey,
-            openaiApiKey,
-            falApiKey,
-            deepgramApiKey,
-            env,
+            skipGroq,
+            diarization: null,
+            totalDurationSeconds: null,
+            onProgress: undefined,
           }),
       }),
-  });
-}
-
-async function transcribeWithGroqFirst({
-  bytes,
-  mediaType,
-  filename,
-  groqApiKey,
-  notes,
-}: {
-  bytes: Uint8Array;
-  mediaType: string;
-  filename: string | null;
-  groqApiKey: string;
-  notes: string[];
-}): Promise<{
-  text: string | null;
-  error: Error | null;
-  bytes: Uint8Array;
-  mediaType: string;
-  filename: string | null;
-}> {
-  let groqError: Error | null = null;
-  try {
-    const text = await transcribeWithGroq(bytes, mediaType, filename, groqApiKey);
-    if (text) return { text, error: null, bytes, mediaType, filename };
-    groqError = new Error("Groq transcription returned empty text");
-  } catch (error) {
-    groqError = wrapError("Groq transcription failed", error);
-  }
-
-  if (groqError && shouldRetryGroqViaFfmpeg(groqError)) {
-    const canTranscode = await isFfmpegAvailable();
-    if (canTranscode) {
+    bytes: async (input) => {
+      const filePath = join(tmpdir(), `summarize-whisper-${randomUUID()}`);
       try {
-        notes.push("Groq could not decode media; transcoding via ffmpeg and retrying");
-        const mp3Bytes = await transcodeBytesToMp3(bytes);
-        const retried = await transcribeWithGroq(mp3Bytes, "audio/mpeg", "audio.mp3", groqApiKey);
-        if (retried) {
-          return {
-            text: retried,
-            error: null,
-            bytes: mp3Bytes,
-            mediaType: "audio/mpeg",
-            filename: "audio.mp3",
-          };
-        }
-        groqError = new Error("Groq transcription returned empty text after ffmpeg transcode");
-        bytes = mp3Bytes;
-        mediaType = "audio/mpeg";
-        filename = "audio.mp3";
-      } catch (error) {
-        notes.push(
-          `ffmpeg transcode failed; cannot retry Groq decode error: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
+        await fs.writeFile(filePath, input.bytes);
+        return await transcribeMediaFileWithWhisper({
+          ...settings,
+          filePath,
+          mediaType: input.mediaType,
+          filename: input.filename,
+          segmentSeconds: DEFAULT_SEGMENT_SECONDS,
+          diarization: null,
+          totalDurationSeconds: null,
+        });
+      } finally {
+        await fs.unlink(filePath).catch(() => {});
       }
+    },
+  };
+
+  if (settings.groqApiKey && !skipGroq) {
+    if (source.kind === "file") {
+      const result = await transcribeGroqFileFirst(source, run, chunking);
+      if (result.text) return result;
+      run.groqError = result.error;
     } else {
-      notes.push("Groq could not decode media; install ffmpeg to enable transcoding retry");
+      const attempt = await transcribeWithDecodeRetry({
+        source,
+        provider: "groq",
+        notes: run.notes,
+        transcribe: (input) =>
+          transcribeWithGroq(input.bytes, input.mediaType, input.filename, settings.groqApiKey!),
+        shouldRetry: shouldRetryGroqViaFfmpeg,
+      });
+      run.source = attempt.source;
+      if (attempt.kind === "result") return { ...attempt.result, notes: run.notes };
+      run.groqError = attempt.error;
+      run.notes.push(
+        `Groq transcription failed; falling back to local/AssemblyAI/Gemini/OpenAI/FAL/Deepgram: ${attempt.error.message}`,
+      );
     }
   }
 
-  return { text: null, error: groqError, bytes, mediaType, filename };
+  return (
+    (await transcribeWithLocalOnnx(run)) ??
+    (await transcribeWithLocalWhisper(run)) ??
+    transcribeWithRemoteFallbacks(run, chunking)
+  );
 }
 
-async function transcribeGroqFileFirst({
-  filePath,
-  mediaType,
-  filename,
-  groqApiKey,
-  assemblyaiApiKey,
-  geminiApiKey,
-  openaiApiKey,
-  falApiKey,
-  deepgramApiKey,
-  segmentSeconds,
-  totalDurationSeconds,
-  onProgress,
-  env,
-  notes,
-}: {
-  filePath: string;
-  mediaType: string;
-  filename: string | null;
-  groqApiKey: string;
-  assemblyaiApiKey: string | null;
-  geminiApiKey: string | null;
-  openaiApiKey: string | null;
-  falApiKey: string | null;
-  deepgramApiKey: string | null;
-  segmentSeconds: number;
-  totalDurationSeconds: number | null;
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  env: Env;
-  notes: string[];
-}): Promise<WhisperTranscriptionResult> {
-  const stat = await fs.stat(filePath);
+async function transcribeGroqFileFirst(
+  source: TranscriptionFile,
+  { options, notes }: TranscriptionRun,
+  chunking: TranscriptionChunking,
+): Promise<WhisperTranscriptionResult> {
+  const stat = await fs.stat(source.filePath);
   if (stat.size <= MAX_OPENAI_UPLOAD_BYTES) {
-    const fileBytes = new Uint8Array(await fs.readFile(filePath));
+    const bytes = new Uint8Array(await fs.readFile(source.filePath));
     try {
-      const text = await transcribeWithGroq(fileBytes, mediaType, filename, groqApiKey);
+      const text = await transcribeWithGroq(
+        bytes,
+        source.mediaType,
+        source.filename,
+        options.groqApiKey!,
+      );
       if (text) return { text, provider: "groq", error: null, notes };
       const error = new Error("Groq transcription returned empty text");
       notes.push(
@@ -391,18 +166,19 @@ async function transcribeGroqFileFirst({
       );
       return { text: null, provider: "groq", error, notes };
     } catch (error) {
-      const wrapped = wrapError("Groq transcription failed", error);
       notes.push(
-        `Groq transcription failed; falling back to local/AssemblyAI/Gemini/OpenAI/FAL/Deepgram: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Groq transcription failed; falling back to local/AssemblyAI/Gemini/OpenAI/FAL/Deepgram: ${error instanceof Error ? error.message : String(error)}`,
       );
-      return { text: null, provider: "groq", error: wrapped, notes };
+      return {
+        text: null,
+        provider: "groq",
+        error: wrapError("Groq transcription failed", error),
+        notes,
+      };
     }
   }
 
-  const canChunk = await isFfmpegAvailable();
-  if (!canChunk) {
+  if (!(await isFfmpegAvailable())) {
     const error = new Error(
       `File too large for Groq upload (${formatBytes(stat.size)}); trying local providers`,
     );
@@ -410,26 +186,8 @@ async function transcribeGroqFileFirst({
     return { text: null, provider: "groq", error, notes };
   }
 
-  const chunked = await transcribeChunkedFile({
-    filePath,
-    segmentSeconds,
-    totalDurationSeconds,
-    onProgress,
-    transcribeSegment: ({ bytes, filename }) =>
-      transcribeMediaWithWhisper({
-        bytes,
-        mediaType: "audio/mpeg",
-        filename,
-        groqApiKey,
-        assemblyaiApiKey,
-        geminiApiKey,
-        openaiApiKey,
-        falApiKey,
-        deepgramApiKey,
-        env,
-      }),
-  });
-  if (chunked.notes.length > 0) notes.push(...chunked.notes);
+  const chunked = await chunking.file(source.filePath, options.segmentSeconds, false);
+  notes.push(...chunked.notes);
   if (chunked.text) return { ...chunked, notes };
   const error = chunked.error ?? new Error("Groq chunked transcription failed");
   notes.push(

--- a/packages/core/src/transcription/whisper/decode-retry.ts
+++ b/packages/core/src/transcription/whisper/decode-retry.ts
@@ -1,0 +1,59 @@
+import { isFfmpegAvailable, transcodeBytesToMp3 } from "./ffmpeg.js";
+import type { ProviderResult, TranscriptionBytes } from "./request.js";
+import { wrapError } from "./utils.js";
+
+export async function transcribeWithDecodeRetry({
+  source,
+  provider,
+  notes,
+  transcribe,
+  shouldRetry,
+}: {
+  source: TranscriptionBytes;
+  provider: "groq" | "openai";
+  notes: string[];
+  transcribe: (source: TranscriptionBytes) => Promise<string | null>;
+  shouldRetry: (error: Error) => boolean;
+}): Promise<ProviderResult & { source: TranscriptionBytes }> {
+  const label = provider === "groq" ? "Groq" : "OpenAI";
+  const success = (
+    text: string,
+    input = source,
+  ): ProviderResult & { source: TranscriptionBytes } => ({
+    kind: "result",
+    source: input,
+    result: { text, provider, error: null, notes: [] },
+  });
+  let failure: Error;
+  try {
+    const text = await transcribe(source);
+    if (text) return success(text);
+    failure = new Error(`${label} transcription returned empty text`);
+  } catch (error) {
+    failure = wrapError(`${label} transcription failed`, error);
+  }
+  if (shouldRetry(failure)) {
+    if (await isFfmpegAvailable()) {
+      try {
+        notes.push(`${label} could not decode media; transcoding via ffmpeg and retrying`);
+        const converted: TranscriptionBytes = {
+          kind: "bytes",
+          bytes: await transcodeBytesToMp3(source.bytes),
+          mediaType: "audio/mpeg",
+          filename: "audio.mp3",
+        };
+        const text = await transcribe(converted);
+        if (text) return success(text, converted);
+        failure = new Error(`${label} transcription returned empty text after ffmpeg transcode`);
+        source = converted;
+      } catch (error) {
+        notes.push(
+          `ffmpeg transcode failed; cannot retry ${label} decode error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    } else {
+      notes.push(`${label} could not decode media; install ffmpeg to enable transcoding retry`);
+    }
+  }
+  return { kind: "error", error: failure, source };
+}

--- a/packages/core/src/transcription/whisper/local.ts
+++ b/packages/core/src/transcription/whisper/local.ts
@@ -4,190 +4,76 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { transcribeWithOnnxCli, transcribeWithOnnxCliFile } from "../onnx-cli.js";
 import { resolveOnnxModelPreference } from "./preferences.js";
-import type { WhisperProgressEvent, WhisperTranscriptionResult } from "./types.js";
+import { emitInitialProgress, type TranscriptionRun } from "./request.js";
+import type { WhisperTranscriptionResult } from "./types.js";
 import { ensureWhisperFilenameExtension, wrapError } from "./utils.js";
 import { isWhisperCppReady, transcribeWithWhisperCppFile } from "./whisper-cpp.js";
 
-type Env = Record<string, string | undefined>;
-
-export async function transcribeWithLocalOnnx({
-  bytes,
-  mediaType,
-  filename,
-  totalDurationSeconds,
-  onProgress,
-  env,
-  notes,
-}: {
-  bytes: Uint8Array;
-  mediaType: string;
-  filename: string | null;
-  totalDurationSeconds: number | null;
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  env: Env;
-  notes: string[];
-}): Promise<WhisperTranscriptionResult | null> {
-  const onnxPreference = resolveOnnxModelPreference(env);
-  if (!onnxPreference) return null;
-  const onnx = await transcribeWithOnnxCli({
-    model: onnxPreference,
-    bytes,
-    mediaType,
-    filename,
-    totalDurationSeconds,
-    onProgress,
-    env,
-  });
-  if (onnx.text) {
-    if (onnx.notes.length > 0) notes.push(...onnx.notes);
-    return { ...onnx, notes };
-  }
-  if (onnx.notes.length > 0) notes.push(...onnx.notes);
-  if (onnx.error) {
-    notes.push(`${onnx.provider ?? "onnx"} failed; falling back to Whisper: ${onnx.error.message}`);
-  }
-  return null;
-}
-
-export async function transcribeWithLocalOnnxFile({
-  filePath,
-  mediaType,
-  totalDurationSeconds,
-  onProgress,
-  env,
-  notes,
-}: {
-  filePath: string;
-  mediaType: string;
-  totalDurationSeconds: number | null;
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  env: Env;
-  notes: string[];
-}): Promise<WhisperTranscriptionResult | null> {
-  const onnxPreference = resolveOnnxModelPreference(env);
-  if (!onnxPreference) return null;
-  onProgress?.({
-    partIndex: null,
-    parts: null,
-    processedDurationSeconds: null,
-    totalDurationSeconds,
-  });
-  const onnx = await transcribeWithOnnxCliFile({
-    model: onnxPreference,
-    filePath,
-    mediaType,
-    totalDurationSeconds,
-    onProgress,
-    env,
-  });
-  if (onnx.text) {
-    if (onnx.notes.length > 0) notes.push(...onnx.notes);
-    return { ...onnx, notes };
-  }
-  if (onnx.notes.length > 0) notes.push(...onnx.notes);
-  if (onnx.error) {
-    notes.push(`${onnx.provider ?? "onnx"} failed; falling back to Whisper: ${onnx.error.message}`);
-  }
-  return null;
-}
-
-export async function transcribeWithLocalWhisperBytes({
-  bytes,
-  mediaType,
-  filename,
-  totalDurationSeconds,
-  onProgress,
-  env,
-  notes,
-}: {
-  bytes: Uint8Array;
-  mediaType: string;
-  filename: string | null;
-  totalDurationSeconds: number | null;
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  env: Env;
-  notes: string[];
-}): Promise<WhisperTranscriptionResult | null> {
-  if (!(await isWhisperCppReady(env))) return null;
-  const nameHint = filename?.trim() ? basename(filename.trim()) : "media";
-  const tempFile = join(
-    tmpdir(),
-    `summarize-whisper-local-${randomUUID()}-${ensureWhisperFilenameExtension(nameHint, mediaType)}`,
-  );
-  try {
-    await fs.writeFile(tempFile, bytes);
-    const result = await safeTranscribeWithWhisperCppFile({
-      filePath: tempFile,
-      mediaType,
-      totalDurationSeconds,
-      onProgress,
-      env,
-    });
-    return mergeLocalWhisperResult(result, notes);
-  } finally {
-    await fs.unlink(tempFile).catch(() => {});
-  }
-}
-
-export async function transcribeWithLocalWhisperFile({
-  filePath,
-  mediaType,
-  totalDurationSeconds,
-  onProgress,
-  env,
-  notes,
-}: {
-  filePath: string;
-  mediaType: string;
-  totalDurationSeconds: number | null;
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  env: Env;
-  notes: string[];
-}): Promise<WhisperTranscriptionResult | null> {
-  if (!(await isWhisperCppReady(env))) return null;
-  onProgress?.({
-    partIndex: null,
-    parts: null,
-    processedDurationSeconds: null,
-    totalDurationSeconds,
-  });
-  const result = await safeTranscribeWithWhisperCppFile({
-    filePath,
-    mediaType,
-    totalDurationSeconds,
-    onProgress,
-    env,
-  });
-  return mergeLocalWhisperResult(result, notes);
-}
-
-function mergeLocalWhisperResult(
-  result: WhisperTranscriptionResult,
-  notes: string[],
-): WhisperTranscriptionResult | null {
-  if (result.notes.length > 0) notes.push(...result.notes);
+export async function transcribeWithLocalOnnx(
+  run: TranscriptionRun,
+): Promise<WhisperTranscriptionResult | null> {
+  const { source, options, notes } = run;
+  const model = resolveOnnxModelPreference(options.env);
+  if (!model) return null;
+  const request = {
+    model,
+    mediaType: source.mediaType,
+    totalDurationSeconds: options.totalDurationSeconds,
+    onProgress: options.onProgress,
+    env: options.env,
+  };
+  if (source.kind === "file") emitInitialProgress(run);
+  const result =
+    source.kind === "bytes"
+      ? await transcribeWithOnnxCli({ ...request, bytes: source.bytes, filename: source.filename })
+      : await transcribeWithOnnxCliFile({ ...request, filePath: source.filePath });
+  notes.push(...result.notes);
   if (result.text) return { ...result, notes };
-  if (result.error) {
-    notes.push(`whisper.cpp failed; falling back to remote Whisper: ${result.error.message}`);
-  }
+  if (result.error)
+    notes.push(
+      `${result.provider ?? "onnx"} failed; falling back to Whisper: ${result.error.message}`,
+    );
   return null;
 }
 
-async function safeTranscribeWithWhisperCppFile(args: {
-  filePath: string;
-  mediaType: string;
-  totalDurationSeconds: number | null;
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  env: Env;
-}): Promise<WhisperTranscriptionResult> {
+export async function transcribeWithLocalWhisper(
+  run: TranscriptionRun,
+): Promise<WhisperTranscriptionResult | null> {
+  const { source, options, notes } = run;
+  if (!(await isWhisperCppReady(options.env))) return null;
+  if (source.kind === "file") emitInitialProgress(run);
+  const tempFile =
+    source.kind === "bytes"
+      ? join(
+          tmpdir(),
+          `summarize-whisper-local-${randomUUID()}-${ensureWhisperFilenameExtension(source.filename?.trim() ? basename(source.filename.trim()) : "media", source.mediaType)}`,
+        )
+      : null;
   try {
-    return await transcribeWithWhisperCppFile(args);
-  } catch (error) {
-    return {
-      text: null,
-      provider: "whisper.cpp",
-      error: wrapError("whisper.cpp failed", error),
-      notes: [],
-    };
+    if (tempFile && source.kind === "bytes") await fs.writeFile(tempFile, source.bytes);
+    let result: WhisperTranscriptionResult;
+    try {
+      result = await transcribeWithWhisperCppFile({
+        filePath: source.kind === "file" ? source.filePath : tempFile!,
+        mediaType: source.mediaType,
+        totalDurationSeconds: options.totalDurationSeconds,
+        onProgress: options.onProgress,
+        env: options.env,
+      });
+    } catch (error) {
+      result = {
+        text: null,
+        provider: "whisper.cpp",
+        error: wrapError("whisper.cpp failed", error),
+        notes: [],
+      };
+    }
+    notes.push(...result.notes);
+    if (result.text) return { ...result, notes };
+    if (result.error)
+      notes.push(`whisper.cpp failed; falling back to remote Whisper: ${result.error.message}`);
+    return null;
+  } finally {
+    if (tempFile) await fs.unlink(tempFile).catch(() => {});
   }
 }

--- a/packages/core/src/transcription/whisper/remote-provider-attempts.ts
+++ b/packages/core/src/transcription/whisper/remote-provider-attempts.ts
@@ -1,353 +1,139 @@
 import { transcribeWithAssemblyAi, transcribeFileWithAssemblyAi } from "./assemblyai.js";
-import type { CloudProvider } from "./cloud-providers.js";
+import { cloudProviderLabel, type CloudProvider } from "./cloud-providers.js";
 import { MAX_OPENAI_UPLOAD_BYTES } from "./constants.js";
-import { transcribeFileWithDeepgram, transcribeWithDeepgram } from "./deepgram.js";
+import { transcribeWithDecodeRetry } from "./decode-retry.js";
+import {
+  transcribeFileWithDeepgram,
+  transcribeWithDeepgram,
+  type DeepgramTranscriptionResult,
+} from "./deepgram.js";
 import { transcribeWithFal } from "./fal.js";
-import { isFfmpegAvailable, transcodeBytesToMp3 } from "./ffmpeg.js";
+import { isFfmpegAvailable } from "./ffmpeg.js";
 import { transcribeFileWithGemini, transcribeWithGemini } from "./gemini.js";
 import { shouldRetryOpenAiViaFfmpeg, transcribeWithOpenAi } from "./openai.js";
-import type { WhisperProgressEvent, WhisperTranscriptionResult } from "./types.js";
+import type {
+  ProviderResult,
+  TranscriptionBytes,
+  TranscriptionChunking,
+  TranscriptionRun,
+} from "./request.js";
 import { formatBytes, wrapError } from "./utils.js";
 
-type Env = Record<string, string | undefined>;
-
-export type RemoteByteState = {
-  bytes: Uint8Array;
-  mediaType: string;
-  filename: string | null;
-};
-
-type RemoteByteAttemptResult = {
-  state: RemoteByteState;
-  result: WhisperTranscriptionResult | null;
-  error: Error | null;
-  skipped?: boolean;
-};
-
-type RemoteFileAttemptResult =
-  | { kind: "result"; result: WhisperTranscriptionResult }
-  | { kind: "error"; error: Error }
-  | { kind: "delegate-to-bytes" };
-
-type TranscribeOversizedBytesWithChunking = (args: {
-  bytes: Uint8Array;
-  mediaType: string;
-  filename: string | null;
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-}) => Promise<WhisperTranscriptionResult>;
-
-export async function attemptRemoteBytesProvider(args: {
-  provider: CloudProvider;
-  state: RemoteByteState;
-  assemblyaiApiKey: string | null;
-  geminiApiKey: string | null;
-  openaiApiKey: string | null;
-  falApiKey: string | null;
-  deepgramApiKey: string | null;
-  env: Env;
-  notes: string[];
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  transcribeOversizedBytesWithChunking?: TranscribeOversizedBytesWithChunking;
-}): Promise<RemoteByteAttemptResult> {
-  const executor = BYTE_PROVIDER_EXECUTORS[args.provider];
-  return executor(args);
+export async function attemptRemoteProvider(
+  provider: CloudProvider,
+  run: TranscriptionRun,
+  chunkBytes?: TranscriptionChunking["bytes"],
+): Promise<ProviderResult | { kind: "skip" }> {
+  const { source, options, notes } = run;
+  if (provider === "openai") {
+    if (source.kind !== "bytes") throw new Error("OpenAI transcription requires prepared bytes");
+    return attemptOpenAi(source, run, chunkBytes);
+  }
+  if (provider === "fal" && !source.mediaType.toLowerCase().startsWith("audio/")) {
+    notes.push(`Skipping FAL transcription: unsupported mediaType ${source.mediaType}`);
+    return { kind: "skip" };
+  }
+  return callProvider(provider, async () => {
+    switch (provider) {
+      case "assemblyai":
+        return source.kind === "file"
+          ? transcribeFileWithAssemblyAi({
+              filePath: source.filePath,
+              mediaType: source.mediaType,
+              apiKey: options.assemblyaiApiKey!,
+            })
+          : transcribeWithAssemblyAi(source.bytes, source.mediaType, options.assemblyaiApiKey!);
+      case "gemini":
+        return source.kind === "file"
+          ? transcribeFileWithGemini({
+              filePath: source.filePath,
+              mediaType: source.mediaType,
+              filename: source.filename,
+              apiKey: options.geminiApiKey!,
+              env: options.env,
+            })
+          : transcribeWithGemini(
+              source.bytes,
+              source.mediaType,
+              source.filename,
+              options.geminiApiKey!,
+              { env: options.env },
+            );
+      case "deepgram":
+        return source.kind === "file"
+          ? transcribeFileWithDeepgram({
+              filePath: source.filePath,
+              mediaType: source.mediaType,
+              apiKey: options.deepgramApiKey!,
+              env: options.env,
+            })
+          : transcribeWithDeepgram(source.bytes, source.mediaType, options.deepgramApiKey!, {
+              env: options.env,
+            });
+      case "fal":
+        if (source.kind !== "bytes") throw new Error("FAL transcription requires prepared bytes");
+        return transcribeWithFal(source.bytes, source.mediaType, options.falApiKey!);
+    }
+  });
 }
 
-export async function attemptRemoteFileProvider(args: {
-  provider: CloudProvider;
-  filePath: string;
-  mediaType: string;
-  filename: string | null;
-  assemblyaiApiKey: string | null;
-  geminiApiKey: string | null;
-  deepgramApiKey: string | null;
-  env: Env;
-}): Promise<RemoteFileAttemptResult> {
-  if (args.provider === "assemblyai") {
-    try {
-      const text = await transcribeFileWithAssemblyAi({
-        filePath: args.filePath,
-        mediaType: args.mediaType,
-        apiKey: args.assemblyaiApiKey!,
-      });
-      if (text)
-        return { kind: "result", result: { text, provider: "assemblyai", error: null, notes: [] } };
-      return { kind: "error", error: new Error("AssemblyAI transcription returned empty text") };
-    } catch (caught) {
-      return {
-        kind: "error",
-        error:
-          caught instanceof Error ? caught : wrapError("AssemblyAI transcription failed", caught),
-      };
-    }
+async function callProvider(
+  provider: Exclude<CloudProvider, "openai">,
+  transcribe: () => Promise<string | null | DeepgramTranscriptionResult>,
+): Promise<ProviderResult> {
+  const label = cloudProviderLabel(provider, true);
+  try {
+    const output = await transcribe();
+    const text = typeof output === "string" ? output : output?.text;
+    if (!text)
+      return { kind: "error", error: new Error(`${label} transcription returned empty text`) };
+    return {
+      kind: "result",
+      result: {
+        text,
+        provider,
+        error: null,
+        notes: [],
+        ...(output && typeof output === "object" ? { segments: output.segments } : {}),
+      },
+    };
+  } catch (error) {
+    return {
+      kind: "error",
+      error:
+        (provider === "assemblyai" || provider === "deepgram") && error instanceof Error
+          ? error
+          : wrapError(`${label} transcription failed`, error),
+    };
   }
-
-  if (args.provider === "gemini") {
-    try {
-      const text = await transcribeFileWithGemini({
-        filePath: args.filePath,
-        mediaType: args.mediaType,
-        filename: args.filename,
-        apiKey: args.geminiApiKey!,
-        env: args.env,
-      });
-      if (text)
-        return { kind: "result", result: { text, provider: "gemini", error: null, notes: [] } };
-      return { kind: "error", error: new Error("Gemini transcription returned empty text") };
-    } catch (caught) {
-      return {
-        kind: "error",
-        error: wrapError("Gemini transcription failed", caught),
-      };
-    }
-  }
-
-  if (args.provider === "deepgram") {
-    try {
-      const result = await transcribeFileWithDeepgram({
-        filePath: args.filePath,
-        mediaType: args.mediaType,
-        apiKey: args.deepgramApiKey!,
-        env: args.env,
-      });
-      if (result.text) {
-        return {
-          kind: "result",
-          result: {
-            text: result.text,
-            provider: "deepgram",
-            error: null,
-            notes: [],
-            segments: result.segments,
-          },
-        };
-      }
-      return { kind: "error", error: new Error("Deepgram transcription returned empty text") };
-    } catch (caught) {
-      return {
-        kind: "error",
-        error:
-          caught instanceof Error ? caught : wrapError("Deepgram transcription failed", caught),
-      };
-    }
-  }
-
-  return { kind: "delegate-to-bytes" };
 }
 
-const BYTE_PROVIDER_EXECUTORS: Record<
-  CloudProvider,
-  (args: {
-    state: RemoteByteState;
-    assemblyaiApiKey: string | null;
-    geminiApiKey: string | null;
-    openaiApiKey: string | null;
-    falApiKey: string | null;
-    deepgramApiKey: string | null;
-    env: Env;
-    notes: string[];
-    onProgress?: ((event: WhisperProgressEvent) => void) | null;
-    transcribeOversizedBytesWithChunking?: TranscribeOversizedBytesWithChunking;
-  }) => Promise<RemoteByteAttemptResult>
-> = {
-  assemblyai: async ({ state, assemblyaiApiKey }) => {
-    try {
-      const text = await transcribeWithAssemblyAi(state.bytes, state.mediaType, assemblyaiApiKey!);
-      if (text) {
-        return {
-          state,
-          result: { text, provider: "assemblyai", error: null, notes: [] },
-          error: null,
-        };
-      }
-      return {
-        state,
-        result: null,
-        error: new Error("AssemblyAI transcription returned empty text"),
-      };
-    } catch (caught) {
-      return {
-        state,
-        result: null,
-        error:
-          caught instanceof Error ? caught : wrapError("AssemblyAI transcription failed", caught),
-      };
-    }
-  },
-  gemini: async ({ state, geminiApiKey, env }) => {
-    try {
-      const text = await transcribeWithGemini(
-        state.bytes,
-        state.mediaType,
-        state.filename,
-        geminiApiKey!,
-        { env },
-      );
-      if (text) {
-        return {
-          state,
-          result: { text, provider: "gemini", error: null, notes: [] },
-          error: null,
-        };
-      }
-      return { state, result: null, error: new Error("Gemini transcription returned empty text") };
-    } catch (caught) {
-      return {
-        state,
-        result: null,
-        error: wrapError("Gemini transcription failed", caught),
-      };
-    }
-  },
-  openai: async ({
-    state,
-    openaiApiKey,
-    env,
+async function attemptOpenAi(
+  source: TranscriptionBytes,
+  run: TranscriptionRun,
+  chunkBytes?: TranscriptionChunking["bytes"],
+): Promise<ProviderResult> {
+  const { options, notes } = run;
+  let input = source;
+  let truncated = false;
+  if (source.bytes.byteLength > MAX_OPENAI_UPLOAD_BYTES && chunkBytes && options.openaiApiKey) {
+    if (await isFfmpegAvailable()) return { kind: "result", result: await chunkBytes(source) };
+    notes.push(
+      `Media too large for Whisper upload (${formatBytes(source.bytes.byteLength)}); transcribing first ${formatBytes(MAX_OPENAI_UPLOAD_BYTES)} only (install ffmpeg for full transcription)`,
+    );
+    input = { ...source, bytes: source.bytes.slice(0, MAX_OPENAI_UPLOAD_BYTES) };
+    truncated = true;
+  }
+  const attempt = await transcribeWithDecodeRetry({
+    source: input,
+    provider: "openai",
     notes,
-    onProgress,
-    transcribeOversizedBytesWithChunking,
-  }) => {
-    let nextState = state;
-    let truncatedForOpenAi = false;
-    if (
-      nextState.bytes.byteLength > MAX_OPENAI_UPLOAD_BYTES &&
-      transcribeOversizedBytesWithChunking &&
-      openaiApiKey
-    ) {
-      const canChunk = await isFfmpegAvailable();
-      if (canChunk) {
-        return {
-          state: nextState,
-          result: await transcribeOversizedBytesWithChunking({
-            bytes: nextState.bytes,
-            mediaType: nextState.mediaType,
-            filename: nextState.filename,
-            onProgress,
-          }),
-          error: null,
-        };
-      }
-      notes.push(
-        `Media too large for Whisper upload (${formatBytes(nextState.bytes.byteLength)}); transcribing first ${formatBytes(MAX_OPENAI_UPLOAD_BYTES)} only (install ffmpeg for full transcription)`,
-      );
-      nextState = {
-        ...nextState,
-        bytes: nextState.bytes.slice(0, MAX_OPENAI_UPLOAD_BYTES),
-      };
-      truncatedForOpenAi = true;
-    }
-
-    let error: Error | null = null;
-    try {
-      const text = await transcribeWithOpenAi(
-        nextState.bytes,
-        nextState.mediaType,
-        nextState.filename,
-        openaiApiKey!,
-        { env },
-      );
-      if (text) {
-        return {
-          state: nextState,
-          result: { text, provider: "openai", error: null, notes: [] },
-          error: null,
-        };
-      }
-      error = new Error("OpenAI transcription returned empty text");
-    } catch (caught) {
-      error = wrapError("OpenAI transcription failed", caught);
-    }
-
-    if (error && shouldRetryOpenAiViaFfmpeg(error)) {
-      const canTranscode = await isFfmpegAvailable();
-      if (canTranscode) {
-        try {
-          notes.push("OpenAI could not decode media; transcoding via ffmpeg and retrying");
-          const mp3Bytes = await transcodeBytesToMp3(nextState.bytes);
-          const retried = await transcribeWithOpenAi(
-            mp3Bytes,
-            "audio/mpeg",
-            "audio.mp3",
-            openaiApiKey!,
-            { env },
-          );
-          if (retried) {
-            return {
-              state: { bytes: mp3Bytes, mediaType: "audio/mpeg", filename: "audio.mp3" },
-              result: { text: retried, provider: "openai", error: null, notes: [] },
-              error: null,
-            };
-          }
-          error = new Error("OpenAI transcription returned empty text after ffmpeg transcode");
-          nextState = { bytes: mp3Bytes, mediaType: "audio/mpeg", filename: "audio.mp3" };
-        } catch (caught) {
-          notes.push(
-            `ffmpeg transcode failed; cannot retry OpenAI decode error: ${
-              caught instanceof Error ? caught.message : String(caught)
-            }`,
-          );
-        }
-      } else {
-        notes.push("OpenAI could not decode media; install ffmpeg to enable transcoding retry");
-      }
-    }
-
-    // OpenAI's upload cap must not discard source bytes accepted by later providers.
-    return { state: truncatedForOpenAi ? state : nextState, result: null, error };
-  },
-  fal: async ({ state, falApiKey, notes }) => {
-    if (!state.mediaType.toLowerCase().startsWith("audio/")) {
-      notes.push(`Skipping FAL transcription: unsupported mediaType ${state.mediaType}`);
-      return { state, result: null, error: null, skipped: true };
-    }
-    try {
-      const text = await transcribeWithFal(state.bytes, state.mediaType, falApiKey!);
-      if (text) {
-        return {
-          state,
-          result: { text, provider: "fal", error: null, notes: [] },
-          error: null,
-        };
-      }
-      return { state, result: null, error: new Error("FAL transcription returned empty text") };
-    } catch (caught) {
-      return {
-        state,
-        result: null,
-        error: wrapError("FAL transcription failed", caught),
-      };
-    }
-  },
-  deepgram: async ({ state, deepgramApiKey, env }) => {
-    try {
-      const result = await transcribeWithDeepgram(state.bytes, state.mediaType, deepgramApiKey!, {
-        env,
-      });
-      if (result.text) {
-        return {
-          state,
-          result: {
-            text: result.text,
-            provider: "deepgram",
-            error: null,
-            notes: [],
-            segments: result.segments,
-          },
-          error: null,
-        };
-      }
-      return {
-        state,
-        result: null,
-        error: new Error("Deepgram transcription returned empty text"),
-      };
-    } catch (caught) {
-      return {
-        state,
-        result: null,
-        error:
-          caught instanceof Error ? caught : wrapError("Deepgram transcription failed", caught),
-      };
-    }
-  },
-};
+    transcribe: (input) =>
+      transcribeWithOpenAi(input.bytes, input.mediaType, input.filename, options.openaiApiKey!, {
+        env: options.env,
+      }),
+    shouldRetry: shouldRetryOpenAiViaFfmpeg,
+  });
+  run.source = truncated && attempt.kind === "error" ? source : attempt.source;
+  return attempt;
+}

--- a/packages/core/src/transcription/whisper/remote.ts
+++ b/packages/core/src/transcription/whisper/remote.ts
@@ -1,7 +1,4 @@
-import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import {
   cloudProviderLabel,
   formatCloudFallbackTargets,
@@ -11,385 +8,109 @@ import {
 import { DEFAULT_SEGMENT_SECONDS, MAX_OPENAI_UPLOAD_BYTES } from "./constants.js";
 import { isFfmpegAvailable } from "./ffmpeg.js";
 import { buildMissingTranscriptionProviderMessage } from "./provider-setup.js";
+import { attemptRemoteProvider } from "./remote-provider-attempts.js";
 import {
-  attemptRemoteBytesProvider,
-  attemptRemoteFileProvider,
-} from "./remote-provider-attempts.js";
-import type { WhisperProgressEvent, WhisperTranscriptionResult } from "./types.js";
+  emitInitialProgress,
+  type TranscriptionChunking,
+  type TranscriptionRun,
+} from "./request.js";
+import type { WhisperTranscriptionResult } from "./types.js";
 import { formatBytes, readFirstBytes } from "./utils.js";
-
-type Env = Record<string, string | undefined>;
-
-type CloudArgs = {
-  groqApiKey: string | null;
-  groqError?: Error | null;
-  assemblyaiApiKey: string | null;
-  geminiApiKey: string | null;
-  openaiApiKey: string | null;
-  falApiKey: string | null;
-  deepgramApiKey: string | null;
-  env: Env;
-};
-
-type FailedAttempt = {
-  provider: CloudProvider | "groq" | null;
-  error: Error;
-};
 
 function withMergedNotes(
   result: WhisperTranscriptionResult,
   notes: string[],
 ): WhisperTranscriptionResult {
-  if (result.notes.length === 0) return { ...result, notes };
-  return { ...result, notes: [...notes, ...result.notes] };
+  return { ...result, notes: result.notes.length ? [...notes, ...result.notes] : notes };
 }
 
-function buildNoProviderResult({
-  notes,
-  groqApiKey,
-  groqError,
-}: {
-  notes: string[];
-  groqApiKey: string | null;
-  groqError: Error | null;
-}): WhisperTranscriptionResult {
-  if (groqApiKey) {
-    return {
-      text: null,
-      provider: "groq",
-      error: groqError ?? new Error("No transcription providers available"),
-      notes,
-    };
-  }
-  return {
-    text: null,
-    provider: null,
-    error: new Error(buildMissingTranscriptionProviderMessage()),
-    notes,
-  };
+function noProvider({ options, groqError, notes }: TranscriptionRun): WhisperTranscriptionResult {
+  return options.groqApiKey
+    ? {
+        text: null,
+        provider: "groq",
+        error: groqError ?? new Error("No transcription providers available"),
+        notes,
+      }
+    : {
+        text: null,
+        provider: null,
+        error: new Error(buildMissingTranscriptionProviderMessage()),
+        notes,
+      };
 }
 
-async function transcribeBytesAcrossProviders({
-  providerOrder,
-  bytes,
-  mediaType,
-  filename,
-  notes,
-  groqApiKey,
-  groqError = null,
-  assemblyaiApiKey,
-  geminiApiKey,
-  openaiApiKey,
-  falApiKey,
-  deepgramApiKey,
-  env,
-  onProgress,
-  transcribeOversizedBytesWithChunking,
-}: {
-  providerOrder: CloudProvider[];
-  bytes: Uint8Array;
-  mediaType: string;
-  filename: string | null;
-  notes: string[];
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  transcribeOversizedBytesWithChunking?: (args: {
-    bytes: Uint8Array;
-    mediaType: string;
-    filename: string | null;
-    onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  }) => Promise<WhisperTranscriptionResult>;
-} & CloudArgs): Promise<WhisperTranscriptionResult> {
-  if (providerOrder.length === 0) {
-    return buildNoProviderResult({ notes, groqApiKey, groqError });
-  }
+export async function transcribeWithRemoteFallbacks(
+  run: TranscriptionRun,
+  chunking: TranscriptionChunking,
+): Promise<WhisperTranscriptionResult> {
+  const { options, notes } = run;
+  const providers = resolveCloudProviderOrder(options);
+  if (!providers.length) return noProvider(run);
+  const allowByteChunking = run.source.kind === "bytes";
+  const fileSize = run.source.kind === "file" ? (await fs.stat(run.source.filePath)).size : null;
+  if (run.source.kind === "file") emitInitialProgress(run);
+  let lastFailure: { provider: CloudProvider; error: Error } | null = null;
 
-  let currentBytes = bytes;
-  let currentMediaType = mediaType;
-  let currentFilename = filename;
-  let lastFailure: FailedAttempt | null = null;
-
-  for (const [index, provider] of providerOrder.entries()) {
-    const attempt = await attemptRemoteBytesProvider({
-      provider,
-      state: {
-        bytes: currentBytes,
-        mediaType: currentMediaType,
-        filename: currentFilename,
-      },
-      assemblyaiApiKey,
-      geminiApiKey,
-      openaiApiKey,
-      falApiKey,
-      deepgramApiKey,
-      env,
-      notes,
-      onProgress,
-      transcribeOversizedBytesWithChunking,
-    });
-    currentBytes = attempt.state.bytes;
-    currentMediaType = attempt.state.mediaType;
-    currentFilename = attempt.state.filename;
-    if (attempt.result) return withMergedNotes(attempt.result, notes);
-    if (!attempt.error) continue;
-
-    lastFailure = { provider, error: attempt.error };
-    const remaining = providerOrder.slice(index + 1).filter((candidate) => {
-      if (candidate !== "fal") return true;
-      return currentMediaType.toLowerCase().startsWith("audio/");
-    });
-    if (remaining.length > 0) {
-      notes.push(
-        `${cloudProviderLabel(provider, false)} transcription failed; falling back to ${formatCloudFallbackTargets(remaining)}: ${attempt.error.message}`,
-      );
-    }
-  }
-
-  if (lastFailure) {
-    return {
-      text: null,
-      provider: lastFailure.provider,
-      error: lastFailure.error,
-      notes,
-    };
-  }
-  return buildNoProviderResult({ notes, groqApiKey, groqError });
-}
-
-export async function transcribeBytesWithRemoteFallbacks({
-  bytes,
-  mediaType,
-  filename,
-  notes,
-  groqApiKey,
-  groqError = null,
-  assemblyaiApiKey,
-  geminiApiKey,
-  openaiApiKey,
-  falApiKey,
-  deepgramApiKey,
-  env,
-  onProgress,
-  transcribeOversizedBytesWithChunking,
-}: {
-  bytes: Uint8Array;
-  mediaType: string;
-  filename: string | null;
-  notes: string[];
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  transcribeOversizedBytesWithChunking: (args: {
-    bytes: Uint8Array;
-    mediaType: string;
-    filename: string | null;
-    onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  }) => Promise<WhisperTranscriptionResult>;
-} & CloudArgs): Promise<WhisperTranscriptionResult> {
-  return await transcribeBytesAcrossProviders({
-    providerOrder: resolveCloudProviderOrder({
-      assemblyaiApiKey,
-      geminiApiKey,
-      openaiApiKey,
-      falApiKey,
-      deepgramApiKey,
-    }),
-    bytes,
-    mediaType,
-    filename,
-    notes,
-    groqApiKey,
-    groqError,
-    assemblyaiApiKey,
-    geminiApiKey,
-    openaiApiKey,
-    falApiKey,
-    deepgramApiKey,
-    env,
-    onProgress,
-    transcribeOversizedBytesWithChunking,
-  });
-}
-
-export async function transcribeFileWithRemoteFallbacks({
-  filePath,
-  mediaType,
-  filename,
-  notes,
-  groqApiKey,
-  groqError = null,
-  assemblyaiApiKey,
-  geminiApiKey,
-  openaiApiKey,
-  falApiKey,
-  deepgramApiKey,
-  env,
-  totalDurationSeconds,
-  onProgress,
-  transcribeChunkedFile,
-}: {
-  filePath: string;
-  mediaType: string;
-  filename: string | null;
-  notes: string[];
-  totalDurationSeconds: number | null;
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  transcribeChunkedFile: (args: {
-    filePath: string;
-    segmentSeconds: number;
-    totalDurationSeconds: number | null;
-    onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  }) => Promise<WhisperTranscriptionResult>;
-} & CloudArgs): Promise<WhisperTranscriptionResult> {
-  const providerOrder = resolveCloudProviderOrder({
-    assemblyaiApiKey,
-    geminiApiKey,
-    openaiApiKey,
-    falApiKey,
-    deepgramApiKey,
-  });
-  if (providerOrder.length === 0) {
-    return buildNoProviderResult({ notes, groqApiKey, groqError });
-  }
-
-  const stat = await fs.stat(filePath);
-  onProgress?.({
-    partIndex: null,
-    parts: null,
-    processedDurationSeconds: null,
-    totalDurationSeconds,
-  });
-  let cachedBytes: Uint8Array | null = null;
-  const readFileBytes = async () => {
-    if (cachedBytes) return cachedBytes;
-    cachedBytes = new Uint8Array(await fs.readFile(filePath));
-    return cachedBytes;
-  };
-
-  let lastFailure: FailedAttempt | null = null;
-
-  for (const [index, provider] of providerOrder.entries()) {
-    const fileAttempt = await attemptRemoteFileProvider({
-      provider,
-      filePath,
-      mediaType,
-      filename,
-      assemblyaiApiKey,
-      geminiApiKey,
-      deepgramApiKey,
-      env,
-    });
-    if (fileAttempt.kind === "result") return withMergedNotes(fileAttempt.result, notes);
-    if (fileAttempt.kind === "delegate-to-bytes") {
-      if (provider === "openai" && stat.size > MAX_OPENAI_UPLOAD_BYTES) {
-        const canChunk = await isFfmpegAvailable();
-        if (canChunk) {
+  for (const [index, provider] of providers.entries()) {
+    const remaining = providers.slice(index + 1);
+    if (run.source.kind === "file" && (provider === "openai" || provider === "fal")) {
+      const source = run.source;
+      let partialRead = false;
+      if (provider === "openai" && fileSize! > MAX_OPENAI_UPLOAD_BYTES) {
+        if (await isFfmpegAvailable()) {
           return withMergedNotes(
-            await transcribeChunkedFile({
-              filePath,
-              segmentSeconds: DEFAULT_SEGMENT_SECONDS,
-              totalDurationSeconds,
-              onProgress,
-            }),
+            await chunking.file(
+              source.filePath,
+              DEFAULT_SEGMENT_SECONDS,
+              Boolean(options.groqApiKey),
+            ),
             notes,
           );
         }
         notes.push(
-          `Media too large for Whisper upload (${formatBytes(stat.size)}); install ffmpeg to enable chunked transcription`,
+          `Media too large for Whisper upload (${formatBytes(fileSize!)}); install ffmpeg to enable chunked transcription`,
         );
-        const remainingProviders = providerOrder.slice(index + 1);
-        if (remainingProviders.includes("deepgram")) {
+        if (remaining.includes("deepgram")) {
           notes.push(
-            `Falling back to ${formatCloudFallbackTargets(remainingProviders)} without truncating the media`,
+            `Falling back to ${formatCloudFallbackTargets(remaining)} without truncating the media`,
           );
           continue;
         }
-        const head = await readFirstBytes(filePath, MAX_OPENAI_UPLOAD_BYTES);
-        return withMergedNotes(
-          await transcribeBytesAcrossProviders({
-            providerOrder: providerOrder.slice(index),
-            bytes: head,
-            mediaType,
-            filename,
-            notes: [],
-            groqApiKey,
-            groqError,
-            assemblyaiApiKey,
-            geminiApiKey,
-            openaiApiKey,
-            falApiKey,
-            deepgramApiKey,
-            env,
-            onProgress,
-          }),
-          notes,
-        );
+        partialRead = true;
       }
-      return withMergedNotes(
-        await transcribeBytesAcrossProviders({
-          providerOrder: providerOrder.slice(index),
-          bytes: await readFileBytes(),
-          mediaType,
-          filename,
-          notes: [],
-          groqApiKey,
-          groqError,
-          assemblyaiApiKey,
-          geminiApiKey,
-          openaiApiKey,
-          falApiKey,
-          deepgramApiKey,
-          env,
-          onProgress,
-        }),
-        notes,
-      );
+      run.source = {
+        kind: "bytes",
+        bytes: partialRead
+          ? await readFirstBytes(source.filePath, MAX_OPENAI_UPLOAD_BYTES)
+          : new Uint8Array(await fs.readFile(source.filePath)),
+        mediaType: source.mediaType,
+        filename: source.filename,
+      };
+      lastFailure = null;
     }
-    lastFailure = { provider, error: fileAttempt.error };
-    const remaining = providerOrder.slice(index + 1);
-    if (remaining.length > 0) {
+
+    const attempt = await attemptRemoteProvider(
+      provider,
+      run,
+      allowByteChunking ? chunking.bytes : undefined,
+    );
+    if (attempt.kind === "result") return withMergedNotes(attempt.result, notes);
+    if (attempt.kind === "skip") continue;
+    lastFailure = { provider, error: attempt.error };
+    const fallbacks = remaining.filter(
+      (candidate) =>
+        run.source.kind === "file" ||
+        candidate !== "fal" ||
+        run.source.mediaType.toLowerCase().startsWith("audio/"),
+    );
+    if (fallbacks.length) {
       notes.push(
-        `${cloudProviderLabel(provider, false)} transcription failed; falling back to ${formatCloudFallbackTargets(remaining)}: ${fileAttempt.error.message}`,
+        `${cloudProviderLabel(provider, false)} transcription failed; falling back to ${formatCloudFallbackTargets(fallbacks)}: ${attempt.error.message}`,
       );
     }
   }
-
-  if (lastFailure) {
-    return {
-      text: null,
-      provider: lastFailure.provider,
-      error: lastFailure.error,
-      notes,
-    };
-  }
-  return buildNoProviderResult({ notes, groqApiKey, groqError });
-}
-
-export async function transcribeOversizedBytesViaTempFile({
-  bytes,
-  mediaType,
-  filename,
-  onProgress,
-  transcribeFile,
-}: {
-  bytes: Uint8Array;
-  mediaType: string;
-  filename: string | null;
-  onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  transcribeFile: (args: {
-    filePath: string;
-    mediaType: string;
-    filename: string | null;
-    onProgress?: ((event: WhisperProgressEvent) => void) | null;
-  }) => Promise<WhisperTranscriptionResult>;
-}): Promise<WhisperTranscriptionResult> {
-  const tempFile = join(tmpdir(), `summarize-whisper-${randomUUID()}`);
-  try {
-    await fs.writeFile(tempFile, bytes);
-    return await transcribeFile({
-      filePath: tempFile,
-      mediaType,
-      filename,
-      onProgress,
-    });
-  } finally {
-    await fs.unlink(tempFile).catch(() => {});
-  }
+  return lastFailure
+    ? { text: null, provider: lastFailure.provider, error: lastFailure.error, notes }
+    : noProvider(run);
 }

--- a/packages/core/src/transcription/whisper/request.ts
+++ b/packages/core/src/transcription/whisper/request.ts
@@ -1,0 +1,66 @@
+import { DEFAULT_SEGMENT_SECONDS } from "./constants.js";
+import type {
+  DiarizationPreference,
+  WhisperProgressEvent,
+  WhisperTranscriptionResult,
+} from "./types.js";
+
+type MediaMetadata = { mediaType: string; filename: string | null };
+export type TranscriptionBytes = MediaMetadata & { kind: "bytes"; bytes: Uint8Array };
+export type TranscriptionFile = MediaMetadata & { kind: "file"; filePath: string };
+export type TranscriptionSource = TranscriptionBytes | TranscriptionFile;
+
+export type TranscriptionOptions = {
+  groqApiKey: string | null;
+  assemblyaiApiKey?: string | null;
+  elevenlabsApiKey?: string | null;
+  geminiApiKey?: string | null;
+  openaiApiKey: string | null;
+  falApiKey: string | null;
+  deepgramApiKey?: string | null;
+  diarization?: DiarizationPreference | null;
+  segmentSeconds?: number;
+  totalDurationSeconds?: number | null;
+  onProgress?: ((event: WhisperProgressEvent) => void) | null;
+  env?: Record<string, string | undefined>;
+};
+
+export type TranscriptionRun = ReturnType<typeof createTranscriptionRun>;
+export type ProviderResult =
+  | { kind: "result"; result: WhisperTranscriptionResult }
+  | { kind: "error"; error: Error };
+
+export type TranscriptionChunking = {
+  file: (
+    filePath: string,
+    segmentSeconds: number,
+    skipGroq: boolean,
+  ) => Promise<WhisperTranscriptionResult>;
+  bytes: (source: TranscriptionBytes) => Promise<WhisperTranscriptionResult>;
+};
+
+export function createTranscriptionRun(
+  source: TranscriptionSource,
+  {
+    env = process.env,
+    segmentSeconds = DEFAULT_SEGMENT_SECONDS,
+    totalDurationSeconds = null,
+    ...options
+  }: TranscriptionOptions,
+) {
+  return {
+    source,
+    options: { ...options, env, segmentSeconds, totalDurationSeconds },
+    notes: [] as string[],
+    groqError: null as Error | null,
+  };
+}
+
+export function emitInitialProgress({ options }: TranscriptionRun): void {
+  options.onProgress?.({
+    partIndex: null,
+    parts: null,
+    processedDurationSeconds: null,
+    totalDurationSeconds: options.totalDurationSeconds,
+  });
+}

--- a/tests/transcription.remote-run.test.ts
+++ b/tests/transcription.remote-run.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_OPENAI_UPLOAD_BYTES } from "../packages/core/src/transcription/whisper/constants.js";
+import { transcribeWithDecodeRetry } from "../packages/core/src/transcription/whisper/decode-retry.js";
+import { transcribeWithRemoteFallbacks } from "../packages/core/src/transcription/whisper/remote.js";
+import {
+  createTranscriptionRun,
+  type TranscriptionOptions,
+} from "../packages/core/src/transcription/whisper/request.js";
+
+const mocks = vi.hoisted(() => ({
+  stat: vi.fn(),
+  readFile: vi.fn(),
+  ffmpeg: vi.fn(),
+  transcode: vi.fn(),
+  assemblyFile: vi.fn(),
+  assemblyBytes: vi.fn(),
+  geminiFile: vi.fn(),
+  geminiBytes: vi.fn(),
+  deepgramFile: vi.fn(),
+  deepgramBytes: vi.fn(),
+  openai: vi.fn(),
+  fal: vi.fn(),
+}));
+vi.mock("node:fs", async (original) => {
+  const actual = await original<typeof import("node:fs")>();
+  return {
+    ...actual,
+    promises: { ...actual.promises, stat: mocks.stat, readFile: mocks.readFile },
+  };
+});
+vi.mock("../packages/core/src/transcription/whisper/assemblyai.js", () => ({
+  ASSEMBLYAI_TRANSCRIPTION_MODEL_ID: "assemblyai/test",
+  transcribeFileWithAssemblyAi: mocks.assemblyFile,
+  transcribeWithAssemblyAi: mocks.assemblyBytes,
+}));
+vi.mock("../packages/core/src/transcription/whisper/gemini.js", () => ({
+  transcribeFileWithGemini: mocks.geminiFile,
+  transcribeWithGemini: mocks.geminiBytes,
+}));
+vi.mock("../packages/core/src/transcription/whisper/deepgram.js", () => ({
+  transcribeFileWithDeepgram: mocks.deepgramFile,
+  transcribeWithDeepgram: mocks.deepgramBytes,
+}));
+vi.mock("../packages/core/src/transcription/whisper/openai.js", () => ({
+  transcribeWithOpenAi: mocks.openai,
+  shouldRetryOpenAiViaFfmpeg: () => false,
+}));
+vi.mock("../packages/core/src/transcription/whisper/fal.js", () => ({
+  transcribeWithFal: mocks.fal,
+}));
+vi.mock("../packages/core/src/transcription/whisper/ffmpeg.js", () => ({
+  isFfmpegAvailable: mocks.ffmpeg,
+  transcodeBytesToMp3: mocks.transcode,
+}));
+
+const chunking = { file: vi.fn(), bytes: vi.fn() };
+const segments = [{ startMs: 0, endMs: 100, text: "transcript" }];
+const createRun = (options: Partial<TranscriptionOptions> = {}) =>
+  createTranscriptionRun(
+    { kind: "file", filePath: "/media.mp3", mediaType: "audio/mpeg", filename: "media.mp3" },
+    { groqApiKey: null, openaiApiKey: null, falApiKey: null, env: {}, ...options },
+  );
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.stat.mockResolvedValue({ size: 3 });
+  mocks.readFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
+  mocks.ffmpeg.mockResolvedValue(false);
+});
+
+describe("source-aware remote transcription", () => {
+  it.each([false, true])(
+    "keeps native-file fallback lazy and preserves the final result (failure=%s)",
+    async (fail) => {
+      const failure = new Error("Deepgram unavailable");
+      mocks.assemblyFile.mockRejectedValue(new Error("AssemblyAI unavailable"));
+      mocks.geminiFile.mockRejectedValue(new Error("Gemini unavailable"));
+      if (fail) mocks.deepgramFile.mockRejectedValue(failure);
+      else mocks.deepgramFile.mockResolvedValue({ text: "transcript", segments });
+      const run = createRun({
+        assemblyaiApiKey: "assembly",
+        geminiApiKey: "gemini",
+        deepgramApiKey: "deepgram",
+      });
+      const result = await transcribeWithRemoteFallbacks(run, chunking);
+      expect(result.provider).toBe("deepgram");
+      if (fail) expect(result.error).toBe(failure);
+      else expect(result.segments).toBe(segments);
+      expect(mocks.readFile).not.toHaveBeenCalled();
+      expect(mocks.assemblyBytes).not.toHaveBeenCalled();
+      expect(mocks.geminiBytes).not.toHaveBeenCalled();
+      expect(mocks.deepgramBytes).not.toHaveBeenCalled();
+    },
+  );
+
+  it("converts a file once before byte-only providers and keeps its full fallback payload", async () => {
+    mocks.assemblyFile.mockRejectedValue(new Error("unavailable"));
+    mocks.openai.mockRejectedValue(new Error("unavailable"));
+    mocks.deepgramBytes.mockResolvedValue({ text: "transcript", segments });
+    const run = createRun({
+      assemblyaiApiKey: "assembly",
+      openaiApiKey: "openai",
+      falApiKey: "fal",
+      deepgramApiKey: "deepgram",
+    });
+    run.source.mediaType = "video/mp4";
+    const result = await transcribeWithRemoteFallbacks(run, chunking);
+    expect(result).toMatchObject({ text: "transcript", provider: "deepgram", segments });
+    expect(mocks.readFile).toHaveBeenCalledExactlyOnceWith("/media.mp3");
+    expect(mocks.deepgramBytes).toHaveBeenCalledWith(
+      new Uint8Array([1, 2, 3]),
+      "video/mp4",
+      "deepgram",
+      { env: {} },
+    );
+    expect(mocks.deepgramFile).not.toHaveBeenCalled();
+    expect(mocks.fal).not.toHaveBeenCalled();
+    expect(run.notes.join(" ")).toContain("Skipping FAL transcription");
+  });
+
+  it("treats a failed chunk result as terminal instead of retrying another provider", async () => {
+    mocks.ffmpeg.mockResolvedValue(true);
+    const failure = new Error("chunk failed");
+    const result = { text: null, provider: "openai", error: failure, notes: ["chunk note"] };
+    chunking.bytes.mockResolvedValue(result);
+    const run = createRun({ openaiApiKey: "openai", deepgramApiKey: "deepgram" });
+    run.source = {
+      kind: "bytes",
+      bytes: new Uint8Array(MAX_OPENAI_UPLOAD_BYTES + 1),
+      mediaType: "audio/mpeg",
+      filename: null,
+    };
+    run.notes.push("earlier note");
+    await expect(transcribeWithRemoteFallbacks(run, chunking)).resolves.toEqual({
+      ...result,
+      notes: ["earlier note", "chunk note"],
+    });
+    expect(mocks.openai).not.toHaveBeenCalled();
+    expect(mocks.deepgramBytes).not.toHaveBeenCalled();
+  });
+});
+
+describe.each(["groq", "openai"] as const)("%s decode retry source ownership", (provider) => {
+  it.each([false, true])(
+    "adopts an empty retry conversion but preserves input after a thrown retry (throws=%s)",
+    async (throws) => {
+      mocks.ffmpeg.mockResolvedValue(true);
+      const converted = new Uint8Array([9]);
+      mocks.transcode.mockResolvedValue(converted);
+      const transcribe = vi.fn().mockRejectedValueOnce(new Error("decode failure"));
+      if (throws) transcribe.mockRejectedValueOnce(new Error("retry unavailable"));
+      else transcribe.mockResolvedValueOnce(null);
+      const source = {
+        kind: "bytes" as const,
+        bytes: new Uint8Array([1]),
+        mediaType: "video/mp4",
+        filename: "video.mp4",
+      };
+      const notes: string[] = [];
+      const attempt = await transcribeWithDecodeRetry({
+        source,
+        provider,
+        notes,
+        transcribe,
+        shouldRetry: () => true,
+      });
+      expect(attempt.kind).toBe("error");
+      if (throws) {
+        expect(attempt.source).toBe(source);
+        expect(notes.join(" ")).toContain("retry unavailable");
+      } else {
+        expect(attempt.source).toMatchObject({
+          bytes: converted,
+          mediaType: "audio/mpeg",
+          filename: "audio.mp3",
+        });
+      }
+    },
+  );
+});

--- a/tests/transcription.whisper-local.test.ts
+++ b/tests/transcription.whisper-local.test.ts
@@ -1,5 +1,10 @@
 import { access } from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  transcribeWithLocalOnnx,
+  transcribeWithLocalWhisper,
+} from "../packages/core/src/transcription/whisper/local.js";
+import { createTranscriptionRun } from "../packages/core/src/transcription/whisper/request.js";
 
 const mocks = vi.hoisted(() => ({
   resolveOnnxModelPreference: vi.fn(),
@@ -8,220 +13,134 @@ const mocks = vi.hoisted(() => ({
   isWhisperCppReady: vi.fn(),
   transcribeWithWhisperCppFile: vi.fn(),
 }));
-
 vi.mock("../packages/core/src/transcription/onnx-cli.js", () => ({
   transcribeWithOnnxCli: mocks.transcribeWithOnnxCli,
   transcribeWithOnnxCliFile: mocks.transcribeWithOnnxCliFile,
 }));
-
 vi.mock("../packages/core/src/transcription/whisper/preferences.js", () => ({
   resolveOnnxModelPreference: mocks.resolveOnnxModelPreference,
 }));
-
 vi.mock("../packages/core/src/transcription/whisper/whisper-cpp.js", () => ({
   isWhisperCppReady: mocks.isWhisperCppReady,
   transcribeWithWhisperCppFile: mocks.transcribeWithWhisperCppFile,
 }));
 
-import {
-  transcribeWithLocalOnnx,
-  transcribeWithLocalOnnxFile,
-  transcribeWithLocalWhisperBytes,
-  transcribeWithLocalWhisperFile,
-} from "../packages/core/src/transcription/whisper/local.js";
+function createRun(kind: "bytes" | "file", filename: string | null = "audio") {
+  return createTranscriptionRun(
+    kind === "bytes"
+      ? { kind, bytes: new Uint8Array([1, 2, 3]), mediaType: "audio/mpeg", filename }
+      : { kind, filePath: "/unused/audio.mp3", mediaType: "audio/mpeg", filename },
+    {
+      groqApiKey: null,
+      openaiApiKey: null,
+      falApiKey: null,
+      env: {},
+      totalDurationSeconds: 4,
+      onProgress: vi.fn(),
+    },
+  );
+}
 
-describe("local Whisper adapters", () => {
+describe.each(["bytes", "file"] as const)("local Whisper adapters (%s)", (kind) => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     mocks.resolveOnnxModelPreference.mockReturnValue(null);
     mocks.isWhisperCppReady.mockResolvedValue(false);
   });
 
-  it("skips unconfigured ONNX byte and file adapters", async () => {
-    const notes: string[] = [];
-    await expect(
-      transcribeWithLocalOnnx({
-        bytes: new Uint8Array([1]),
-        mediaType: "audio/mpeg",
-        filename: "audio.mp3",
-        totalDurationSeconds: null,
-        env: {},
-        notes,
-      }),
-    ).resolves.toBeNull();
-    await expect(
-      transcribeWithLocalOnnxFile({
-        filePath: "/unused/audio.mp3",
-        mediaType: "audio/mpeg",
-        totalDurationSeconds: null,
-        env: {},
-        notes,
-      }),
-    ).resolves.toBeNull();
+  it("skips unconfigured ONNX without emitting progress", async () => {
+    const run = createRun(kind);
+    await expect(transcribeWithLocalOnnx(run)).resolves.toBeNull();
+    expect(run.options.onProgress).not.toHaveBeenCalled();
+    expect(mocks.transcribeWithOnnxCli).not.toHaveBeenCalled();
+    expect(mocks.transcribeWithOnnxCliFile).not.toHaveBeenCalled();
   });
 
-  it("merges ONNX success notes for byte and file inputs", async () => {
+  it("keeps source dispatch, progress, and accumulated ONNX notes", async () => {
     mocks.resolveOnnxModelPreference.mockReturnValue("parakeet");
-    mocks.transcribeWithOnnxCli.mockResolvedValue({
-      text: "bytes result",
+    const transcribe =
+      kind === "bytes" ? mocks.transcribeWithOnnxCli : mocks.transcribeWithOnnxCliFile;
+    transcribe.mockResolvedValue({
+      text: "result",
       provider: "onnx-parakeet",
       error: null,
-      notes: ["bytes note"],
+      notes: ["engine note"],
     });
-    mocks.transcribeWithOnnxCliFile.mockResolvedValue({
-      text: "file result",
-      provider: "onnx-parakeet",
-      error: null,
-      notes: ["file note"],
-    });
-    const notes: string[] = [];
-    const progress = vi.fn();
-
-    await expect(
-      transcribeWithLocalOnnx({
-        bytes: new Uint8Array([1]),
-        mediaType: "audio/mpeg",
-        filename: "audio.mp3",
+    const run = createRun(kind);
+    run.notes.push("earlier");
+    const result = await transcribeWithLocalOnnx(run);
+    expect(result).toMatchObject({ text: "result", notes: ["earlier", "engine note"] });
+    expect(result?.notes).toBe(run.notes);
+    expect(transcribe).toHaveBeenCalledOnce();
+    if (kind === "file") {
+      expect(run.options.onProgress).toHaveBeenCalledExactlyOnceWith({
+        partIndex: null,
+        parts: null,
+        processedDurationSeconds: null,
         totalDurationSeconds: 4,
-        env: {},
-        notes,
-      }),
-    ).resolves.toMatchObject({ text: "bytes result", notes: ["bytes note"] });
-    await expect(
-      transcribeWithLocalOnnxFile({
-        filePath: "/unused/audio.mp3",
-        mediaType: "audio/mpeg",
-        totalDurationSeconds: 4,
-        onProgress: progress,
-        env: {},
-        notes,
-      }),
-    ).resolves.toMatchObject({ text: "file result", notes: ["bytes note", "file note"] });
-    expect(progress).toHaveBeenCalledWith({
-      partIndex: null,
-      parts: null,
-      processedDurationSeconds: null,
-      totalDurationSeconds: 4,
-    });
+      });
+    } else {
+      expect(run.options.onProgress).not.toHaveBeenCalled();
+    }
   });
 
   it("records ONNX failures and allows provider fallback", async () => {
     mocks.resolveOnnxModelPreference.mockReturnValue("canary");
-    mocks.transcribeWithOnnxCli.mockResolvedValue({
+    const transcribe =
+      kind === "bytes" ? mocks.transcribeWithOnnxCli : mocks.transcribeWithOnnxCliFile;
+    const provider = kind === "file" ? "onnx-canary" : null;
+    transcribe.mockResolvedValue({
       text: null,
-      provider: null,
-      error: new Error("bytes failed"),
-      notes: ["bytes diagnostic"],
+      provider,
+      error: new Error("failed"),
+      notes: ["diagnostic"],
     });
-    mocks.transcribeWithOnnxCliFile.mockResolvedValue({
-      text: null,
-      provider: "onnx-canary",
-      error: new Error("file failed"),
-      notes: [],
-    });
-    const notes: string[] = [];
-
-    await transcribeWithLocalOnnx({
-      bytes: new Uint8Array([1]),
-      mediaType: "audio/mpeg",
-      filename: null,
-      totalDurationSeconds: null,
-      env: {},
-      notes,
-    });
-    await transcribeWithLocalOnnxFile({
-      filePath: "/unused/audio.mp3",
-      mediaType: "audio/mpeg",
-      totalDurationSeconds: null,
-      env: {},
-      notes,
-    });
-
-    expect(notes).toEqual([
-      "bytes diagnostic",
-      "onnx failed; falling back to Whisper: bytes failed",
-      "onnx-canary failed; falling back to Whisper: file failed",
+    const run = createRun(kind);
+    await expect(transcribeWithLocalOnnx(run)).resolves.toBeNull();
+    expect(run.notes).toEqual([
+      "diagnostic",
+      `${provider ?? "onnx"} failed; falling back to Whisper: failed`,
     ]);
   });
 
   it("passes through empty ONNX results without manufacturing diagnostics", async () => {
     mocks.resolveOnnxModelPreference.mockReturnValue("parakeet");
-    const empty = { text: null, provider: "onnx-parakeet", error: null, notes: [] };
-    mocks.transcribeWithOnnxCli.mockResolvedValue(empty);
-    mocks.transcribeWithOnnxCliFile.mockResolvedValue(empty);
-    const notes: string[] = [];
-
-    await expect(
-      transcribeWithLocalOnnx({
-        bytes: new Uint8Array([1]),
-        mediaType: "audio/mpeg",
-        filename: null,
-        totalDurationSeconds: null,
-        env: {},
-        notes,
-      }),
-    ).resolves.toBeNull();
-    await expect(
-      transcribeWithLocalOnnxFile({
-        filePath: "/unused/audio.mp3",
-        mediaType: "audio/mpeg",
-        totalDurationSeconds: null,
-        env: {},
-        notes,
-      }),
-    ).resolves.toBeNull();
-    expect(notes).toEqual([]);
+    const transcribe =
+      kind === "bytes" ? mocks.transcribeWithOnnxCli : mocks.transcribeWithOnnxCliFile;
+    transcribe.mockResolvedValue({ text: null, provider: "onnx-parakeet", error: null, notes: [] });
+    const run = createRun(kind);
+    await expect(transcribeWithLocalOnnx(run)).resolves.toBeNull();
+    expect(run.notes).toEqual([]);
   });
 
-  it("skips whisper.cpp when the local engine is unavailable", async () => {
-    const notes: string[] = [];
-    await expect(
-      transcribeWithLocalWhisperBytes({
-        bytes: new Uint8Array([1]),
-        mediaType: "audio/mpeg",
-        filename: null,
-        totalDurationSeconds: null,
-        env: {},
-        notes,
-      }),
-    ).resolves.toBeNull();
-    await expect(
-      transcribeWithLocalWhisperFile({
-        filePath: "/unused/audio.mp3",
-        mediaType: "audio/mpeg",
-        totalDurationSeconds: null,
-        env: {},
-        notes,
-      }),
-    ).resolves.toBeNull();
+  it("skips unavailable whisper.cpp without emitting progress", async () => {
+    const run = createRun(kind);
+    await expect(transcribeWithLocalWhisper(run)).resolves.toBeNull();
+    expect(run.options.onProgress).not.toHaveBeenCalled();
+    expect(mocks.transcribeWithWhisperCppFile).not.toHaveBeenCalled();
   });
 
-  it("transcribes byte input through a cleaned-up whisper.cpp temp file", async () => {
+  it("preserves whisper.cpp results and cleans temporary input", async () => {
     mocks.isWhisperCppReady.mockResolvedValue(true);
-    let tempFile = "";
+    let inputPath = "";
     mocks.transcribeWithWhisperCppFile.mockImplementation(async ({ filePath }) => {
-      tempFile = filePath;
-      await expect(access(filePath)).resolves.toBeUndefined();
-      return {
-        text: "local result",
-        provider: "whisper.cpp",
-        error: null,
-        notes: ["local note"],
-      };
+      inputPath = filePath;
+      if (kind === "bytes") await expect(access(filePath)).resolves.toBeUndefined();
+      return { text: "local result", provider: "whisper.cpp", error: null, notes: ["local note"] };
     });
-    const notes: string[] = [];
-
-    await expect(
-      transcribeWithLocalWhisperBytes({
-        bytes: new Uint8Array([1, 2, 3]),
-        mediaType: "audio/mpeg",
-        filename: "audio",
-        totalDurationSeconds: 3,
-        env: {},
-        notes,
-      }),
-    ).resolves.toMatchObject({ text: "local result", notes: ["local note"] });
-    await expect(access(tempFile)).rejects.toMatchObject({ code: "ENOENT" });
+    const run = createRun(kind, "../audio");
+    await expect(transcribeWithLocalWhisper(run)).resolves.toMatchObject({
+      text: "local result",
+      notes: ["local note"],
+    });
+    if (kind === "bytes") {
+      expect(inputPath).toMatch(/-audio\.mp3$/);
+      await expect(access(inputPath)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(run.options.onProgress).not.toHaveBeenCalled();
+    } else {
+      expect(inputPath).toBe("/unused/audio.mp3");
+      expect(run.options.onProgress).toHaveBeenCalledOnce();
+    }
   });
 
   it("converts thrown and returned whisper.cpp failures into fallback notes", async () => {
@@ -234,72 +153,26 @@ describe("local Whisper adapters", () => {
         error: new Error("empty"),
         notes: ["engine note"],
       });
-    const notes: string[] = [];
-    const progress = vi.fn();
-
-    await expect(
-      transcribeWithLocalWhisperFile({
-        filePath: "/unused/one.mp3",
-        mediaType: "audio/mpeg",
-        totalDurationSeconds: 10,
-        onProgress: progress,
-        env: {},
-        notes,
-      }),
-    ).resolves.toBeNull();
-    await expect(
-      transcribeWithLocalWhisperFile({
-        filePath: "/unused/two.mp3",
-        mediaType: "audio/mpeg",
-        totalDurationSeconds: 10,
-        env: {},
-        notes,
-      }),
-    ).resolves.toBeNull();
-
-    expect(notes).toEqual([
+    const run = createRun(kind);
+    await expect(transcribeWithLocalWhisper(run)).resolves.toBeNull();
+    await expect(transcribeWithLocalWhisper(run)).resolves.toBeNull();
+    expect(run.notes).toEqual([
       "whisper.cpp failed; falling back to remote Whisper: whisper.cpp failed: crashed",
       "engine note",
       "whisper.cpp failed; falling back to remote Whisper: empty",
     ]);
-    expect(progress).toHaveBeenCalled();
   });
 
-  it("handles default byte filenames and note-free whisper.cpp results", async () => {
+  it("handles default filenames and note-free results", async () => {
     mocks.isWhisperCppReady.mockResolvedValue(true);
     mocks.transcribeWithWhisperCppFile
-      .mockResolvedValueOnce({
-        text: null,
-        provider: "whisper.cpp",
-        error: null,
-        notes: [],
-      })
-      .mockResolvedValueOnce({
-        text: "file success",
-        provider: "whisper.cpp",
-        error: null,
-        notes: [],
-      });
-    const notes: string[] = [];
-
-    await expect(
-      transcribeWithLocalWhisperBytes({
-        bytes: new Uint8Array([1]),
-        mediaType: "audio/mpeg",
-        filename: null,
-        totalDurationSeconds: null,
-        env: {},
-        notes,
-      }),
-    ).resolves.toBeNull();
-    await expect(
-      transcribeWithLocalWhisperFile({
-        filePath: "/unused/audio.mp3",
-        mediaType: "audio/mpeg",
-        totalDurationSeconds: null,
-        env: {},
-        notes,
-      }),
-    ).resolves.toMatchObject({ text: "file success", notes: [] });
+      .mockResolvedValueOnce({ text: null, provider: "whisper.cpp", error: null, notes: [] })
+      .mockResolvedValueOnce({ text: "success", provider: "whisper.cpp", error: null, notes: [] });
+    const run = createRun(kind, null);
+    await expect(transcribeWithLocalWhisper(run)).resolves.toBeNull();
+    await expect(transcribeWithLocalWhisper(run)).resolves.toMatchObject({
+      text: "success",
+      notes: [],
+    });
   });
 });


### PR DESCRIPTION
## What changed

Replace the parallel file/byte orchestration stacks with one source-aware transcription run. Local engines, cloud provider ordering, decode retries, progress, and accumulated notes now have one owner. File and byte adapters remain only where their I/O and upload policies genuinely differ.

This removes 724 production lines from the orchestration cluster and 669 lines overall, including additional regression coverage. No public API or provider configuration changes.

## Preserved boundaries

Keep native-file providers lazy, read full input only when a byte provider requires it, and retain provider-specific upload/chunking policies. A failed chunking result remains terminal. Decode retries replace the source only after a completed retry; a thrown retry preserves the original source. Nested segment calls clear parent duration, progress, and diarization.

## Validation

- Build, formatting, lint, and type checking pass.
- Eight new source-routing/decode-retry regressions pass; local engine coverage is now shared across file and byte inputs.
- Independent Codex review: no actionable P0–P2 findings.
- Final local full gate: 3,048 passed, 43 skipped; 94.21% line coverage and 85.25% branch coverage. An earlier run hit filesystem timeouts on a heavily loaded host; all 86 tests in those suites and then the full gate passed unchanged. Timeout settings remain unchanged.
- Hosted CI passed on the exact PR head: Node 24, Chromium extension E2E, Firefox extension smoke, and GitGuardian.
