### PR TITLE
refactor(providers): centralize metadata and config parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Dependencies and maintenance
 
+- Make provider metadata the shared source for configuration and model parsing; remove duplicated provider inventories, native model constructors, client defaults, and request-option parsing.
 - Replace duplicated file/byte transcription orchestration with one source-aware runner, shared local/provider handling, and common decode retries while preserving lazy file uploads and full-input fallback.
 - Unify model execution around one resolved request and completion path; centralize stream consumption while preserving output-failure and retry boundaries.
 - Consolidate LLM request options and SDK stream handling while preserving provider-specific configuration, errors, and fallback behavior.

--- a/docs/model-provider-resolution.md
+++ b/docs/model-provider-resolution.md
@@ -13,15 +13,19 @@ Goal: reduce implicit provider knowledge.
 
 ## Shared capability registry
 
-- `src/llm/provider-capabilities.ts`
-  Source of truth for:
+- `src/llm/provider-registry.ts` is a dependency-free registry consumed by configuration, model parsing, and runtime capability helpers.
+  It owns:
   - required env per provider
   - CLI default models
   - auto CLI order
   - document support
   - streaming support
+  - provider names and their TypeScript unions
+  - default endpoints and transport selection
 
-If a provider rule changes, update this file first.
+If provider metadata changes, update the registry first. `src/llm/provider-profile.ts` owns runtime environment aliases and client configuration; `src/llm/provider-capabilities.ts` exposes their combined capability surface.
+
+Configuration-only allowlists stay separate: legacy `apiKeys` names belong to `src/config/legacy-api-keys.ts`, and provider base-URL sections remain an explicit supported configuration surface. Adding a model provider must not implicitly expand either.
 
 ## Auto model selection
 

--- a/src/application/environment-state.ts
+++ b/src/application/environment-state.ts
@@ -1,6 +1,6 @@
 import { isOpenRouterBaseUrl, resolveConfiguredBaseUrl } from "@steipete/summarize-core";
 import type { CliProvider, SummarizeConfig } from "../config.js";
-import { DEFAULT_MINIMAX_BASE_URL, DEFAULT_OLLAMA_BASE_URL } from "../llm/provider-profile.js";
+import { DEFAULT_MINIMAX_BASE_URL, DEFAULT_OLLAMA_BASE_URL } from "../llm/provider-registry.js";
 import { resolveCliAvailability, resolveExecutableInPath } from "./environment.js";
 
 export type EnvState = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,25 +97,19 @@ export function loadSummarizeConfig({ env }: { env: Record<string, string | unde
   const logging = parseLoggingConfig(parsed, path);
   const openai = parseOpenAiConfig(parsed, path);
 
-  const nvidia = parseProviderBaseUrlConfig(
-    (parsed as Record<string, unknown>).nvidia,
-    path,
+  const providerConfigs: Partial<SummarizeConfig> = {};
+  for (const provider of [
     "nvidia",
-  );
-  const minimax = parseProviderBaseUrlConfig(
-    (parsed as Record<string, unknown>).minimax,
-    path,
     "minimax",
-  );
-  const anthropic = parseProviderBaseUrlConfig(parsed.anthropic, path, "anthropic");
-  const google = parseProviderBaseUrlConfig(parsed.google, path, "google");
-  const xai = parseProviderBaseUrlConfig(parsed.xai, path, "xai");
-  const zai = parseProviderBaseUrlConfig((parsed as Record<string, unknown>).zai, path, "zai");
-  const ollama = parseProviderBaseUrlConfig(
-    (parsed as Record<string, unknown>).ollama,
-    path,
+    "anthropic",
+    "google",
+    "xai",
+    "zai",
     "ollama",
-  );
+  ] as const) {
+    const providerConfig = parseProviderBaseUrlConfig(parsed[provider], path, provider);
+    if (providerConfig) providerConfigs[provider] = providerConfig;
+  }
 
   const configEnv = parseEnvConfig(parsed, path);
   const apiKeys = parseApiKeysConfig(parsed, path);
@@ -134,13 +128,7 @@ export function loadSummarizeConfig({ env }: { env: Record<string, string | unde
       ...(ui ? { ui } : {}),
       ...(cli ? { cli } : {}),
       ...(openai ? { openai } : {}),
-      ...(nvidia ? { nvidia } : {}),
-      ...(minimax ? { minimax } : {}),
-      ...(anthropic ? { anthropic } : {}),
-      ...(google ? { google } : {}),
-      ...(xai ? { xai } : {}),
-      ...(zai ? { zai } : {}),
-      ...(ollama ? { ollama } : {}),
+      ...providerConfigs,
       ...(logging ? { logging } : {}),
       ...(configEnv ? { env: configEnv } : {}),
       ...(apiKeys ? { apiKeys } : {}),

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,21 +1,5 @@
+import { LEGACY_API_KEY_ENV_MAP } from "./legacy-api-keys.js";
 import type { ApiKeysConfig, EnvConfig, SummarizeConfig } from "./types.js";
-
-const LEGACY_API_KEY_ENV_MAP = {
-  openai: "OPENAI_API_KEY",
-  nvidia: "NVIDIA_API_KEY",
-  minimax: "MINIMAX_API_KEY",
-  anthropic: "ANTHROPIC_API_KEY",
-  google: "GEMINI_API_KEY",
-  xai: "XAI_API_KEY",
-  openrouter: "OPENROUTER_API_KEY",
-  zai: "Z_AI_API_KEY",
-  apify: "APIFY_API_TOKEN",
-  firecrawl: "FIRECRAWL_API_KEY",
-  fal: "FAL_KEY",
-  groq: "GROQ_API_KEY",
-  assemblyai: "ASSEMBLYAI_API_KEY",
-  elevenlabs: "ELEVENLABS_API_KEY",
-} as const satisfies Record<keyof ApiKeysConfig, string>;
 
 function resolveLegacyApiKeysEnv(apiKeys: ApiKeysConfig | undefined): EnvConfig {
   if (!apiKeys) return {};

--- a/src/config/legacy-api-keys.ts
+++ b/src/config/legacy-api-keys.ts
@@ -1,0 +1,16 @@
+export const LEGACY_API_KEY_ENV_MAP = {
+  openai: "OPENAI_API_KEY",
+  nvidia: "NVIDIA_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  google: "GEMINI_API_KEY",
+  xai: "XAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  zai: "Z_AI_API_KEY",
+  apify: "APIFY_API_TOKEN",
+  firecrawl: "FIRECRAWL_API_KEY",
+  fal: "FAL_KEY",
+  groq: "GROQ_API_KEY",
+  assemblyai: "ASSEMBLYAI_API_KEY",
+  elevenlabs: "ELEVENLABS_API_KEY",
+} as const;

--- a/src/config/model.ts
+++ b/src/config/model.ts
@@ -1,6 +1,4 @@
-import { parseOpenAiReasoningEffort, parseOpenAiTextVerbosity } from "../llm/model-options.js";
-import type { ModelRequestOptions } from "../llm/model-options.js";
-import { isRecord } from "./parse-helpers.js";
+import { isRecord, parseModelRequestOptions } from "./parse-helpers.js";
 import type { AutoRule, AutoRuleKind, ModelConfig } from "./types.js";
 
 function parseAutoRuleKind(value: unknown): AutoRuleKind | null {
@@ -56,45 +54,6 @@ function parseModelCandidates(raw: unknown, path: string): string[] {
     throw new Error(`Invalid config file ${path}: "model.rules[].candidates" must not be empty.`);
   }
   return candidates;
-}
-
-function parseModelRequestOptions(
-  raw: Record<string, unknown>,
-  path: string,
-  label: string,
-): ModelRequestOptions {
-  const serviceTier =
-    typeof raw.serviceTier === "string" && raw.serviceTier.trim().length > 0
-      ? raw.serviceTier.trim()
-      : undefined;
-  const reasoningRaw =
-    typeof raw.reasoningEffort === "string"
-      ? raw.reasoningEffort
-      : typeof raw.thinking === "string"
-        ? raw.thinking
-        : undefined;
-  if (
-    typeof raw.reasoningEffort !== "undefined" &&
-    typeof raw.thinking !== "undefined" &&
-    String(raw.reasoningEffort).trim().toLowerCase() !== String(raw.thinking).trim().toLowerCase()
-  ) {
-    throw new Error(
-      `Invalid config file ${path}: "${label}.reasoningEffort" and "${label}.thinking" must not conflict.`,
-    );
-  }
-  const reasoningEffort =
-    typeof reasoningRaw === "string"
-      ? parseOpenAiReasoningEffort(reasoningRaw, `${label}.reasoningEffort`)
-      : undefined;
-  const textVerbosity =
-    typeof raw.textVerbosity === "string"
-      ? parseOpenAiTextVerbosity(raw.textVerbosity, `${label}.textVerbosity`)
-      : undefined;
-  return {
-    ...(serviceTier ? { serviceTier } : {}),
-    ...(reasoningEffort ? { reasoningEffort } : {}),
-    ...(textVerbosity ? { textVerbosity } : {}),
-  };
 }
 
 function parseTokenBand(

--- a/src/config/parse-helpers.ts
+++ b/src/config/parse-helpers.ts
@@ -1,7 +1,52 @@
+import {
+  parseOpenAiReasoningEffort,
+  parseOpenAiTextVerbosity,
+  type ModelRequestOptions,
+} from "../llm/model-options.js";
+import { parseCliProviderName } from "../llm/provider-registry.js";
 import type { CliProvider, LoggingFormat, LoggingLevel } from "./types.js";
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseModelRequestOptions(
+  raw: Record<string, unknown>,
+  path: string,
+  label: string,
+): ModelRequestOptions {
+  const serviceTier =
+    typeof raw.serviceTier === "string" && raw.serviceTier.trim().length > 0
+      ? raw.serviceTier.trim()
+      : undefined;
+  const reasoningRaw =
+    typeof raw.reasoningEffort === "string"
+      ? raw.reasoningEffort
+      : typeof raw.thinking === "string"
+        ? raw.thinking
+        : undefined;
+  if (
+    typeof raw.reasoningEffort !== "undefined" &&
+    typeof raw.thinking !== "undefined" &&
+    String(raw.reasoningEffort).trim().toLowerCase() !== String(raw.thinking).trim().toLowerCase()
+  ) {
+    throw new Error(
+      `Invalid config file ${path}: "${label}.reasoningEffort" and "${label}.thinking" must not conflict.`,
+    );
+  }
+  const reasoningEffort =
+    typeof reasoningRaw === "string"
+      ? parseOpenAiReasoningEffort(reasoningRaw, `${label}.reasoningEffort`)
+      : undefined;
+  const textVerbosity =
+    typeof raw.textVerbosity === "string"
+      ? parseOpenAiTextVerbosity(raw.textVerbosity, `${label}.textVerbosity`)
+      : undefined;
+  return {
+    ...(serviceTier ? { serviceTier } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+    ...(textVerbosity ? { textVerbosity } : {}),
+  };
 }
 
 export function parseOptionalBaseUrl(raw: unknown): string | undefined {
@@ -47,20 +92,8 @@ export function parseOptionalNumber(
 }
 
 export function parseCliProvider(value: unknown, path: string): CliProvider {
-  const trimmed = typeof value === "string" ? value.trim().toLowerCase() : "";
-  if (
-    trimmed === "claude" ||
-    trimmed === "codex" ||
-    trimmed === "gemini" ||
-    trimmed === "agent" ||
-    trimmed === "openclaw" ||
-    trimmed === "opencode" ||
-    trimmed === "copilot" ||
-    trimmed === "agy" ||
-    trimmed === "pi"
-  ) {
-    return trimmed as CliProvider;
-  }
+  const provider = typeof value === "string" ? parseCliProviderName(value) : null;
+  if (provider) return provider;
   throw new Error(`Invalid config file ${path}: unknown CLI provider "${String(value)}".`);
 }
 

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -1,8 +1,10 @@
 import { parseLengthArg } from "../flags.js";
-import { parseOpenAiReasoningEffort, parseOpenAiTextVerbosity } from "../llm/model-options.js";
+import { CLI_PROVIDERS } from "../llm/provider-registry.js";
 import { isCliThemeName, listCliThemes } from "../tty/theme.js";
+import { LEGACY_API_KEY_ENV_MAP } from "./legacy-api-keys.js";
 import {
   isRecord,
+  parseModelRequestOptions,
   parseCliProvider,
   parseLoggingFormat,
   parseLoggingLevel,
@@ -241,21 +243,12 @@ export function parseCliConfig(root: Record<string, unknown>, path: string): Cli
     typeof value.enabled !== "undefined"
       ? parseCliProviderList(value.enabled, path, "cli.enabled")
       : undefined;
-  const claude = value.claude ? parseCliProviderConfig(value.claude, path, "claude") : undefined;
-  const codex = value.codex ? parseCliProviderConfig(value.codex, path, "codex") : undefined;
-  const gemini = value.gemini ? parseCliProviderConfig(value.gemini, path, "gemini") : undefined;
-  const agent = value.agent ? parseCliProviderConfig(value.agent, path, "agent") : undefined;
-  const openclaw = value.openclaw
-    ? parseCliProviderConfig(value.openclaw, path, "openclaw")
-    : undefined;
-  const opencode = value.opencode
-    ? parseCliProviderConfig(value.opencode, path, "opencode")
-    : undefined;
-  const copilot = value.copilot
-    ? parseCliProviderConfig(value.copilot, path, "copilot")
-    : undefined;
-  const agy = value.agy ? parseCliProviderConfig(value.agy, path, "agy") : undefined;
-  const pi = value.pi ? parseCliProviderConfig(value.pi, path, "pi") : undefined;
+  const providers: Partial<Record<CliProvider, CliProviderConfig>> = {};
+  for (const provider of CLI_PROVIDERS) {
+    if (value[provider]) {
+      providers[provider] = parseCliProviderConfig(value[provider], path, provider);
+    }
+  }
   if (typeof value.autoFallback !== "undefined" && typeof value.magicAuto !== "undefined") {
     throw new Error(
       `Invalid config file ${path}: use only one of "cli.autoFallback" or legacy "cli.magicAuto".`,
@@ -283,15 +276,7 @@ export function parseCliConfig(root: Record<string, unknown>, path: string): Cli
       : parseStringArray(value.extraArgs, path, "cli.extraArgs");
 
   return enabled ||
-    claude ||
-    codex ||
-    gemini ||
-    agent ||
-    openclaw ||
-    opencode ||
-    copilot ||
-    agy ||
-    pi ||
+    Object.keys(providers).length > 0 ||
     autoFallback ||
     promptOverride ||
     typeof allowTools === "boolean" ||
@@ -299,15 +284,7 @@ export function parseCliConfig(root: Record<string, unknown>, path: string): Cli
     (extraArgs && extraArgs.length > 0)
     ? {
         ...(enabled ? { enabled } : {}),
-        ...(claude ? { claude } : {}),
-        ...(codex ? { codex } : {}),
-        ...(gemini ? { gemini } : {}),
-        ...(agent ? { agent } : {}),
-        ...(openclaw ? { openclaw } : {}),
-        ...(opencode ? { opencode } : {}),
-        ...(copilot ? { copilot } : {}),
-        ...(agy ? { agy } : {}),
-        ...(pi ? { pi } : {}),
+        ...providers,
         ...(autoFallback ? { autoFallback } : {}),
         ...(promptOverride ? { promptOverride } : {}),
         ...(typeof allowTools === "boolean" ? { allowTools } : {}),
@@ -420,34 +397,7 @@ export function parseOpenAiConfig(
   const baseUrl = parseOptionalBaseUrl(value.baseUrl);
   const useChatCompletions =
     typeof value.useChatCompletions === "boolean" ? value.useChatCompletions : undefined;
-  const serviceTier =
-    typeof value.serviceTier === "string" && value.serviceTier.trim().length > 0
-      ? value.serviceTier.trim()
-      : undefined;
-  const reasoningRaw =
-    typeof value.reasoningEffort === "string"
-      ? value.reasoningEffort
-      : typeof value.thinking === "string"
-        ? value.thinking
-        : undefined;
-  if (
-    typeof value.reasoningEffort !== "undefined" &&
-    typeof value.thinking !== "undefined" &&
-    String(value.reasoningEffort).trim().toLowerCase() !==
-      String(value.thinking).trim().toLowerCase()
-  ) {
-    throw new Error(
-      `Invalid config file ${path}: "openai.reasoningEffort" and "openai.thinking" must not conflict.`,
-    );
-  }
-  const reasoningEffort =
-    typeof reasoningRaw === "string"
-      ? parseOpenAiReasoningEffort(reasoningRaw, "openai.reasoningEffort")
-      : undefined;
-  const textVerbosity =
-    typeof value.textVerbosity === "string"
-      ? parseOpenAiTextVerbosity(value.textVerbosity, "openai.textVerbosity")
-      : undefined;
+  const requestOptions = parseModelRequestOptions(value, path, "openai");
   const whisperUsdPerMinuteRaw = value.whisperUsdPerMinute;
   const whisperUsdPerMinute =
     typeof whisperUsdPerMinuteRaw === "number" &&
@@ -458,16 +408,12 @@ export function parseOpenAiConfig(
 
   return typeof baseUrl === "string" ||
     typeof useChatCompletions === "boolean" ||
-    typeof serviceTier === "string" ||
-    typeof reasoningEffort === "string" ||
-    typeof textVerbosity === "string" ||
+    Object.keys(requestOptions).length > 0 ||
     typeof whisperUsdPerMinute === "number"
     ? {
         ...(typeof baseUrl === "string" ? { baseUrl } : {}),
         ...(typeof useChatCompletions === "boolean" ? { useChatCompletions } : {}),
-        ...(typeof serviceTier === "string" ? { serviceTier } : {}),
-        ...(typeof reasoningEffort === "string" ? { reasoningEffort } : {}),
-        ...(typeof textVerbosity === "string" ? { textVerbosity } : {}),
+        ...requestOptions,
         ...(typeof whisperUsdPerMinute === "number" ? { whisperUsdPerMinute } : {}),
       }
     : undefined;
@@ -503,25 +449,9 @@ export function parseApiKeysConfig(
     throw new Error(`Invalid config file ${path}: "apiKeys" must be an object.`);
   }
   const keys: Record<string, string> = {};
-  const allowed = [
-    "openai",
-    "nvidia",
-    "minimax",
-    "anthropic",
-    "google",
-    "xai",
-    "openrouter",
-    "zai",
-    "apify",
-    "firecrawl",
-    "fal",
-    "groq",
-    "assemblyai",
-    "elevenlabs",
-  ];
   for (const [key, val] of Object.entries(value)) {
     const normalizedKey = key.trim().toLowerCase();
-    if (!allowed.includes(normalizedKey)) {
+    if (!Object.hasOwn(LEGACY_API_KEY_ENV_MAP, normalizedKey)) {
       throw new Error(`Invalid config file ${path}: unknown apiKeys provider "${key}".`);
     }
     if (typeof val !== "string" || val.trim().length === 0) {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,23 +1,16 @@
+import type {
+  ModelRequestOptions,
+  OpenAiReasoningEffort,
+  OpenAiTextVerbosity,
+} from "../llm/model-options.js";
+import type { CliProvider } from "../llm/provider-registry.js";
+import type { LEGACY_API_KEY_ENV_MAP } from "./legacy-api-keys.js";
+
+export type { CliProvider, ModelRequestOptions, OpenAiReasoningEffort, OpenAiTextVerbosity };
+
 export type AutoRuleKind = "text" | "website" | "youtube" | "image" | "video" | "file";
 export type VideoMode = "auto" | "transcript" | "understand";
 export type EmbeddedVideoMode = "auto" | "off" | "prefer" | "both";
-export type CliProvider =
-  | "claude"
-  | "codex"
-  | "gemini"
-  | "agent"
-  | "openclaw"
-  | "opencode"
-  | "copilot"
-  | "agy"
-  | "pi";
-export type OpenAiReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh";
-export type OpenAiTextVerbosity = "low" | "medium" | "high";
-export type ModelRequestOptions = {
-  serviceTier?: string;
-  reasoningEffort?: OpenAiReasoningEffort;
-  textVerbosity?: OpenAiTextVerbosity;
-};
 export type CliProviderConfig = {
   binary?: string;
   extraArgs?: string[];
@@ -30,17 +23,8 @@ export type CliAutoFallbackConfig = {
   order?: CliProvider[];
 };
 export type CliMagicAutoConfig = CliAutoFallbackConfig;
-export type CliConfig = {
+export type CliConfig = Partial<Record<CliProvider, CliProviderConfig>> & {
   enabled?: CliProvider[];
-  claude?: CliProviderConfig;
-  codex?: CliProviderConfig;
-  gemini?: CliProviderConfig;
-  agent?: CliProviderConfig;
-  openclaw?: CliProviderConfig;
-  opencode?: CliProviderConfig;
-  copilot?: CliProviderConfig;
-  agy?: CliProviderConfig;
-  pi?: CliProviderConfig;
   autoFallback?: CliAutoFallbackConfig;
   magicAuto?: CliAutoFallbackConfig;
   promptOverride?: string;
@@ -137,22 +121,7 @@ export type NvidiaConfig = {
   baseUrl?: string;
 };
 
-export type ApiKeysConfig = {
-  openai?: string;
-  nvidia?: string;
-  minimax?: string;
-  anthropic?: string;
-  google?: string;
-  xai?: string;
-  openrouter?: string;
-  zai?: string;
-  apify?: string;
-  firecrawl?: string;
-  fal?: string;
-  groq?: string;
-  assemblyai?: string;
-  elevenlabs?: string;
-};
+export type ApiKeysConfig = Partial<Record<keyof typeof LEGACY_API_KEY_ENV_MAP, string>>;
 
 export type EnvConfig = Record<string, string>;
 

--- a/src/llm/github-models.ts
+++ b/src/llm/github-models.ts
@@ -1,4 +1,4 @@
-export const GITHUB_MODELS_BASE_URL = "https://models.github.ai/inference";
+export { GITHUB_MODELS_BASE_URL } from "./provider-registry.js";
 export const GITHUB_MODELS_API_VERSION = "2026-03-10";
 
 const GITHUB_COPILOT_PROVIDER_PATTERNS = {

--- a/src/llm/model-id.ts
+++ b/src/llm/model-id.ts
@@ -1,15 +1,7 @@
 import { resolveGitHubCopilotBackendModelId } from "./github-models.js";
+import { isGatewayProvider, type GatewayProvider } from "./provider-registry.js";
 
-export type LlmProvider =
-  | "xai"
-  | "openai"
-  | "google"
-  | "anthropic"
-  | "zai"
-  | "nvidia"
-  | "minimax"
-  | "github-copilot"
-  | "ollama";
+export type LlmProvider = GatewayProvider;
 
 export type ParsedModelId = {
   provider: LlmProvider;
@@ -22,18 +14,6 @@ export type ParsedModelId = {
    */
   canonical: string;
 };
-
-const PROVIDERS: LlmProvider[] = [
-  "xai",
-  "openai",
-  "google",
-  "anthropic",
-  "zai",
-  "nvidia",
-  "minimax",
-  "github-copilot",
-  "ollama",
-];
 
 /**
  * Anthropic short model aliases that are NOT valid API model identifiers.
@@ -90,7 +70,7 @@ export function normalizeGatewayStyleModelId(raw: string): string {
     }
     return `github-copilot/${resolved}`;
   }
-  if (!PROVIDERS.includes(provider as LlmProvider)) {
+  if (!isGatewayProvider(provider)) {
     throw new Error(
       `Unsupported model provider "${provider}". Use xai/..., openai/..., google/..., anthropic/..., zai/..., nvidia/..., minimax/..., github-copilot/..., or ollama/...`,
     );

--- a/src/llm/provider-capabilities.ts
+++ b/src/llm/provider-capabilities.ts
@@ -1,17 +1,11 @@
 export {
-  DEFAULT_AUTO_CLI_ORDER,
-  DEFAULT_CLI_MODELS,
   cliProviderForRequiredEnv,
   envHasRequiredKey,
   formatMissingCliModelError,
   gatewayProviderForRequiredEnv,
-  getCliProviderProfile,
-  getGatewayProviderProfile,
-  isGatewayProvider,
   isVideoUnderstandingCapableModelId,
   isVideoUnderstandingCapableProvider,
   isOpenAiCompatibleProvider,
-  parseCliProviderName,
   requiredEnvForCliProvider,
   requiredEnvForGatewayProvider,
   resolveOpenAiCompatibleClientConfigForProvider,
@@ -21,12 +15,21 @@ export {
   supportsStreaming,
 } from "./provider-profile.js";
 
+export type { ProviderOpenAiOverrides, ProviderRuntimeBindings } from "./provider-profile.js";
+
+export {
+  DEFAULT_AUTO_CLI_ORDER,
+  DEFAULT_CLI_MODELS,
+  getCliProviderProfile,
+  getGatewayProviderProfile,
+  isGatewayProvider,
+  parseCliProviderName,
+} from "./provider-registry.js";
+
 export type {
   GatewayProvider,
   GatewayProviderProfile,
   CliProviderProfile,
-  ProviderOpenAiOverrides,
   ProviderExecution,
-  ProviderRuntimeBindings,
   RequiredModelEnv,
-} from "./provider-profile.js";
+} from "./provider-registry.js";

--- a/src/llm/provider-profile.ts
+++ b/src/llm/provider-profile.ts
@@ -1,142 +1,20 @@
-import type { CliProvider } from "../config.js";
-import {
-  buildGitHubModelsHeaders,
-  GITHUB_MODELS_BASE_URL,
-  resolveGitHubModelsApiKey,
-} from "./github-models.js";
+import { buildGitHubModelsHeaders, resolveGitHubModelsApiKey } from "./github-models.js";
 import { normalizeGatewayStyleModelId, parseGatewayStyleModelId } from "./model-id.js";
 import type { ModelRequestOptions } from "./model-options.js";
 import { resolveOpenAiClientConfig } from "./openai-client-config.js";
+import {
+  CLI_PROVIDER_PROFILES,
+  GATEWAY_PROVIDER_PROFILES,
+  getCliProviderProfile,
+  getGatewayProviderProfile,
+  parseCliProviderName,
+  type CliProvider,
+  type CliRequiredModelEnv,
+  type GatewayProvider,
+  type GatewayRequiredModelEnv,
+  type RequiredModelEnv,
+} from "./provider-registry.js";
 import type { OpenAiClientConfig } from "./providers/types.js";
-
-export type GatewayProvider =
-  | "xai"
-  | "openai"
-  | "google"
-  | "anthropic"
-  | "zai"
-  | "nvidia"
-  | "minimax"
-  | "github-copilot"
-  | "ollama";
-
-export type RequiredModelEnv =
-  | "XAI_API_KEY"
-  | "OPENAI_API_KEY"
-  | "NVIDIA_API_KEY"
-  | "GEMINI_API_KEY"
-  | "ANTHROPIC_API_KEY"
-  | "OPENROUTER_API_KEY"
-  | "Z_AI_API_KEY"
-  | "MINIMAX_API_KEY"
-  | "GITHUB_TOKEN"
-  | "OLLAMA_BASE_URL"
-  | "CLI_CLAUDE"
-  | "CLI_CODEX"
-  | "CLI_GEMINI"
-  | "CLI_AGENT"
-  | "CLI_OPENCLAW"
-  | "CLI_OPENCODE"
-  | "CLI_COPILOT"
-  | "CLI_AGY"
-  | "CLI_PI";
-
-export type ProviderExecution =
-  | "simple"
-  | "google"
-  | "anthropic"
-  | "openai-http"
-  | "openai-compatible";
-
-export type GatewayProviderProfile = {
-  requiredEnv: RequiredModelEnv;
-  execution: ProviderExecution;
-  supportsDocuments: boolean;
-  supportsStreaming: boolean;
-  supportsVideoUnderstanding: boolean;
-  defaultBaseUrl?: string;
-  forceChatCompletions?: boolean;
-};
-
-export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/v1";
-
-export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
-
-const GATEWAY_PROVIDER_PROFILES: Record<GatewayProvider, GatewayProviderProfile> = {
-  xai: {
-    requiredEnv: "XAI_API_KEY",
-    execution: "simple",
-    supportsDocuments: false,
-    supportsStreaming: true,
-    supportsVideoUnderstanding: false,
-  },
-  openai: {
-    requiredEnv: "OPENAI_API_KEY",
-    execution: "openai-http",
-    supportsDocuments: true,
-    supportsStreaming: true,
-    supportsVideoUnderstanding: false,
-  },
-  google: {
-    requiredEnv: "GEMINI_API_KEY",
-    execution: "google",
-    supportsDocuments: true,
-    supportsStreaming: true,
-    supportsVideoUnderstanding: true,
-  },
-  anthropic: {
-    requiredEnv: "ANTHROPIC_API_KEY",
-    execution: "anthropic",
-    supportsDocuments: true,
-    supportsStreaming: true,
-    supportsVideoUnderstanding: false,
-  },
-  zai: {
-    requiredEnv: "Z_AI_API_KEY",
-    execution: "openai-compatible",
-    supportsDocuments: false,
-    supportsStreaming: true,
-    supportsVideoUnderstanding: false,
-    defaultBaseUrl: "https://api.z.ai/api/paas/v4",
-    forceChatCompletions: true,
-  },
-  nvidia: {
-    requiredEnv: "NVIDIA_API_KEY",
-    execution: "openai-compatible",
-    supportsDocuments: false,
-    supportsStreaming: true,
-    supportsVideoUnderstanding: false,
-    defaultBaseUrl: "https://integrate.api.nvidia.com/v1",
-    forceChatCompletions: true,
-  },
-  minimax: {
-    requiredEnv: "MINIMAX_API_KEY",
-    execution: "openai-compatible",
-    supportsDocuments: false,
-    supportsStreaming: true,
-    supportsVideoUnderstanding: false,
-    defaultBaseUrl: DEFAULT_MINIMAX_BASE_URL,
-    forceChatCompletions: true,
-  },
-  "github-copilot": {
-    requiredEnv: "GITHUB_TOKEN",
-    execution: "openai-http",
-    supportsDocuments: false,
-    supportsStreaming: true,
-    supportsVideoUnderstanding: false,
-    defaultBaseUrl: GITHUB_MODELS_BASE_URL,
-    forceChatCompletions: true,
-  },
-  ollama: {
-    requiredEnv: "OLLAMA_BASE_URL",
-    execution: "openai-compatible",
-    supportsDocuments: false,
-    supportsStreaming: true,
-    supportsVideoUnderstanding: false,
-    defaultBaseUrl: DEFAULT_OLLAMA_BASE_URL,
-    forceChatCompletions: true,
-  },
-};
 
 export type ProviderRuntimeBindings = {
   apiKeys: Partial<Record<GatewayProvider, string | null>>;
@@ -180,112 +58,7 @@ export function resolveProviderOpenAiOverrides({
   };
 }
 
-type CliRequiredModelEnv = Extract<RequiredModelEnv, `CLI_${string}`>;
-
-export type CliProviderProfile = {
-  requiredEnv: CliRequiredModelEnv;
-  defaultModel: string | null;
-  missingBinaryLabel: string;
-  installLabel: string;
-  pathEnv: string;
-};
-
-const CLI_PROVIDER_PROFILES: Record<CliProvider, CliProviderProfile> = {
-  claude: {
-    requiredEnv: "CLI_CLAUDE",
-    defaultModel: "sonnet",
-    missingBinaryLabel: "Claude CLI",
-    installLabel: "Claude CLI",
-    pathEnv: "CLAUDE_PATH",
-  },
-  codex: {
-    requiredEnv: "CLI_CODEX",
-    defaultModel: null,
-    missingBinaryLabel: "Codex CLI",
-    installLabel: "Codex CLI",
-    pathEnv: "CODEX_PATH",
-  },
-  gemini: {
-    requiredEnv: "CLI_GEMINI",
-    defaultModel: "flash",
-    missingBinaryLabel: "Gemini CLI",
-    installLabel: "Gemini CLI",
-    pathEnv: "GEMINI_PATH",
-  },
-  agent: {
-    requiredEnv: "CLI_AGENT",
-    defaultModel: "auto",
-    missingBinaryLabel: "Cursor Agent CLI",
-    installLabel: "Cursor CLI",
-    pathEnv: "AGENT_PATH",
-  },
-  openclaw: {
-    requiredEnv: "CLI_OPENCLAW",
-    defaultModel: "main",
-    missingBinaryLabel: "OpenClaw CLI",
-    installLabel: "OpenClaw CLI",
-    pathEnv: "OPENCLAW_PATH",
-  },
-  opencode: {
-    requiredEnv: "CLI_OPENCODE",
-    defaultModel: null,
-    missingBinaryLabel: "OpenCode CLI",
-    installLabel: "OpenCode CLI",
-    pathEnv: "OPENCODE_PATH",
-  },
-  copilot: {
-    requiredEnv: "CLI_COPILOT",
-    defaultModel: null,
-    missingBinaryLabel: "GitHub Copilot CLI",
-    installLabel: "Copilot CLI",
-    pathEnv: "COPILOT_PATH",
-  },
-  agy: {
-    requiredEnv: "CLI_AGY",
-    defaultModel: null,
-    missingBinaryLabel: "Antigravity CLI",
-    installLabel: "agy",
-    pathEnv: "AGY_PATH",
-  },
-  pi: {
-    requiredEnv: "CLI_PI",
-    defaultModel: null,
-    missingBinaryLabel: "pi CLI",
-    installLabel: "pi",
-    pathEnv: "PI_PATH",
-  },
-};
-
-export const DEFAULT_CLI_MODELS = Object.fromEntries(
-  Object.entries(CLI_PROVIDER_PROFILES).map(([provider, profile]) => [
-    provider,
-    profile.defaultModel,
-  ]),
-) as Record<CliProvider, string | null>;
-
-export const DEFAULT_AUTO_CLI_ORDER: CliProvider[] = [
-  "claude",
-  "gemini",
-  "codex",
-  "agent",
-  "openclaw",
-  "opencode",
-  "copilot",
-  // agy is intentionally excluded from the default auto-fallback order.
-  // Use --cli agy or --model cli/agy to opt in explicitly.
-  // pi is also excluded; use --cli pi or --model cli/pi explicitly.
-];
-
-export function parseCliProviderName(raw: string): CliProvider | null {
-  const normalized = raw.trim().toLowerCase();
-  return Object.hasOwn(CLI_PROVIDER_PROFILES, normalized) ? (normalized as CliProvider) : null;
-}
-
-export function getCliProviderProfile(provider: CliProvider): CliProviderProfile {
-  return CLI_PROVIDER_PROFILES[provider];
-}
-
-export function requiredEnvForCliProvider(provider: CliProvider): RequiredModelEnv {
+export function requiredEnvForCliProvider(provider: CliProvider): CliRequiredModelEnv {
   return getCliProviderProfile(provider).requiredEnv;
 }
 
@@ -309,15 +82,7 @@ export function formatMissingCliModelError({
   return `${profile.missingBinaryLabel} not found for model ${userModelId}. Install ${profile.installLabel} or set ${profile.pathEnv}.`;
 }
 
-export function isGatewayProvider(provider: string): provider is GatewayProvider {
-  return Object.hasOwn(GATEWAY_PROVIDER_PROFILES, provider);
-}
-
-export function getGatewayProviderProfile(provider: GatewayProvider): GatewayProviderProfile {
-  return GATEWAY_PROVIDER_PROFILES[provider];
-}
-
-export function requiredEnvForGatewayProvider(provider: GatewayProvider): RequiredModelEnv {
+export function requiredEnvForGatewayProvider(provider: GatewayProvider): GatewayRequiredModelEnv {
   return getGatewayProviderProfile(provider).requiredEnv;
 }
 
@@ -422,52 +187,22 @@ export function resolveOpenAiCompatibleClientConfigForProvider({
       requestOptions,
     });
   }
-  if (provider === "github-copilot") {
-    const apiKey = openaiApiKey;
-    if (!apiKey) {
-      throw new Error("Missing GITHUB_TOKEN (or GH_TOKEN) for github-copilot/... model");
-    }
-    return {
-      apiKey,
-      baseURL: openaiBaseUrlOverride ?? GITHUB_MODELS_BASE_URL,
-      useChatCompletions: true,
-      isOpenRouter: false,
-      extraHeaders: buildGitHubModelsHeaders(),
-    };
-  }
-  if (provider === "ollama") {
-    return {
-      apiKey: openaiApiKey?.trim() || "ollama",
-      baseURL: openaiBaseUrlOverride ?? DEFAULT_OLLAMA_BASE_URL,
-      useChatCompletions: true,
-      isOpenRouter: false,
-      ...(requestOptions ? { requestOptions } : {}),
-    };
-  }
-
-  const apiKey = openaiApiKey;
+  const profile = GATEWAY_PROVIDER_PROFILES[provider];
+  const apiKey = provider === "ollama" ? openaiApiKey?.trim() || "ollama" : openaiApiKey;
   if (!apiKey) {
-    throw new Error(
-      provider === "zai"
-        ? "Missing Z_AI_API_KEY for zai/... model"
-        : provider === "minimax"
-          ? "Missing MINIMAX_API_KEY for minimax/... model"
-          : "Missing NVIDIA_API_KEY for nvidia/... model",
-    );
+    const requiredEnv =
+      provider === "github-copilot" ? "GITHUB_TOKEN (or GH_TOKEN)" : profile.requiredEnv;
+    throw new Error(`Missing ${requiredEnv} for ${provider}/... model`);
   }
-
-  const defaultBaseUrl =
-    provider === "zai"
-      ? "https://api.z.ai/api/paas/v4"
-      : provider === "minimax"
-        ? DEFAULT_MINIMAX_BASE_URL
-        : "https://integrate.api.nvidia.com/v1";
-
   return {
     apiKey,
-    baseURL: openaiBaseUrlOverride ?? defaultBaseUrl,
-    useChatCompletions: true,
+    baseURL: openaiBaseUrlOverride ?? profile.defaultBaseUrl,
+    useChatCompletions: profile.forceChatCompletions,
     isOpenRouter: false,
-    ...(requestOptions ? { requestOptions } : {}),
+    ...(provider === "github-copilot"
+      ? { extraHeaders: buildGitHubModelsHeaders() }
+      : requestOptions
+        ? { requestOptions }
+        : {}),
   };
 }

--- a/src/llm/provider-registry.ts
+++ b/src/llm/provider-registry.ts
@@ -1,0 +1,218 @@
+export const GITHUB_MODELS_BASE_URL = "https://models.github.ai/inference";
+
+export type ProviderExecution =
+  | "simple"
+  | "google"
+  | "anthropic"
+  | "openai-http"
+  | "openai-compatible";
+
+export type GatewayProviderProfile = {
+  requiredEnv: GatewayRequiredModelEnv;
+  execution: ProviderExecution;
+  supportsDocuments: boolean;
+  supportsStreaming: boolean;
+  supportsVideoUnderstanding: boolean;
+  defaultBaseUrl?: string;
+  forceChatCompletions?: boolean;
+};
+
+export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/v1";
+
+export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
+
+export const GATEWAY_PROVIDER_PROFILES = {
+  xai: {
+    requiredEnv: "XAI_API_KEY",
+    execution: "simple",
+    supportsDocuments: false,
+    supportsStreaming: true,
+    supportsVideoUnderstanding: false,
+  },
+  openai: {
+    requiredEnv: "OPENAI_API_KEY",
+    execution: "openai-http",
+    supportsDocuments: true,
+    supportsStreaming: true,
+    supportsVideoUnderstanding: false,
+  },
+  google: {
+    requiredEnv: "GEMINI_API_KEY",
+    execution: "google",
+    supportsDocuments: true,
+    supportsStreaming: true,
+    supportsVideoUnderstanding: true,
+  },
+  anthropic: {
+    requiredEnv: "ANTHROPIC_API_KEY",
+    execution: "anthropic",
+    supportsDocuments: true,
+    supportsStreaming: true,
+    supportsVideoUnderstanding: false,
+  },
+  zai: {
+    requiredEnv: "Z_AI_API_KEY",
+    execution: "openai-compatible",
+    supportsDocuments: false,
+    supportsStreaming: true,
+    supportsVideoUnderstanding: false,
+    defaultBaseUrl: "https://api.z.ai/api/paas/v4",
+    forceChatCompletions: true,
+  },
+  nvidia: {
+    requiredEnv: "NVIDIA_API_KEY",
+    execution: "openai-compatible",
+    supportsDocuments: false,
+    supportsStreaming: true,
+    supportsVideoUnderstanding: false,
+    defaultBaseUrl: "https://integrate.api.nvidia.com/v1",
+    forceChatCompletions: true,
+  },
+  minimax: {
+    requiredEnv: "MINIMAX_API_KEY",
+    execution: "openai-compatible",
+    supportsDocuments: false,
+    supportsStreaming: true,
+    supportsVideoUnderstanding: false,
+    defaultBaseUrl: DEFAULT_MINIMAX_BASE_URL,
+    forceChatCompletions: true,
+  },
+  "github-copilot": {
+    requiredEnv: "GITHUB_TOKEN",
+    execution: "openai-http",
+    supportsDocuments: false,
+    supportsStreaming: true,
+    supportsVideoUnderstanding: false,
+    defaultBaseUrl: GITHUB_MODELS_BASE_URL,
+    forceChatCompletions: true,
+  },
+  ollama: {
+    requiredEnv: "OLLAMA_BASE_URL",
+    execution: "openai-compatible",
+    supportsDocuments: false,
+    supportsStreaming: true,
+    supportsVideoUnderstanding: false,
+    defaultBaseUrl: DEFAULT_OLLAMA_BASE_URL,
+    forceChatCompletions: true,
+  },
+} as const;
+
+export type CliProviderProfile = {
+  requiredEnv: CliRequiredModelEnv;
+  defaultModel: string | null;
+  missingBinaryLabel: string;
+  installLabel: string;
+  pathEnv: string;
+};
+
+export const CLI_PROVIDER_PROFILES = {
+  claude: {
+    requiredEnv: "CLI_CLAUDE",
+    defaultModel: "sonnet",
+    missingBinaryLabel: "Claude CLI",
+    installLabel: "Claude CLI",
+    pathEnv: "CLAUDE_PATH",
+  },
+  codex: {
+    requiredEnv: "CLI_CODEX",
+    defaultModel: null,
+    missingBinaryLabel: "Codex CLI",
+    installLabel: "Codex CLI",
+    pathEnv: "CODEX_PATH",
+  },
+  gemini: {
+    requiredEnv: "CLI_GEMINI",
+    defaultModel: "flash",
+    missingBinaryLabel: "Gemini CLI",
+    installLabel: "Gemini CLI",
+    pathEnv: "GEMINI_PATH",
+  },
+  agent: {
+    requiredEnv: "CLI_AGENT",
+    defaultModel: "auto",
+    missingBinaryLabel: "Cursor Agent CLI",
+    installLabel: "Cursor CLI",
+    pathEnv: "AGENT_PATH",
+  },
+  openclaw: {
+    requiredEnv: "CLI_OPENCLAW",
+    defaultModel: "main",
+    missingBinaryLabel: "OpenClaw CLI",
+    installLabel: "OpenClaw CLI",
+    pathEnv: "OPENCLAW_PATH",
+  },
+  opencode: {
+    requiredEnv: "CLI_OPENCODE",
+    defaultModel: null,
+    missingBinaryLabel: "OpenCode CLI",
+    installLabel: "OpenCode CLI",
+    pathEnv: "OPENCODE_PATH",
+  },
+  copilot: {
+    requiredEnv: "CLI_COPILOT",
+    defaultModel: null,
+    missingBinaryLabel: "GitHub Copilot CLI",
+    installLabel: "Copilot CLI",
+    pathEnv: "COPILOT_PATH",
+  },
+  agy: {
+    requiredEnv: "CLI_AGY",
+    defaultModel: null,
+    missingBinaryLabel: "Antigravity CLI",
+    installLabel: "agy",
+    pathEnv: "AGY_PATH",
+  },
+  pi: {
+    requiredEnv: "CLI_PI",
+    defaultModel: null,
+    missingBinaryLabel: "pi CLI",
+    installLabel: "pi",
+    pathEnv: "PI_PATH",
+  },
+} as const;
+
+export type GatewayProvider = keyof typeof GATEWAY_PROVIDER_PROFILES;
+export type CliProvider = keyof typeof CLI_PROVIDER_PROFILES;
+export type GatewayRequiredModelEnv =
+  (typeof GATEWAY_PROVIDER_PROFILES)[GatewayProvider]["requiredEnv"];
+export type CliRequiredModelEnv = (typeof CLI_PROVIDER_PROFILES)[CliProvider]["requiredEnv"];
+export type RequiredModelEnv = GatewayRequiredModelEnv | CliRequiredModelEnv | "OPENROUTER_API_KEY";
+
+export const CLI_PROVIDERS = Object.keys(CLI_PROVIDER_PROFILES) as CliProvider[];
+
+export const DEFAULT_CLI_MODELS = Object.fromEntries(
+  Object.entries(CLI_PROVIDER_PROFILES).map(([provider, profile]) => [
+    provider,
+    profile.defaultModel,
+  ]),
+) as Record<CliProvider, string | null>;
+
+export const DEFAULT_AUTO_CLI_ORDER: CliProvider[] = [
+  "claude",
+  "gemini",
+  "codex",
+  "agent",
+  "openclaw",
+  "opencode",
+  "copilot",
+  // agy is intentionally excluded from the default auto-fallback order.
+  // Use --cli agy or --model cli/agy to opt in explicitly.
+  // pi is also excluded; use --cli pi or --model cli/pi explicitly.
+];
+
+export function parseCliProviderName(raw: string): CliProvider | null {
+  const normalized = raw.trim().toLowerCase();
+  return Object.hasOwn(CLI_PROVIDER_PROFILES, normalized) ? (normalized as CliProvider) : null;
+}
+
+export function getCliProviderProfile(provider: CliProvider): CliProviderProfile {
+  return CLI_PROVIDER_PROFILES[provider];
+}
+
+export function isGatewayProvider(provider: string): provider is GatewayProvider {
+  return Object.hasOwn(GATEWAY_PROVIDER_PROFILES, provider);
+}
+
+export function getGatewayProviderProfile(provider: GatewayProvider): GatewayProviderProfile {
+  return GATEWAY_PROVIDER_PROFILES[provider];
+}

--- a/src/llm/providers/models.ts
+++ b/src/llm/providers/models.ts
@@ -1,5 +1,5 @@
 import type { Api, Context, Model } from "@earendil-works/pi-ai";
-import { DEFAULT_MINIMAX_BASE_URL, DEFAULT_OLLAMA_BASE_URL } from "../provider-profile.js";
+import { DEFAULT_MINIMAX_BASE_URL, DEFAULT_OLLAMA_BASE_URL } from "../provider-registry.js";
 import {
   createSyntheticModel,
   resolveBaseUrlOverride,

--- a/src/model-auto-cli.ts
+++ b/src/model-auto-cli.ts
@@ -101,24 +101,7 @@ export function prependCliCandidates({
   };
 
   for (const provider of providerOrder) {
-    const modelOverride =
-      provider === "gemini"
-        ? cli?.gemini?.model
-        : provider === "codex"
-          ? cli?.codex?.model
-          : provider === "agent"
-            ? cli?.agent?.model
-            : provider === "openclaw"
-              ? cli?.openclaw?.model
-              : provider === "opencode"
-                ? cli?.opencode?.model
-                : provider === "copilot"
-                  ? cli?.copilot?.model
-                  : provider === "agy"
-                    ? undefined
-                    : provider === "pi"
-                      ? cli?.pi?.model
-                      : cli?.claude?.model;
+    const modelOverride = provider === "agy" ? undefined : cli?.[provider]?.model;
     add(provider, modelOverride);
   }
 

--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -4,11 +4,16 @@ import type { LlmProvider } from "./llm/model-id.js";
 import type { ModelRequestOptions } from "./llm/model-options.js";
 import {
   DEFAULT_CLI_MODELS,
-  type RequiredModelEnv,
   requiredEnvForCliProvider,
-  resolveRequiredEnvForModelId,
+  requiredEnvForGatewayProvider,
 } from "./llm/provider-capabilities.js";
-import { DEFAULT_OLLAMA_BASE_URL } from "./llm/provider-profile.js";
+import {
+  getGatewayProviderProfile,
+  isGatewayProvider,
+  parseCliProviderName,
+  type CliRequiredModelEnv,
+  type GatewayRequiredModelEnv,
+} from "./llm/provider-registry.js";
 
 export type FixedModelSpec =
   | {
@@ -18,16 +23,7 @@ export type FixedModelSpec =
       provider: LlmProvider;
       openrouterProviders: string[] | null;
       forceOpenRouter: false;
-      requiredEnv:
-        | "XAI_API_KEY"
-        | "OPENAI_API_KEY"
-        | "GEMINI_API_KEY"
-        | "ANTHROPIC_API_KEY"
-        | "Z_AI_API_KEY"
-        | "NVIDIA_API_KEY"
-        | "MINIMAX_API_KEY"
-        | "GITHUB_TOKEN"
-        | "OLLAMA_BASE_URL";
+      requiredEnv: GatewayRequiredModelEnv;
       openaiBaseUrlOverride?: string | null;
       forceChatCompletions?: boolean;
       requestOptions?: ModelRequestOptions;
@@ -48,16 +44,7 @@ export type FixedModelSpec =
       llmModelId: null;
       openrouterProviders: null;
       forceOpenRouter: false;
-      requiredEnv:
-        | "CLI_CLAUDE"
-        | "CLI_CODEX"
-        | "CLI_GEMINI"
-        | "CLI_AGENT"
-        | "CLI_OPENCLAW"
-        | "CLI_OPENCODE"
-        | "CLI_COPILOT"
-        | "CLI_AGY"
-        | "CLI_PI";
+      requiredEnv: CliRequiredModelEnv;
       cliProvider: CliProvider;
       cliModel: string | null;
     };
@@ -102,125 +89,15 @@ export function parseRequestedModelId(raw: string): RequestedModel {
     };
   }
 
-  if (lower.startsWith("zai/")) {
-    const model = trimmed.slice("zai/".length).trim();
-    if (model.length === 0) {
-      throw new Error("Invalid model id: zai/… is missing the model id");
-    }
-    return {
-      kind: "fixed",
-      transport: "native",
-      userModelId: `zai/${model}`,
-      llmModelId: `zai/${model}`,
-      provider: "zai",
-      openrouterProviders: null,
-      forceOpenRouter: false,
-      requiredEnv: "Z_AI_API_KEY",
-      openaiBaseUrlOverride: "https://api.z.ai/api/paas/v4",
-      forceChatCompletions: true,
-    };
-  }
-
-  if (lower.startsWith("nvidia/")) {
-    const model = trimmed.slice("nvidia/".length).trim();
-    if (model.length === 0) {
-      throw new Error("Invalid model id: nvidia/… is missing the model id");
-    }
-    return {
-      kind: "fixed",
-      transport: "native",
-      userModelId: `nvidia/${model}`,
-      llmModelId: `nvidia/${model}`,
-      provider: "nvidia",
-      openrouterProviders: null,
-      forceOpenRouter: false,
-      requiredEnv: "NVIDIA_API_KEY",
-      // Default; can be overridden at runtime via NVIDIA_BASE_URL / config.nvidia.baseUrl.
-      openaiBaseUrlOverride: "https://integrate.api.nvidia.com/v1",
-      forceChatCompletions: true,
-    };
-  }
-
-  if (lower.startsWith("minimax/")) {
-    const model = trimmed.slice("minimax/".length).trim();
-    if (model.length === 0) {
-      throw new Error("Invalid model id: minimax/… is missing the model id");
-    }
-    return {
-      kind: "fixed",
-      transport: "native",
-      userModelId: `minimax/${model}`,
-      llmModelId: `minimax/${model}`,
-      provider: "minimax",
-      openrouterProviders: null,
-      forceOpenRouter: false,
-      requiredEnv: "MINIMAX_API_KEY",
-      // Default; can be overridden at runtime via MINIMAX_BASE_URL / config.minimax.baseUrl.
-      openaiBaseUrlOverride: "https://api.minimax.io/v1",
-      forceChatCompletions: true,
-    };
-  }
-
-  if (lower.startsWith("ollama/")) {
-    const model = trimmed.slice("ollama/".length).trim();
-    if (model.length === 0) {
-      throw new Error("Invalid model id: ollama/… is missing the model id");
-    }
-    return {
-      kind: "fixed",
-      transport: "native",
-      userModelId: `ollama/${model}`,
-      llmModelId: `ollama/${model}`,
-      provider: "ollama",
-      openrouterProviders: null,
-      forceOpenRouter: false,
-      requiredEnv: "OLLAMA_BASE_URL",
-      // Default; can be overridden at runtime via OLLAMA_BASE_URL / config.ollama.baseUrl.
-      openaiBaseUrlOverride: DEFAULT_OLLAMA_BASE_URL,
-      forceChatCompletions: true,
-    };
-  }
-
-  if (lower.startsWith("github-copilot/")) {
-    const model = trimmed.slice("github-copilot/".length).trim();
-    if (model.length === 0) {
-      throw new Error("Invalid model id: github-copilot/… is missing the model id");
-    }
-    const userModelId = normalizeGatewayStyleModelId(`github-copilot/${model}`);
-    return {
-      kind: "fixed",
-      transport: "native",
-      userModelId,
-      llmModelId: userModelId,
-      provider: "github-copilot",
-      openrouterProviders: null,
-      forceOpenRouter: false,
-      requiredEnv: "GITHUB_TOKEN",
-      openaiBaseUrlOverride: "https://models.github.ai/inference",
-      forceChatCompletions: true,
-    };
-  }
-
   if (lower.startsWith("cli/")) {
     const parts = trimmed
       .split("/")
       .map((part) => part.trim())
       .filter((part) => part.length > 0);
-    const providerRaw = parts[1]?.toLowerCase() ?? "";
-    if (
-      providerRaw !== "claude" &&
-      providerRaw !== "codex" &&
-      providerRaw !== "gemini" &&
-      providerRaw !== "agent" &&
-      providerRaw !== "openclaw" &&
-      providerRaw !== "opencode" &&
-      providerRaw !== "copilot" &&
-      providerRaw !== "agy" &&
-      providerRaw !== "pi"
-    ) {
+    const cliProvider = parseCliProviderName(parts[1] ?? "");
+    if (!cliProvider) {
       throw new Error(`Invalid CLI model id "${trimmed}". Expected cli/<provider>/<model>.`);
     }
-    const cliProvider = providerRaw as CliProvider;
     const requestedModel = parts.slice(2).join("/").trim();
     if (cliProvider === "agy" && requestedModel.length > 0) {
       throw new Error(
@@ -228,18 +105,7 @@ export function parseRequestedModelId(raw: string): RequestedModel {
       );
     }
     const cliModel = requestedModel.length > 0 ? requestedModel : DEFAULT_CLI_MODELS[cliProvider];
-    const requiredEnv = requiredEnvForCliProvider(cliProvider) as Extract<
-      RequiredModelEnv,
-      | "CLI_CLAUDE"
-      | "CLI_CODEX"
-      | "CLI_GEMINI"
-      | "CLI_AGENT"
-      | "CLI_OPENCLAW"
-      | "CLI_OPENCODE"
-      | "CLI_COPILOT"
-      | "CLI_AGY"
-      | "CLI_PI"
-    >;
+    const requiredEnv = requiredEnvForCliProvider(cliProvider);
     const userModelId = cliModel ? `cli/${cliProvider}/${cliModel}` : `cli/${cliProvider}`;
     return {
       kind: "fixed",
@@ -289,22 +155,35 @@ export function parseRequestedModelId(raw: string): RequestedModel {
     );
   }
 
+  const provider = lower.slice(0, lower.indexOf("/"));
+  if (isGatewayProvider(provider)) {
+    const profile = getGatewayProviderProfile(provider);
+    if (profile.defaultBaseUrl) {
+      const model = trimmed.slice(provider.length + 1).trim();
+      if (model.length === 0) {
+        throw new Error(`Invalid model id: ${provider}/… is missing the model id`);
+      }
+      const userModelId = normalizeGatewayStyleModelId(`${provider}/${model}`);
+      return {
+        kind: "fixed",
+        transport: "native",
+        userModelId,
+        llmModelId: userModelId,
+        provider,
+        openrouterProviders: null,
+        forceOpenRouter: false,
+        requiredEnv: profile.requiredEnv,
+        openaiBaseUrlOverride: profile.defaultBaseUrl,
+        forceChatCompletions: profile.forceChatCompletions,
+      };
+    }
+  }
+
   const userModelId = normalizeGatewayStyleModelId(trimmed);
   const parsed = parseGatewayStyleModelId(userModelId);
   const fastOpenAi = parsed.provider === "openai" ? resolveOpenAiFastModelId(parsed.model) : null;
   const llmModelId = fastOpenAi ? `openai/${fastOpenAi.modelId}` : userModelId;
-  const requiredEnv = resolveRequiredEnvForModelId(userModelId) as Extract<
-    RequiredModelEnv,
-    | "XAI_API_KEY"
-    | "OPENAI_API_KEY"
-    | "GEMINI_API_KEY"
-    | "ANTHROPIC_API_KEY"
-    | "Z_AI_API_KEY"
-    | "NVIDIA_API_KEY"
-    | "MINIMAX_API_KEY"
-    | "GITHUB_TOKEN"
-    | "OLLAMA_BASE_URL"
-  >;
+  const requiredEnv = requiredEnvForGatewayProvider(parsed.provider);
   return {
     kind: "fixed",
     transport: "native",

--- a/tests/provider-registry.contract.test.ts
+++ b/tests/provider-registry.contract.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { resolveConfigEnv } from "../src/config/env.js";
+import { LEGACY_API_KEY_ENV_MAP } from "../src/config/legacy-api-keys.js";
+import { parseModelConfig } from "../src/config/model.js";
+import { parseCliProvider } from "../src/config/parse-helpers.js";
+import { parseApiKeysConfig, parseCliConfig, parseOpenAiConfig } from "../src/config/sections.js";
+import { resolveOpenAiCompatibleClientConfigForProvider } from "../src/llm/provider-capabilities.js";
+import {
+  CLI_PROVIDERS,
+  getCliProviderProfile,
+  getGatewayProviderProfile,
+} from "../src/llm/provider-registry.js";
+import { parseRequestedModelId } from "../src/model-spec.js";
+
+const path = "/tmp/provider-config.json";
+const compatibleProviders = ["zai", "nvidia", "minimax", "github-copilot", "ollama"] as const;
+
+describe("provider registry contracts", () => {
+  it.each(compatibleProviders)("rejects unprefixed %s names as unknown models", (provider) => {
+    expect(() => parseRequestedModelId(provider)).toThrow("Unknown model");
+    expect(() => parseRequestedModelId(`${provider}x`)).toThrow("Unknown model");
+  });
+
+  it.each(CLI_PROVIDERS)("uses the same %s provider in model IDs and configuration", (provider) => {
+    const profile = getCliProviderProfile(provider);
+    expect(parseCliProvider(` ${provider.toUpperCase()} `, path)).toBe(provider);
+    expect(parseRequestedModelId(` CLI/ ${provider.toUpperCase()} `)).toMatchObject({
+      transport: "cli",
+      cliProvider: provider,
+      cliModel: profile.defaultModel,
+      requiredEnv: profile.requiredEnv,
+    });
+    expect(
+      parseCliConfig({ cli: { [provider]: { binary: " executable ", model: " custom " } } }, path),
+    ).toEqual({
+      [provider]: { binary: "executable", model: "custom" },
+    });
+    expect(parseCliConfig({ cli: { [provider]: {} } }, path)).toEqual({ [provider]: {} });
+    expect(parseCliConfig({ cli: { [provider]: false } }, path)).toBeUndefined();
+    expect(() => parseCliConfig({ cli: { [provider]: { enabled: true } } }, path)).toThrow(
+      `"cli.${provider}.enabled" is not supported`,
+    );
+  });
+
+  it.each(compatibleProviders)("shares %s defaults without changing model spelling", (provider) => {
+    const profile = getGatewayProviderProfile(provider);
+    expect(parseRequestedModelId(` ${provider.toUpperCase()}/ MiXeD/Model `)).toEqual({
+      kind: "fixed",
+      transport: "native",
+      userModelId: `${provider}/MiXeD/Model`,
+      llmModelId: `${provider}/MiXeD/Model`,
+      provider,
+      openrouterProviders: null,
+      forceOpenRouter: false,
+      requiredEnv: profile.requiredEnv,
+      openaiBaseUrlOverride: profile.defaultBaseUrl,
+      forceChatCompletions: true,
+    });
+    expect(() => parseRequestedModelId(`${provider}/  `)).toThrow(
+      `Invalid model id: ${provider}/… is missing the model id`,
+    );
+    const client = resolveOpenAiCompatibleClientConfigForProvider({
+      provider,
+      openaiApiKey: "synthetic-key",
+      openrouterApiKey: null,
+      requestOptions: { serviceTier: "flex" },
+    });
+    expect(client.baseURL).toBe(profile.defaultBaseUrl);
+    expect(client.requestOptions).toEqual(
+      provider === "github-copilot" ? undefined : { serviceTier: "flex" },
+    );
+  });
+
+  it("keeps legacy keys separate from the model-provider inventory", () => {
+    const apiKeys = Object.fromEntries(
+      Object.keys(LEGACY_API_KEY_ENV_MAP).map((provider) => [
+        ` ${provider.toUpperCase()} `,
+        " synthetic-key ",
+      ]),
+    );
+    const parsed = parseApiKeysConfig({ apiKeys }, path);
+    expect(resolveConfigEnv({ apiKeys: parsed })).toEqual(
+      Object.fromEntries(
+        Object.values(LEGACY_API_KEY_ENV_MAP).map((name) => [name, "synthetic-key"]),
+      ),
+    );
+    for (const unsupported of ["deepgram", "ollama", "github-copilot", "constructor", "toString"]) {
+      expect(() =>
+        parseApiKeysConfig({ apiKeys: { [unsupported]: "synthetic-key" } }, path),
+      ).toThrow("unknown apiKeys provider");
+    }
+  });
+
+  it("shares request-option aliases and conflict validation across config scopes", () => {
+    const options = { serviceTier: " flex ", thinking: "extra-high", textVerbosity: "LOW" };
+    const expected = { serviceTier: "flex", reasoningEffort: "xhigh", textVerbosity: "low" };
+    expect(parseOpenAiConfig({ openai: options }, path)).toEqual(expected);
+    expect(parseModelConfig({ id: "openai/example", ...options }, path, "models.test")).toEqual({
+      id: "openai/example",
+      ...expected,
+    });
+    const conflict = { reasoningEffort: "high", thinking: "low" };
+    expect(() => parseOpenAiConfig({ openai: conflict }, path)).toThrow(
+      '"openai.reasoningEffort" and "openai.thinking" must not conflict',
+    );
+    expect(() =>
+      parseModelConfig({ id: "openai/example", ...conflict }, path, "models.test"),
+    ).toThrow('"models.test.reasoningEffort" and "models.test.thinking" must not conflict');
+  });
+});


### PR DESCRIPTION
## What changed

Give configuration and model parsing one dependency-free provider registry. Provider names, required environment variables, CLI defaults, capabilities, and default endpoints now have one owner instead of competing unions, arrays, condition chains, and model constructors.

The runtime profile module retains environment alias handling and client construction. Configuration-specific contracts stay separate: a small legacy API-key map owns its existing allowlist, and base-URL configuration sections remain explicit. Global and per-model request options use the same parser.

This removes 323 production lines and 208 lines overall, including new contract tests. No dependencies or public configuration features added.

## Preserved behavior

Keep model spelling, CLI defaults, Antigravity opt-in/model rules, GitHub-specific headers and request-option handling, Ollama optional credentials, endpoint precedence, falsey configuration omission, retained empty provider objects, and request-option aliases/conflicts.

## Validation

- Contract tests cover every CLI provider and all five endpoint-backed native providers, legacy-key allowlist isolation, and shared request-option parsing.
- The architecture gate caught a type-only import cycle during development; the legacy map now lives in its own dependency-free module. The gate remains unchanged.
- Self-review caught bare names such as `zaix` being misclassified by prefix parsing. Five regression cases reproduced the issue and now pass after unprefixed IDs are handled before provider-prefixed IDs.
- Focused model/registry/architecture tests pass (49 tests).
- Build and the complete local gate pass: formatting, lint, type checking, import-cycle checks, and 3,069 tests (43 skipped).
- Final independent Codex review: no actionable P0–P2 findings.
- Hosted CI passed on the exact PR head: Node 24, Chromium extension E2E, Firefox extension smoke, and GitGuardian.
