### PR TITLE
refactor(extension): remove redundant panel state dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Dependencies and maintenance
 
+- Remove the sidepanel's redundant action/reducer/dispatch layer; use one state object with explicit lifecycle transitions while preserving navigation, chat, and slide restoration.
 - Make provider metadata the shared source for configuration and model parsing; remove duplicated provider inventories, native model constructors, client defaults, and request-option parsing.
 - Replace duplicated file/byte transcription orchestration with one source-aware runner, shared local/provider handling, and common decode retries while preserving lazy file uploads and full-input fallback.
 - Unify model execution around one resolved request and completion path; centralize stream consumption while preserving output-failure and retry boundaries.

--- a/apps/chrome-extension/src/entrypoints/sidepanel/automation-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/automation-runtime.ts
@@ -8,7 +8,7 @@ import { runChatAgentLoop } from "./chat-agent-loop";
 import type { ChatController } from "./chat-controller";
 import { buildEmptyUsage } from "./chat-history-store";
 import { isPanelAutomationAvailable } from "./panel-capabilities";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { ChatMessage, PanelState } from "./types";
 
 type AutomationNoticeAction = "extensions" | "options";
@@ -32,7 +32,7 @@ type RuntimeMessageListener = (
 
 export function createAutomationRuntime({
   panelState,
-  dispatchPanelState,
+
   automationNoticeActionBtn,
   automationNoticeEl,
   automationNoticeMessageEl,
@@ -47,7 +47,7 @@ export function createAutomationRuntime({
   addRuntimeMessageListener = (listener) => chrome.runtime.onMessage.addListener(listener),
 }: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   automationNoticeActionBtn: HTMLButtonElement;
   automationNoticeEl: HTMLElement;
   automationNoticeMessageEl: HTMLElement;
@@ -74,17 +74,9 @@ export function createAutomationRuntime({
   };
   addRuntimeMessageListener?: (listener: RuntimeMessageListener) => void;
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
-
   const hideNotice = (options?: { force?: boolean }) => {
     if (panelState.panelSession.automationNoticeSticky && !options?.force) return;
-    dispatch({ type: "panel-session-update", value: { automationNoticeSticky: false } });
+    patchPanelState(panelState, "panelSession", { automationNoticeSticky: false });
     automationNoticeEl.classList.add("hidden");
   };
 
@@ -101,10 +93,7 @@ export function createAutomationRuntime({
     ctaAction?: AutomationNoticeAction;
     sticky?: boolean;
   }) => {
-    dispatch({
-      type: "panel-session-update",
-      value: { automationNoticeSticky: Boolean(sticky) },
-    });
+    patchPanelState(panelState, "panelSession", { automationNoticeSticky: Boolean(sticky) });
     automationNoticeTitleEl.textContent = title;
     automationNoticeMessageEl.textContent = message;
     automationNoticeActionBtn.textContent = ctaLabel || "Open extension details";

--- a/apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime.ts
@@ -1,5 +1,4 @@
 import type { BgToPanel, RunStart, UiState } from "../../lib/panel-contracts";
-import type { PanelStateAction } from "./panel-state-store";
 import {
   normalizePanelUrl,
   shouldAcceptRunForCurrentPage,
@@ -76,7 +75,7 @@ type SummarySnapshotPayload = Omit<Extract<BgToPanel, { type: "run:snapshot" }>,
 
 export function createSidepanelBgMessageRuntime(options: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   applyUiState: (state: UiState) => void;
   setStatus: (text: string) => void;
   isStreaming: () => boolean;
@@ -128,11 +127,7 @@ export function createSidepanelBgMessageRuntime(options: {
       handleSidepanelBgMessage({
         msg,
         applyUiState: (state) => {
-          if (options.dispatchPanelState) {
-            options.dispatchPanelState({ type: "ui", ui: state });
-          } else {
-            Object.assign(options.panelState, { ui: state });
-          }
+          options.panelState.ui = state;
           options.applyUiState(state);
         },
         setStatus: options.setStatus,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/bindings.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/bindings.ts
@@ -1,5 +1,5 @@
 import type { Settings, SlidesLayout } from "../../lib/settings";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { PanelState } from "./types";
 
 export function bindSidepanelUiEvents({
@@ -187,53 +187,36 @@ export function bindSidepanelLifecycle({
 
 export function bindSettingsStorage({
   panelState,
-  dispatchPanelState,
+
   applyChatEnabled,
   hideAutomationNotice,
 }: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   applyChatEnabled: () => void;
   hideAutomationNotice: () => void;
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
-
   chrome.storage.onChanged.addListener((changes, areaName) => {
     if (areaName !== "local") return;
     const nextSettings = changes.settings?.newValue;
     if (!nextSettings || typeof nextSettings !== "object") return;
     if (!panelState.panelSession.settingsHydrated) {
-      dispatch({
-        type: "panel-session-update",
-        value: {
-          pendingSettingsSnapshot: {
-            ...(panelState.panelSession.pendingSettingsSnapshot ?? {}),
-            ...(nextSettings as Partial<Settings>),
-          },
+      patchPanelState(panelState, "panelSession", {
+        pendingSettingsSnapshot: {
+          ...(panelState.panelSession.pendingSettingsSnapshot ?? {}),
+          ...(nextSettings as Partial<Settings>),
         },
       });
     }
     const nextChatEnabled = (nextSettings as { chatEnabled?: unknown }).chatEnabled;
     if (typeof nextChatEnabled === "boolean") {
-      dispatch({
-        type: "panel-session-update",
-        value: { chatEnabled: nextChatEnabled },
-      });
+      patchPanelState(panelState, "panelSession", { chatEnabled: nextChatEnabled });
       applyChatEnabled();
     }
     const nextAutomationEnabled = (nextSettings as { automationEnabled?: unknown })
       .automationEnabled;
     if (typeof nextAutomationEnabled === "boolean") {
-      dispatch({
-        type: "panel-session-update",
-        value: { automationEnabled: nextAutomationEnabled },
-      });
+      patchPanelState(panelState, "panelSession", { automationEnabled: nextAutomationEnabled });
       if (!nextAutomationEnabled) hideAutomationNotice();
     }
   });

--- a/apps/chrome-extension/src/entrypoints/sidepanel/bootstrap-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/bootstrap-runtime.ts
@@ -1,6 +1,6 @@
 import type { Settings } from "../../lib/settings";
 import { bindSettingsStorage, bindSidepanelLifecycle } from "./bindings";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { PanelState } from "./types";
 
 type LoadedSettings = Pick<
@@ -16,25 +16,11 @@ type LoadedSettings = Pick<
   | "token"
 >;
 
-function dispatchPanelState(
-  options: {
-    panelState: PanelState;
-    dispatchPanelState?: (action: PanelStateAction) => void;
-  },
-  action: PanelStateAction,
-) {
-  if (options.dispatchPanelState) {
-    options.dispatchPanelState(action);
-  } else {
-    applyPanelStateAction(options.panelState, action);
-  }
-}
-
 export function bootstrapSidepanel(options: {
   ensurePanelPort: () => Promise<void>;
   loadSettings: () => Promise<LoadedSettings>;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   typographyController: {
     setCurrentFontSize: (value: number) => void;
     setCurrentLineHeight: (value: number) => void;
@@ -66,27 +52,18 @@ export function bootstrapSidepanel(options: {
     const settings = pendingSettingsSnapshot
       ? { ...loadedSettings, ...pendingSettingsSnapshot }
       : loadedSettings;
-    dispatchPanelState(options, {
-      type: "panel-session-update",
-      value: {
-        pendingSettingsSnapshot: null,
-        settingsHydrated: true,
-      },
+    patchPanelState(options.panelState, "panelSession", {
+      pendingSettingsSnapshot: null,
+      settingsHydrated: true,
     });
     options.typographyController.setCurrentFontSize(settings.fontSize);
     options.typographyController.setCurrentLineHeight(settings.lineHeight);
-    dispatchPanelState(options, {
-      type: "panel-session-update",
-      value: {
-        autoSummarize: settings.autoSummarize,
-        chatEnabled: settings.chatEnabled,
-        automationEnabled: settings.automationEnabled,
-      },
+    patchPanelState(options.panelState, "panelSession", {
+      autoSummarize: settings.autoSummarize,
+      chatEnabled: settings.chatEnabled,
+      automationEnabled: settings.automationEnabled,
     });
-    dispatchPanelState(options, {
-      type: "slides-session-update",
-      value: { slidesLayout: settings.slidesLayout },
-    });
+    patchPanelState(options.panelState, "slidesSession", { slidesLayout: settings.slidesLayout });
     options.setSlidesLayoutInputValue(settings.slidesLayout);
     if (!settings.automationEnabled) options.hideAutomationNotice();
     options.appearanceControls.setAutoValue(settings.autoSummarize);
@@ -110,7 +87,7 @@ export function bootstrapSidepanel(options: {
 
   bindSettingsStorage({
     panelState: options.panelState,
-    dispatchPanelState: options.dispatchPanelState,
+
     applyChatEnabled: options.applyChatEnabled,
     hideAutomationNotice: options.hideAutomationNotice,
   });

--- a/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime.ts
@@ -2,7 +2,6 @@ import { buildBrowserAiSummaryMarkdown } from "../../lib/browser-summary";
 import { logExtensionEvent } from "../../lib/extension-logs";
 import type { BgToPanel } from "../../lib/panel-contracts";
 import type { BrowserAiRequestKey } from "./browser-ai-summary-runtime";
-import type { PanelStateAction } from "./panel-state-store";
 import { panelUrlsMatch } from "./session-policy";
 import type { PanelState } from "./types";
 
@@ -10,7 +9,7 @@ type BrowserSummarySnapshot = Extract<BgToPanel, { type: "run:snapshot" }>;
 
 export function createBrowserAiSnapshotRuntime(options: {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   browserAi: {
     cancel: (requestKey?: BrowserAiRequestKey) => void;
     summarize: (options: {
@@ -55,14 +54,11 @@ export function createBrowserAiSnapshotRuntime(options: {
           });
           return;
         }
-        options.dispatchPanelState({
-          type: "meta",
-          meta: {
-            ...options.panelState.lastMeta,
-            model: "Gemini Nano",
-            modelLabel: "Gemini Nano",
-          },
-        });
+        options.panelState.lastMeta = {
+          ...options.panelState.lastMeta,
+          model: "Gemini Nano",
+          modelLabel: "Gemini Nano",
+        };
         options.renderMarkdown(
           buildBrowserAiSummaryMarkdown({
             title: snapshot.run.title,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-controller.ts
@@ -5,7 +5,7 @@ import {
   computeChatContextUsage,
   hasUserChatMessage,
 } from "./chat-state";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState, replacePanelChatMessage } from "./panel-state-store";
 import { parseTimestampSeconds } from "./timestamp-links";
 import type { ChatMessage, PanelState } from "./types";
 
@@ -19,7 +19,7 @@ export type ChatControllerOptions = {
   markdown: MarkdownIt;
   limits: ChatHistoryLimits;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   scrollToBottom?: () => void;
   onNewContent?: () => void;
 };
@@ -32,7 +32,7 @@ export class ChatController {
   private readonly markdown: MarkdownIt;
   private readonly limits: ChatHistoryLimits;
   private readonly panelState: PanelState;
-  private readonly dispatchPanelState?: (action: PanelStateAction) => void;
+
   private readonly scrollToBottom?: () => void;
   private readonly onNewContent?: () => void;
   private readonly typingIndicatorHtml =
@@ -48,7 +48,7 @@ export class ChatController {
     this.markdown = opts.markdown;
     this.limits = opts.limits;
     this.panelState = opts.panelState;
-    this.dispatchPanelState = opts.dispatchPanelState;
+
     this.scrollToBottom = opts.scrollToBottom;
     this.onNewContent = opts.onNewContent;
   }
@@ -66,7 +66,7 @@ export class ChatController {
   }
 
   reset() {
-    this.dispatch({ type: "chat-reset" });
+    this.panelState.chat = { messages: [], streaming: false, queue: [] };
     this.messagesEl.innerHTML = "";
     this.inputEl.value = "";
     this.sendBtn.disabled = false;
@@ -75,7 +75,7 @@ export class ChatController {
   }
 
   setMessages(messages: ChatMessage[], opts?: RenderOptions) {
-    this.dispatch({ type: "chat-messages", messages });
+    patchPanelState(this.panelState, "chat", { messages: messages });
     this.messagesEl.innerHTML = "";
     for (const message of messages) {
       this.renderMessage(message, { scroll: false });
@@ -89,7 +89,9 @@ export class ChatController {
   }
 
   addMessage(message: ChatMessage, opts?: RenderOptions) {
-    this.dispatch({ type: "chat-message-add", message });
+    patchPanelState(this.panelState, "chat", {
+      messages: [...this.panelState.chat.messages, message],
+    });
     this.renderMessage(message, opts);
     this.updateVisibility();
     this.updateContextStatus();
@@ -101,7 +103,7 @@ export class ChatController {
       this.addMessage(message, opts);
       return;
     }
-    this.dispatch({ type: "chat-message-replace", message });
+    replacePanelChatMessage(this.panelState, message);
     const existing = this.messagesEl.querySelector(`[data-id="${message.id}"]`);
     if (existing) {
       const nextEl = this.createMessageElement(message);
@@ -120,7 +122,9 @@ export class ChatController {
   removeMessage(id: string) {
     const index = this.getMessages().findIndex((item) => item.id === id);
     if (index === -1) return;
-    this.dispatch({ type: "chat-message-remove", id });
+    patchPanelState(this.panelState, "chat", {
+      messages: this.panelState.chat.messages.filter((message) => message.id !== id),
+    });
     const existing = this.messagesEl.querySelector(`[data-id="${id}"]`);
     existing?.remove();
     this.updateVisibility();
@@ -131,12 +135,9 @@ export class ChatController {
     const messages = this.getMessages();
     const lastMsg = messages[messages.length - 1];
     if (lastMsg?.role === "assistant") {
-      this.dispatch({
-        type: "chat-message-replace",
-        message: {
-          ...lastMsg,
-          content: [{ type: "text", text: content }],
-        },
+      replacePanelChatMessage(this.panelState, {
+        ...lastMsg,
+        content: [{ type: "text", text: content }],
       });
       const msgEl = this.messagesEl.querySelector(`[data-id="${lastMsg.id}"]`);
       if (msgEl) {
@@ -211,14 +212,6 @@ export class ChatController {
       if (seconds == null) return match;
       return `[${time}](timestamp:${seconds})`;
     });
-  }
-
-  private dispatch(action: PanelStateAction) {
-    if (this.dispatchPanelState) {
-      this.dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(this.panelState, action);
-    }
   }
 
   private createMessageElement(message: ChatMessage): HTMLDivElement {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-queue-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-queue-runtime.ts
@@ -1,9 +1,9 @@
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { PanelState } from "./types";
 
 type ChatQueueRuntimeOpts = {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   chatQueueEl: HTMLElement;
   maxQueue: number;
   setStatus: (value: string) => void;
@@ -15,7 +15,9 @@ export function createChatQueueRuntime(opts: ChatQueueRuntimeOpts) {
   }
 
   function removeQueuedMessage(id: string) {
-    opts.dispatchPanelState({ type: "chat-queue-remove", id });
+    patchPanelState(opts.panelState, "chat", {
+      queue: opts.panelState.chat.queue.filter((item) => item.id !== id),
+    });
     renderChatQueue();
   }
 
@@ -59,9 +61,11 @@ export function createChatQueueRuntime(opts: ChatQueueRuntimeOpts) {
       opts.setStatus(`Queue full (${opts.maxQueue}). Remove one to add more.`);
       return false;
     }
-    opts.dispatchPanelState({
-      type: "chat-queue-add",
-      item: { id: crypto.randomUUID(), text, createdAt: Date.now() },
+    patchPanelState(opts.panelState, "chat", {
+      queue: [
+        ...opts.panelState.chat.queue,
+        { id: crypto.randomUUID(), text, createdAt: Date.now() },
+      ],
     });
     renderChatQueue();
     return true;
@@ -69,13 +73,16 @@ export function createChatQueueRuntime(opts: ChatQueueRuntimeOpts) {
 
   function clearQueuedMessages() {
     if (opts.panelState.chat.queue.length === 0) return;
-    opts.dispatchPanelState({ type: "chat-queue-clear" });
+    patchPanelState(opts.panelState, "chat", { queue: [] });
     renderChatQueue();
   }
 
   function dequeueQueuedMessage() {
     const next = opts.panelState.chat.queue[0];
-    if (next) opts.dispatchPanelState({ type: "chat-queue-remove", id: next.id });
+    if (next)
+      patchPanelState(opts.panelState, "chat", {
+        queue: opts.panelState.chat.queue.filter((item) => item.id !== next.id),
+      });
     return next;
   }
 

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime.ts
@@ -11,7 +11,7 @@ import type { ChatHistoryLimits } from "./chat-state";
 import { createChatStreamRuntime } from "./chat-stream-runtime";
 import { createChatUiRuntime } from "./chat-ui-runtime";
 import { isPanelChatAvailable } from "./panel-capabilities";
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import { parseTimestampHref } from "./timestamp-links";
 import type { ChatMessage, PanelState } from "./types";
 
@@ -28,7 +28,7 @@ type NavigationRuntime = {
 
 export function createSidepanelChatRuntime({
   panelState,
-  dispatchPanelState,
+
   markdown,
   mainEl,
   renderEl,
@@ -58,7 +58,7 @@ export function createSidepanelChatRuntime({
   seekToTimestamp,
 }: {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   markdown: MarkdownIt;
   mainEl: HTMLElement;
   renderEl: HTMLElement;
@@ -104,7 +104,7 @@ export function createSidepanelChatRuntime({
     markdown,
     limits: CHAT_LIMITS,
     panelState,
-    dispatchPanelState,
+
     scrollToBottom: () => chatUiRuntime.scrollToBottom(),
     onNewContent: renderInlineSlides,
   });
@@ -126,7 +126,7 @@ export function createSidepanelChatRuntime({
 
   const chatQueueRuntime = createChatQueueRuntime({
     panelState,
-    dispatchPanelState,
+
     chatQueueEl,
     maxQueue: MAX_CHAT_QUEUE,
     setStatus,
@@ -155,7 +155,7 @@ export function createSidepanelChatRuntime({
 
   automationRuntime = createAutomationRuntime({
     panelState,
-    dispatchPanelState,
+
     automationNoticeActionBtn,
     automationNoticeEl,
     automationNoticeMessageEl,
@@ -172,7 +172,7 @@ export function createSidepanelChatRuntime({
     chatEnabled: () => isPanelChatAvailable(panelState),
     isChatStreaming: () => panelState.chat.streaming,
     setChatStreaming: (value) => {
-      dispatchPanelState({ type: "chat-streaming", value });
+      patchPanelState(panelState, "chat", { streaming: value });
     },
     hasUserMessages: () => chatController.hasUserMessages(),
     addUserMessage: (text) => {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
@@ -10,7 +10,7 @@ import { createSidepanelInteractionRuntime } from "./interaction-runtime";
 import { createMetricsController } from "./metrics-controller";
 import { isPanelChatAvailable } from "./panel-capabilities";
 import { createPanelMessagingRuntime } from "./panel-messaging";
-import { createPanelStateStore } from "./panel-state-store";
+import { createInitialPanelState, patchPanelState } from "./panel-state-store";
 import { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import { createSidepanelRunRuntime } from "./run-runtime";
 import { createSidepanelSessionRuntime } from "./session-runtime";
@@ -67,18 +67,17 @@ const typographyController = createTypographyController({
   defaultLineHeight: defaultSettings.lineHeight,
 });
 
-const panelStateStore = createPanelStateStore();
-const panelState = panelStateStore.state;
+const panelState = createInitialPanelState();
 const getActiveTabId = () => panelState.navigation.activeTabId;
 const getActiveTabUrl = () => panelState.navigation.activeTabUrl;
 const getPanelSession = () => panelState.panelSession;
 const updatePanelSession = (value: Partial<typeof panelState.panelSession>) => {
-  panelStateStore.dispatch({ type: "panel-session-update", value });
+  patchPanelState(panelState, "panelSession", value);
 };
 
 const panelMessagingRuntime = createPanelMessagingRuntime({
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   onMessage: (msg) => {
     handleBgMessage(msg);
   },
@@ -119,7 +118,7 @@ const appearanceControls = createAppearanceControls({
 const presentationRuntime = createSidepanelPresentationRuntime({
   dom,
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   appearanceControls,
   metricsController,
   resolveLocalSlides,
@@ -137,7 +136,7 @@ const { applySlidesLayout, setSlidesLayout } = summarizeControlRuntime;
 const sessionRuntime = createSidepanelSessionRuntime({
   dom,
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   metricsController,
   presentationRuntime,
   send,
@@ -147,7 +146,7 @@ const { bindRunActions, chatRuntime, clearCurrentView, navigationRuntime, syncWi
 
 const runRuntime = createSidepanelRunRuntime({
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   getActiveTabId,
   getActiveTabUrl,
   appearanceControls,
@@ -199,7 +198,7 @@ const {
 const stateEffectsRuntime = createSidepanelStateEffectsRuntime({
   dom,
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   appearanceControls,
   typographyController,
   panelMessagingRuntime,
@@ -217,7 +216,7 @@ function handleBgMessage(msg: BgToPanel) {
 registerSidepanelRuntimeTestHooks({
   dom,
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   presentationRuntime,
   runRuntime,
   stateEffectsRuntime,
@@ -310,7 +309,7 @@ bootstrapSidepanel({
   ensurePanelPort: () => panelMessagingRuntime.ensure(),
   loadSettings,
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   typographyController,
   setSlidesLayoutInputValue: (value) => {
     slidesLayoutEl.value = value;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/panel-messaging.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/panel-messaging.ts
@@ -1,7 +1,7 @@
 import type { BgToPanel, PanelToBg } from "../../lib/panel-contracts";
 import type { SseSlidesData } from "../../lib/runtime-contracts";
 import { createPanelPortRuntime } from "./panel-port";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { PanelState } from "./types";
 
 type PanelPortRuntimeLike = {
@@ -11,7 +11,7 @@ type PanelPortRuntimeLike = {
 
 export function createPanelMessagingRuntime({
   panelState,
-  dispatchPanelState,
+
   onMessage,
   portRuntime = createPanelPortRuntime({ onMessage }),
   createRequestId = () => `local-slides-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -20,7 +20,7 @@ export function createPanelMessagingRuntime({
   clearTimer = (timer) => clearTimeout(timer),
 }: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   onMessage: (message: BgToPanel) => void;
   portRuntime?: PanelPortRuntimeLike;
   createRequestId?: () => string;
@@ -36,21 +36,13 @@ export function createPanelMessagingRuntime({
     }
   >();
 
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
-
   const sendRaw = (message: PanelToBg) => portRuntime.send(message);
 
   const send = async (message: PanelToBg) => {
     if (message.type === "panel:summarize") {
-      dispatch({ type: "panel-session-update", value: { lastAction: "summarize" } });
+      patchPanelState(panelState, "panelSession", { lastAction: "summarize" });
     } else if (message.type === "panel:agent") {
-      dispatch({ type: "panel-session-update", value: { lastAction: "chat" } });
+      patchPanelState(panelState, "panelSession", { lastAction: "chat" });
     }
     await sendRaw(message);
   };

--- a/apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store.ts
@@ -1,72 +1,6 @@
 import { defaultSettings } from "../../lib/settings";
 import { createInitialSlidesSessionState } from "./slides-session-state";
-import type { NavigationPolicyState, PanelState } from "./types";
-
-export type PanelStateAction =
-  | { type: "phase"; phase: PanelState["phase"]; error?: string | null }
-  | { type: "ui"; ui: PanelState["ui"] }
-  | {
-      type: "active-tab";
-      tabId: PanelState["navigation"]["activeTabId"];
-      url: PanelState["navigation"]["activeTabUrl"];
-    }
-  | { type: "active-tab-url"; url: PanelState["navigation"]["activeTabUrl"] }
-  | { type: "navigation-policy-update"; value: Partial<NavigationPolicyState> }
-  | {
-      type: "pending-summary-run";
-      urlKey: string;
-      value: PanelState["pendingRuns"]["summaryByUrl"][string] | null;
-    }
-  | {
-      type: "pending-slides-run";
-      urlKey: string;
-      value: PanelState["pendingRuns"]["slidesByUrl"][string] | null;
-    }
-  | { type: "active-slides-run"; value: PanelState["slidesLifecycle"]["activeRun"] }
-  | { type: "planned-slides-run"; value: PanelState["slidesLifecycle"]["plannedRun"] }
-  | { type: "slides-summary-update"; value: Partial<PanelState["slidesSummary"]> }
-  | { type: "slides-summary-reset" }
-  | { type: "slides-text-update"; value: Partial<PanelState["slidesText"]> }
-  | { type: "slides-text-reset" }
-  | { type: "slides-session-update"; value: Partial<PanelState["slidesSession"]> }
-  | { type: "slides-context-request-next" }
-  | { type: "panel-session-update"; value: Partial<PanelState["panelSession"]> }
-  | { type: "source"; source: PanelState["currentSource"] }
-  | { type: "meta"; meta: PanelState["lastMeta"] }
-  | { type: "summary"; markdown: string | null }
-  | { type: "summary-cache"; value: boolean | null }
-  | { type: "retained-slide-summary"; value: PanelState["retainedSlideSummary"] }
-  | { type: "slides"; slides: PanelState["slides"] }
-  | { type: "slides-run"; runId: string | null }
-  | { type: "chat-streaming"; value: boolean }
-  | { type: "chat-reset" }
-  | { type: "chat-messages"; messages: PanelState["chat"]["messages"] }
-  | { type: "chat-message-add"; message: PanelState["chat"]["messages"][number] }
-  | { type: "chat-message-replace"; message: PanelState["chat"]["messages"][number] }
-  | { type: "chat-message-remove"; id: string }
-  | { type: "chat-queue-add"; item: PanelState["chat"]["queue"][number] }
-  | { type: "chat-queue-remove"; id: string }
-  | { type: "chat-queue-clear" }
-  | {
-      type: "attach-run";
-      tabId: PanelState["activeRun"]["tabId"];
-      runId: string;
-      slidesRunId: string | null;
-      plannedSlidesRun: PanelState["slidesLifecycle"]["plannedRun"];
-      source: NonNullable<PanelState["currentSource"]>;
-      meta: PanelState["lastMeta"];
-    }
-  | {
-      type: "restore-session";
-      tabId: PanelState["activeRun"]["tabId"];
-      runId: string | null;
-      slidesRunId: string | null;
-      source: NonNullable<PanelState["currentSource"]>;
-      meta: PanelState["lastMeta"];
-      summaryFromCache: boolean | null;
-      slides?: PanelState["slides"];
-    }
-  | { type: "reset-summary"; clearRunId: boolean; clearSlides: boolean };
+import type { PanelState } from "./types";
 
 export function createInitialPanelState(): PanelState {
   return {
@@ -125,258 +59,109 @@ export function createInitialPanelState(): PanelState {
   };
 }
 
-export function reducePanelState(state: PanelState, action: PanelStateAction): PanelState {
-  switch (action.type) {
-    case "phase":
-      return {
-        ...state,
-        phase: action.phase,
-        error: action.phase === "error" ? (action.error ?? state.error) : null,
-      };
-    case "ui":
-      return { ...state, ui: action.ui };
-    case "active-tab":
-      return {
-        ...state,
-        navigation: {
-          ...state.navigation,
-          activeTabId: action.tabId,
-          activeTabUrl: action.url,
-        },
-      };
-    case "active-tab-url":
-      return {
-        ...state,
-        navigation: {
-          ...state.navigation,
-          activeTabUrl: action.url,
-        },
-      };
-    case "navigation-policy-update":
-      return {
-        ...state,
-        navigation: {
-          ...state.navigation,
-          ...action.value,
-        },
-      };
-    case "pending-summary-run":
-      return {
-        ...state,
-        pendingRuns: {
-          ...state.pendingRuns,
-          summaryByUrl: updateKeyedValue(
-            state.pendingRuns.summaryByUrl,
-            action.urlKey,
-            action.value,
-          ),
-        },
-      };
-    case "pending-slides-run":
-      return {
-        ...state,
-        pendingRuns: {
-          ...state.pendingRuns,
-          slidesByUrl: updateKeyedValue(state.pendingRuns.slidesByUrl, action.urlKey, action.value),
-        },
-      };
-    case "active-slides-run":
-      return {
-        ...state,
-        slidesLifecycle: {
-          ...state.slidesLifecycle,
-          activeRun: action.value,
-        },
-      };
-    case "planned-slides-run":
-      return {
-        ...state,
-        slidesLifecycle: {
-          ...state.slidesLifecycle,
-          plannedRun: action.value,
-        },
-      };
-    case "slides-summary-update":
-      return {
-        ...state,
-        slidesSummary: {
-          ...state.slidesSummary,
-          ...action.value,
-        },
-      };
-    case "slides-summary-reset":
-      return {
-        ...state,
-        slidesSummary: createInitialSlidesSummaryState(),
-      };
-    case "slides-text-update":
-      return {
-        ...state,
-        slidesText: {
-          ...state.slidesText,
-          ...action.value,
-        },
-      };
-    case "slides-text-reset":
-      return {
-        ...state,
-        slidesText: createInitialSlidesTextState(),
-      };
-    case "slides-session-update":
-      return {
-        ...state,
-        slidesSession: {
-          ...state.slidesSession,
-          ...action.value,
-        },
-      };
-    case "slides-context-request-next":
-      return {
-        ...state,
-        slidesSession: {
-          ...state.slidesSession,
-          slidesContextRequestId: state.slidesSession.slidesContextRequestId + 1,
-        },
-      };
-    case "panel-session-update":
-      return {
-        ...state,
-        panelSession: {
-          ...state.panelSession,
-          ...action.value,
-        },
-      };
-    case "source":
-      return { ...state, currentSource: action.source };
-    case "meta":
-      return { ...state, lastMeta: action.meta };
-    case "summary":
-      return { ...state, summaryMarkdown: action.markdown };
-    case "summary-cache":
-      return { ...state, summaryFromCache: action.value };
-    case "retained-slide-summary":
-      return { ...state, retainedSlideSummary: action.value };
-    case "slides":
-      return { ...state, slides: action.slides };
-    case "slides-run":
-      return { ...state, slidesRunId: action.runId };
-    case "chat-streaming":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          streaming: action.value,
-        },
-      };
-    case "chat-reset":
-      return {
-        ...state,
-        chat: {
-          messages: [],
-          streaming: false,
-          queue: [],
-        },
-      };
-    case "chat-messages":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          messages: action.messages,
-        },
-      };
-    case "chat-message-add":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          messages: [...state.chat.messages, action.message],
-        },
-      };
-    case "chat-message-replace":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          messages: state.chat.messages.map((message) =>
-            message.id === action.message.id ? action.message : message,
-          ),
-        },
-      };
-    case "chat-message-remove":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          messages: state.chat.messages.filter((message) => message.id !== action.id),
-        },
-      };
-    case "chat-queue-add":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          queue: [...state.chat.queue, action.item],
-        },
-      };
-    case "chat-queue-remove":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          queue: state.chat.queue.filter((item) => item.id !== action.id),
-        },
-      };
-    case "chat-queue-clear":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          queue: [],
-        },
-      };
-    case "attach-run":
-      return {
-        ...state,
-        activeRun: { tabId: action.tabId },
-        slidesLifecycle: {
-          ...state.slidesLifecycle,
-          plannedRun: action.plannedSlidesRun,
-        },
-        runId: action.runId,
-        slidesRunId: action.slidesRunId,
-        currentSource: action.source,
-        lastMeta: action.meta,
-      };
-    case "restore-session":
-      return {
-        ...state,
-        activeRun: { tabId: action.tabId },
-        runId: action.runId,
-        slidesRunId: action.slidesRunId,
-        currentSource: action.source,
-        lastMeta: action.meta,
-        summaryFromCache: action.summaryFromCache,
-        ...(typeof action.slides === "undefined" ? {} : { slides: action.slides }),
-      };
-    case "reset-summary":
-      return {
-        ...state,
-        activeRun: { tabId: null },
-        summaryMarkdown: null,
-        summaryFromCache: null,
-        ...(action.clearRunId ? { runId: null } : {}),
-        ...(action.clearSlides
-          ? {
-              slides: null,
-              ...(action.clearRunId ? { slidesRunId: null } : {}),
-            }
-          : {}),
-      };
+export function patchPanelState<
+  Key extends
+    | "navigation"
+    | "slidesLifecycle"
+    | "slidesSummary"
+    | "slidesText"
+    | "slidesSession"
+    | "panelSession"
+    | "chat",
+>(state: PanelState, key: Key, patch: Partial<PanelState[Key]>) {
+  state[key] = { ...state[key], ...patch };
+}
+
+export function setPanelPhase(
+  state: PanelState,
+  phase: PanelState["phase"],
+  error?: string | null,
+) {
+  state.phase = phase;
+  state.error = phase === "error" ? (error ?? state.error) : null;
+}
+
+export function setPendingSummaryRun(
+  state: PanelState,
+  urlKey: string,
+  value: PanelState["pendingRuns"]["summaryByUrl"][string] | null,
+) {
+  state.pendingRuns = {
+    ...state.pendingRuns,
+    summaryByUrl: updateKeyedValue(state.pendingRuns.summaryByUrl, urlKey, value),
+  };
+}
+
+export function setPendingSlidesRun(
+  state: PanelState,
+  urlKey: string,
+  value: PanelState["pendingRuns"]["slidesByUrl"][string] | null,
+) {
+  state.pendingRuns = {
+    ...state.pendingRuns,
+    slidesByUrl: updateKeyedValue(state.pendingRuns.slidesByUrl, urlKey, value),
+  };
+}
+
+type PanelRun = {
+  tabId: PanelState["activeRun"]["tabId"];
+  runId: string | null;
+  slidesRunId: string | null;
+  source: NonNullable<PanelState["currentSource"]>;
+  meta: PanelState["lastMeta"];
+};
+
+export function attachPanelRun(
+  state: PanelState,
+  run: PanelRun & { runId: string; plannedSlidesRun: PanelState["slidesLifecycle"]["plannedRun"] },
+) {
+  state.activeRun = { tabId: run.tabId };
+  patchPanelState(state, "slidesLifecycle", { plannedRun: run.plannedSlidesRun });
+  state.runId = run.runId;
+  state.slidesRunId = run.slidesRunId;
+  state.currentSource = run.source;
+  state.lastMeta = run.meta;
+}
+
+export function restorePanelSession(
+  state: PanelState,
+  session: PanelRun & { summaryFromCache: boolean | null; slides?: PanelState["slides"] },
+) {
+  state.activeRun = { tabId: session.tabId };
+  state.runId = session.runId;
+  state.slidesRunId = session.slidesRunId;
+  state.currentSource = session.source;
+  state.lastMeta = session.meta;
+  state.summaryFromCache = session.summaryFromCache;
+  if (session.slides !== undefined) state.slides = session.slides;
+}
+
+export function resetPanelSummary(
+  state: PanelState,
+  options: { clearRunId: boolean; clearSlides: boolean },
+) {
+  state.activeRun = { tabId: null };
+  state.summaryMarkdown = null;
+  state.summaryFromCache = null;
+  if (options.clearRunId) state.runId = null;
+  if (options.clearSlides) {
+    state.slides = null;
+    if (options.clearRunId) state.slidesRunId = null;
   }
 }
 
-function createInitialSlidesSummaryState(): PanelState["slidesSummary"] {
+export function replacePanelChatMessage(
+  state: PanelState,
+  message: PanelState["chat"]["messages"][number],
+) {
+  patchPanelState(state, "chat", {
+    messages: state.chat.messages.map((existing) =>
+      existing.id === message.id ? message : existing,
+    ),
+  });
+}
+
+export function createInitialSlidesSummaryState(): PanelState["slidesSummary"] {
   return {
     runId: null,
     url: null,
@@ -388,7 +173,7 @@ function createInitialSlidesSummaryState(): PanelState["slidesSummary"] {
   };
 }
 
-function createInitialSlidesTextState(): PanelState["slidesText"] {
+export function createInitialSlidesTextState(): PanelState["slidesText"] {
   return {
     mode: "transcript",
     toggleVisible: false,
@@ -412,19 +197,4 @@ function updateKeyedValue<T>(
   const next = { ...values };
   delete next[key];
   return next;
-}
-
-export function applyPanelStateAction(state: PanelState, action: PanelStateAction): PanelState {
-  Object.assign(state, reducePanelState(state, action));
-  return state;
-}
-
-export function createPanelStateStore(initial = createInitialPanelState()) {
-  const state = initial;
-  return {
-    state,
-    dispatch(action: PanelStateAction) {
-      applyPanelStateAction(state, action);
-    },
-  };
 }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/phase-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/phase-runtime.ts
@@ -1,6 +1,6 @@
 import type { ErrorController } from "./error-controller";
 import type { HeaderController } from "./header-controller";
-import type { PanelStateAction } from "./panel-state-store";
+import { setPanelPhase } from "./panel-state-store";
 import type { PanelPhase, PanelState } from "./types";
 
 type PhaseEventTarget = {
@@ -9,7 +9,7 @@ type PhaseEventTarget = {
 
 export function createPanelPhaseRuntime({
   panelState,
-  dispatchPanelState,
+
   errorController,
   headerController,
   setSlidesBusy,
@@ -18,7 +18,7 @@ export function createPanelPhaseRuntime({
   eventTarget = window,
 }: {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   errorController: ErrorController;
   headerController: HeaderController;
   setSlidesBusy: (value: boolean) => void;
@@ -27,7 +27,7 @@ export function createPanelPhaseRuntime({
   eventTarget?: PhaseEventTarget;
 }) {
   const setPhase = (phase: PanelPhase, options?: { error?: string | null }) => {
-    dispatchPanelState({ type: "phase", phase, error: options?.error });
+    setPanelPhase(panelState, phase, options?.error);
     const running = phase === "connecting" || phase === "streaming";
     if (phase === "error") {
       const message =

--- a/apps/chrome-extension/src/entrypoints/sidepanel/planned-slides-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/planned-slides-runtime.ts
@@ -1,5 +1,5 @@
 import { extractYouTubeVideoId } from "@steipete/summarize-core/content/url";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import { panelUrlsMatch } from "./session-policy";
 import { shouldSeedPlannedSlidesForRun } from "./slides-seed-policy";
 import { resolveSlidesInputMode } from "./slides-session-state";
@@ -7,7 +7,7 @@ import type { PanelState, RunStart } from "./types";
 
 export function createPlannedSlidesRuntime({
   panelState,
-  dispatchPanelState,
+
   getActiveTabUrl,
   getLengthValue,
   updateSlidesTextState,
@@ -15,21 +15,13 @@ export function createPlannedSlidesRuntime({
   schedulePanelCacheSync,
 }: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   getActiveTabUrl: () => string | null;
   getLengthValue: () => string;
   updateSlidesTextState: () => void;
   queueSlidesRender: () => void;
   schedulePanelCacheSync: (delayMs?: number) => void;
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
-
   const getSourceId = (run: RunStart) => {
     const youtubeId = extractYouTubeVideoId(run.url);
     return youtubeId ? `youtube-${youtubeId}` : `planned-${run.id}`;
@@ -108,20 +100,14 @@ export function createPlannedSlidesRuntime({
       return { index: index + 1, timestamp, imageUrl: "" };
     });
 
-    dispatch({
-      type: "slides",
-      slides: {
-        sourceUrl: run.url,
-        sourceId,
-        sourceKind,
-        ocrAvailable: false,
-        slides,
-      },
-    });
-    dispatch({
-      type: "slides-session-update",
-      value: { slidesSeededSourceId: sourceId },
-    });
+    panelState.slides = {
+      sourceUrl: run.url,
+      sourceId,
+      sourceKind,
+      ocrAvailable: false,
+      slides,
+    };
+    patchPanelState(panelState, "slidesSession", { slidesSeededSourceId: sourceId });
     updateSlidesTextState();
     queueSlidesRender();
     schedulePanelCacheSync(0);
@@ -152,7 +138,7 @@ export function createPlannedSlidesRuntime({
   };
 
   const clearPendingRun = () => {
-    dispatch({ type: "planned-slides-run", value: null });
+    patchPanelState(panelState, "slidesLifecycle", { plannedRun: null });
   };
 
   const maybeSeedPendingRun = () => {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime.ts
@@ -8,7 +8,7 @@ import type { SidepanelDom } from "./dom";
 import { createSidepanelFeedbackRuntime } from "./feedback-runtime";
 import type { createMetricsController } from "./metrics-controller";
 import { buildPanelCachePayload, createPanelCacheController } from "./panel-cache";
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import { createPanelPhaseRuntime } from "./phase-runtime";
 import {
   retainRenderedSlideSummary,
@@ -64,7 +64,7 @@ function createMarkdownRenderer() {
 export function createSidepanelPresentationRuntime({
   dom,
   panelState,
-  dispatchPanelState,
+
   appearanceControls,
   metricsController,
   resolveLocalSlides,
@@ -72,7 +72,7 @@ export function createSidepanelPresentationRuntime({
 }: {
   dom: SidepanelDom;
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   appearanceControls: AppearanceControls;
   metricsController: MetricsController;
   resolveLocalSlides: ResolveLocalSlides;
@@ -81,7 +81,7 @@ export function createSidepanelPresentationRuntime({
   const markdown = createMarkdownRenderer();
   const slidesTextController = createSlidesTextController({
     panelState,
-    dispatchPanelState,
+
     getSlides: () => panelState.slides?.slides ?? null,
     getLengthValue: appearanceControls.getLengthValue,
     getSlidesOcrEnabled: () => panelState.slidesSession.slidesOcrEnabled,
@@ -133,7 +133,7 @@ export function createSidepanelPresentationRuntime({
   const sendSummarize = createSummarizeCommand({
     send,
     setLastAction: (value) => {
-      dispatchPanelState({ type: "panel-session-update", value: { lastAction: value } });
+      patchPanelState(panelState, "panelSession", { lastAction: value });
     },
     clearInlineError: errorController.clearInlineError,
     getInputModeOverride: () => panelState.slidesSession.inputModeOverride,
@@ -184,12 +184,12 @@ export function createSidepanelPresentationRuntime({
     refreshSummarizeControl,
     hideSlideNotice,
     panelState,
-    dispatchPanelState,
+
     getFallbackSummaryMarkdown: () => selectRetainedSlideSummaryMarkdown(panelState),
   });
 
   const renderMarkdown = (value: string) => {
-    retainRenderedSlideSummary(panelState, dispatchPanelState, value);
+    retainRenderedSlideSummary(panelState, value);
     slidesViewRuntime.renderMarkdown(value);
   };
   let refreshBrowserAiSlides = () => {};
@@ -206,7 +206,7 @@ export function createSidepanelPresentationRuntime({
     browserAi: browserAiRuntime,
     clearSummarySource: slidesTextController.clearSummarySource,
     panelState,
-    dispatchPanelState,
+
     friendlyFetchError,
     getLengthValue: appearanceControls.getLengthValue,
     getToken: async () => (await loadSettings()).token,
@@ -236,7 +236,7 @@ export function createSidepanelPresentationRuntime({
     slidesLayoutEl: dom.slidesLayoutEl,
     slidesTextController,
     panelState,
-    dispatchPanelState,
+
     patchSettings,
     loadSettings,
     showSlideNotice,
@@ -271,7 +271,7 @@ export function createSidepanelPresentationRuntime({
 
   const phaseRuntime = createPanelPhaseRuntime({
     panelState,
-    dispatchPanelState,
+
     errorController,
     headerController,
     setSlidesBusy: slidesViewRuntime.setSlidesBusy,
@@ -281,7 +281,7 @@ export function createSidepanelPresentationRuntime({
 
   const summaryViewRuntime = createSummaryViewRuntime({
     panelState,
-    dispatchPanelState,
+
     renderEl: dom.renderEl,
     renderSlidesHostEl: dom.renderSlidesHostEl,
     renderMarkdownHostEl: dom.renderMarkdownHostEl,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/retained-slide-summary.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/retained-slide-summary.ts
@@ -1,4 +1,3 @@
-import type { PanelStateAction } from "./panel-state-store";
 import { panelUrlsMatch } from "./session-policy";
 import type { PanelState } from "./types";
 
@@ -7,17 +6,14 @@ const getSummaryScopeUrl = (panelState: PanelState) =>
 
 export function retainRenderedSlideSummary(
   panelState: PanelState,
-  dispatchPanelState: (action: PanelStateAction) => void,
+
   markdown: string,
 ) {
   if (!markdown.trim()) return;
-  dispatchPanelState({
-    type: "retained-slide-summary",
-    value: {
-      markdown,
-      url: getSummaryScopeUrl(panelState),
-    },
-  });
+  panelState.retainedSlideSummary = {
+    markdown,
+    url: getSummaryScopeUrl(panelState),
+  };
 }
 
 export function selectRetainedSlideSummaryMarkdown(panelState: PanelState) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/run-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/run-runtime.ts
@@ -8,7 +8,6 @@ import type { HeaderController } from "./header-controller";
 import type { createMetricsController } from "./metrics-controller";
 import type { NavigationRuntime } from "./navigation-runtime";
 import type { PanelCacheController } from "./panel-cache";
-import type { PanelStateAction } from "./panel-state-store";
 import { createPlannedSlidesRuntime } from "./planned-slides-runtime";
 import type { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import { friendlyFetchError } from "./setup-runtime";
@@ -32,7 +31,7 @@ type PresentationRuntime = ReturnType<typeof createSidepanelPresentationRuntime>
 
 export function createSidepanelRunRuntime({
   panelState,
-  dispatchPanelState,
+
   getActiveTabId,
   getActiveTabUrl,
   appearanceControls,
@@ -46,7 +45,7 @@ export function createSidepanelRunRuntime({
   syncWithActiveTab,
 }: {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   getActiveTabId: () => number | null;
   getActiveTabUrl: () => string | null;
   appearanceControls: AppearanceControls;
@@ -82,7 +81,7 @@ export function createSidepanelRunRuntime({
 
   const plannedSlidesRuntime = createPlannedSlidesRuntime({
     panelState,
-    dispatchPanelState,
+
     getActiveTabUrl,
     getLengthValue: appearanceControls.getLengthValue,
     updateSlidesTextState,
@@ -104,7 +103,7 @@ export function createSidepanelRunRuntime({
     isStreaming,
     maybeApplyPendingSlidesSummary,
     panelState,
-    dispatchPanelState,
+
     queueSlidesRender,
     rebuildSlideDescriptions,
     refreshSummaryMetrics: (summary) => {
@@ -138,14 +137,14 @@ export function createSidepanelRunRuntime({
   });
   const browserAiSnapshotRuntime = createBrowserAiSnapshotRuntime({
     panelState,
-    dispatchPanelState,
+
     browserAi: presentationRuntime.summary.browserAiRuntime,
     renderMarkdown,
   });
 
   const summaryRunRuntime = createSummaryRunRuntime({
     panelState,
-    dispatchPanelState,
+
     getActiveTabId,
     cancelAutoSummarize: autoSummarizeRuntime.cancel,
     summaryStream: {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/session-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/session-runtime.ts
@@ -4,7 +4,7 @@ import { createSidepanelChatRuntime } from "./chat-runtime";
 import type { SidepanelDom } from "./dom";
 import type { createMetricsController } from "./metrics-controller";
 import { createNavigationRuntime } from "./navigation-runtime";
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import { createPanelViewRuntime } from "./panel-view-runtime";
 import type { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import type { PanelState } from "./types";
@@ -23,14 +23,14 @@ type RunActions = {
 export function createSidepanelSessionRuntime({
   dom,
   panelState,
-  dispatchPanelState,
+
   metricsController,
   presentationRuntime,
   send,
 }: {
   dom: SidepanelDom;
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   metricsController: MetricsController;
   presentationRuntime: PresentationRuntime;
   send: (message: PanelToBg) => Promise<void>;
@@ -46,7 +46,7 @@ export function createSidepanelSessionRuntime({
   const navigationRuntime = createNavigationRuntime({
     getState: () => panelState.navigation,
     updateState: (value) => {
-      dispatchPanelState({ type: "navigation-policy-update", value });
+      patchPanelState(panelState, "navigation", value);
     },
   });
 
@@ -54,7 +54,7 @@ export function createSidepanelSessionRuntime({
   const getActiveTabUrl = () => panelState.navigation.activeTabUrl;
   const chatRuntime = createSidepanelChatRuntime({
     panelState,
-    dispatchPanelState,
+
     markdown,
     mainEl: dom.mainEl,
     renderEl: dom.renderEl,
@@ -84,7 +84,7 @@ export function createSidepanelSessionRuntime({
       metricsController.setActiveMode("chat");
     },
     setLastActionChat: () => {
-      dispatchPanelState({ type: "panel-session-update", value: { lastAction: "chat" } });
+      patchPanelState(panelState, "panelSession", { lastAction: "chat" });
     },
     renderInlineSlides: () => {
       renderInlineSlides(dom.chatMessagesEl);
@@ -105,7 +105,7 @@ export function createSidepanelSessionRuntime({
       navigationRuntime,
       getCurrentSource: () => panelState.currentSource,
       setCurrentSource: (source) => {
-        dispatchPanelState({ type: "source", source });
+        panelState.currentSource = source;
       },
       resetForNavigation: (preserveChat) => {
         setPhase("idle");
@@ -123,7 +123,7 @@ export function createSidepanelSessionRuntime({
   };
 
   const clearCurrentView = async () => {
-    dispatchPanelState({ type: "retained-slide-summary", value: null });
+    panelState.retainedSlideSummary = null;
     if (panelState.chat.streaming) {
       chatRuntime.requestAbort("Cleared");
     }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-run-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-run-runtime.ts
@@ -1,4 +1,4 @@
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState, setPendingSlidesRun } from "./panel-state-store";
 import { normalizePanelUrl } from "./session-policy";
 import { hasResolvedSlidesPayload } from "./slides-pending";
 import { resolveSlidesInputMode } from "./slides-session-state";
@@ -6,7 +6,7 @@ import type { PanelState, RunStart } from "./types";
 
 export function createSlidesRunRuntime(options: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   refreshSummarizeControl: () => void;
   hideSlideNotice: () => void;
   setSlidesBusy: (value: boolean) => void;
@@ -30,22 +30,11 @@ export function createSlidesRunRuntime(options: {
   shouldUseBrowserAiSlides: () => boolean;
   headerSetStatus: (text: string) => void;
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (options.dispatchPanelState) {
-      options.dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(options.panelState, action);
-    }
-  };
-
   const ensureVideoMode = () => {
     if (resolveSlidesInputMode(options.panelState.slidesSession) === "video") return;
-    dispatch({
-      type: "slides-session-update",
-      value: {
-        inputMode: "video",
-        inputModeOverride: "video",
-      },
+    patchPanelState(options.panelState, "slidesSession", {
+      inputMode: "video",
+      inputModeOverride: "video",
     });
     options.refreshSummarizeControl();
   };
@@ -68,10 +57,10 @@ export function createSlidesRunRuntime(options: {
   };
 
   const stopSlidesStream = () => {
-    dispatch({ type: "active-slides-run", value: null });
+    patchPanelState(options.panelState, "slidesLifecycle", { activeRun: null });
     options.stopSlidesHydrator();
     options.setSlidesBusy(false);
-    dispatch({ type: "slides-run", runId: null });
+    options.panelState.slidesRunId = null;
     stopSlidesSummaryStream();
   };
 
@@ -83,7 +72,7 @@ export function createSlidesRunRuntime(options: {
     ensureVideoMode();
     options.hideSlideNotice();
     options.setSlidesBusy(true);
-    dispatch({ type: "slides-run", runId });
+    options.panelState.slidesRunId = runId;
     options.schedulePanelCacheSync();
     options.startSlidesHydrator(runId, opts);
   };
@@ -104,7 +93,7 @@ export function createSlidesRunRuntime(options: {
         null,
       local: meta?.local ?? existing?.local ?? false,
     };
-    dispatch({ type: "active-slides-run", value: activeRun });
+    patchPanelState(options.panelState, "slidesLifecycle", { activeRun: activeRun });
     startSlidesStreamCore(runId, { local: activeRun.local });
   };
 
@@ -161,11 +150,7 @@ export function createSlidesRunRuntime(options: {
     local?: boolean;
   }) => {
     if (!value.url) return;
-    dispatch({
-      type: "pending-slides-run",
-      urlKey: normalizePanelUrl(value.url),
-      value,
-    });
+    setPendingSlidesRun(options.panelState, normalizePanelUrl(value.url), value);
   };
 
   const maybeStartPendingSlidesForUrl = (url: string | null) => {
@@ -176,7 +161,7 @@ export function createSlidesRunRuntime(options: {
     if (!options.panelState.slidesSession.slidesEnabled) return;
     if (resolveSlidesInputMode(options.panelState.slidesSession) !== "video") return;
     if (options.isSlidesHydratorStreaming()) return;
-    dispatch({ type: "pending-slides-run", urlKey: key, value: null });
+    setPendingSlidesRun(options.panelState, key, null);
     if (
       hasResolvedSlidesPayload(
         options.panelState.slides,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-runtime.ts
@@ -3,7 +3,6 @@ import {
   shouldUseBrowserAiForSlides,
 } from "./browser-ai-slides-runtime";
 import type { createBrowserAiSummaryRuntime } from "./browser-ai-summary-runtime";
-import type { PanelStateAction } from "./panel-state-store";
 import { createSlidesHydrator } from "./slides-hydrator";
 import { createSlidesRunRuntime } from "./slides-run-runtime";
 import { createSlidesSummaryController } from "./slides-summary-controller";
@@ -14,7 +13,7 @@ export function createSidepanelSlidesRuntime({
   browserAi,
   clearSummarySource,
   panelState,
-  dispatchPanelState,
+
   friendlyFetchError,
   getLengthValue,
   getToken,
@@ -40,7 +39,7 @@ export function createSidepanelSlidesRuntime({
   browserAi: ReturnType<typeof createBrowserAiSummaryRuntime>;
   clearSummarySource: () => void;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   friendlyFetchError: (error: unknown, fallback: string) => string;
   getLengthValue: () => string;
   getToken: () => Promise<string>;
@@ -68,7 +67,7 @@ export function createSidepanelSlidesRuntime({
 }) {
   const slidesSummaryController = createSlidesSummaryController({
     getToken,
-    dispatchPanelState,
+
     friendlyFetchError,
     panelUrlsMatch,
     getPanelState: () => panelState,
@@ -139,7 +138,7 @@ export function createSidepanelSlidesRuntime({
 
   const slidesRunRuntime = createSlidesRunRuntime({
     panelState,
-    dispatchPanelState,
+
     refreshSummarizeControl,
     hideSlideNotice,
     setSlidesBusy,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-summary-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-summary-controller.ts
@@ -1,5 +1,5 @@
 import { buildSlidePresentation } from "../../lib/slides-presentation";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { createInitialSlidesSummaryState, patchPanelState } from "./panel-state-store";
 import { resolveSlidesLengthArg } from "./slides-state";
 import { createStreamController } from "./stream-controller";
 import type { PanelState, RunStart, SlideSummarySource, UiState } from "./types";
@@ -13,7 +13,7 @@ type SlidesSummarySnapshot = {
 
 type SlidesSummaryControllerOptions = {
   getToken: () => Promise<string>;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   friendlyFetchError: (error: unknown, fallback: string) => string;
   panelUrlsMatch: (left: string | null | undefined, right: string | null | undefined) => boolean;
   getPanelState: () => PanelState;
@@ -36,16 +36,9 @@ type SlidesSummaryControllerOptions = {
 export function createSlidesSummaryController(options: SlidesSummaryControllerOptions) {
   let activeGeneration = 0;
 
-  const dispatch = (action: PanelStateAction) => {
-    if (options.dispatchPanelState) {
-      options.dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(options.getPanelState(), action);
-    }
-  };
   const getState = () => options.getPanelState().slidesSummary;
   const updateState = (value: Partial<PanelState["slidesSummary"]>) => {
-    dispatch({ type: "slides-summary-update", value });
+    patchPanelState(options.getPanelState(), "slidesSummary", value);
   };
   const isCurrentGeneration = (generation: number) => generation === activeGeneration;
 
@@ -215,7 +208,7 @@ export function createSlidesSummaryController(options: SlidesSummaryControllerOp
       activeGeneration += 1;
       streamController.abort();
       streamController = createGenerationStreamController(activeGeneration);
-      dispatch({ type: "slides-summary-reset" });
+      options.getPanelState().slidesSummary = createInitialSlidesSummaryState();
       options.clearSummarySource();
     },
     start(run: RunStart) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-text-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-text-controller.ts
@@ -1,7 +1,7 @@
 import { logExtensionEvent } from "../../lib/extension-logs";
 import type { SseSlidesData } from "../../lib/runtime-contracts";
 import { parseTranscriptTimedText } from "../../lib/slides-text";
-import type { PanelStateAction } from "./panel-state-store";
+import { createInitialSlidesTextState, patchPanelState } from "./panel-state-store";
 import {
   buildSlideDescriptions,
   deriveSlideSummaries,
@@ -12,7 +12,7 @@ import type { PanelState, SlideSummarySource } from "./types";
 
 export function createSlidesTextController(options: {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   getSlides: () => SseSlidesData["slides"] | null | undefined;
   getLengthValue: () => string;
   getSlidesOcrEnabled: () => boolean;
@@ -22,7 +22,7 @@ export function createSlidesTextController(options: {
   const getSlides = () => options.getSlides() ?? [];
   const getState = () => options.panelState.slidesText;
   const updateState = (value: Partial<PanelState["slidesText"]>) => {
-    options.dispatchPanelState({ type: "slides-text-update", value });
+    patchPanelState(options.panelState, "slidesText", value);
   };
 
   const rebuildDescriptions = () => {
@@ -71,7 +71,7 @@ export function createSlidesTextController(options: {
 
   return {
     reset() {
-      options.dispatchPanelState({ type: "slides-text-reset" });
+      options.panelState.slidesText = createInitialSlidesTextState();
       lastDescriptionLogKey = "";
     },
     clearSummarySource() {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime.ts
@@ -2,7 +2,7 @@ import { shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import type MarkdownIt from "markdown-it";
 import { logExtensionEvent } from "../../lib/extension-logs";
 import type { SseSlidesData } from "../../lib/runtime-contracts";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import { createSlideImageLoader, normalizeSlideImageUrl } from "./slide-images";
 import {
   normalizeSlidesPayload,
@@ -29,7 +29,7 @@ export function createSlidesViewRuntime({
   refreshSummarizeControl,
   hideSlideNotice,
   panelState,
-  dispatchPanelState,
+
   getFallbackSummaryMarkdown,
 }: {
   renderMarkdownHostEl: HTMLElement;
@@ -61,19 +61,13 @@ export function createSlidesViewRuntime({
   refreshSummarizeControl: () => void;
   hideSlideNotice: () => void;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   getFallbackSummaryMarkdown?: () => string | null;
 }) {
   const slideImageLoader = createSlideImageLoader();
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
+
   const updateSlidesSession = (value: Partial<PanelState["slidesSession"]>) => {
-    dispatch({ type: "slides-session-update", value });
+    patchPanelState(panelState, "slidesSession", value);
   };
   const resolveActiveSlidesRunId = () => {
     if (panelState.slidesRunId) return panelState.slidesRunId;
@@ -214,7 +208,7 @@ export function createSlidesViewRuntime({
   };
 
   const renderMarkdown = (markdown: string) => {
-    dispatch({ type: "summary", markdown });
+    panelState.summaryMarkdown = markdown;
     updateSlideSummaryFromMarkdown(markdown, {
       preserveIfEmpty: slidesTextController.hasSummaryTitles(),
       source: "summary",
@@ -238,7 +232,9 @@ export function createSlidesViewRuntime({
     if (!panelState.slides || panelState.slidesSession.slidesContextPending) return;
     const sourceUrl = panelState.slides.sourceUrl || panelState.currentSource?.url || null;
     if (sourceUrl && panelState.slidesSession.slidesContextUrl === sourceUrl) return;
-    dispatch({ type: "slides-context-request-next" });
+    patchPanelState(panelState, "slidesSession", {
+      slidesContextRequestId: panelState.slidesSession.slidesContextRequestId + 1,
+    });
     const requestId = `slides-${panelState.slidesSession.slidesContextRequestId}`;
     updateSlidesSession({
       slidesContextPending: true,
@@ -294,7 +290,7 @@ export function createSlidesViewRuntime({
       }
       return;
     }
-    dispatch({ type: "slides", slides: merged });
+    panelState.slides = merged;
     if (activeSlidesRunId) {
       updateSlidesSession({ slidesAppliedRunId: activeSlidesRunId });
     }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/state-effects-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/state-effects-runtime.ts
@@ -6,7 +6,7 @@ import type { createDaemonHintRuntime } from "./daemon-hint-runtime";
 import type { SidepanelDom } from "./dom";
 import type { PanelCachePayload } from "./panel-cache";
 import type { createPanelMessagingRuntime } from "./panel-messaging";
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import type { createSidepanelRunRuntime } from "./run-runtime";
 import type { createSidepanelSessionRuntime } from "./session-runtime";
@@ -27,7 +27,7 @@ type TypographyController = ReturnType<typeof createTypographyController>;
 export function createSidepanelStateEffectsRuntime({
   dom,
   panelState,
-  dispatchPanelState,
+
   appearanceControls,
   typographyController,
   panelMessagingRuntime,
@@ -39,7 +39,7 @@ export function createSidepanelStateEffectsRuntime({
 }: {
   dom: SidepanelDom;
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   appearanceControls: AppearanceControls;
   typographyController: TypographyController;
   panelMessagingRuntime: PanelMessagingRuntime;
@@ -89,7 +89,7 @@ export function createSidepanelStateEffectsRuntime({
 
   const uiStateRuntime = createUiStateRuntime({
     panelState,
-    dispatchPanelState,
+
     appearanceControls,
     typographyController,
     navigationRuntime,
@@ -142,7 +142,7 @@ export function createSidepanelStateEffectsRuntime({
 
   const bgMessageRuntime = createSidepanelBgMessageRuntime({
     panelState,
-    dispatchPanelState,
+
     applyUiState,
     setStatus: headerController.setStatus,
     isStreaming,
@@ -159,7 +159,7 @@ export function createSidepanelStateEffectsRuntime({
     handleSlidesLocal: handleLocalSlidesResponse,
     getSlidesContextRequestId: () => panelState.slidesSession.slidesContextRequestId,
     setSlidesContextPending: (value) => {
-      dispatchPanelState({ type: "slides-session-update", value: { slidesContextPending: value } });
+      patchPanelState(panelState, "slidesSession", { slidesContextPending: value });
     },
     setSlidesTranscriptTimedText,
     updateSlidesTextState,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime.ts
@@ -1,7 +1,7 @@
 import { daemonFetch } from "../../lib/daemon-fetch";
 import { getDaemonOrigin } from "../../lib/daemon-url";
 import type { Settings, SlidesLayout } from "../../lib/settings";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { SlideTextMode } from "./slides-state";
 import { resolveSlidesRenderLayout } from "./slides-view-policy";
 import type { PanelState } from "./types";
@@ -16,7 +16,7 @@ type SummarizeControlRuntimeOptions = {
   slidesLayoutEl: HTMLSelectElement;
   slidesTextController: SlidesTextControllerLike;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   patchSettings: (patch: Partial<Settings>) => Promise<void>;
   loadSettings: () => Promise<Pick<Settings, "slideRuntime" | "token">>;
   showSlideNotice: (message: string) => void;
@@ -68,13 +68,6 @@ async function fetchSlideTools(
 }
 
 export function createSummarizeControlRuntime(options: SummarizeControlRuntimeOptions) {
-  const dispatch = (action: PanelStateAction) => {
-    if (options.dispatchPanelState) {
-      options.dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(options.panelState, action);
-    }
-  };
   const getEffectiveMode = () =>
     options.panelState.slidesSession.inputModeOverride ??
     options.panelState.slidesSession.inputMode;
@@ -114,13 +107,10 @@ export function createSummarizeControlRuntime(options: SummarizeControlRuntimeOp
       options.stopSlidesStream();
     }
 
-    dispatch({
-      type: "slides-session-update",
-      value: {
-        inputMode: value.mode,
-        inputModeOverride: value.mode,
-        slidesEnabled: value.slides,
-      },
+    patchPanelState(options.panelState, "slidesSession", {
+      inputMode: value.mode,
+      inputModeOverride: value.mode,
+      slidesEnabled: value.slides,
     });
     await options.patchSettings({ slidesEnabled: value.slides });
 
@@ -166,10 +156,7 @@ export function createSummarizeControlRuntime(options: SummarizeControlRuntimeOp
 
   const setSlidesLayout = (next: SlidesLayout) => {
     if (next === options.panelState.slidesSession.slidesLayout) return;
-    dispatch({
-      type: "slides-session-update",
-      value: { slidesLayout: next },
-    });
+    patchPanelState(options.panelState, "slidesSession", { slidesLayout: next });
     options.slidesLayoutEl.value = next;
     applySlidesLayout();
   };

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summary-run-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summary-run-runtime.ts
@@ -1,5 +1,10 @@
 import type { BrowserAiSummaryInput } from "../../lib/panel-contracts";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import {
+  attachPanelRun,
+  patchPanelState,
+  restorePanelSession,
+  setPendingSummaryRun,
+} from "./panel-state-store";
 import { normalizePanelUrl, panelUrlsMatch } from "./session-policy";
 import { resolveSlidesInputMode } from "./slides-session-state";
 import type { PanelPhase, PanelState, RunStart } from "./types";
@@ -37,7 +42,7 @@ type SummaryViewPort = {
 
 export function createSummaryRunRuntime({
   panelState,
-  dispatchPanelState,
+
   getActiveTabId,
   cancelAutoSummarize,
   summaryStream,
@@ -47,7 +52,7 @@ export function createSummaryRunRuntime({
   browserAi,
 }: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   getActiveTabId: () => number | null;
   cancelAutoSummarize: () => void;
   summaryStream: SummaryStreamPort;
@@ -64,14 +69,6 @@ export function createSummaryRunRuntime({
     }) => void;
   };
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
-
   const attachRun = (run: RunStart) => {
     browserAi.cancel();
     const activeSlidesRun = panelState.slidesLifecycle.activeRun;
@@ -81,7 +78,7 @@ export function createSummaryRunRuntime({
     if (!preserveActiveLocalSlideRun) slides.stop();
 
     view.setPhase("connecting");
-    dispatch({ type: "panel-session-update", value: { lastAction: "summarize" } });
+    patchPanelState(panelState, "panelSession", { lastAction: "summarize" });
     cancelAutoSummarize();
     if (panelState.chat.streaming) chat.finishStreamingMessage();
 
@@ -106,8 +103,7 @@ export function createSummaryRunRuntime({
     view.setHeaderTitle(run.title || run.url || "Summarize");
     view.setHeaderSubtitle("");
     const fallbackModel = panelState.ui?.settings.model ?? null;
-    dispatch({
-      type: "attach-run",
+    attachPanelRun(panelState, {
       tabId: getActiveTabId(),
       runId: run.id,
       slidesRunId,
@@ -154,8 +150,7 @@ export function createSummaryRunRuntime({
     const slidesRunId =
       preservedSlides?.sourceId ??
       (preserveActiveSlideRun ? (activeSlidesRun?.runId ?? null) : null);
-    dispatch({
-      type: "restore-session",
+    restorePanelSession(panelState, {
       tabId: getActiveTabId(),
       runId: payload.run.id,
       slidesRunId,
@@ -181,11 +176,7 @@ export function createSummaryRunRuntime({
   };
 
   const rememberPendingRun = (run: RunStart) => {
-    dispatch({
-      type: "pending-summary-run",
-      urlKey: normalizePanelUrl(run.url),
-      value: { type: "run", run },
-    });
+    setPendingSummaryRun(panelState, normalizePanelUrl(run.url), { type: "run", run });
   };
 
   const rememberPendingSnapshot = (payload: {
@@ -193,15 +184,11 @@ export function createSummaryRunRuntime({
     markdown: string;
     browserAi?: BrowserAiSummaryInput;
   }) => {
-    dispatch({
-      type: "pending-summary-run",
-      urlKey: normalizePanelUrl(payload.run.url),
-      value: {
-        type: "snapshot",
-        run: payload.run,
-        markdown: payload.markdown,
-        browserAi: payload.browserAi,
-      },
+    setPendingSummaryRun(panelState, normalizePanelUrl(payload.run.url), {
+      type: "snapshot",
+      run: payload.run,
+      markdown: payload.markdown,
+      browserAi: payload.browserAi,
     });
   };
 
@@ -210,7 +197,7 @@ export function createSummaryRunRuntime({
     const key = normalizePanelUrl(url);
     const pending = panelState.pendingRuns.summaryByUrl[key];
     if (!pending || summaryStream.isStreaming()) return false;
-    dispatch({ type: "pending-summary-run", urlKey: key, value: null });
+    setPendingSummaryRun(panelState, key, null);
     if (pending.type === "snapshot") {
       applySnapshot({
         run: pending.run,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summary-stream-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summary-stream-runtime.ts
@@ -1,5 +1,4 @@
 import { buildIdleSubtitle } from "../../lib/header";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
 import { createStreamController } from "./stream-controller";
 import type { PanelPhase, PanelState } from "./types";
 
@@ -17,7 +16,7 @@ export function createSummaryStreamRuntime({
   isStreaming,
   maybeApplyPendingSlidesSummary,
   panelState,
-  dispatchPanelState,
+
   queueSlidesRender,
   rebuildSlideDescriptions,
   refreshSummaryMetrics,
@@ -44,7 +43,7 @@ export function createSummaryStreamRuntime({
   isStreaming: () => boolean;
   maybeApplyPendingSlidesSummary: () => void;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   queueSlidesRender: () => void;
   rebuildSlideDescriptions: () => void;
   refreshSummaryMetrics: (summary: string) => void;
@@ -58,13 +57,6 @@ export function createSummaryStreamRuntime({
   shouldRebuildSlideDescriptions: () => boolean;
   syncWithActiveTab: () => Promise<void>;
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
   let lastStreamError: string | null = null;
 
   return {
@@ -73,14 +65,11 @@ export function createSummaryStreamRuntime({
       onReset: () => {
         resetSummaryView({ clearRunId: false, stopSlides: false });
         const fallbackModel = getFallbackModel();
-        dispatch({
-          type: "meta",
-          meta: {
-            inputSummary: null,
-            model: fallbackModel,
-            modelLabel: fallbackModel,
-          },
-        });
+        panelState.lastMeta = {
+          inputSummary: null,
+          model: fallbackModel,
+          modelLabel: fallbackModel,
+        };
         lastStreamError = null;
         seedPlannedSlidesForPendingRun();
       },
@@ -110,20 +99,15 @@ export function createSummaryStreamRuntime({
         rememberUrl(url);
       },
       onMeta: (data) => {
-        dispatch({
-          type: "meta",
-          meta: {
-            model: typeof data.model === "string" ? data.model : panelState.lastMeta.model,
-            modelLabel:
-              typeof data.modelLabel === "string"
-                ? data.modelLabel
-                : panelState.lastMeta.modelLabel,
-            inputSummary:
-              typeof data.inputSummary === "string"
-                ? data.inputSummary
-                : panelState.lastMeta.inputSummary,
-          },
-        });
+        panelState.lastMeta = {
+          model: typeof data.model === "string" ? data.model : panelState.lastMeta.model,
+          modelLabel:
+            typeof data.modelLabel === "string" ? data.modelLabel : panelState.lastMeta.modelLabel,
+          inputSummary:
+            typeof data.inputSummary === "string"
+              ? data.inputSummary
+              : panelState.lastMeta.inputSummary,
+        };
         headerSetBaseSubtitle(
           buildIdleSubtitle({
             inputSummary: panelState.lastMeta.inputSummary,
@@ -135,7 +119,7 @@ export function createSummaryStreamRuntime({
       },
       onSlides: handleSlides,
       onSummaryFromCache: (value) => {
-        dispatch({ type: "summary-cache", value });
+        panelState.summaryFromCache = value;
         handleSummaryFromCache(value);
         schedulePanelCacheSync();
         if (value === true) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summary-view-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summary-view-runtime.ts
@@ -1,7 +1,7 @@
 import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import { buildIdleSubtitle } from "../../lib/header";
 import type { PanelCachePayload } from "./panel-cache";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState, resetPanelSummary, restorePanelSession } from "./panel-state-store";
 import { normalizeSlideImageUrl } from "./slide-images";
 import { normalizeSlidesPayload } from "./slides-payload";
 import { clearSummaryCopyButton } from "./summary-renderer";
@@ -31,7 +31,7 @@ type HeaderControllerLike = {
 
 type SummaryViewRuntimeOpts = {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   renderEl: HTMLElement;
   renderSlidesHostEl: HTMLElement;
   renderMarkdownHostEl: HTMLElement;
@@ -59,13 +59,6 @@ type SummaryViewRuntimeOpts = {
 };
 
 export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
-  const dispatch = (action: PanelStateAction) => {
-    if (opts.dispatchPanelState) {
-      opts.dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(opts.panelState, action);
-    }
-  };
   const resolveActiveSlidesRunId = () => {
     if (opts.panelState.slidesRunId) return opts.panelState.slidesRunId;
     if (opts.panelState.slides && opts.panelState.runId) return opts.panelState.runId;
@@ -83,20 +76,17 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
     opts.renderMarkdownHostEl.innerHTML = "";
     clearSummaryCopyButton(opts.summaryCopyBtn);
     opts.metricsController.clearForMode("summary");
-    dispatch({ type: "reset-summary", clearRunId, clearSlides: stopSlides });
-    dispatch({
-      type: "slides-session-update",
-      value: {
-        slidesExpanded: true,
-        ...(stopSlides
-          ? {
-              slidesContextPending: false,
-              slidesContextUrl: null,
-              slidesSeededSourceId: null,
-              slidesAppliedRunId: null,
-            }
-          : {}),
-      },
+    resetPanelSummary(opts.panelState, { clearRunId, clearSlides: stopSlides });
+    patchPanelState(opts.panelState, "slidesSession", {
+      slidesExpanded: true,
+      ...(stopSlides
+        ? {
+            slidesContextPending: false,
+            slidesContextUrl: null,
+            slidesSeededSourceId: null,
+            slidesAppliedRunId: null,
+          }
+        : {}),
     });
     if (stopSlides) {
       opts.slidesRenderer.clear();
@@ -112,8 +102,7 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
     const slidesRunId =
       payload.slidesRunId ??
       (opts.panelState.slidesSession.slidesParallel ? null : (payload.runId ?? null));
-    dispatch({
-      type: "restore-session",
+    restorePanelSession(opts.panelState, {
       tabId: payload.tabId,
       runId: payload.runId ?? null,
       slidesRunId,
@@ -125,20 +114,17 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
       },
       summaryFromCache: payload.summaryFromCache ?? null,
     });
-    dispatch({
-      type: "slides-summary-update",
-      value: {
-        markdown: payload.slidesSummaryMarkdown ?? "",
-        complete:
-          payload.slidesSummaryComplete ?? Boolean((payload.slidesSummaryMarkdown ?? "").trim()),
-        model:
-          payload.slidesSummaryModel ??
-          opts.panelState.lastMeta.model ??
-          opts.panelState.ui?.settings.model ??
-          null,
-        pending: null,
-        hadError: false,
-      },
+    patchPanelState(opts.panelState, "slidesSummary", {
+      markdown: payload.slidesSummaryMarkdown ?? "",
+      complete:
+        payload.slidesSummaryComplete ?? Boolean((payload.slidesSummaryMarkdown ?? "").trim()),
+      model:
+        payload.slidesSummaryModel ??
+        opts.panelState.lastMeta.model ??
+        opts.panelState.ui?.settings.model ??
+        null,
+      pending: null,
+      hadError: false,
     });
     opts.headerController.setBaseTitle(payload.title || payload.url || "Summarize");
     opts.headerController.setBaseSubtitle(
@@ -152,26 +138,16 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
     const normalizedSlides = normalizeSlidesPayload(payload.slides);
     const hasNormalizedSlides = Boolean(normalizedSlides && normalizedSlides.slides.length > 0);
     if (normalizedSlides && hasNormalizedSlides) {
-      dispatch({
-        type: "slides",
-        slides: {
-          ...normalizedSlides,
-          slides: normalizedSlides.slides.map((slide) => ({
-            ...slide,
-            imageUrl: normalizeSlideImageUrl(
-              slide.imageUrl,
-              normalizedSlides.sourceId,
-              slide.index,
-            ),
-          })),
-        },
-      });
-      dispatch({
-        type: "slides-session-update",
-        value: {
-          slidesContextPending: false,
-          slidesContextUrl: opts.slidesTextController.getTranscriptAvailable() ? payload.url : null,
-        },
+      opts.panelState.slides = {
+        ...normalizedSlides,
+        slides: normalizedSlides.slides.map((slide) => ({
+          ...slide,
+          imageUrl: normalizeSlideImageUrl(slide.imageUrl, normalizedSlides.sourceId, slide.index),
+        })),
+      };
+      patchPanelState(opts.panelState, "slidesSession", {
+        slidesContextPending: false,
+        slidesContextUrl: opts.slidesTextController.getTranscriptAvailable() ? payload.url : null,
       });
       opts.updateSlidesTextState();
       if (
@@ -181,19 +157,15 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
       ) {
         void opts.requestSlidesContext();
       }
-      dispatch({
-        type: "slides-session-update",
-        value: { slidesAppliedRunId: resolveActiveSlidesRunId() },
+      patchPanelState(opts.panelState, "slidesSession", {
+        slidesAppliedRunId: resolveActiveSlidesRunId(),
       });
     } else {
-      dispatch({ type: "slides", slides: null });
-      dispatch({
-        type: "slides-session-update",
-        value: {
-          slidesContextPending: false,
-          slidesContextUrl: null,
-          slidesAppliedRunId: null,
-        },
+      opts.panelState.slides = null;
+      patchPanelState(opts.panelState, "slidesSession", {
+        slidesContextPending: false,
+        slidesContextUrl: null,
+        slidesAppliedRunId: null,
       });
       opts.updateSlidesTextState();
       if (payload.summaryMarkdown && payload.url && isYouTubeVideoUrl(payload.url)) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/test-hooks-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/test-hooks-runtime.ts
@@ -1,7 +1,7 @@
 import type { BgToPanel, UiState } from "../../lib/panel-contracts";
 import type { SidepanelDom } from "./dom";
 import { isPanelChatAvailable } from "./panel-capabilities";
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import { selectRetainedSlideSummaryMarkdown } from "./retained-slide-summary";
 import type { createSidepanelRunRuntime } from "./run-runtime";
@@ -17,14 +17,14 @@ type StateEffectsRuntime = ReturnType<typeof createSidepanelStateEffectsRuntime>
 export function registerSidepanelRuntimeTestHooks({
   dom,
   panelState,
-  dispatchPanelState,
+
   presentationRuntime,
   runRuntime,
   stateEffectsRuntime,
 }: {
   dom: SidepanelDom;
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   presentationRuntime: PresentationRuntime;
   runRuntime: RunRuntime;
   stateEffectsRuntime: StateEffectsRuntime;
@@ -85,7 +85,7 @@ export function registerSidepanelRuntimeTestHooks({
     }),
     renderSlidesNow: slidesViewRuntime.queueSlidesRender,
     applyUiState: (state: UiState) => {
-      dispatchPanelState({ type: "ui", ui: state });
+      panelState.ui = state;
       stateEffectsRuntime.applyUiState(state);
     },
     applyBgMessage: (message: BgToPanel) => {
@@ -104,13 +104,10 @@ export function registerSidepanelRuntimeTestHooks({
       setPhase("idle");
     },
     forceRenderSlides: () => {
-      dispatchPanelState({
-        type: "slides-session-update",
-        value: {
-          slidesEnabled: true,
-          inputMode: "video",
-          inputModeOverride: "video",
-        },
+      patchPanelState(panelState, "slidesSession", {
+        slidesEnabled: true,
+        inputMode: "video",
+        inputModeOverride: "video",
       });
       return slidesViewRuntime.slidesRenderer.forceRender();
     },

--- a/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
@@ -1,7 +1,7 @@
 import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import type { PanelCachePayload } from "./panel-cache";
 import { isPanelChatAvailable } from "./panel-capabilities";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import {
   resolvePanelNavigationDecision,
   shouldIgnoreTransientPanelTabState,
@@ -43,7 +43,7 @@ type PanelCacheControllerLike = {
 
 type UiStateRuntimeOpts = {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   appearanceControls: AppearanceControlsLike;
   typographyController: TypographyControllerLike;
   navigationRuntime: NavigationRuntimeLike;
@@ -88,22 +88,10 @@ type UiStateRuntimeOpts = {
   onSlidesOcrChanged: () => void;
 };
 
-function dispatchPanelState(
-  opts: Pick<UiStateRuntimeOpts, "panelState" | "dispatchPanelState">,
-  action: PanelStateAction,
-) {
-  if (opts.dispatchPanelState) {
-    opts.dispatchPanelState(action);
-  } else {
-    applyPanelStateAction(opts.panelState, action);
-  }
-}
-
 function applyCachedOrReset(
   opts: Pick<
     UiStateRuntimeOpts,
     | "panelState"
-    | "dispatchPanelState"
     | "panelCacheController"
     | "applyPanelCache"
     | "requestSlidesCapture"
@@ -126,14 +114,14 @@ function applyCachedOrReset(
         opts.requestSlidesCapture();
       }
     } else {
-      dispatchPanelState(opts, { type: "source", source: null });
+      opts.panelState.currentSource = null;
       opts.resetSummaryView({ preserveChat });
       opts.panelCacheController.request(tabId, url, preserveChat);
     }
     return;
   }
 
-  dispatchPanelState(opts, { type: "source", source: null });
+  opts.panelState.currentSource = null;
   opts.resetSummaryView({ preserveChat });
 }
 
@@ -142,12 +130,9 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
     if (state.panelOpen && !opts.panelState.panelSession.lastPanelOpen) {
       opts.clearInlineError();
     }
-    dispatchPanelState(opts, {
-      type: "panel-session-update",
-      value: {
-        lastPanelOpen: state.panelOpen,
-        autoSummarize: state.settings.autoSummarize,
-      },
+    patchPanelState(opts.panelState, "panelSession", {
+      lastPanelOpen: state.panelOpen,
+      autoSummarize: state.settings.autoSummarize,
     });
     opts.appearanceControls.setAutoValue(state.settings.autoSummarize);
 
@@ -206,7 +191,10 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
         );
       }
       const previousTabId = activeTabId;
-      dispatchPanelState(opts, { type: "active-tab", tabId: nextTabId, url: nextTabUrl });
+      patchPanelState(opts.panelState, "navigation", {
+        activeTabId: nextTabId,
+        activeTabUrl: nextTabUrl,
+      });
       if (opts.panelState.chat.streaming && navigation.shouldAbortChatStream) {
         opts.requestAgentAbort("Tab changed");
       }
@@ -216,23 +204,17 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
         void opts.migrateChatHistory(previousTabId, nextTabId, nextTabUrl);
       }
       if (navigation.nextInputMode) {
-        dispatchPanelState(opts, {
-          type: "slides-session-update",
-          value: { inputMode: navigation.nextInputMode },
-        });
+        patchPanelState(opts.panelState, "slidesSession", { inputMode: navigation.nextInputMode });
       }
       if (navigation.resetInputModeOverride) {
-        dispatchPanelState(opts, {
-          type: "slides-session-update",
-          value: { inputModeOverride: null },
-        });
+        patchPanelState(opts.panelState, "slidesSession", { inputModeOverride: null });
       }
       opts.abortSummaryStream();
       if (!opts.maybeStartPendingSummaryRunForUrl(nextTabUrl)) {
         applyCachedOrReset(opts, nextTabId, nextTabUrl, navigation.preserveChat);
       }
     } else if (navigation.kind === "url") {
-      dispatchPanelState(opts, { type: "active-tab-url", url: nextTabUrl });
+      patchPanelState(opts.panelState, "navigation", { activeTabUrl: nextTabUrl });
       if (navigation.preserveChat) {
         opts.navigationRuntime.notePreserveChatForUrl(nextTabUrl);
       } else if (navigation.shouldClearChat) {
@@ -248,33 +230,24 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
         );
       }
       if (navigation.nextInputMode) {
-        dispatchPanelState(opts, {
-          type: "slides-session-update",
-          value: { inputMode: navigation.nextInputMode },
-        });
+        patchPanelState(opts.panelState, "slidesSession", { inputMode: navigation.nextInputMode });
       }
     }
 
-    dispatchPanelState(opts, {
-      type: "panel-session-update",
-      value: {
-        chatEnabled: state.settings.chatEnabled,
-        automationEnabled: state.settings.automationEnabled,
-        daemonFeaturesAvailable:
-          (state.settings.summaryRuntime === "direct" && state.settings.providerConfigured) ||
-          (state.settings.summaryRuntime === "daemon" && state.daemon.ok && state.daemon.authed),
-      },
+    patchPanelState(opts.panelState, "panelSession", {
+      chatEnabled: state.settings.chatEnabled,
+      automationEnabled: state.settings.automationEnabled,
+      daemonFeaturesAvailable:
+        (state.settings.summaryRuntime === "direct" && state.settings.providerConfigured) ||
+        (state.settings.summaryRuntime === "daemon" && state.daemon.ok && state.daemon.authed),
     });
     const nextSlidesOcrEnabled = Boolean(state.settings.slidesOcrEnabled);
     const slidesOcrChanged =
       nextSlidesOcrEnabled !== opts.panelState.slidesSession.slidesOcrEnabled;
-    dispatchPanelState(opts, {
-      type: "slides-session-update",
-      value: {
-        slidesEnabled: state.settings.slidesEnabled,
-        slidesParallel: state.settings.slidesParallel,
-        ...(slidesOcrChanged ? { slidesOcrEnabled: nextSlidesOcrEnabled } : {}),
-      },
+    patchPanelState(opts.panelState, "slidesSession", {
+      slidesEnabled: state.settings.slidesEnabled,
+      slidesParallel: state.settings.slidesParallel,
+      ...(slidesOcrChanged ? { slidesOcrEnabled: nextSlidesOcrEnabled } : {}),
     });
     if (slidesOcrChanged) {
       opts.onSlidesOcrChanged();
@@ -285,22 +258,16 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
       fallbackModel &&
       (!opts.panelState.lastMeta.model || !opts.panelState.lastMeta.model.trim())
     ) {
-      dispatchPanelState(opts, {
-        type: "meta",
-        meta: {
-          ...opts.panelState.lastMeta,
-          model: fallbackModel,
-          modelLabel: fallbackModel,
-        },
-      });
+      opts.panelState.lastMeta = {
+        ...opts.panelState.lastMeta,
+        model: fallbackModel,
+        modelLabel: fallbackModel,
+      };
     }
     if (opts.panelState.slidesSession.slidesEnabled && nextMediaAvailable) {
-      dispatchPanelState(opts, {
-        type: "slides-session-update",
-        value: {
-          inputMode: "video",
-          inputModeOverride: "video",
-        },
+      patchPanelState(opts.panelState, "slidesSession", {
+        inputMode: "video",
+        inputModeOverride: "video",
       });
     }
     if (state.settings.slidesLayout && state.settings.slidesLayout !== slidesLayoutValue) {
@@ -363,28 +330,22 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
         if (preserveChat) {
           opts.navigationRuntime.notePreserveChatForUrl(nextTabUrl);
         }
-        dispatchPanelState(opts, { type: "source", source: null });
+        opts.panelState.currentSource = null;
         if (opts.isStreaming()) {
           opts.abortSummaryStream();
         }
         opts.resetSummaryView({ preserveChat });
       } else if (nextTabTitle && nextTabTitle !== opts.panelState.currentSource.title) {
-        dispatchPanelState(opts, {
-          type: "source",
-          source: {
-            ...opts.panelState.currentSource,
-            title: nextTabTitle,
-          },
-        });
+        opts.panelState.currentSource = {
+          ...opts.panelState.currentSource,
+          title: nextTabTitle,
+        };
         opts.headerController.setBaseTitle(nextTabTitle);
       }
     }
     if (!opts.panelState.currentSource) {
       if (!ignoreTransientTabState) {
-        dispatchPanelState(opts, {
-          type: "meta",
-          meta: { inputSummary: null, model: null, modelLabel: null },
-        });
+        opts.panelState.lastMeta = { inputSummary: null, model: null, modelLabel: null };
         opts.headerController.setBaseTitle(nextTabTitle || nextTabUrl || "Summarize");
         opts.headerController.setBaseSubtitle("");
       }
@@ -393,22 +354,16 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
       opts.headerController.setStatus(state.status);
     }
     if (!nextMediaAvailable && hasMediaInfo) {
-      dispatchPanelState(opts, {
-        type: "slides-session-update",
-        value: {
-          inputMode: "page",
-          inputModeOverride: null,
-        },
+      patchPanelState(opts.panelState, "slidesSession", {
+        inputMode: "page",
+        inputModeOverride: null,
       });
     }
-    dispatchPanelState(opts, {
-      type: "slides-session-update",
-      value: {
-        mediaAvailable: nextMediaAvailable,
-        summarizeVideoLabel: nextVideoLabel,
-        summarizePageWords: state.stats.pageWords,
-        summarizeVideoDurationSeconds: state.stats.videoDurationSeconds,
-      },
+    patchPanelState(opts.panelState, "slidesSession", {
+      mediaAvailable: nextMediaAvailable,
+      summarizeVideoLabel: nextVideoLabel,
+      summarizePageWords: state.stats.pageWords,
+      summarizeVideoDurationSeconds: state.stats.videoDurationSeconds,
     });
     opts.maybeSeedPlannedSlidesForPendingRun();
     opts.refreshSummarizeControl();

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -90,6 +90,8 @@ Dev (repo checkout):
 
 ## Architecture
 
+The sidepanel owns one plain `PanelState` object. Simple fields update directly; phase, run attachment, restoration, and reset use named transitions in `panel-state-store.ts`. Nested-slice updates replace the slice so previously captured navigation/chat/slide snapshots remain unchanged. There is no secondary action bus or optional dispatch path.
+
 - **Extension (MV3, WXT)**
   - Side Panel UI: length + typography controls (font family + size), auto/manual toggle.
   - Background service worker: tab + navigation tracking, content extraction, starts summarize runs.

--- a/tests/sidepanel.bootstrap-runtime.test.ts
+++ b/tests/sidepanel.bootstrap-runtime.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 const bindingSpies = vi.hoisted(() => ({
   bindSettingsStorage: vi.fn(),
@@ -11,10 +12,6 @@ vi.mock("../apps/chrome-extension/src/entrypoints/sidepanel/bindings", () => ({
 }));
 
 import { bootstrapSidepanel } from "../apps/chrome-extension/src/entrypoints/sidepanel/bootstrap-runtime";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 describe("sidepanel bootstrap runtime", () => {
   beforeEach(() => {
@@ -31,7 +28,7 @@ describe("sidepanel bootstrap runtime", () => {
     const calls: string[] = [];
     const initialState = createInitialPanelState();
     initialState.panelSession.pendingSettingsSnapshot = { chatEnabled: true };
-    const panelStateStore = createPanelStateStore(initialState);
+    const panelStateStore = initialState;
     const loadedSettings = {
       autoSummarize: true,
       chatEnabled: false,
@@ -49,8 +46,8 @@ describe("sidepanel bootstrap runtime", () => {
         calls.push("ensure");
       },
       loadSettings: async () => loadedSettings,
-      panelState: panelStateStore.state,
-      dispatchPanelState: panelStateStore.dispatch,
+      panelState: panelStateStore,
+
       typographyController: {
         setCurrentFontSize: (value) => calls.push(`font:${value}`),
         setCurrentLineHeight: (value) => calls.push(`line:${value}`),
@@ -84,19 +81,19 @@ describe("sidepanel bootstrap runtime", () => {
     expect(calls).toContain("model-disabled:true");
     expect(calls).toContain("ready");
     expect(calls).toContain("ping");
-    expect(panelStateStore.state.panelSession).toMatchObject({
+    expect(panelStateStore.panelSession).toMatchObject({
       autoSummarize: true,
       chatEnabled: true,
       automationEnabled: false,
       settingsHydrated: true,
       pendingSettingsSnapshot: null,
     });
-    expect(panelStateStore.state.slidesSession.slidesLayout).toBe("gallery");
+    expect(panelStateStore.slidesSession.slidesLayout).toBe("gallery");
   });
 
   it("uses loaded settings directly when there is no pending snapshot", async () => {
     const calls: string[] = [];
-    const panelStateStore = createPanelStateStore();
+    const panelStateStore = createInitialPanelState();
 
     bootstrapSidepanel({
       ensurePanelPort: async () => {
@@ -113,8 +110,8 @@ describe("sidepanel bootstrap runtime", () => {
         model: "openai/gpt-5.4",
         token: "abc123",
       }),
-      panelState: panelStateStore.state,
-      dispatchPanelState: panelStateStore.dispatch,
+      panelState: panelStateStore,
+
       typographyController: {
         setCurrentFontSize: (value) => calls.push(`font:${value}`),
         setCurrentLineHeight: (value) => calls.push(`line:${value}`),
@@ -144,13 +141,13 @@ describe("sidepanel bootstrap runtime", () => {
 
     expect(calls).not.toContain("hide-automation");
     expect(calls).toContain("model-disabled:false");
-    expect(panelStateStore.state.panelSession).toMatchObject({
+    expect(panelStateStore.panelSession).toMatchObject({
       autoSummarize: false,
       chatEnabled: true,
       automationEnabled: true,
       settingsHydrated: true,
       pendingSettingsSnapshot: null,
     });
-    expect(panelStateStore.state.slidesSession.slidesLayout).toBe("strip");
+    expect(panelStateStore.slidesSession.slidesLayout).toBe("strip");
   });
 });

--- a/tests/sidepanel.browser-ai-snapshot-runtime.test.ts
+++ b/tests/sidepanel.browser-ai-snapshot-runtime.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createBrowserAiSnapshotRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime";
-import {
-  applyPanelStateAction,
-  createInitialPanelState,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 describe("sidepanel browser AI snapshot runtime", () => {
   it("upgrades the current extractive snapshot and records Gemini Nano metadata", async () => {
@@ -13,7 +10,7 @@ describe("sidepanel browser AI snapshot runtime", () => {
     const renderMarkdown = vi.fn();
     const runtime = createBrowserAiSnapshotRuntime({
       panelState,
-      dispatchPanelState: (action) => applyPanelStateAction(panelState, action),
+
       browserAi: {
         cancel: vi.fn(),
         summarize: vi.fn(async () => "- First point\n- Second point"),
@@ -55,7 +52,7 @@ describe("sidepanel browser AI snapshot runtime", () => {
     const renderMarkdown = vi.fn();
     const runtime = createBrowserAiSnapshotRuntime({
       panelState,
-      dispatchPanelState: (action) => applyPanelStateAction(panelState, action),
+
       browserAi: {
         cancel: vi.fn(),
         summarize: vi.fn(async () => await summaryPromise),

--- a/tests/sidepanel.chat-controller.test.ts
+++ b/tests/sidepanel.chat-controller.test.ts
@@ -1,22 +1,17 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatController } from "../apps/chrome-extension/src/entrypoints/sidepanel/chat-controller";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { ChatMessage } from "../apps/chrome-extension/src/entrypoints/sidepanel/types";
 
-function createHarness(options: { injectedDispatch?: boolean } = {}) {
+function createHarness() {
   const panelState = createInitialPanelState();
-  const store = createPanelStateStore(panelState);
   const messagesEl = document.createElement("div");
   const inputEl = document.createElement("textarea");
   const sendBtn = document.createElement("button");
   const contextEl = document.createElement("div");
   const scrollToBottom = vi.fn();
   const onNewContent = vi.fn();
-  const dispatchPanelState = vi.fn(store.dispatch);
   const controller = new ChatController({
     messagesEl,
     inputEl,
@@ -28,14 +23,14 @@ function createHarness(options: { injectedDispatch?: boolean } = {}) {
     } as never,
     limits: { maxMessages: 10, maxChars: 10 },
     panelState,
-    dispatchPanelState: options.injectedDispatch ? dispatchPanelState : undefined,
+
     scrollToBottom,
     onNewContent,
   });
   return {
     contextEl,
     controller,
-    dispatchPanelState,
+
     inputEl,
     messagesEl,
     onNewContent,
@@ -74,7 +69,7 @@ describe("sidepanel chat controller", () => {
   });
 
   it("sets, replaces, appends missing replacements, and removes canonical messages", () => {
-    const harness = createHarness({ injectedDispatch: true });
+    const harness = createHarness();
     const user = userMessage();
     const assistant = assistantMessage();
 
@@ -86,7 +81,6 @@ describe("sidepanel chat controller", () => {
 
     expect(harness.panelState.chat.messages).toEqual([assistantMessage("assistant-1", "Updated")]);
     expect(harness.messagesEl.textContent).toContain("Updated");
-    expect(harness.dispatchPanelState).toHaveBeenCalled();
     expect(harness.onNewContent).toHaveBeenCalledOnce();
     expect(harness.scrollToBottom).toHaveBeenCalledOnce();
   });

--- a/tests/sidepanel.chat-runtime.test.ts
+++ b/tests/sidepanel.chat-runtime.test.ts
@@ -1,11 +1,10 @@
-// @vitest-environment happy-dom
-
 import type { Message } from "@earendil-works/pi-ai";
+// @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSidepanelChatRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime";
 import {
   createInitialPanelState,
-  createPanelStateStore,
+  patchPanelState,
 } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 const agentLoopMock = vi.hoisted(() => ({
@@ -38,13 +37,13 @@ function setScrollMetrics(element: HTMLElement) {
 }
 
 function createHarness(options: { chatEnabled?: boolean } = {}) {
-  const store = createPanelStateStore(createInitialPanelState());
-  store.state.panelSession.chatEnabled = options.chatEnabled ?? true;
-  store.state.panelSession.automationEnabled = true;
-  store.state.panelSession.daemonFeaturesAvailable = true;
-  store.state.navigation.activeTabId = 7;
-  store.state.navigation.activeTabUrl = "https://example.com/current";
-  store.state.summaryMarkdown = "Current summary";
+  const store = createInitialPanelState();
+  store.panelSession.chatEnabled = options.chatEnabled ?? true;
+  store.panelSession.automationEnabled = true;
+  store.panelSession.daemonFeaturesAvailable = true;
+  store.navigation.activeTabId = 7;
+  store.navigation.activeTabUrl = "https://example.com/current";
+  store.summaryMarkdown = "Current summary";
 
   const mainEl = document.createElement("main");
   setScrollMetrics(mainEl);
@@ -125,8 +124,8 @@ function createHarness(options: { chatEnabled?: boolean } = {}) {
     markAgentNavigationResult: vi.fn(),
   };
   const runtime = createSidepanelChatRuntime({
-    panelState: store.state,
-    dispatchPanelState: store.dispatch,
+    panelState: store,
+
     markdown: { render: (value: string) => value } as never,
     mainEl,
     renderEl,
@@ -142,8 +141,8 @@ function createHarness(options: { chatEnabled?: boolean } = {}) {
     automationNoticeEl,
     automationNoticeMessageEl,
     automationNoticeTitleEl,
-    getActiveTabId: () => store.state.navigation.activeTabId,
-    getActiveTabUrl: () => store.state.navigation.activeTabUrl,
+    getActiveTabId: () => store.navigation.activeTabId,
+    getActiveTabUrl: () => store.navigation.activeTabUrl,
     navigationRuntime,
     send,
     setStatus,
@@ -193,9 +192,9 @@ describe("sidepanel chat runtime", () => {
     harness.runtime.startMessage("  hello  ");
 
     await vi.waitFor(() => expect(agentLoopMock.run).toHaveBeenCalledOnce());
-    await vi.waitFor(() => expect(harness.store.state.chat.streaming).toBe(false));
+    await vi.waitFor(() => expect(harness.store.chat.streaming).toBe(false));
 
-    expect(harness.store.state.chat.messages).toMatchObject([{ role: "user", content: "hello" }]);
+    expect(harness.store.chat.messages).toMatchObject([{ role: "user", content: "hello" }]);
     expect(harness.clearErrors).toHaveBeenCalledOnce();
     expect(harness.setChatMetricsMode).toHaveBeenCalledOnce();
     expect(harness.setLastActionChat).toHaveBeenCalledOnce();
@@ -213,20 +212,20 @@ describe("sidepanel chat runtime", () => {
 
   it("queues normalized messages while streaming and drains them afterward", async () => {
     const harness = createHarness();
-    harness.store.dispatch({ type: "chat-streaming", value: true });
+    patchPanelState(harness.store, "chat", { streaming: true });
 
     expect(harness.runtime.enqueueMessage("  queued \n message  ")).toBe(true);
     harness.runtime.maybeSendQueuedMessage();
     expect(harness.runtime.getQueueLength()).toBe(1);
-    expect(harness.store.state.chat.queue).toMatchObject([{ text: "queued message" }]);
+    expect(harness.store.chat.queue).toMatchObject([{ text: "queued message" }]);
 
-    harness.store.dispatch({ type: "chat-streaming", value: false });
+    patchPanelState(harness.store, "chat", { streaming: false });
     harness.runtime.maybeSendQueuedMessage();
 
     await vi.waitFor(() => expect(harness.runtime.getQueueLength()).toBe(0));
-    expect(harness.store.state.chat.queue).toEqual([]);
-    await vi.waitFor(() => expect(harness.store.state.chat.streaming).toBe(false));
-    expect(harness.store.state.chat.messages).toMatchObject([
+    expect(harness.store.chat.queue).toEqual([]);
+    await vi.waitFor(() => expect(harness.store.chat.streaming).toBe(false));
+    expect(harness.store.chat.messages).toMatchObject([
       { role: "user", content: "queued message" },
     ]);
     expect(harness.chatQueueEl.classList.contains("isHidden")).toBe(true);
@@ -252,9 +251,7 @@ describe("sidepanel chat runtime", () => {
     });
     await restore;
 
-    expect(harness.store.state.chat.messages).toMatchObject([
-      { role: "user", content: "restored" },
-    ]);
+    expect(harness.store.chat.messages).toMatchObject([{ role: "user", content: "restored" }]);
     expect(harness.storage.set).toHaveBeenCalled();
   });
 
@@ -298,9 +295,11 @@ describe("sidepanel chat runtime", () => {
 
   it("migrates non-empty history to the destination tab URL", async () => {
     const harness = createHarness();
-    harness.store.dispatch({
-      type: "chat-message-add",
-      message: { id: "1", role: "user", content: "keep", timestamp: 1 },
+    patchPanelState(harness.store, "chat", {
+      messages: [
+        ...harness.store.chat.messages,
+        { id: "1", role: "user", content: "keep", timestamp: 1 },
+      ],
     });
 
     await harness.runtime.migrateHistory(7, 8, "https://example.com/next");
@@ -333,10 +332,10 @@ describe("sidepanel chat runtime", () => {
     expect(harness.seekToTimestamp).toHaveBeenCalledWith(42);
 
     harness.runtime.startMessage("temporary");
-    await vi.waitFor(() => expect(harness.store.state.chat.messages.length).toBe(1));
-    harness.store.state.panelSession.chatEnabled = false;
+    await vi.waitFor(() => expect(harness.store.chat.messages.length).toBe(1));
+    harness.store.panelSession.chatEnabled = false;
     harness.runtime.applyEnabled();
-    expect(harness.store.state.chat.messages).toEqual([]);
+    expect(harness.store.chat.messages).toEqual([]);
     expect(harness.chatContainerEl.hasAttribute("hidden")).toBe(true);
     expect(harness.clearChatMetrics).toHaveBeenCalledOnce();
 

--- a/tests/sidepanel.feedback-runtime.test.ts
+++ b/tests/sidepanel.feedback-runtime.test.ts
@@ -1,15 +1,11 @@
-// @vitest-environment happy-dom
-
 import { beforeEach, describe, expect, it, vi } from "vitest";
+// @vitest-environment happy-dom
 import { createSidepanelFeedbackRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/feedback-runtime";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createPanelPhaseRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/phase-runtime";
 
 function createHarness(options: { storageThrows?: boolean } = {}) {
-  const store = createPanelStateStore(createInitialPanelState());
+  const store = createInitialPanelState();
   const headerEl = document.createElement("header");
   headerEl.getBoundingClientRect = () => ({ height: 64 }) as DOMRect;
   const titleEl = document.createElement("div");
@@ -56,7 +52,7 @@ function createHarness(options: { storageThrows?: boolean } = {}) {
       : vi.fn(),
   };
   const runtime = createSidepanelFeedbackRuntime({
-    panelState: store.state,
+    panelState: store,
     headerEl,
     titleEl,
     subtitleEl,
@@ -83,8 +79,8 @@ function createHarness(options: { storageThrows?: boolean } = {}) {
   });
   runtime.bindActions({ retryLastAction, retrySlidesStream });
   const phaseRuntime = createPanelPhaseRuntime({
-    panelState: store.state,
-    dispatchPanelState: store.dispatch,
+    panelState: store,
+
     errorController: runtime.errorController,
     headerController: runtime.headerController,
     setSlidesBusy,
@@ -153,21 +149,21 @@ describe("sidepanel feedback runtime", () => {
     const harness = createHarness();
 
     harness.phaseRuntime.setPhase("connecting");
-    expect(harness.store.state.phase).toBe("connecting");
+    expect(harness.store.phase).toBe("connecting");
     expect(harness.setSlidesBusy).not.toHaveBeenCalled();
 
     harness.phaseRuntime.setPhase("idle");
     expect(harness.setSlidesBusy).toHaveBeenCalledWith(false);
     expect(harness.rebuildSlideDescriptions).not.toHaveBeenCalled();
 
-    harness.store.state.slides = { slides: [] } as never;
+    harness.store.slides = { slides: [] } as never;
     harness.phaseRuntime.setPhase("streaming");
     harness.phaseRuntime.setPhase("idle");
     expect(harness.rebuildSlideDescriptions).toHaveBeenCalledOnce();
     expect(harness.queueSlidesRender).toHaveBeenCalledOnce();
 
     harness.phaseRuntime.setPhase("error", { error: "Failure" });
-    expect(harness.store.state.error).toBe("Failure");
+    expect(harness.store.error).toBe("Failure");
     expect(harness.panelErrorMessageEl.textContent).toBe("Failure");
     expect(harness.panelErrorEl.classList.contains("hidden")).toBe(false);
     expect(harness.setSlidesBusy).toHaveBeenLastCalledWith(false);
@@ -214,20 +210,20 @@ describe("sidepanel feedback runtime", () => {
         message: "fallback",
       }),
     );
-    expect(harness.store.state.phase).toBe("error");
-    expect(harness.store.state.error).toContain("window failure");
+    expect(harness.store.phase).toBe("error");
+    expect(harness.store.error).toContain("window failure");
     expect(harness.panelErrorMessageEl.textContent).toContain("window failure");
 
     errorListener?.(new ErrorEvent("error", { message: "message-only failure" }));
-    expect(harness.store.state.error).toBe("message-only failure");
+    expect(harness.store.error).toBe("message-only failure");
 
     rejectionListener?.({
       reason: new Error("promise failure"),
     } as PromiseRejectionEvent);
-    expect(harness.store.state.error).toContain("promise failure");
+    expect(harness.store.error).toContain("promise failure");
 
     rejectionListener?.({ reason: "rejected" } as PromiseRejectionEvent);
-    expect(harness.store.state.error).toBe("rejected");
+    expect(harness.store.error).toBe("rejected");
     expect(harness.panelErrorMessageEl.textContent).toBe("rejected");
   });
 });

--- a/tests/sidepanel.navigation-runtime.test.ts
+++ b/tests/sidepanel.navigation-runtime.test.ts
@@ -4,14 +4,17 @@ import {
   type PanelSource,
 } from "../apps/chrome-extension/src/entrypoints/sidepanel/active-tab-sync.js";
 import { createNavigationRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/navigation-runtime.js";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store.js";
+import {
+  createInitialPanelState,
+  patchPanelState,
+} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 function createRuntime(options: { ttlMs?: number } = {}) {
-  const store = createPanelStateStore();
+  const store = createInitialPanelState();
   return createNavigationRuntime({
-    getState: () => store.state.navigation,
+    getState: () => store.navigation,
     updateState: (value) => {
-      store.dispatch({ type: "navigation-policy-update", value });
+      patchPanelState(store, "navigation", value);
     },
     ...options,
   });

--- a/tests/sidepanel.panel-messaging.test.ts
+++ b/tests/sidepanel.panel-messaging.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPanelMessagingRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-messaging";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { SseSlidesData } from "../apps/chrome-extension/src/lib/runtime-contracts";
 
 describe("sidepanel panel messaging runtime", () => {
@@ -12,11 +9,11 @@ describe("sidepanel panel messaging runtime", () => {
   });
 
   it("tracks user actions only for normal sends", async () => {
-    const panelStateStore = createPanelStateStore();
+    const panelStateStore = createInitialPanelState();
     const send = vi.fn(async () => {});
     const runtime = createPanelMessagingRuntime({
-      panelState: panelStateStore.state,
-      dispatchPanelState: panelStateStore.dispatch,
+      panelState: panelStateStore,
+
       onMessage: vi.fn(),
       portRuntime: {
         ensure: async () => null,
@@ -25,7 +22,7 @@ describe("sidepanel panel messaging runtime", () => {
     });
 
     await runtime.send({ type: "panel:summarize", refresh: true });
-    expect(panelStateStore.state.panelSession.lastAction).toBe("summarize");
+    expect(panelStateStore.panelSession.lastAction).toBe("summarize");
 
     await runtime.sendRaw({
       type: "panel:agent",
@@ -33,7 +30,7 @@ describe("sidepanel panel messaging runtime", () => {
       messages: [],
       tools: [],
     });
-    expect(panelStateStore.state.panelSession.lastAction).toBe("summarize");
+    expect(panelStateStore.panelSession.lastAction).toBe("summarize");
     expect(send).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/sidepanel.panel-state-store.test.ts
+++ b/tests/sidepanel.panel-state-store.test.ts
@@ -1,27 +1,32 @@
 import { describe, expect, it } from "vitest";
 import {
-  createPanelStateStore,
-  reducePanelState,
+  attachPanelRun,
+  createInitialPanelState,
+  createInitialSlidesSummaryState,
+  createInitialSlidesTextState,
+  patchPanelState,
+  setPanelPhase,
+  replacePanelChatMessage,
+  resetPanelSummary,
+  restorePanelSession,
+  setPendingSlidesRun,
+  setPendingSummaryRun,
 } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 describe("sidepanel panel state store", () => {
   it("updates active tab identity as one navigation transition", () => {
-    const store = createPanelStateStore();
-    store.dispatch({
-      type: "active-tab",
-      tabId: 42,
-      url: "https://example.com",
-    });
+    const store = createInitialPanelState();
+    patchPanelState(store, "navigation", { activeTabId: 42, activeTabUrl: "https://example.com" });
 
-    expect(store.state.navigation).toEqual({
+    expect(store.navigation).toEqual({
       activeTabId: 42,
       activeTabUrl: "https://example.com",
       lastAgentNavigation: null,
       pendingPreserveChatForUrl: null,
     });
 
-    store.dispatch({ type: "active-tab-url", url: "https://example.com/next" });
-    expect(store.state.navigation).toEqual({
+    patchPanelState(store, "navigation", { activeTabUrl: "https://example.com/next" });
+    expect(store.navigation).toEqual({
       activeTabId: 42,
       activeTabUrl: "https://example.com/next",
       lastAgentNavigation: null,
@@ -30,24 +35,21 @@ describe("sidepanel panel state store", () => {
   });
 
   it("owns navigation policy markers without losing active tab identity", () => {
-    const store = createPanelStateStore();
-    store.dispatch({ type: "active-tab", tabId: 42, url: "https://example.com" });
-    store.dispatch({
-      type: "navigation-policy-update",
-      value: {
-        lastAgentNavigation: {
-          url: "https://example.com/next",
-          tabId: 43,
-          at: 100,
-        },
-        pendingPreserveChatForUrl: {
-          url: "https://example.com/next",
-          at: 101,
-        },
+    const store = createInitialPanelState();
+    patchPanelState(store, "navigation", { activeTabId: 42, activeTabUrl: "https://example.com" });
+    patchPanelState(store, "navigation", {
+      lastAgentNavigation: {
+        url: "https://example.com/next",
+        tabId: 43,
+        at: 100,
+      },
+      pendingPreserveChatForUrl: {
+        url: "https://example.com/next",
+        at: 101,
       },
     });
 
-    expect(store.state.navigation).toEqual({
+    expect(store.navigation).toEqual({
       activeTabId: 42,
       activeTabUrl: "https://example.com",
       lastAgentNavigation: {
@@ -61,14 +63,16 @@ describe("sidepanel panel state store", () => {
       },
     });
 
-    store.dispatch({ type: "active-tab", tabId: 44, url: "https://example.com/final" });
-    expect(store.state.navigation.lastAgentNavigation?.tabId).toBe(43);
+    patchPanelState(store, "navigation", {
+      activeTabId: 44,
+      activeTabUrl: "https://example.com/final",
+    });
+    expect(store.navigation.lastAgentNavigation?.tabId).toBe(43);
   });
 
   it("attaches runs as one transition", () => {
-    const store = createPanelStateStore();
-    store.dispatch({
-      type: "attach-run",
+    const store = createInitialPanelState();
+    attachPanelRun(store, {
       tabId: 42,
       runId: "run-1",
       slidesRunId: "run-1",
@@ -77,7 +81,7 @@ describe("sidepanel panel state store", () => {
       meta: { inputSummary: null, model: "auto", modelLabel: "auto" },
     });
 
-    expect(store.state).toMatchObject({
+    expect(store).toMatchObject({
       runId: "run-1",
       activeRun: { tabId: 42 },
       slidesRunId: "run-1",
@@ -88,7 +92,7 @@ describe("sidepanel panel state store", () => {
   });
 
   it("queues and consumes deferred runs by normalized URL key", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const urlKey = "https://example.com/video";
     const run = {
       id: "run-1",
@@ -98,31 +102,23 @@ describe("sidepanel panel state store", () => {
       reason: "tab-activated",
     } as const;
 
-    store.dispatch({
-      type: "pending-summary-run",
-      urlKey,
-      value: { type: "run", run },
-    });
-    store.dispatch({
-      type: "pending-slides-run",
-      urlKey,
-      value: { runId: "slides-1", url: urlKey, local: true },
-    });
+    setPendingSummaryRun(store, urlKey, { type: "run", run });
+    setPendingSlidesRun(store, urlKey, { runId: "slides-1", url: urlKey, local: true });
 
-    expect(store.state.pendingRuns).toEqual({
+    expect(store.pendingRuns).toEqual({
       summaryByUrl: { [urlKey]: { type: "run", run } },
       slidesByUrl: {
         [urlKey]: { runId: "slides-1", url: urlKey, local: true },
       },
     });
 
-    store.dispatch({ type: "pending-summary-run", urlKey, value: null });
-    store.dispatch({ type: "pending-slides-run", urlKey, value: null });
-    expect(store.state.pendingRuns).toEqual({ summaryByUrl: {}, slidesByUrl: {} });
+    setPendingSummaryRun(store, urlKey, null);
+    setPendingSlidesRun(store, urlKey, null);
+    expect(store.pendingRuns).toEqual({ summaryByUrl: {}, slidesByUrl: {} });
   });
 
   it("owns active and planned slides lifecycle state", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const plannedRun = {
       id: "run-1",
       url: "https://example.com/video",
@@ -131,37 +127,25 @@ describe("sidepanel panel state store", () => {
       reason: "tab-activated",
     } as const;
 
-    store.dispatch({
-      type: "active-slides-run",
-      value: { runId: "slides-1", url: plannedRun.url, local: true },
+    patchPanelState(store, "slidesLifecycle", {
+      activeRun: { runId: "slides-1", url: plannedRun.url, local: true },
     });
-    store.dispatch({ type: "planned-slides-run", value: plannedRun });
+    patchPanelState(store, "slidesLifecycle", { plannedRun: plannedRun });
 
-    expect(store.state.slidesLifecycle).toEqual({
+    expect(store.slidesLifecycle).toEqual({
       activeRun: { runId: "slides-1", url: plannedRun.url, local: true },
       plannedRun,
     });
 
-    store.dispatch({ type: "active-slides-run", value: null });
-    store.dispatch({ type: "planned-slides-run", value: null });
-    expect(store.state.slidesLifecycle).toEqual({ activeRun: null, plannedRun: null });
+    patchPanelState(store, "slidesLifecycle", { activeRun: null });
+    patchPanelState(store, "slidesLifecycle", { plannedRun: null });
+    expect(store.slidesLifecycle).toEqual({ activeRun: null, plannedRun: null });
   });
 
   it("owns slides summary lifecycle state", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
 
-    store.dispatch({
-      type: "slides-summary-update",
-      value: {
-        runId: "slides-1",
-        url: "https://example.com/video",
-        markdown: "Summary",
-        complete: true,
-        model: "test-model",
-      },
-    });
-
-    expect(store.state.slidesSummary).toMatchObject({
+    patchPanelState(store, "slidesSummary", {
       runId: "slides-1",
       url: "https://example.com/video",
       markdown: "Summary",
@@ -169,8 +153,16 @@ describe("sidepanel panel state store", () => {
       model: "test-model",
     });
 
-    store.dispatch({ type: "slides-summary-reset" });
-    expect(store.state.slidesSummary).toEqual({
+    expect(store.slidesSummary).toMatchObject({
+      runId: "slides-1",
+      url: "https://example.com/video",
+      markdown: "Summary",
+      complete: true,
+      model: "test-model",
+    });
+
+    store.slidesSummary = createInitialSlidesSummaryState();
+    expect(store.slidesSummary).toEqual({
       runId: null,
       url: null,
       markdown: "",
@@ -182,16 +174,17 @@ describe("sidepanel panel state store", () => {
   });
 
   it("updates slides session state and advances request identity", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
 
-    store.dispatch({
-      type: "slides-session-update",
-      value: { inputMode: "video", slidesBusy: true },
+    patchPanelState(store, "slidesSession", { inputMode: "video", slidesBusy: true });
+    patchPanelState(store, "slidesSession", {
+      slidesContextRequestId: store.slidesSession.slidesContextRequestId + 1,
     });
-    store.dispatch({ type: "slides-context-request-next" });
-    store.dispatch({ type: "slides-context-request-next" });
+    patchPanelState(store, "slidesSession", {
+      slidesContextRequestId: store.slidesSession.slidesContextRequestId + 1,
+    });
 
-    expect(store.state.slidesSession).toMatchObject({
+    expect(store.slidesSession).toMatchObject({
       inputMode: "video",
       slidesBusy: true,
       slidesContextRequestId: 2,
@@ -199,24 +192,21 @@ describe("sidepanel panel state store", () => {
   });
 
   it("owns serializable slides text state", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
 
-    store.dispatch({
-      type: "slides-text-update",
-      value: {
-        mode: "ocr",
-        toggleVisible: true,
-        transcriptTimedText: "[00:00] Intro",
-        transcriptAvailable: true,
-        ocrAvailable: true,
-        descriptionsByIndex: { 1: "Description" },
-        summariesByIndex: { 1: "Summary" },
-        titlesByIndex: { 1: "Title" },
-        summarySource: "slides",
-      },
+    patchPanelState(store, "slidesText", {
+      mode: "ocr",
+      toggleVisible: true,
+      transcriptTimedText: "[00:00] Intro",
+      transcriptAvailable: true,
+      ocrAvailable: true,
+      descriptionsByIndex: { 1: "Description" },
+      summariesByIndex: { 1: "Summary" },
+      titlesByIndex: { 1: "Title" },
+      summarySource: "slides",
     });
 
-    expect(store.state.slidesText).toMatchObject({
+    expect(store.slidesText).toMatchObject({
       mode: "ocr",
       toggleVisible: true,
       descriptionsByIndex: { 1: "Description" },
@@ -224,8 +214,8 @@ describe("sidepanel panel state store", () => {
       summarySource: "slides",
     });
 
-    store.dispatch({ type: "slides-text-reset" });
-    expect(store.state.slidesText).toEqual({
+    store.slidesText = createInitialSlidesTextState();
+    expect(store.slidesText).toEqual({
       mode: "transcript",
       toggleVisible: false,
       transcriptTimedText: null,
@@ -239,18 +229,15 @@ describe("sidepanel panel state store", () => {
   });
 
   it("owns local panel session state", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
 
-    store.dispatch({
-      type: "panel-session-update",
-      value: {
-        autoSummarize: true,
-        settingsHydrated: true,
-        lastAction: "summarize",
-      },
+    patchPanelState(store, "panelSession", {
+      autoSummarize: true,
+      settingsHydrated: true,
+      lastAction: "summarize",
     });
 
-    expect(store.state.panelSession).toMatchObject({
+    expect(store.panelSession).toMatchObject({
       autoSummarize: true,
       settingsHydrated: true,
       lastAction: "summarize",
@@ -259,7 +246,7 @@ describe("sidepanel panel state store", () => {
   });
 
   it("owns chat messages and streaming state", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const userMessage = {
       id: "user-1",
       role: "user" as const,
@@ -273,60 +260,57 @@ describe("sidepanel panel state store", () => {
       timestamp: 2,
     };
 
-    store.dispatch({ type: "chat-message-add", message: userMessage });
-    store.dispatch({ type: "chat-message-add", message: assistantMessage });
-    store.dispatch({ type: "chat-streaming", value: true });
-    store.dispatch({
-      type: "chat-message-replace",
-      message: { ...assistantMessage, content: "Updated" },
+    patchPanelState(store, "chat", { messages: [...store.chat.messages, userMessage] });
+    patchPanelState(store, "chat", { messages: [...store.chat.messages, assistantMessage] });
+    patchPanelState(store, "chat", { streaming: true });
+    replacePanelChatMessage(store, { ...assistantMessage, content: "Updated" });
+    patchPanelState(store, "chat", {
+      messages: store.chat.messages.filter((message) => message.id !== userMessage.id),
     });
-    store.dispatch({ type: "chat-message-remove", id: userMessage.id });
 
-    expect(store.state.chat).toEqual({
+    expect(store.chat).toEqual({
       messages: [{ ...assistantMessage, content: "Updated" }],
       streaming: true,
       queue: [],
     });
 
-    store.dispatch({ type: "chat-messages", messages: [userMessage] });
-    expect(store.state.chat.messages).toEqual([userMessage]);
+    patchPanelState(store, "chat", { messages: [userMessage] });
+    expect(store.chat.messages).toEqual([userMessage]);
 
-    store.dispatch({ type: "chat-reset" });
-    expect(store.state.chat).toEqual({ messages: [], streaming: false, queue: [] });
+    store.chat = { messages: [], streaming: false, queue: [] };
+    expect(store.chat).toEqual({ messages: [], streaming: false, queue: [] });
   });
 
   it("owns queued chat messages", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const first = { id: "queue-1", text: "First", createdAt: 1 };
     const second = { id: "queue-2", text: "Second", createdAt: 2 };
 
-    store.dispatch({ type: "chat-queue-add", item: first });
-    store.dispatch({ type: "chat-queue-add", item: second });
-    expect(store.state.chat.queue).toEqual([first, second]);
+    patchPanelState(store, "chat", { queue: [...store.chat.queue, first] });
+    patchPanelState(store, "chat", { queue: [...store.chat.queue, second] });
+    expect(store.chat.queue).toEqual([first, second]);
 
-    store.dispatch({ type: "chat-queue-remove", id: first.id });
-    expect(store.state.chat.queue).toEqual([second]);
+    patchPanelState(store, "chat", {
+      queue: store.chat.queue.filter((item) => item.id !== first.id),
+    });
+    expect(store.chat.queue).toEqual([second]);
 
-    store.dispatch({ type: "chat-queue-clear" });
-    expect(store.state.chat.queue).toEqual([]);
+    patchPanelState(store, "chat", { queue: [] });
+    expect(store.chat.queue).toEqual([]);
   });
 
   it("restores cached sessions without replacing omitted slides", () => {
-    const store = createPanelStateStore();
-    store.dispatch({
-      type: "slides",
-      slides: {
-        sourceUrl: "https://example.com",
-        sourceId: "slides-1",
-        sourceKind: "youtube",
-        ocrAvailable: false,
-        slides: [],
-      },
-    });
-    const existingSlides = store.state.slides;
+    const store = createInitialPanelState();
+    store.slides = {
+      sourceUrl: "https://example.com",
+      sourceId: "slides-1",
+      sourceKind: "youtube",
+      ocrAvailable: false,
+      slides: [],
+    };
+    const existingSlides = store.slides;
 
-    store.dispatch({
-      type: "restore-session",
+    restorePanelSession(store, {
       tabId: 42,
       runId: "run-1",
       slidesRunId: null,
@@ -335,27 +319,38 @@ describe("sidepanel panel state store", () => {
       summaryFromCache: true,
     });
 
-    expect(store.state.summaryFromCache).toBe(true);
-    expect(store.state.activeRun.tabId).toBe(42);
-    expect(store.state.slides).toBe(existingSlides);
+    expect(store.summaryFromCache).toBe(true);
+    expect(store.activeRun.tabId).toBe(42);
+    expect(store.slides).toBe(existingSlides);
   });
 
   it("keeps phase and error invariants together", () => {
-    const failed = reducePanelState(createPanelStateStore().state, {
-      type: "phase",
-      phase: "error",
-      error: "failed",
-    });
-    expect(failed).toMatchObject({ phase: "error", error: "failed" });
+    const state = createInitialPanelState();
+    setPanelPhase(state, "error", "failed");
+    expect(state).toMatchObject({ phase: "error", error: "failed" });
+    setPanelPhase(state, "error");
+    expect(state.error).toBe("failed");
+    setPanelPhase(state, "idle");
+    expect(state).toMatchObject({ phase: "idle", error: null });
+  });
 
-    const recovered = reducePanelState(failed, { type: "phase", phase: "idle" });
-    expect(recovered).toMatchObject({ phase: "idle", error: null });
+  it("keeps the root identity and replaces nested slices without mutating snapshots", () => {
+    const state = createInitialPanelState();
+    const original = state;
+    const navigation = state.navigation;
+    const chat = state.chat;
+    patchPanelState(state, "navigation", { activeTabId: 42 });
+    patchPanelState(state, "chat", { streaming: true });
+    expect(state).toBe(original);
+    expect(state.navigation).not.toBe(navigation);
+    expect(navigation.activeTabId).toBeNull();
+    expect(state.chat).not.toBe(chat);
+    expect(chat.streaming).toBe(false);
   });
 
   it("resets summary and run-owned slides together", () => {
-    const store = createPanelStateStore();
-    store.dispatch({
-      type: "attach-run",
+    const store = createInitialPanelState();
+    attachPanelRun(store, {
       tabId: 42,
       runId: "run-1",
       slidesRunId: "run-1",
@@ -363,15 +358,12 @@ describe("sidepanel panel state store", () => {
       source: { url: "https://example.com", title: null },
       meta: { inputSummary: null, model: null, modelLabel: null },
     });
-    store.dispatch({ type: "summary", markdown: "Summary" });
-    store.dispatch({ type: "summary-cache", value: true });
-    store.dispatch({
-      type: "retained-slide-summary",
-      value: { markdown: "Retained", url: "https://example.com" },
-    });
-    store.dispatch({ type: "reset-summary", clearRunId: true, clearSlides: true });
+    store.summaryMarkdown = "Summary";
+    store.summaryFromCache = true;
+    store.retainedSlideSummary = { markdown: "Retained", url: "https://example.com" };
+    resetPanelSummary(store, { clearRunId: true, clearSlides: true });
 
-    expect(store.state).toMatchObject({
+    expect(store).toMatchObject({
       runId: null,
       activeRun: { tabId: null },
       slidesRunId: null,
@@ -379,12 +371,12 @@ describe("sidepanel panel state store", () => {
       summaryFromCache: null,
       slides: null,
     });
-    expect(store.state.retainedSlideSummary).toEqual({
+    expect(store.retainedSlideSummary).toEqual({
       markdown: "Retained",
       url: "https://example.com",
     });
 
-    store.dispatch({ type: "retained-slide-summary", value: null });
-    expect(store.state.retainedSlideSummary).toBeNull();
+    store.retainedSlideSummary = null;
+    expect(store.retainedSlideSummary).toBeNull();
   });
 });

--- a/tests/sidepanel.planned-slides-runtime.test.ts
+++ b/tests/sidepanel.planned-slides-runtime.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  applyPanelStateAction,
-  createInitialPanelState,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createPlannedSlidesRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/planned-slides-runtime";
 import type {
   PanelState,
@@ -35,9 +32,7 @@ function createHarness(
   const schedulePanelCacheSync = vi.fn();
   const runtime = createPlannedSlidesRuntime({
     panelState,
-    dispatchPanelState: options.dispatch
-      ? (action) => applyPanelStateAction(panelState, action)
-      : undefined,
+
     getActiveTabUrl: () => options.activeTabUrl ?? null,
     getLengthValue: () => options.length ?? "medium",
     updateSlidesTextState,

--- a/tests/sidepanel.presentation-runtime.test.ts
+++ b/tests/sidepanel.presentation-runtime.test.ts
@@ -1,10 +1,9 @@
-// @vitest-environment happy-dom
-
 import { readFileSync } from "node:fs";
+// @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSidepanelDom } from "../apps/chrome-extension/src/entrypoints/sidepanel/dom";
 import { createMetricsController } from "../apps/chrome-extension/src/entrypoints/sidepanel/metrics-controller";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSidepanelPresentationRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime";
 
 vi.mock("../apps/chrome-extension/src/entrypoints/sidepanel/pickers", () => ({
@@ -36,12 +35,12 @@ describe("sidepanel presentation runtime", () => {
 
   it("composes controls, summary dispatch, and deferred feedback actions", async () => {
     const dom = createSidepanelDom();
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const send = vi.fn(async () => {});
     const runtime = createSidepanelPresentationRuntime({
       dom,
-      panelState: store.state,
-      dispatchPanelState: store.dispatch,
+      panelState: store,
+
       appearanceControls: {
         getLengthValue: () => "medium",
       },
@@ -59,7 +58,7 @@ describe("sidepanel presentation runtime", () => {
     dom.summarizeControlRoot.querySelector("button")?.click();
     await Promise.resolve();
 
-    expect(store.state.panelSession.lastAction).toBe("summarize");
+    expect(store.panelSession.lastAction).toBe("summarize");
     expect(send).toHaveBeenCalledWith({
       type: "panel:summarize",
       refresh: false,

--- a/tests/sidepanel.retained-slide-summary.test.ts
+++ b/tests/sidepanel.retained-slide-summary.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import {
   retainRenderedSlideSummary,
   selectRetainedSlideSummaryMarkdown,
@@ -10,34 +7,34 @@ import {
 
 describe("retained slide summary", () => {
   it("retains non-empty rendered markdown for the current source only", () => {
-    const store = createPanelStateStore(createInitialPanelState());
-    store.state.currentSource = {
+    const store = createInitialPanelState();
+    store.currentSource = {
       url: "https://example.com/watch?v=1#chapter",
       title: "Example",
     };
 
-    expect(selectRetainedSlideSummaryMarkdown(store.state)).toBeNull();
-    retainRenderedSlideSummary(store.state, store.dispatch, "  ");
-    expect(store.state.retainedSlideSummary).toBeNull();
+    expect(selectRetainedSlideSummaryMarkdown(store)).toBeNull();
+    retainRenderedSlideSummary(store, "  ");
+    expect(store.retainedSlideSummary).toBeNull();
 
-    retainRenderedSlideSummary(store.state, store.dispatch, "# Summary");
-    expect(selectRetainedSlideSummaryMarkdown(store.state)).toBe("# Summary");
+    retainRenderedSlideSummary(store, "# Summary");
+    expect(selectRetainedSlideSummaryMarkdown(store)).toBe("# Summary");
 
-    store.state.currentSource = { url: "https://example.com/other", title: "Other" };
-    expect(selectRetainedSlideSummaryMarkdown(store.state)).toBeNull();
+    store.currentSource = { url: "https://example.com/other", title: "Other" };
+    expect(selectRetainedSlideSummaryMarkdown(store)).toBeNull();
   });
 
   it("uses the active tab as the retained-summary scope fallback", () => {
-    const store = createPanelStateStore(createInitialPanelState());
-    store.state.navigation.activeTabUrl = "https://example.com/watch?v=1";
+    const store = createInitialPanelState();
+    store.navigation.activeTabUrl = "https://example.com/watch?v=1";
 
-    retainRenderedSlideSummary(store.state, store.dispatch, "Summary");
+    retainRenderedSlideSummary(store, "Summary");
 
-    expect(store.state.retainedSlideSummary).toEqual({
+    expect(store.retainedSlideSummary).toEqual({
       markdown: "Summary",
       url: "https://example.com/watch?v=1",
     });
-    store.state.navigation.activeTabUrl = null;
-    expect(selectRetainedSlideSummaryMarkdown(store.state)).toBe("Summary");
+    store.navigation.activeTabUrl = null;
+    expect(selectRetainedSlideSummaryMarkdown(store)).toBe("Summary");
   });
 });

--- a/tests/sidepanel.run-runtime.test.ts
+++ b/tests/sidepanel.run-runtime.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  applyPanelStateAction,
-  createInitialPanelState,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSidepanelRunRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/run-runtime";
 import type { RunStart } from "../apps/chrome-extension/src/entrypoints/sidepanel/types";
 
@@ -46,7 +43,7 @@ describe("sidepanel run runtime", () => {
 
     const runtime = createSidepanelRunRuntime({
       panelState,
-      dispatchPanelState: (action) => applyPanelStateAction(panelState, action),
+
       getActiveTabId: () => panelState.navigation.activeTabId,
       getActiveTabUrl: () => panelState.navigation.activeTabUrl,
       appearanceControls: {

--- a/tests/sidepanel.session-runtime.test.ts
+++ b/tests/sidepanel.session-runtime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SidepanelDom } from "../apps/chrome-extension/src/entrypoints/sidepanel/dom";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { createSidepanelPresentationRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime";
 import { createSidepanelSessionRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/session-runtime";
 
@@ -25,8 +25,8 @@ afterEach(() => {
 
 describe("sidepanel session runtime", () => {
   it("owns tab sync and coordinated view clearing", async () => {
-    const store = createPanelStateStore();
-    store.state.chat.streaming = true;
+    const store = createInitialPanelState();
+    store.chat.streaming = true;
     const abortSummaryStream = vi.fn();
     const stopSlidesStream = vi.fn();
     const resetSummaryView = vi.fn();
@@ -68,8 +68,8 @@ describe("sidepanel session runtime", () => {
 
     const runtime = createSidepanelSessionRuntime({
       dom: {} as SidepanelDom,
-      panelState: store.state,
-      dispatchPanelState: store.dispatch,
+      panelState: store,
+
       metricsController: {
         clearForMode: vi.fn(),
         setActiveMode: vi.fn(),

--- a/tests/sidepanel.settings-storage-binding.test.ts
+++ b/tests/sidepanel.settings-storage-binding.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { bindSettingsStorage } from "../apps/chrome-extension/src/entrypoints/sidepanel/bindings";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 describe("sidepanel settings storage binding", () => {
   let onChanged: (changes: Record<string, chrome.storage.StorageChange>, areaName: string) => void;
@@ -23,13 +20,13 @@ describe("sidepanel settings storage binding", () => {
   it("merges pre-hydration settings while applying live controls", () => {
     const initialState = createInitialPanelState();
     initialState.panelSession.pendingSettingsSnapshot = { autoSummarize: true };
-    const panelStateStore = createPanelStateStore(initialState);
+    const panelStateStore = initialState;
     const applyChatEnabled = vi.fn();
     const hideAutomationNotice = vi.fn();
 
     bindSettingsStorage({
-      panelState: panelStateStore.state,
-      dispatchPanelState: panelStateStore.dispatch,
+      panelState: panelStateStore,
+
       applyChatEnabled,
       hideAutomationNotice,
     });
@@ -46,7 +43,7 @@ describe("sidepanel settings storage binding", () => {
       "local",
     );
 
-    expect(panelStateStore.state.panelSession).toMatchObject({
+    expect(panelStateStore.panelSession).toMatchObject({
       chatEnabled: false,
       automationEnabled: false,
       pendingSettingsSnapshot: {
@@ -62,11 +59,11 @@ describe("sidepanel settings storage binding", () => {
   it("does not queue settings after hydration", () => {
     const initialState = createInitialPanelState();
     initialState.panelSession.settingsHydrated = true;
-    const panelStateStore = createPanelStateStore(initialState);
+    const panelStateStore = initialState;
 
     bindSettingsStorage({
-      panelState: panelStateStore.state,
-      dispatchPanelState: panelStateStore.dispatch,
+      panelState: panelStateStore,
+
       applyChatEnabled: vi.fn(),
       hideAutomationNotice: vi.fn(),
     });
@@ -80,7 +77,7 @@ describe("sidepanel settings storage binding", () => {
       "local",
     );
 
-    expect(panelStateStore.state.panelSession.pendingSettingsSnapshot).toBeNull();
-    expect(panelStateStore.state.panelSession.chatEnabled).toBe(true);
+    expect(panelStateStore.panelSession.pendingSettingsSnapshot).toBeNull();
+    expect(panelStateStore.panelSession.chatEnabled).toBe(true);
   });
 });

--- a/tests/sidepanel.slides-run-runtime.test.ts
+++ b/tests/sidepanel.slides-run-runtime.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  applyPanelStateAction,
-  createInitialPanelState,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSlidesRunRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/slides-run-runtime";
 import type {
   PanelState,
@@ -53,9 +50,7 @@ function createHarness(
   };
   const runtime = createSlidesRunRuntime({
     panelState,
-    dispatchPanelState: options.dispatch
-      ? (action) => applyPanelStateAction(panelState, action)
-      : undefined,
+
     refreshSummarizeControl: calls.refreshSummarizeControl,
     hideSlideNotice: calls.hideSlideNotice,
     setSlidesBusy: calls.setSlidesBusy,

--- a/tests/sidepanel.slides-text-controller.test.ts
+++ b/tests/sidepanel.slides-text-controller.test.ts
@@ -1,18 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store.js";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSlidesTextController } from "../apps/chrome-extension/src/entrypoints/sidepanel/slides-text-controller.js";
 
-type ControllerOptions = Omit<
-  Parameters<typeof createSlidesTextController>[0],
-  "panelState" | "dispatchPanelState"
->;
+type ControllerOptions = Omit<Parameters<typeof createSlidesTextController>[0], "panelState">;
 
 function createController(options: ControllerOptions) {
-  const store = createPanelStateStore();
+  const store = createInitialPanelState();
   return createSlidesTextController({
     ...options,
-    panelState: store.state,
-    dispatchPanelState: store.dispatch,
+    panelState: store,
   });
 }
 

--- a/tests/sidepanel.slides-view-runtime.test.ts
+++ b/tests/sidepanel.slides-view-runtime.test.ts
@@ -1,9 +1,6 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSlidesViewRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime";
 import type { PanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/types";
 
@@ -60,7 +57,7 @@ function createHarness(
   const panelState = options.panelState ?? createInitialPanelState();
   panelState.currentSource ??= { url: "https://example.com/video", title: "Video" };
   panelState.slides ??= createSlidePayload();
-  const store = createPanelStateStore(panelState);
+  const store = panelState;
   const send = vi.fn(async () => {});
   const refreshSummarizeControl = vi.fn();
   const headerSetProgressOverride = vi.fn();
@@ -95,7 +92,7 @@ function createHarness(
     refreshSummarizeControl,
     hideSlideNotice,
     panelState,
-    dispatchPanelState: options.dispatch ? store.dispatch : undefined,
+
     getFallbackSummaryMarkdown: () => options.fallbackSummary ?? null,
   });
   return {

--- a/tests/sidepanel.state-effects-runtime.test.ts
+++ b/tests/sidepanel.state-effects-runtime.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { createSidepanelBgMessageRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime";
 import type { SidepanelDom } from "../apps/chrome-extension/src/entrypoints/sidepanel/dom";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { createSidepanelPresentationRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime";
 import type { createSidepanelRunRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/run-runtime";
 import type { createSidepanelSessionRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/session-runtime";
@@ -35,7 +35,7 @@ afterEach(() => {
 
 describe("sidepanel state effects runtime", () => {
   it("wires UI state and background messages through subsystem ports", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const send = vi.fn(async () => {});
     const renderInlineSlides = vi.fn();
     const startSlidesSummaryStreamForRunId = vi.fn();
@@ -48,8 +48,8 @@ describe("sidepanel state effects runtime", () => {
         modelRefreshBtn: { disabled: false },
         renderMarkdownHostEl,
       } as SidepanelDom,
-      panelState: store.state,
-      dispatchPanelState: store.dispatch,
+      panelState: store,
+
       appearanceControls: {} as Parameters<
         typeof createSidepanelStateEffectsRuntime
       >[0]["appearanceControls"],
@@ -168,7 +168,7 @@ describe("sidepanel state effects runtime", () => {
     expect(handleBgMessage).toHaveBeenCalledWith(message);
     expect(send).toHaveBeenCalledWith({ type: "panel:slides-capture" });
     expect(setSlidesLayout).toHaveBeenCalledWith("gallery");
-    expect(store.state.slidesSession.slidesContextPending).toBe(true);
+    expect(store.slidesSession.slidesContextPending).toBe(true);
     expect(applyPanelCache).toHaveBeenCalledWith({}, { preserveChat: true });
     expect(renderInlineSlides).toHaveBeenCalledWith(renderMarkdownHostEl, { fallback: true });
     expect(startSlidesSummaryStreamForRunId).toHaveBeenCalledWith("run-1", null);

--- a/tests/sidepanel.summarize-control-runtime.test.ts
+++ b/tests/sidepanel.summarize-control-runtime.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createInitialPanelState,
-  createPanelStateStore,
+  patchPanelState,
 } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { SlideTextMode } from "../apps/chrome-extension/src/entrypoints/sidepanel/slides-state";
 import { createSummarizeControlRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime";
@@ -93,7 +93,7 @@ function buildRuntime(
   initialPanelState.currentSource = state.currentSourceUrl
     ? { url: state.currentSourceUrl, title: null }
     : null;
-  const panelStateStore = createPanelStateStore(initialPanelState);
+  const panelStateStore = initialPanelState;
   const calls = {
     patchSettings: vi.fn(async (_patch: Partial<Settings>) => {}),
     loadSettings: vi.fn(
@@ -102,10 +102,7 @@ function buildRuntime(
     showSlideNotice: vi.fn(),
     hideSlideNotice: vi.fn(),
     setSlidesBusy: vi.fn((value: boolean) => {
-      panelStateStore.dispatch({
-        type: "slides-session-update",
-        value: { slidesBusy: value },
-      });
+      patchPanelState(panelStateStore, "slidesSession", { slidesBusy: value });
     }),
     stopSlidesStream: vi.fn(),
     maybeApplyPendingSlidesSummary: vi.fn(),
@@ -133,7 +130,7 @@ function buildRuntime(
 
   const view = createSummarizeControlView({
     root: {} as HTMLElement,
-    panelState: panelStateStore.state,
+    panelState: panelStateStore,
     slidesTextController,
   });
   const runtime = createSummarizeControlRuntime({
@@ -141,8 +138,8 @@ function buildRuntime(
     renderSlidesHostEl,
     slidesLayoutEl,
     slidesTextController,
-    panelState: panelStateStore.state,
-    dispatchPanelState: panelStateStore.dispatch,
+    panelState: panelStateStore,
+
     patchSettings: calls.patchSettings,
     loadSettings: calls.loadSettings,
     showSlideNotice: calls.showSlideNotice,
@@ -169,7 +166,7 @@ function buildRuntime(
   });
 
   return {
-    state: panelStateStore.state,
+    state: panelStateStore,
     calls,
     runtime,
     view,

--- a/tests/sidepanel.summary-run-runtime.test.ts
+++ b/tests/sidepanel.summary-run-runtime.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  applyPanelStateAction,
-  createInitialPanelState,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSummaryRunRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/summary-run-runtime";
 import type {
   PanelState,
@@ -58,9 +55,7 @@ function createHarness(
   };
   const runtime = createSummaryRunRuntime({
     panelState,
-    dispatchPanelState: options.dispatch
-      ? (action) => applyPanelStateAction(panelState, action)
-      : undefined,
+
     getActiveTabId: () => panelState.navigation.activeTabId,
     cancelAutoSummarize: calls.cancelAutoSummarize,
     summaryStream: {

--- a/tests/sidepanel.test-hooks-runtime.test.ts
+++ b/tests/sidepanel.test-hooks-runtime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SidepanelDom } from "../apps/chrome-extension/src/entrypoints/sidepanel/dom";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { createSidepanelPresentationRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime";
 import type { createSidepanelRunRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/run-runtime";
 import type { createSidepanelStateEffectsRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/state-effects-runtime";
@@ -22,14 +22,14 @@ describe("sidepanel test hooks runtime", () => {
       }
     ).__summarizeTestHooks = hooks;
 
-    const store = createPanelStateStore();
-    store.state.runId = "run-1";
-    store.state.summaryMarkdown = "summary";
-    store.state.lastMeta.model = "openai/gpt-5.4";
-    store.state.slidesSession.mediaAvailable = true;
-    store.state.slidesSummary.markdown = "slide summary";
-    store.state.slidesSummary.complete = true;
-    store.state.slidesSummary.model = "openai/gpt-5.4";
+    const store = createInitialPanelState();
+    store.runId = "run-1";
+    store.summaryMarkdown = "summary";
+    store.lastMeta.model = "openai/gpt-5.4";
+    store.slidesSession.mediaAvailable = true;
+    store.slidesSummary.markdown = "slide summary";
+    store.slidesSummary.complete = true;
+    store.slidesSummary.model = "openai/gpt-5.4";
 
     const setSlidesTranscriptTimedText = vi.fn();
     const updateSlidesTextState = vi.fn();
@@ -99,8 +99,8 @@ describe("sidepanel test hooks runtime", () => {
           textContent: "Failure",
         },
       } as unknown as SidepanelDom,
-      panelState: store.state,
-      dispatchPanelState: store.dispatch,
+      panelState: store,
+
       presentationRuntime,
       runRuntime,
       stateEffectsRuntime,
@@ -135,7 +135,7 @@ describe("sidepanel test hooks runtime", () => {
     expect(updateSlidesTextState).toHaveBeenCalledOnce();
     expect(handleSummarizeControlChange).toHaveBeenCalledWith({ mode: "video", slides: true });
     expect(refreshSummarizeControl).toHaveBeenCalledOnce();
-    expect(store.state.ui).toEqual({ panelOpen: true });
+    expect(store.ui).toEqual({ panelOpen: true });
     expect(applyUiState).toHaveBeenCalledWith({ panelOpen: true });
     expect(handleBgMessage).toHaveBeenCalledWith({ type: "ui:status", status: "Ready" });
     expect(renderMarkdown).toHaveBeenCalledWith("next summary");
@@ -144,7 +144,7 @@ describe("sidepanel test hooks runtime", () => {
       source: "slides-partial",
     });
     expect(setPhase).toHaveBeenCalledTimes(2);
-    expect(store.state.slidesSession).toMatchObject({
+    expect(store.slidesSession).toMatchObject({
       slidesEnabled: true,
       inputMode: "video",
       inputModeOverride: "video",


### PR DESCRIPTION
## What changed

Delete the sidepanel action union, pure reducer, mutable wrapper store, optional dispatch dependencies, and repeated fallback dispatchers. They were translating plain state updates into action objects, constructing immutable root copies, then copying those copies straight back into one mutable root.

PanelState is now the single data owner. Scalars update directly; a typed nested-slice patch preserves captured snapshots; named transitions retain coupled phase/error, attach/restore, and reset behavior. No compatibility dispatcher remains.

This removes 463 production lines and 520 lines overall. Navigation, pending runs, chat, settings hydration, retained summaries, and omitted-versus-null slide restoration retain their behavior.

## Proof

- 372 sidepanel unit tests pass, including explicit root identity and nested snapshot checks.
- Build and the full project gate pass: formatting, lint, core/CLI type checks, and 3,070 tests (43 skipped).
- 28 Chromium scenarios pass: core UI, chat, cache/navigation, slide restoration, and synthetic rendered-state proof.
- Independent Codex review: no actionable P0–P2 findings.
- Synthetic before/after screenshots are byte-identical. Hosted CI run 33938440683 passed on this exact head: Node 24, Chromium E2E, Firefox smoke, and security checks.

A separate standalone extension tsc invocation reports the extension's extensionless-import/NodeNext configuration errors; that configuration is unchanged. The supported extension build and browser tests above pass.

## Before and after

Both synthetic captures have the same SHA-256, so the same uploaded image represents their identical content.

Before:

![Before: synthetic summary panel](https://github.com/user-attachments/assets/31761771-3def-49d7-a8df-b1a7b55537ed)

After:

![After: identical synthetic summary panel](https://github.com/user-attachments/assets/31761771-3def-49d7-a8df-b1a7b55537ed)
