### PR TITLE
test: centralize stream and extension lifecycle fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Dependencies and maintenance
 
+- Centralize test output streams and browser-extension lifecycles while preserving isolated profiles, runtime-error checks, and scenario coverage.
 - Remove the sidepanel's redundant action/reducer/dispatch layer; use one state object with explicit lifecycle transitions while preserving navigation, chat, and slide restoration.
 - Make provider metadata the shared source for configuration and model parsing; remove duplicated provider inventories, native model constructors, client defaults, and request-option parsing.
 - Replace duplicated file/byte transcription orchestration with one source-aware runner, shared local/provider handling, and common decode retries while preserving lazy file uploads and full-input fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Dependencies and maintenance
 
+- Remove the sidepanel's redundant action/reducer/dispatch layer; use one state object with explicit lifecycle transitions while preserving navigation, chat, and slide restoration.
 - Make provider metadata the shared source for configuration and model parsing; remove duplicated provider inventories, native model constructors, client defaults, and request-option parsing.
 - Replace duplicated file/byte transcription orchestration with one source-aware runner, shared local/provider handling, and common decode retries while preserving lazy file uploads and full-input fallback.
 - Unify model execution around one resolved request and completion path; centralize stream consumption while preserving output-failure and retry boundaries.

--- a/apps/chrome-extension/src/entrypoints/sidepanel/automation-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/automation-runtime.ts
@@ -8,7 +8,7 @@ import { runChatAgentLoop } from "./chat-agent-loop";
 import type { ChatController } from "./chat-controller";
 import { buildEmptyUsage } from "./chat-history-store";
 import { isPanelAutomationAvailable } from "./panel-capabilities";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { ChatMessage, PanelState } from "./types";
 
 type AutomationNoticeAction = "extensions" | "options";
@@ -32,7 +32,7 @@ type RuntimeMessageListener = (
 
 export function createAutomationRuntime({
   panelState,
-  dispatchPanelState,
+
   automationNoticeActionBtn,
   automationNoticeEl,
   automationNoticeMessageEl,
@@ -47,7 +47,7 @@ export function createAutomationRuntime({
   addRuntimeMessageListener = (listener) => chrome.runtime.onMessage.addListener(listener),
 }: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   automationNoticeActionBtn: HTMLButtonElement;
   automationNoticeEl: HTMLElement;
   automationNoticeMessageEl: HTMLElement;
@@ -74,17 +74,9 @@ export function createAutomationRuntime({
   };
   addRuntimeMessageListener?: (listener: RuntimeMessageListener) => void;
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
-
   const hideNotice = (options?: { force?: boolean }) => {
     if (panelState.panelSession.automationNoticeSticky && !options?.force) return;
-    dispatch({ type: "panel-session-update", value: { automationNoticeSticky: false } });
+    patchPanelState(panelState, "panelSession", { automationNoticeSticky: false });
     automationNoticeEl.classList.add("hidden");
   };
 
@@ -101,10 +93,7 @@ export function createAutomationRuntime({
     ctaAction?: AutomationNoticeAction;
     sticky?: boolean;
   }) => {
-    dispatch({
-      type: "panel-session-update",
-      value: { automationNoticeSticky: Boolean(sticky) },
-    });
+    patchPanelState(panelState, "panelSession", { automationNoticeSticky: Boolean(sticky) });
     automationNoticeTitleEl.textContent = title;
     automationNoticeMessageEl.textContent = message;
     automationNoticeActionBtn.textContent = ctaLabel || "Open extension details";

--- a/apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime.ts
@@ -1,5 +1,4 @@
 import type { BgToPanel, RunStart, UiState } from "../../lib/panel-contracts";
-import type { PanelStateAction } from "./panel-state-store";
 import {
   normalizePanelUrl,
   shouldAcceptRunForCurrentPage,
@@ -76,7 +75,7 @@ type SummarySnapshotPayload = Omit<Extract<BgToPanel, { type: "run:snapshot" }>,
 
 export function createSidepanelBgMessageRuntime(options: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   applyUiState: (state: UiState) => void;
   setStatus: (text: string) => void;
   isStreaming: () => boolean;
@@ -128,11 +127,7 @@ export function createSidepanelBgMessageRuntime(options: {
       handleSidepanelBgMessage({
         msg,
         applyUiState: (state) => {
-          if (options.dispatchPanelState) {
-            options.dispatchPanelState({ type: "ui", ui: state });
-          } else {
-            Object.assign(options.panelState, { ui: state });
-          }
+          options.panelState.ui = state;
           options.applyUiState(state);
         },
         setStatus: options.setStatus,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/bindings.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/bindings.ts
@@ -1,5 +1,5 @@
 import type { Settings, SlidesLayout } from "../../lib/settings";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { PanelState } from "./types";
 
 export function bindSidepanelUiEvents({
@@ -187,53 +187,36 @@ export function bindSidepanelLifecycle({
 
 export function bindSettingsStorage({
   panelState,
-  dispatchPanelState,
+
   applyChatEnabled,
   hideAutomationNotice,
 }: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   applyChatEnabled: () => void;
   hideAutomationNotice: () => void;
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
-
   chrome.storage.onChanged.addListener((changes, areaName) => {
     if (areaName !== "local") return;
     const nextSettings = changes.settings?.newValue;
     if (!nextSettings || typeof nextSettings !== "object") return;
     if (!panelState.panelSession.settingsHydrated) {
-      dispatch({
-        type: "panel-session-update",
-        value: {
-          pendingSettingsSnapshot: {
-            ...(panelState.panelSession.pendingSettingsSnapshot ?? {}),
-            ...(nextSettings as Partial<Settings>),
-          },
+      patchPanelState(panelState, "panelSession", {
+        pendingSettingsSnapshot: {
+          ...(panelState.panelSession.pendingSettingsSnapshot ?? {}),
+          ...(nextSettings as Partial<Settings>),
         },
       });
     }
     const nextChatEnabled = (nextSettings as { chatEnabled?: unknown }).chatEnabled;
     if (typeof nextChatEnabled === "boolean") {
-      dispatch({
-        type: "panel-session-update",
-        value: { chatEnabled: nextChatEnabled },
-      });
+      patchPanelState(panelState, "panelSession", { chatEnabled: nextChatEnabled });
       applyChatEnabled();
     }
     const nextAutomationEnabled = (nextSettings as { automationEnabled?: unknown })
       .automationEnabled;
     if (typeof nextAutomationEnabled === "boolean") {
-      dispatch({
-        type: "panel-session-update",
-        value: { automationEnabled: nextAutomationEnabled },
-      });
+      patchPanelState(panelState, "panelSession", { automationEnabled: nextAutomationEnabled });
       if (!nextAutomationEnabled) hideAutomationNotice();
     }
   });

--- a/apps/chrome-extension/src/entrypoints/sidepanel/bootstrap-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/bootstrap-runtime.ts
@@ -1,6 +1,6 @@
 import type { Settings } from "../../lib/settings";
 import { bindSettingsStorage, bindSidepanelLifecycle } from "./bindings";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { PanelState } from "./types";
 
 type LoadedSettings = Pick<
@@ -16,25 +16,11 @@ type LoadedSettings = Pick<
   | "token"
 >;
 
-function dispatchPanelState(
-  options: {
-    panelState: PanelState;
-    dispatchPanelState?: (action: PanelStateAction) => void;
-  },
-  action: PanelStateAction,
-) {
-  if (options.dispatchPanelState) {
-    options.dispatchPanelState(action);
-  } else {
-    applyPanelStateAction(options.panelState, action);
-  }
-}
-
 export function bootstrapSidepanel(options: {
   ensurePanelPort: () => Promise<void>;
   loadSettings: () => Promise<LoadedSettings>;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   typographyController: {
     setCurrentFontSize: (value: number) => void;
     setCurrentLineHeight: (value: number) => void;
@@ -66,27 +52,18 @@ export function bootstrapSidepanel(options: {
     const settings = pendingSettingsSnapshot
       ? { ...loadedSettings, ...pendingSettingsSnapshot }
       : loadedSettings;
-    dispatchPanelState(options, {
-      type: "panel-session-update",
-      value: {
-        pendingSettingsSnapshot: null,
-        settingsHydrated: true,
-      },
+    patchPanelState(options.panelState, "panelSession", {
+      pendingSettingsSnapshot: null,
+      settingsHydrated: true,
     });
     options.typographyController.setCurrentFontSize(settings.fontSize);
     options.typographyController.setCurrentLineHeight(settings.lineHeight);
-    dispatchPanelState(options, {
-      type: "panel-session-update",
-      value: {
-        autoSummarize: settings.autoSummarize,
-        chatEnabled: settings.chatEnabled,
-        automationEnabled: settings.automationEnabled,
-      },
+    patchPanelState(options.panelState, "panelSession", {
+      autoSummarize: settings.autoSummarize,
+      chatEnabled: settings.chatEnabled,
+      automationEnabled: settings.automationEnabled,
     });
-    dispatchPanelState(options, {
-      type: "slides-session-update",
-      value: { slidesLayout: settings.slidesLayout },
-    });
+    patchPanelState(options.panelState, "slidesSession", { slidesLayout: settings.slidesLayout });
     options.setSlidesLayoutInputValue(settings.slidesLayout);
     if (!settings.automationEnabled) options.hideAutomationNotice();
     options.appearanceControls.setAutoValue(settings.autoSummarize);
@@ -110,7 +87,7 @@ export function bootstrapSidepanel(options: {
 
   bindSettingsStorage({
     panelState: options.panelState,
-    dispatchPanelState: options.dispatchPanelState,
+
     applyChatEnabled: options.applyChatEnabled,
     hideAutomationNotice: options.hideAutomationNotice,
   });

--- a/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime.ts
@@ -2,7 +2,6 @@ import { buildBrowserAiSummaryMarkdown } from "../../lib/browser-summary";
 import { logExtensionEvent } from "../../lib/extension-logs";
 import type { BgToPanel } from "../../lib/panel-contracts";
 import type { BrowserAiRequestKey } from "./browser-ai-summary-runtime";
-import type { PanelStateAction } from "./panel-state-store";
 import { panelUrlsMatch } from "./session-policy";
 import type { PanelState } from "./types";
 
@@ -10,7 +9,7 @@ type BrowserSummarySnapshot = Extract<BgToPanel, { type: "run:snapshot" }>;
 
 export function createBrowserAiSnapshotRuntime(options: {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   browserAi: {
     cancel: (requestKey?: BrowserAiRequestKey) => void;
     summarize: (options: {
@@ -55,14 +54,11 @@ export function createBrowserAiSnapshotRuntime(options: {
           });
           return;
         }
-        options.dispatchPanelState({
-          type: "meta",
-          meta: {
-            ...options.panelState.lastMeta,
-            model: "Gemini Nano",
-            modelLabel: "Gemini Nano",
-          },
-        });
+        options.panelState.lastMeta = {
+          ...options.panelState.lastMeta,
+          model: "Gemini Nano",
+          modelLabel: "Gemini Nano",
+        };
         options.renderMarkdown(
           buildBrowserAiSummaryMarkdown({
             title: snapshot.run.title,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-controller.ts
@@ -5,7 +5,7 @@ import {
   computeChatContextUsage,
   hasUserChatMessage,
 } from "./chat-state";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState, replacePanelChatMessage } from "./panel-state-store";
 import { parseTimestampSeconds } from "./timestamp-links";
 import type { ChatMessage, PanelState } from "./types";
 
@@ -19,7 +19,7 @@ export type ChatControllerOptions = {
   markdown: MarkdownIt;
   limits: ChatHistoryLimits;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   scrollToBottom?: () => void;
   onNewContent?: () => void;
 };
@@ -32,7 +32,7 @@ export class ChatController {
   private readonly markdown: MarkdownIt;
   private readonly limits: ChatHistoryLimits;
   private readonly panelState: PanelState;
-  private readonly dispatchPanelState?: (action: PanelStateAction) => void;
+
   private readonly scrollToBottom?: () => void;
   private readonly onNewContent?: () => void;
   private readonly typingIndicatorHtml =
@@ -48,7 +48,7 @@ export class ChatController {
     this.markdown = opts.markdown;
     this.limits = opts.limits;
     this.panelState = opts.panelState;
-    this.dispatchPanelState = opts.dispatchPanelState;
+
     this.scrollToBottom = opts.scrollToBottom;
     this.onNewContent = opts.onNewContent;
   }
@@ -66,7 +66,7 @@ export class ChatController {
   }
 
   reset() {
-    this.dispatch({ type: "chat-reset" });
+    this.panelState.chat = { messages: [], streaming: false, queue: [] };
     this.messagesEl.innerHTML = "";
     this.inputEl.value = "";
     this.sendBtn.disabled = false;
@@ -75,7 +75,7 @@ export class ChatController {
   }
 
   setMessages(messages: ChatMessage[], opts?: RenderOptions) {
-    this.dispatch({ type: "chat-messages", messages });
+    patchPanelState(this.panelState, "chat", { messages: messages });
     this.messagesEl.innerHTML = "";
     for (const message of messages) {
       this.renderMessage(message, { scroll: false });
@@ -89,7 +89,9 @@ export class ChatController {
   }
 
   addMessage(message: ChatMessage, opts?: RenderOptions) {
-    this.dispatch({ type: "chat-message-add", message });
+    patchPanelState(this.panelState, "chat", {
+      messages: [...this.panelState.chat.messages, message],
+    });
     this.renderMessage(message, opts);
     this.updateVisibility();
     this.updateContextStatus();
@@ -101,7 +103,7 @@ export class ChatController {
       this.addMessage(message, opts);
       return;
     }
-    this.dispatch({ type: "chat-message-replace", message });
+    replacePanelChatMessage(this.panelState, message);
     const existing = this.messagesEl.querySelector(`[data-id="${message.id}"]`);
     if (existing) {
       const nextEl = this.createMessageElement(message);
@@ -120,7 +122,9 @@ export class ChatController {
   removeMessage(id: string) {
     const index = this.getMessages().findIndex((item) => item.id === id);
     if (index === -1) return;
-    this.dispatch({ type: "chat-message-remove", id });
+    patchPanelState(this.panelState, "chat", {
+      messages: this.panelState.chat.messages.filter((message) => message.id !== id),
+    });
     const existing = this.messagesEl.querySelector(`[data-id="${id}"]`);
     existing?.remove();
     this.updateVisibility();
@@ -131,12 +135,9 @@ export class ChatController {
     const messages = this.getMessages();
     const lastMsg = messages[messages.length - 1];
     if (lastMsg?.role === "assistant") {
-      this.dispatch({
-        type: "chat-message-replace",
-        message: {
-          ...lastMsg,
-          content: [{ type: "text", text: content }],
-        },
+      replacePanelChatMessage(this.panelState, {
+        ...lastMsg,
+        content: [{ type: "text", text: content }],
       });
       const msgEl = this.messagesEl.querySelector(`[data-id="${lastMsg.id}"]`);
       if (msgEl) {
@@ -211,14 +212,6 @@ export class ChatController {
       if (seconds == null) return match;
       return `[${time}](timestamp:${seconds})`;
     });
-  }
-
-  private dispatch(action: PanelStateAction) {
-    if (this.dispatchPanelState) {
-      this.dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(this.panelState, action);
-    }
   }
 
   private createMessageElement(message: ChatMessage): HTMLDivElement {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-queue-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-queue-runtime.ts
@@ -1,9 +1,9 @@
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { PanelState } from "./types";
 
 type ChatQueueRuntimeOpts = {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   chatQueueEl: HTMLElement;
   maxQueue: number;
   setStatus: (value: string) => void;
@@ -15,7 +15,9 @@ export function createChatQueueRuntime(opts: ChatQueueRuntimeOpts) {
   }
 
   function removeQueuedMessage(id: string) {
-    opts.dispatchPanelState({ type: "chat-queue-remove", id });
+    patchPanelState(opts.panelState, "chat", {
+      queue: opts.panelState.chat.queue.filter((item) => item.id !== id),
+    });
     renderChatQueue();
   }
 
@@ -59,9 +61,11 @@ export function createChatQueueRuntime(opts: ChatQueueRuntimeOpts) {
       opts.setStatus(`Queue full (${opts.maxQueue}). Remove one to add more.`);
       return false;
     }
-    opts.dispatchPanelState({
-      type: "chat-queue-add",
-      item: { id: crypto.randomUUID(), text, createdAt: Date.now() },
+    patchPanelState(opts.panelState, "chat", {
+      queue: [
+        ...opts.panelState.chat.queue,
+        { id: crypto.randomUUID(), text, createdAt: Date.now() },
+      ],
     });
     renderChatQueue();
     return true;
@@ -69,13 +73,16 @@ export function createChatQueueRuntime(opts: ChatQueueRuntimeOpts) {
 
   function clearQueuedMessages() {
     if (opts.panelState.chat.queue.length === 0) return;
-    opts.dispatchPanelState({ type: "chat-queue-clear" });
+    patchPanelState(opts.panelState, "chat", { queue: [] });
     renderChatQueue();
   }
 
   function dequeueQueuedMessage() {
     const next = opts.panelState.chat.queue[0];
-    if (next) opts.dispatchPanelState({ type: "chat-queue-remove", id: next.id });
+    if (next)
+      patchPanelState(opts.panelState, "chat", {
+        queue: opts.panelState.chat.queue.filter((item) => item.id !== next.id),
+      });
     return next;
   }
 

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime.ts
@@ -11,7 +11,7 @@ import type { ChatHistoryLimits } from "./chat-state";
 import { createChatStreamRuntime } from "./chat-stream-runtime";
 import { createChatUiRuntime } from "./chat-ui-runtime";
 import { isPanelChatAvailable } from "./panel-capabilities";
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import { parseTimestampHref } from "./timestamp-links";
 import type { ChatMessage, PanelState } from "./types";
 
@@ -28,7 +28,7 @@ type NavigationRuntime = {
 
 export function createSidepanelChatRuntime({
   panelState,
-  dispatchPanelState,
+
   markdown,
   mainEl,
   renderEl,
@@ -58,7 +58,7 @@ export function createSidepanelChatRuntime({
   seekToTimestamp,
 }: {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   markdown: MarkdownIt;
   mainEl: HTMLElement;
   renderEl: HTMLElement;
@@ -104,7 +104,7 @@ export function createSidepanelChatRuntime({
     markdown,
     limits: CHAT_LIMITS,
     panelState,
-    dispatchPanelState,
+
     scrollToBottom: () => chatUiRuntime.scrollToBottom(),
     onNewContent: renderInlineSlides,
   });
@@ -126,7 +126,7 @@ export function createSidepanelChatRuntime({
 
   const chatQueueRuntime = createChatQueueRuntime({
     panelState,
-    dispatchPanelState,
+
     chatQueueEl,
     maxQueue: MAX_CHAT_QUEUE,
     setStatus,
@@ -155,7 +155,7 @@ export function createSidepanelChatRuntime({
 
   automationRuntime = createAutomationRuntime({
     panelState,
-    dispatchPanelState,
+
     automationNoticeActionBtn,
     automationNoticeEl,
     automationNoticeMessageEl,
@@ -172,7 +172,7 @@ export function createSidepanelChatRuntime({
     chatEnabled: () => isPanelChatAvailable(panelState),
     isChatStreaming: () => panelState.chat.streaming,
     setChatStreaming: (value) => {
-      dispatchPanelState({ type: "chat-streaming", value });
+      patchPanelState(panelState, "chat", { streaming: value });
     },
     hasUserMessages: () => chatController.hasUserMessages(),
     addUserMessage: (text) => {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
@@ -10,7 +10,7 @@ import { createSidepanelInteractionRuntime } from "./interaction-runtime";
 import { createMetricsController } from "./metrics-controller";
 import { isPanelChatAvailable } from "./panel-capabilities";
 import { createPanelMessagingRuntime } from "./panel-messaging";
-import { createPanelStateStore } from "./panel-state-store";
+import { createInitialPanelState, patchPanelState } from "./panel-state-store";
 import { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import { createSidepanelRunRuntime } from "./run-runtime";
 import { createSidepanelSessionRuntime } from "./session-runtime";
@@ -67,18 +67,17 @@ const typographyController = createTypographyController({
   defaultLineHeight: defaultSettings.lineHeight,
 });
 
-const panelStateStore = createPanelStateStore();
-const panelState = panelStateStore.state;
+const panelState = createInitialPanelState();
 const getActiveTabId = () => panelState.navigation.activeTabId;
 const getActiveTabUrl = () => panelState.navigation.activeTabUrl;
 const getPanelSession = () => panelState.panelSession;
 const updatePanelSession = (value: Partial<typeof panelState.panelSession>) => {
-  panelStateStore.dispatch({ type: "panel-session-update", value });
+  patchPanelState(panelState, "panelSession", value);
 };
 
 const panelMessagingRuntime = createPanelMessagingRuntime({
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   onMessage: (msg) => {
     handleBgMessage(msg);
   },
@@ -119,7 +118,7 @@ const appearanceControls = createAppearanceControls({
 const presentationRuntime = createSidepanelPresentationRuntime({
   dom,
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   appearanceControls,
   metricsController,
   resolveLocalSlides,
@@ -137,7 +136,7 @@ const { applySlidesLayout, setSlidesLayout } = summarizeControlRuntime;
 const sessionRuntime = createSidepanelSessionRuntime({
   dom,
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   metricsController,
   presentationRuntime,
   send,
@@ -147,7 +146,7 @@ const { bindRunActions, chatRuntime, clearCurrentView, navigationRuntime, syncWi
 
 const runRuntime = createSidepanelRunRuntime({
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   getActiveTabId,
   getActiveTabUrl,
   appearanceControls,
@@ -199,7 +198,7 @@ const {
 const stateEffectsRuntime = createSidepanelStateEffectsRuntime({
   dom,
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   appearanceControls,
   typographyController,
   panelMessagingRuntime,
@@ -217,7 +216,7 @@ function handleBgMessage(msg: BgToPanel) {
 registerSidepanelRuntimeTestHooks({
   dom,
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   presentationRuntime,
   runRuntime,
   stateEffectsRuntime,
@@ -310,7 +309,7 @@ bootstrapSidepanel({
   ensurePanelPort: () => panelMessagingRuntime.ensure(),
   loadSettings,
   panelState,
-  dispatchPanelState: panelStateStore.dispatch,
+
   typographyController,
   setSlidesLayoutInputValue: (value) => {
     slidesLayoutEl.value = value;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/panel-messaging.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/panel-messaging.ts
@@ -1,7 +1,7 @@
 import type { BgToPanel, PanelToBg } from "../../lib/panel-contracts";
 import type { SseSlidesData } from "../../lib/runtime-contracts";
 import { createPanelPortRuntime } from "./panel-port";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { PanelState } from "./types";
 
 type PanelPortRuntimeLike = {
@@ -11,7 +11,7 @@ type PanelPortRuntimeLike = {
 
 export function createPanelMessagingRuntime({
   panelState,
-  dispatchPanelState,
+
   onMessage,
   portRuntime = createPanelPortRuntime({ onMessage }),
   createRequestId = () => `local-slides-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -20,7 +20,7 @@ export function createPanelMessagingRuntime({
   clearTimer = (timer) => clearTimeout(timer),
 }: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   onMessage: (message: BgToPanel) => void;
   portRuntime?: PanelPortRuntimeLike;
   createRequestId?: () => string;
@@ -36,21 +36,13 @@ export function createPanelMessagingRuntime({
     }
   >();
 
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
-
   const sendRaw = (message: PanelToBg) => portRuntime.send(message);
 
   const send = async (message: PanelToBg) => {
     if (message.type === "panel:summarize") {
-      dispatch({ type: "panel-session-update", value: { lastAction: "summarize" } });
+      patchPanelState(panelState, "panelSession", { lastAction: "summarize" });
     } else if (message.type === "panel:agent") {
-      dispatch({ type: "panel-session-update", value: { lastAction: "chat" } });
+      patchPanelState(panelState, "panelSession", { lastAction: "chat" });
     }
     await sendRaw(message);
   };

--- a/apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store.ts
@@ -1,72 +1,6 @@
 import { defaultSettings } from "../../lib/settings";
 import { createInitialSlidesSessionState } from "./slides-session-state";
-import type { NavigationPolicyState, PanelState } from "./types";
-
-export type PanelStateAction =
-  | { type: "phase"; phase: PanelState["phase"]; error?: string | null }
-  | { type: "ui"; ui: PanelState["ui"] }
-  | {
-      type: "active-tab";
-      tabId: PanelState["navigation"]["activeTabId"];
-      url: PanelState["navigation"]["activeTabUrl"];
-    }
-  | { type: "active-tab-url"; url: PanelState["navigation"]["activeTabUrl"] }
-  | { type: "navigation-policy-update"; value: Partial<NavigationPolicyState> }
-  | {
-      type: "pending-summary-run";
-      urlKey: string;
-      value: PanelState["pendingRuns"]["summaryByUrl"][string] | null;
-    }
-  | {
-      type: "pending-slides-run";
-      urlKey: string;
-      value: PanelState["pendingRuns"]["slidesByUrl"][string] | null;
-    }
-  | { type: "active-slides-run"; value: PanelState["slidesLifecycle"]["activeRun"] }
-  | { type: "planned-slides-run"; value: PanelState["slidesLifecycle"]["plannedRun"] }
-  | { type: "slides-summary-update"; value: Partial<PanelState["slidesSummary"]> }
-  | { type: "slides-summary-reset" }
-  | { type: "slides-text-update"; value: Partial<PanelState["slidesText"]> }
-  | { type: "slides-text-reset" }
-  | { type: "slides-session-update"; value: Partial<PanelState["slidesSession"]> }
-  | { type: "slides-context-request-next" }
-  | { type: "panel-session-update"; value: Partial<PanelState["panelSession"]> }
-  | { type: "source"; source: PanelState["currentSource"] }
-  | { type: "meta"; meta: PanelState["lastMeta"] }
-  | { type: "summary"; markdown: string | null }
-  | { type: "summary-cache"; value: boolean | null }
-  | { type: "retained-slide-summary"; value: PanelState["retainedSlideSummary"] }
-  | { type: "slides"; slides: PanelState["slides"] }
-  | { type: "slides-run"; runId: string | null }
-  | { type: "chat-streaming"; value: boolean }
-  | { type: "chat-reset" }
-  | { type: "chat-messages"; messages: PanelState["chat"]["messages"] }
-  | { type: "chat-message-add"; message: PanelState["chat"]["messages"][number] }
-  | { type: "chat-message-replace"; message: PanelState["chat"]["messages"][number] }
-  | { type: "chat-message-remove"; id: string }
-  | { type: "chat-queue-add"; item: PanelState["chat"]["queue"][number] }
-  | { type: "chat-queue-remove"; id: string }
-  | { type: "chat-queue-clear" }
-  | {
-      type: "attach-run";
-      tabId: PanelState["activeRun"]["tabId"];
-      runId: string;
-      slidesRunId: string | null;
-      plannedSlidesRun: PanelState["slidesLifecycle"]["plannedRun"];
-      source: NonNullable<PanelState["currentSource"]>;
-      meta: PanelState["lastMeta"];
-    }
-  | {
-      type: "restore-session";
-      tabId: PanelState["activeRun"]["tabId"];
-      runId: string | null;
-      slidesRunId: string | null;
-      source: NonNullable<PanelState["currentSource"]>;
-      meta: PanelState["lastMeta"];
-      summaryFromCache: boolean | null;
-      slides?: PanelState["slides"];
-    }
-  | { type: "reset-summary"; clearRunId: boolean; clearSlides: boolean };
+import type { PanelState } from "./types";
 
 export function createInitialPanelState(): PanelState {
   return {
@@ -125,258 +59,109 @@ export function createInitialPanelState(): PanelState {
   };
 }
 
-export function reducePanelState(state: PanelState, action: PanelStateAction): PanelState {
-  switch (action.type) {
-    case "phase":
-      return {
-        ...state,
-        phase: action.phase,
-        error: action.phase === "error" ? (action.error ?? state.error) : null,
-      };
-    case "ui":
-      return { ...state, ui: action.ui };
-    case "active-tab":
-      return {
-        ...state,
-        navigation: {
-          ...state.navigation,
-          activeTabId: action.tabId,
-          activeTabUrl: action.url,
-        },
-      };
-    case "active-tab-url":
-      return {
-        ...state,
-        navigation: {
-          ...state.navigation,
-          activeTabUrl: action.url,
-        },
-      };
-    case "navigation-policy-update":
-      return {
-        ...state,
-        navigation: {
-          ...state.navigation,
-          ...action.value,
-        },
-      };
-    case "pending-summary-run":
-      return {
-        ...state,
-        pendingRuns: {
-          ...state.pendingRuns,
-          summaryByUrl: updateKeyedValue(
-            state.pendingRuns.summaryByUrl,
-            action.urlKey,
-            action.value,
-          ),
-        },
-      };
-    case "pending-slides-run":
-      return {
-        ...state,
-        pendingRuns: {
-          ...state.pendingRuns,
-          slidesByUrl: updateKeyedValue(state.pendingRuns.slidesByUrl, action.urlKey, action.value),
-        },
-      };
-    case "active-slides-run":
-      return {
-        ...state,
-        slidesLifecycle: {
-          ...state.slidesLifecycle,
-          activeRun: action.value,
-        },
-      };
-    case "planned-slides-run":
-      return {
-        ...state,
-        slidesLifecycle: {
-          ...state.slidesLifecycle,
-          plannedRun: action.value,
-        },
-      };
-    case "slides-summary-update":
-      return {
-        ...state,
-        slidesSummary: {
-          ...state.slidesSummary,
-          ...action.value,
-        },
-      };
-    case "slides-summary-reset":
-      return {
-        ...state,
-        slidesSummary: createInitialSlidesSummaryState(),
-      };
-    case "slides-text-update":
-      return {
-        ...state,
-        slidesText: {
-          ...state.slidesText,
-          ...action.value,
-        },
-      };
-    case "slides-text-reset":
-      return {
-        ...state,
-        slidesText: createInitialSlidesTextState(),
-      };
-    case "slides-session-update":
-      return {
-        ...state,
-        slidesSession: {
-          ...state.slidesSession,
-          ...action.value,
-        },
-      };
-    case "slides-context-request-next":
-      return {
-        ...state,
-        slidesSession: {
-          ...state.slidesSession,
-          slidesContextRequestId: state.slidesSession.slidesContextRequestId + 1,
-        },
-      };
-    case "panel-session-update":
-      return {
-        ...state,
-        panelSession: {
-          ...state.panelSession,
-          ...action.value,
-        },
-      };
-    case "source":
-      return { ...state, currentSource: action.source };
-    case "meta":
-      return { ...state, lastMeta: action.meta };
-    case "summary":
-      return { ...state, summaryMarkdown: action.markdown };
-    case "summary-cache":
-      return { ...state, summaryFromCache: action.value };
-    case "retained-slide-summary":
-      return { ...state, retainedSlideSummary: action.value };
-    case "slides":
-      return { ...state, slides: action.slides };
-    case "slides-run":
-      return { ...state, slidesRunId: action.runId };
-    case "chat-streaming":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          streaming: action.value,
-        },
-      };
-    case "chat-reset":
-      return {
-        ...state,
-        chat: {
-          messages: [],
-          streaming: false,
-          queue: [],
-        },
-      };
-    case "chat-messages":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          messages: action.messages,
-        },
-      };
-    case "chat-message-add":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          messages: [...state.chat.messages, action.message],
-        },
-      };
-    case "chat-message-replace":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          messages: state.chat.messages.map((message) =>
-            message.id === action.message.id ? action.message : message,
-          ),
-        },
-      };
-    case "chat-message-remove":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          messages: state.chat.messages.filter((message) => message.id !== action.id),
-        },
-      };
-    case "chat-queue-add":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          queue: [...state.chat.queue, action.item],
-        },
-      };
-    case "chat-queue-remove":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          queue: state.chat.queue.filter((item) => item.id !== action.id),
-        },
-      };
-    case "chat-queue-clear":
-      return {
-        ...state,
-        chat: {
-          ...state.chat,
-          queue: [],
-        },
-      };
-    case "attach-run":
-      return {
-        ...state,
-        activeRun: { tabId: action.tabId },
-        slidesLifecycle: {
-          ...state.slidesLifecycle,
-          plannedRun: action.plannedSlidesRun,
-        },
-        runId: action.runId,
-        slidesRunId: action.slidesRunId,
-        currentSource: action.source,
-        lastMeta: action.meta,
-      };
-    case "restore-session":
-      return {
-        ...state,
-        activeRun: { tabId: action.tabId },
-        runId: action.runId,
-        slidesRunId: action.slidesRunId,
-        currentSource: action.source,
-        lastMeta: action.meta,
-        summaryFromCache: action.summaryFromCache,
-        ...(typeof action.slides === "undefined" ? {} : { slides: action.slides }),
-      };
-    case "reset-summary":
-      return {
-        ...state,
-        activeRun: { tabId: null },
-        summaryMarkdown: null,
-        summaryFromCache: null,
-        ...(action.clearRunId ? { runId: null } : {}),
-        ...(action.clearSlides
-          ? {
-              slides: null,
-              ...(action.clearRunId ? { slidesRunId: null } : {}),
-            }
-          : {}),
-      };
+export function patchPanelState<
+  Key extends
+    | "navigation"
+    | "slidesLifecycle"
+    | "slidesSummary"
+    | "slidesText"
+    | "slidesSession"
+    | "panelSession"
+    | "chat",
+>(state: PanelState, key: Key, patch: Partial<PanelState[Key]>) {
+  state[key] = { ...state[key], ...patch };
+}
+
+export function setPanelPhase(
+  state: PanelState,
+  phase: PanelState["phase"],
+  error?: string | null,
+) {
+  state.phase = phase;
+  state.error = phase === "error" ? (error ?? state.error) : null;
+}
+
+export function setPendingSummaryRun(
+  state: PanelState,
+  urlKey: string,
+  value: PanelState["pendingRuns"]["summaryByUrl"][string] | null,
+) {
+  state.pendingRuns = {
+    ...state.pendingRuns,
+    summaryByUrl: updateKeyedValue(state.pendingRuns.summaryByUrl, urlKey, value),
+  };
+}
+
+export function setPendingSlidesRun(
+  state: PanelState,
+  urlKey: string,
+  value: PanelState["pendingRuns"]["slidesByUrl"][string] | null,
+) {
+  state.pendingRuns = {
+    ...state.pendingRuns,
+    slidesByUrl: updateKeyedValue(state.pendingRuns.slidesByUrl, urlKey, value),
+  };
+}
+
+type PanelRun = {
+  tabId: PanelState["activeRun"]["tabId"];
+  runId: string | null;
+  slidesRunId: string | null;
+  source: NonNullable<PanelState["currentSource"]>;
+  meta: PanelState["lastMeta"];
+};
+
+export function attachPanelRun(
+  state: PanelState,
+  run: PanelRun & { runId: string; plannedSlidesRun: PanelState["slidesLifecycle"]["plannedRun"] },
+) {
+  state.activeRun = { tabId: run.tabId };
+  patchPanelState(state, "slidesLifecycle", { plannedRun: run.plannedSlidesRun });
+  state.runId = run.runId;
+  state.slidesRunId = run.slidesRunId;
+  state.currentSource = run.source;
+  state.lastMeta = run.meta;
+}
+
+export function restorePanelSession(
+  state: PanelState,
+  session: PanelRun & { summaryFromCache: boolean | null; slides?: PanelState["slides"] },
+) {
+  state.activeRun = { tabId: session.tabId };
+  state.runId = session.runId;
+  state.slidesRunId = session.slidesRunId;
+  state.currentSource = session.source;
+  state.lastMeta = session.meta;
+  state.summaryFromCache = session.summaryFromCache;
+  if (session.slides !== undefined) state.slides = session.slides;
+}
+
+export function resetPanelSummary(
+  state: PanelState,
+  options: { clearRunId: boolean; clearSlides: boolean },
+) {
+  state.activeRun = { tabId: null };
+  state.summaryMarkdown = null;
+  state.summaryFromCache = null;
+  if (options.clearRunId) state.runId = null;
+  if (options.clearSlides) {
+    state.slides = null;
+    if (options.clearRunId) state.slidesRunId = null;
   }
 }
 
-function createInitialSlidesSummaryState(): PanelState["slidesSummary"] {
+export function replacePanelChatMessage(
+  state: PanelState,
+  message: PanelState["chat"]["messages"][number],
+) {
+  patchPanelState(state, "chat", {
+    messages: state.chat.messages.map((existing) =>
+      existing.id === message.id ? message : existing,
+    ),
+  });
+}
+
+export function createInitialSlidesSummaryState(): PanelState["slidesSummary"] {
   return {
     runId: null,
     url: null,
@@ -388,7 +173,7 @@ function createInitialSlidesSummaryState(): PanelState["slidesSummary"] {
   };
 }
 
-function createInitialSlidesTextState(): PanelState["slidesText"] {
+export function createInitialSlidesTextState(): PanelState["slidesText"] {
   return {
     mode: "transcript",
     toggleVisible: false,
@@ -412,19 +197,4 @@ function updateKeyedValue<T>(
   const next = { ...values };
   delete next[key];
   return next;
-}
-
-export function applyPanelStateAction(state: PanelState, action: PanelStateAction): PanelState {
-  Object.assign(state, reducePanelState(state, action));
-  return state;
-}
-
-export function createPanelStateStore(initial = createInitialPanelState()) {
-  const state = initial;
-  return {
-    state,
-    dispatch(action: PanelStateAction) {
-      applyPanelStateAction(state, action);
-    },
-  };
 }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/phase-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/phase-runtime.ts
@@ -1,6 +1,6 @@
 import type { ErrorController } from "./error-controller";
 import type { HeaderController } from "./header-controller";
-import type { PanelStateAction } from "./panel-state-store";
+import { setPanelPhase } from "./panel-state-store";
 import type { PanelPhase, PanelState } from "./types";
 
 type PhaseEventTarget = {
@@ -9,7 +9,7 @@ type PhaseEventTarget = {
 
 export function createPanelPhaseRuntime({
   panelState,
-  dispatchPanelState,
+
   errorController,
   headerController,
   setSlidesBusy,
@@ -18,7 +18,7 @@ export function createPanelPhaseRuntime({
   eventTarget = window,
 }: {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   errorController: ErrorController;
   headerController: HeaderController;
   setSlidesBusy: (value: boolean) => void;
@@ -27,7 +27,7 @@ export function createPanelPhaseRuntime({
   eventTarget?: PhaseEventTarget;
 }) {
   const setPhase = (phase: PanelPhase, options?: { error?: string | null }) => {
-    dispatchPanelState({ type: "phase", phase, error: options?.error });
+    setPanelPhase(panelState, phase, options?.error);
     const running = phase === "connecting" || phase === "streaming";
     if (phase === "error") {
       const message =

--- a/apps/chrome-extension/src/entrypoints/sidepanel/planned-slides-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/planned-slides-runtime.ts
@@ -1,5 +1,5 @@
 import { extractYouTubeVideoId } from "@steipete/summarize-core/content/url";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import { panelUrlsMatch } from "./session-policy";
 import { shouldSeedPlannedSlidesForRun } from "./slides-seed-policy";
 import { resolveSlidesInputMode } from "./slides-session-state";
@@ -7,7 +7,7 @@ import type { PanelState, RunStart } from "./types";
 
 export function createPlannedSlidesRuntime({
   panelState,
-  dispatchPanelState,
+
   getActiveTabUrl,
   getLengthValue,
   updateSlidesTextState,
@@ -15,21 +15,13 @@ export function createPlannedSlidesRuntime({
   schedulePanelCacheSync,
 }: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   getActiveTabUrl: () => string | null;
   getLengthValue: () => string;
   updateSlidesTextState: () => void;
   queueSlidesRender: () => void;
   schedulePanelCacheSync: (delayMs?: number) => void;
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
-
   const getSourceId = (run: RunStart) => {
     const youtubeId = extractYouTubeVideoId(run.url);
     return youtubeId ? `youtube-${youtubeId}` : `planned-${run.id}`;
@@ -108,20 +100,14 @@ export function createPlannedSlidesRuntime({
       return { index: index + 1, timestamp, imageUrl: "" };
     });
 
-    dispatch({
-      type: "slides",
-      slides: {
-        sourceUrl: run.url,
-        sourceId,
-        sourceKind,
-        ocrAvailable: false,
-        slides,
-      },
-    });
-    dispatch({
-      type: "slides-session-update",
-      value: { slidesSeededSourceId: sourceId },
-    });
+    panelState.slides = {
+      sourceUrl: run.url,
+      sourceId,
+      sourceKind,
+      ocrAvailable: false,
+      slides,
+    };
+    patchPanelState(panelState, "slidesSession", { slidesSeededSourceId: sourceId });
     updateSlidesTextState();
     queueSlidesRender();
     schedulePanelCacheSync(0);
@@ -152,7 +138,7 @@ export function createPlannedSlidesRuntime({
   };
 
   const clearPendingRun = () => {
-    dispatch({ type: "planned-slides-run", value: null });
+    patchPanelState(panelState, "slidesLifecycle", { plannedRun: null });
   };
 
   const maybeSeedPendingRun = () => {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime.ts
@@ -8,7 +8,7 @@ import type { SidepanelDom } from "./dom";
 import { createSidepanelFeedbackRuntime } from "./feedback-runtime";
 import type { createMetricsController } from "./metrics-controller";
 import { buildPanelCachePayload, createPanelCacheController } from "./panel-cache";
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import { createPanelPhaseRuntime } from "./phase-runtime";
 import {
   retainRenderedSlideSummary,
@@ -64,7 +64,7 @@ function createMarkdownRenderer() {
 export function createSidepanelPresentationRuntime({
   dom,
   panelState,
-  dispatchPanelState,
+
   appearanceControls,
   metricsController,
   resolveLocalSlides,
@@ -72,7 +72,7 @@ export function createSidepanelPresentationRuntime({
 }: {
   dom: SidepanelDom;
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   appearanceControls: AppearanceControls;
   metricsController: MetricsController;
   resolveLocalSlides: ResolveLocalSlides;
@@ -81,7 +81,7 @@ export function createSidepanelPresentationRuntime({
   const markdown = createMarkdownRenderer();
   const slidesTextController = createSlidesTextController({
     panelState,
-    dispatchPanelState,
+
     getSlides: () => panelState.slides?.slides ?? null,
     getLengthValue: appearanceControls.getLengthValue,
     getSlidesOcrEnabled: () => panelState.slidesSession.slidesOcrEnabled,
@@ -133,7 +133,7 @@ export function createSidepanelPresentationRuntime({
   const sendSummarize = createSummarizeCommand({
     send,
     setLastAction: (value) => {
-      dispatchPanelState({ type: "panel-session-update", value: { lastAction: value } });
+      patchPanelState(panelState, "panelSession", { lastAction: value });
     },
     clearInlineError: errorController.clearInlineError,
     getInputModeOverride: () => panelState.slidesSession.inputModeOverride,
@@ -184,12 +184,12 @@ export function createSidepanelPresentationRuntime({
     refreshSummarizeControl,
     hideSlideNotice,
     panelState,
-    dispatchPanelState,
+
     getFallbackSummaryMarkdown: () => selectRetainedSlideSummaryMarkdown(panelState),
   });
 
   const renderMarkdown = (value: string) => {
-    retainRenderedSlideSummary(panelState, dispatchPanelState, value);
+    retainRenderedSlideSummary(panelState, value);
     slidesViewRuntime.renderMarkdown(value);
   };
   let refreshBrowserAiSlides = () => {};
@@ -206,7 +206,7 @@ export function createSidepanelPresentationRuntime({
     browserAi: browserAiRuntime,
     clearSummarySource: slidesTextController.clearSummarySource,
     panelState,
-    dispatchPanelState,
+
     friendlyFetchError,
     getLengthValue: appearanceControls.getLengthValue,
     getToken: async () => (await loadSettings()).token,
@@ -236,7 +236,7 @@ export function createSidepanelPresentationRuntime({
     slidesLayoutEl: dom.slidesLayoutEl,
     slidesTextController,
     panelState,
-    dispatchPanelState,
+
     patchSettings,
     loadSettings,
     showSlideNotice,
@@ -271,7 +271,7 @@ export function createSidepanelPresentationRuntime({
 
   const phaseRuntime = createPanelPhaseRuntime({
     panelState,
-    dispatchPanelState,
+
     errorController,
     headerController,
     setSlidesBusy: slidesViewRuntime.setSlidesBusy,
@@ -281,7 +281,7 @@ export function createSidepanelPresentationRuntime({
 
   const summaryViewRuntime = createSummaryViewRuntime({
     panelState,
-    dispatchPanelState,
+
     renderEl: dom.renderEl,
     renderSlidesHostEl: dom.renderSlidesHostEl,
     renderMarkdownHostEl: dom.renderMarkdownHostEl,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/retained-slide-summary.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/retained-slide-summary.ts
@@ -1,4 +1,3 @@
-import type { PanelStateAction } from "./panel-state-store";
 import { panelUrlsMatch } from "./session-policy";
 import type { PanelState } from "./types";
 
@@ -7,17 +6,14 @@ const getSummaryScopeUrl = (panelState: PanelState) =>
 
 export function retainRenderedSlideSummary(
   panelState: PanelState,
-  dispatchPanelState: (action: PanelStateAction) => void,
+
   markdown: string,
 ) {
   if (!markdown.trim()) return;
-  dispatchPanelState({
-    type: "retained-slide-summary",
-    value: {
-      markdown,
-      url: getSummaryScopeUrl(panelState),
-    },
-  });
+  panelState.retainedSlideSummary = {
+    markdown,
+    url: getSummaryScopeUrl(panelState),
+  };
 }
 
 export function selectRetainedSlideSummaryMarkdown(panelState: PanelState) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/run-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/run-runtime.ts
@@ -8,7 +8,6 @@ import type { HeaderController } from "./header-controller";
 import type { createMetricsController } from "./metrics-controller";
 import type { NavigationRuntime } from "./navigation-runtime";
 import type { PanelCacheController } from "./panel-cache";
-import type { PanelStateAction } from "./panel-state-store";
 import { createPlannedSlidesRuntime } from "./planned-slides-runtime";
 import type { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import { friendlyFetchError } from "./setup-runtime";
@@ -32,7 +31,7 @@ type PresentationRuntime = ReturnType<typeof createSidepanelPresentationRuntime>
 
 export function createSidepanelRunRuntime({
   panelState,
-  dispatchPanelState,
+
   getActiveTabId,
   getActiveTabUrl,
   appearanceControls,
@@ -46,7 +45,7 @@ export function createSidepanelRunRuntime({
   syncWithActiveTab,
 }: {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   getActiveTabId: () => number | null;
   getActiveTabUrl: () => string | null;
   appearanceControls: AppearanceControls;
@@ -82,7 +81,7 @@ export function createSidepanelRunRuntime({
 
   const plannedSlidesRuntime = createPlannedSlidesRuntime({
     panelState,
-    dispatchPanelState,
+
     getActiveTabUrl,
     getLengthValue: appearanceControls.getLengthValue,
     updateSlidesTextState,
@@ -104,7 +103,7 @@ export function createSidepanelRunRuntime({
     isStreaming,
     maybeApplyPendingSlidesSummary,
     panelState,
-    dispatchPanelState,
+
     queueSlidesRender,
     rebuildSlideDescriptions,
     refreshSummaryMetrics: (summary) => {
@@ -138,14 +137,14 @@ export function createSidepanelRunRuntime({
   });
   const browserAiSnapshotRuntime = createBrowserAiSnapshotRuntime({
     panelState,
-    dispatchPanelState,
+
     browserAi: presentationRuntime.summary.browserAiRuntime,
     renderMarkdown,
   });
 
   const summaryRunRuntime = createSummaryRunRuntime({
     panelState,
-    dispatchPanelState,
+
     getActiveTabId,
     cancelAutoSummarize: autoSummarizeRuntime.cancel,
     summaryStream: {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/session-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/session-runtime.ts
@@ -4,7 +4,7 @@ import { createSidepanelChatRuntime } from "./chat-runtime";
 import type { SidepanelDom } from "./dom";
 import type { createMetricsController } from "./metrics-controller";
 import { createNavigationRuntime } from "./navigation-runtime";
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import { createPanelViewRuntime } from "./panel-view-runtime";
 import type { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import type { PanelState } from "./types";
@@ -23,14 +23,14 @@ type RunActions = {
 export function createSidepanelSessionRuntime({
   dom,
   panelState,
-  dispatchPanelState,
+
   metricsController,
   presentationRuntime,
   send,
 }: {
   dom: SidepanelDom;
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   metricsController: MetricsController;
   presentationRuntime: PresentationRuntime;
   send: (message: PanelToBg) => Promise<void>;
@@ -46,7 +46,7 @@ export function createSidepanelSessionRuntime({
   const navigationRuntime = createNavigationRuntime({
     getState: () => panelState.navigation,
     updateState: (value) => {
-      dispatchPanelState({ type: "navigation-policy-update", value });
+      patchPanelState(panelState, "navigation", value);
     },
   });
 
@@ -54,7 +54,7 @@ export function createSidepanelSessionRuntime({
   const getActiveTabUrl = () => panelState.navigation.activeTabUrl;
   const chatRuntime = createSidepanelChatRuntime({
     panelState,
-    dispatchPanelState,
+
     markdown,
     mainEl: dom.mainEl,
     renderEl: dom.renderEl,
@@ -84,7 +84,7 @@ export function createSidepanelSessionRuntime({
       metricsController.setActiveMode("chat");
     },
     setLastActionChat: () => {
-      dispatchPanelState({ type: "panel-session-update", value: { lastAction: "chat" } });
+      patchPanelState(panelState, "panelSession", { lastAction: "chat" });
     },
     renderInlineSlides: () => {
       renderInlineSlides(dom.chatMessagesEl);
@@ -105,7 +105,7 @@ export function createSidepanelSessionRuntime({
       navigationRuntime,
       getCurrentSource: () => panelState.currentSource,
       setCurrentSource: (source) => {
-        dispatchPanelState({ type: "source", source });
+        panelState.currentSource = source;
       },
       resetForNavigation: (preserveChat) => {
         setPhase("idle");
@@ -123,7 +123,7 @@ export function createSidepanelSessionRuntime({
   };
 
   const clearCurrentView = async () => {
-    dispatchPanelState({ type: "retained-slide-summary", value: null });
+    panelState.retainedSlideSummary = null;
     if (panelState.chat.streaming) {
       chatRuntime.requestAbort("Cleared");
     }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-run-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-run-runtime.ts
@@ -1,4 +1,4 @@
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState, setPendingSlidesRun } from "./panel-state-store";
 import { normalizePanelUrl } from "./session-policy";
 import { hasResolvedSlidesPayload } from "./slides-pending";
 import { resolveSlidesInputMode } from "./slides-session-state";
@@ -6,7 +6,7 @@ import type { PanelState, RunStart } from "./types";
 
 export function createSlidesRunRuntime(options: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   refreshSummarizeControl: () => void;
   hideSlideNotice: () => void;
   setSlidesBusy: (value: boolean) => void;
@@ -30,22 +30,11 @@ export function createSlidesRunRuntime(options: {
   shouldUseBrowserAiSlides: () => boolean;
   headerSetStatus: (text: string) => void;
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (options.dispatchPanelState) {
-      options.dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(options.panelState, action);
-    }
-  };
-
   const ensureVideoMode = () => {
     if (resolveSlidesInputMode(options.panelState.slidesSession) === "video") return;
-    dispatch({
-      type: "slides-session-update",
-      value: {
-        inputMode: "video",
-        inputModeOverride: "video",
-      },
+    patchPanelState(options.panelState, "slidesSession", {
+      inputMode: "video",
+      inputModeOverride: "video",
     });
     options.refreshSummarizeControl();
   };
@@ -68,10 +57,10 @@ export function createSlidesRunRuntime(options: {
   };
 
   const stopSlidesStream = () => {
-    dispatch({ type: "active-slides-run", value: null });
+    patchPanelState(options.panelState, "slidesLifecycle", { activeRun: null });
     options.stopSlidesHydrator();
     options.setSlidesBusy(false);
-    dispatch({ type: "slides-run", runId: null });
+    options.panelState.slidesRunId = null;
     stopSlidesSummaryStream();
   };
 
@@ -83,7 +72,7 @@ export function createSlidesRunRuntime(options: {
     ensureVideoMode();
     options.hideSlideNotice();
     options.setSlidesBusy(true);
-    dispatch({ type: "slides-run", runId });
+    options.panelState.slidesRunId = runId;
     options.schedulePanelCacheSync();
     options.startSlidesHydrator(runId, opts);
   };
@@ -104,7 +93,7 @@ export function createSlidesRunRuntime(options: {
         null,
       local: meta?.local ?? existing?.local ?? false,
     };
-    dispatch({ type: "active-slides-run", value: activeRun });
+    patchPanelState(options.panelState, "slidesLifecycle", { activeRun: activeRun });
     startSlidesStreamCore(runId, { local: activeRun.local });
   };
 
@@ -161,11 +150,7 @@ export function createSlidesRunRuntime(options: {
     local?: boolean;
   }) => {
     if (!value.url) return;
-    dispatch({
-      type: "pending-slides-run",
-      urlKey: normalizePanelUrl(value.url),
-      value,
-    });
+    setPendingSlidesRun(options.panelState, normalizePanelUrl(value.url), value);
   };
 
   const maybeStartPendingSlidesForUrl = (url: string | null) => {
@@ -176,7 +161,7 @@ export function createSlidesRunRuntime(options: {
     if (!options.panelState.slidesSession.slidesEnabled) return;
     if (resolveSlidesInputMode(options.panelState.slidesSession) !== "video") return;
     if (options.isSlidesHydratorStreaming()) return;
-    dispatch({ type: "pending-slides-run", urlKey: key, value: null });
+    setPendingSlidesRun(options.panelState, key, null);
     if (
       hasResolvedSlidesPayload(
         options.panelState.slides,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-runtime.ts
@@ -3,7 +3,6 @@ import {
   shouldUseBrowserAiForSlides,
 } from "./browser-ai-slides-runtime";
 import type { createBrowserAiSummaryRuntime } from "./browser-ai-summary-runtime";
-import type { PanelStateAction } from "./panel-state-store";
 import { createSlidesHydrator } from "./slides-hydrator";
 import { createSlidesRunRuntime } from "./slides-run-runtime";
 import { createSlidesSummaryController } from "./slides-summary-controller";
@@ -14,7 +13,7 @@ export function createSidepanelSlidesRuntime({
   browserAi,
   clearSummarySource,
   panelState,
-  dispatchPanelState,
+
   friendlyFetchError,
   getLengthValue,
   getToken,
@@ -40,7 +39,7 @@ export function createSidepanelSlidesRuntime({
   browserAi: ReturnType<typeof createBrowserAiSummaryRuntime>;
   clearSummarySource: () => void;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   friendlyFetchError: (error: unknown, fallback: string) => string;
   getLengthValue: () => string;
   getToken: () => Promise<string>;
@@ -68,7 +67,7 @@ export function createSidepanelSlidesRuntime({
 }) {
   const slidesSummaryController = createSlidesSummaryController({
     getToken,
-    dispatchPanelState,
+
     friendlyFetchError,
     panelUrlsMatch,
     getPanelState: () => panelState,
@@ -139,7 +138,7 @@ export function createSidepanelSlidesRuntime({
 
   const slidesRunRuntime = createSlidesRunRuntime({
     panelState,
-    dispatchPanelState,
+
     refreshSummarizeControl,
     hideSlideNotice,
     setSlidesBusy,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-summary-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-summary-controller.ts
@@ -1,5 +1,5 @@
 import { buildSlidePresentation } from "../../lib/slides-presentation";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { createInitialSlidesSummaryState, patchPanelState } from "./panel-state-store";
 import { resolveSlidesLengthArg } from "./slides-state";
 import { createStreamController } from "./stream-controller";
 import type { PanelState, RunStart, SlideSummarySource, UiState } from "./types";
@@ -13,7 +13,7 @@ type SlidesSummarySnapshot = {
 
 type SlidesSummaryControllerOptions = {
   getToken: () => Promise<string>;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   friendlyFetchError: (error: unknown, fallback: string) => string;
   panelUrlsMatch: (left: string | null | undefined, right: string | null | undefined) => boolean;
   getPanelState: () => PanelState;
@@ -36,16 +36,9 @@ type SlidesSummaryControllerOptions = {
 export function createSlidesSummaryController(options: SlidesSummaryControllerOptions) {
   let activeGeneration = 0;
 
-  const dispatch = (action: PanelStateAction) => {
-    if (options.dispatchPanelState) {
-      options.dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(options.getPanelState(), action);
-    }
-  };
   const getState = () => options.getPanelState().slidesSummary;
   const updateState = (value: Partial<PanelState["slidesSummary"]>) => {
-    dispatch({ type: "slides-summary-update", value });
+    patchPanelState(options.getPanelState(), "slidesSummary", value);
   };
   const isCurrentGeneration = (generation: number) => generation === activeGeneration;
 
@@ -215,7 +208,7 @@ export function createSlidesSummaryController(options: SlidesSummaryControllerOp
       activeGeneration += 1;
       streamController.abort();
       streamController = createGenerationStreamController(activeGeneration);
-      dispatch({ type: "slides-summary-reset" });
+      options.getPanelState().slidesSummary = createInitialSlidesSummaryState();
       options.clearSummarySource();
     },
     start(run: RunStart) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-text-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-text-controller.ts
@@ -1,7 +1,7 @@
 import { logExtensionEvent } from "../../lib/extension-logs";
 import type { SseSlidesData } from "../../lib/runtime-contracts";
 import { parseTranscriptTimedText } from "../../lib/slides-text";
-import type { PanelStateAction } from "./panel-state-store";
+import { createInitialSlidesTextState, patchPanelState } from "./panel-state-store";
 import {
   buildSlideDescriptions,
   deriveSlideSummaries,
@@ -12,7 +12,7 @@ import type { PanelState, SlideSummarySource } from "./types";
 
 export function createSlidesTextController(options: {
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   getSlides: () => SseSlidesData["slides"] | null | undefined;
   getLengthValue: () => string;
   getSlidesOcrEnabled: () => boolean;
@@ -22,7 +22,7 @@ export function createSlidesTextController(options: {
   const getSlides = () => options.getSlides() ?? [];
   const getState = () => options.panelState.slidesText;
   const updateState = (value: Partial<PanelState["slidesText"]>) => {
-    options.dispatchPanelState({ type: "slides-text-update", value });
+    patchPanelState(options.panelState, "slidesText", value);
   };
 
   const rebuildDescriptions = () => {
@@ -71,7 +71,7 @@ export function createSlidesTextController(options: {
 
   return {
     reset() {
-      options.dispatchPanelState({ type: "slides-text-reset" });
+      options.panelState.slidesText = createInitialSlidesTextState();
       lastDescriptionLogKey = "";
     },
     clearSummarySource() {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime.ts
@@ -2,7 +2,7 @@ import { shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import type MarkdownIt from "markdown-it";
 import { logExtensionEvent } from "../../lib/extension-logs";
 import type { SseSlidesData } from "../../lib/runtime-contracts";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import { createSlideImageLoader, normalizeSlideImageUrl } from "./slide-images";
 import {
   normalizeSlidesPayload,
@@ -29,7 +29,7 @@ export function createSlidesViewRuntime({
   refreshSummarizeControl,
   hideSlideNotice,
   panelState,
-  dispatchPanelState,
+
   getFallbackSummaryMarkdown,
 }: {
   renderMarkdownHostEl: HTMLElement;
@@ -61,19 +61,13 @@ export function createSlidesViewRuntime({
   refreshSummarizeControl: () => void;
   hideSlideNotice: () => void;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   getFallbackSummaryMarkdown?: () => string | null;
 }) {
   const slideImageLoader = createSlideImageLoader();
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
+
   const updateSlidesSession = (value: Partial<PanelState["slidesSession"]>) => {
-    dispatch({ type: "slides-session-update", value });
+    patchPanelState(panelState, "slidesSession", value);
   };
   const resolveActiveSlidesRunId = () => {
     if (panelState.slidesRunId) return panelState.slidesRunId;
@@ -214,7 +208,7 @@ export function createSlidesViewRuntime({
   };
 
   const renderMarkdown = (markdown: string) => {
-    dispatch({ type: "summary", markdown });
+    panelState.summaryMarkdown = markdown;
     updateSlideSummaryFromMarkdown(markdown, {
       preserveIfEmpty: slidesTextController.hasSummaryTitles(),
       source: "summary",
@@ -238,7 +232,9 @@ export function createSlidesViewRuntime({
     if (!panelState.slides || panelState.slidesSession.slidesContextPending) return;
     const sourceUrl = panelState.slides.sourceUrl || panelState.currentSource?.url || null;
     if (sourceUrl && panelState.slidesSession.slidesContextUrl === sourceUrl) return;
-    dispatch({ type: "slides-context-request-next" });
+    patchPanelState(panelState, "slidesSession", {
+      slidesContextRequestId: panelState.slidesSession.slidesContextRequestId + 1,
+    });
     const requestId = `slides-${panelState.slidesSession.slidesContextRequestId}`;
     updateSlidesSession({
       slidesContextPending: true,
@@ -294,7 +290,7 @@ export function createSlidesViewRuntime({
       }
       return;
     }
-    dispatch({ type: "slides", slides: merged });
+    panelState.slides = merged;
     if (activeSlidesRunId) {
       updateSlidesSession({ slidesAppliedRunId: activeSlidesRunId });
     }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/state-effects-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/state-effects-runtime.ts
@@ -6,7 +6,7 @@ import type { createDaemonHintRuntime } from "./daemon-hint-runtime";
 import type { SidepanelDom } from "./dom";
 import type { PanelCachePayload } from "./panel-cache";
 import type { createPanelMessagingRuntime } from "./panel-messaging";
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import type { createSidepanelRunRuntime } from "./run-runtime";
 import type { createSidepanelSessionRuntime } from "./session-runtime";
@@ -27,7 +27,7 @@ type TypographyController = ReturnType<typeof createTypographyController>;
 export function createSidepanelStateEffectsRuntime({
   dom,
   panelState,
-  dispatchPanelState,
+
   appearanceControls,
   typographyController,
   panelMessagingRuntime,
@@ -39,7 +39,7 @@ export function createSidepanelStateEffectsRuntime({
 }: {
   dom: SidepanelDom;
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   appearanceControls: AppearanceControls;
   typographyController: TypographyController;
   panelMessagingRuntime: PanelMessagingRuntime;
@@ -89,7 +89,7 @@ export function createSidepanelStateEffectsRuntime({
 
   const uiStateRuntime = createUiStateRuntime({
     panelState,
-    dispatchPanelState,
+
     appearanceControls,
     typographyController,
     navigationRuntime,
@@ -142,7 +142,7 @@ export function createSidepanelStateEffectsRuntime({
 
   const bgMessageRuntime = createSidepanelBgMessageRuntime({
     panelState,
-    dispatchPanelState,
+
     applyUiState,
     setStatus: headerController.setStatus,
     isStreaming,
@@ -159,7 +159,7 @@ export function createSidepanelStateEffectsRuntime({
     handleSlidesLocal: handleLocalSlidesResponse,
     getSlidesContextRequestId: () => panelState.slidesSession.slidesContextRequestId,
     setSlidesContextPending: (value) => {
-      dispatchPanelState({ type: "slides-session-update", value: { slidesContextPending: value } });
+      patchPanelState(panelState, "slidesSession", { slidesContextPending: value });
     },
     setSlidesTranscriptTimedText,
     updateSlidesTextState,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime.ts
@@ -1,7 +1,7 @@
 import { daemonFetch } from "../../lib/daemon-fetch";
 import { getDaemonOrigin } from "../../lib/daemon-url";
 import type { Settings, SlidesLayout } from "../../lib/settings";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { SlideTextMode } from "./slides-state";
 import { resolveSlidesRenderLayout } from "./slides-view-policy";
 import type { PanelState } from "./types";
@@ -16,7 +16,7 @@ type SummarizeControlRuntimeOptions = {
   slidesLayoutEl: HTMLSelectElement;
   slidesTextController: SlidesTextControllerLike;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   patchSettings: (patch: Partial<Settings>) => Promise<void>;
   loadSettings: () => Promise<Pick<Settings, "slideRuntime" | "token">>;
   showSlideNotice: (message: string) => void;
@@ -68,13 +68,6 @@ async function fetchSlideTools(
 }
 
 export function createSummarizeControlRuntime(options: SummarizeControlRuntimeOptions) {
-  const dispatch = (action: PanelStateAction) => {
-    if (options.dispatchPanelState) {
-      options.dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(options.panelState, action);
-    }
-  };
   const getEffectiveMode = () =>
     options.panelState.slidesSession.inputModeOverride ??
     options.panelState.slidesSession.inputMode;
@@ -114,13 +107,10 @@ export function createSummarizeControlRuntime(options: SummarizeControlRuntimeOp
       options.stopSlidesStream();
     }
 
-    dispatch({
-      type: "slides-session-update",
-      value: {
-        inputMode: value.mode,
-        inputModeOverride: value.mode,
-        slidesEnabled: value.slides,
-      },
+    patchPanelState(options.panelState, "slidesSession", {
+      inputMode: value.mode,
+      inputModeOverride: value.mode,
+      slidesEnabled: value.slides,
     });
     await options.patchSettings({ slidesEnabled: value.slides });
 
@@ -166,10 +156,7 @@ export function createSummarizeControlRuntime(options: SummarizeControlRuntimeOp
 
   const setSlidesLayout = (next: SlidesLayout) => {
     if (next === options.panelState.slidesSession.slidesLayout) return;
-    dispatch({
-      type: "slides-session-update",
-      value: { slidesLayout: next },
-    });
+    patchPanelState(options.panelState, "slidesSession", { slidesLayout: next });
     options.slidesLayoutEl.value = next;
     applySlidesLayout();
   };

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summary-run-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summary-run-runtime.ts
@@ -1,5 +1,10 @@
 import type { BrowserAiSummaryInput } from "../../lib/panel-contracts";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import {
+  attachPanelRun,
+  patchPanelState,
+  restorePanelSession,
+  setPendingSummaryRun,
+} from "./panel-state-store";
 import { normalizePanelUrl, panelUrlsMatch } from "./session-policy";
 import { resolveSlidesInputMode } from "./slides-session-state";
 import type { PanelPhase, PanelState, RunStart } from "./types";
@@ -37,7 +42,7 @@ type SummaryViewPort = {
 
 export function createSummaryRunRuntime({
   panelState,
-  dispatchPanelState,
+
   getActiveTabId,
   cancelAutoSummarize,
   summaryStream,
@@ -47,7 +52,7 @@ export function createSummaryRunRuntime({
   browserAi,
 }: {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   getActiveTabId: () => number | null;
   cancelAutoSummarize: () => void;
   summaryStream: SummaryStreamPort;
@@ -64,14 +69,6 @@ export function createSummaryRunRuntime({
     }) => void;
   };
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
-
   const attachRun = (run: RunStart) => {
     browserAi.cancel();
     const activeSlidesRun = panelState.slidesLifecycle.activeRun;
@@ -81,7 +78,7 @@ export function createSummaryRunRuntime({
     if (!preserveActiveLocalSlideRun) slides.stop();
 
     view.setPhase("connecting");
-    dispatch({ type: "panel-session-update", value: { lastAction: "summarize" } });
+    patchPanelState(panelState, "panelSession", { lastAction: "summarize" });
     cancelAutoSummarize();
     if (panelState.chat.streaming) chat.finishStreamingMessage();
 
@@ -106,8 +103,7 @@ export function createSummaryRunRuntime({
     view.setHeaderTitle(run.title || run.url || "Summarize");
     view.setHeaderSubtitle("");
     const fallbackModel = panelState.ui?.settings.model ?? null;
-    dispatch({
-      type: "attach-run",
+    attachPanelRun(panelState, {
       tabId: getActiveTabId(),
       runId: run.id,
       slidesRunId,
@@ -154,8 +150,7 @@ export function createSummaryRunRuntime({
     const slidesRunId =
       preservedSlides?.sourceId ??
       (preserveActiveSlideRun ? (activeSlidesRun?.runId ?? null) : null);
-    dispatch({
-      type: "restore-session",
+    restorePanelSession(panelState, {
       tabId: getActiveTabId(),
       runId: payload.run.id,
       slidesRunId,
@@ -181,11 +176,7 @@ export function createSummaryRunRuntime({
   };
 
   const rememberPendingRun = (run: RunStart) => {
-    dispatch({
-      type: "pending-summary-run",
-      urlKey: normalizePanelUrl(run.url),
-      value: { type: "run", run },
-    });
+    setPendingSummaryRun(panelState, normalizePanelUrl(run.url), { type: "run", run });
   };
 
   const rememberPendingSnapshot = (payload: {
@@ -193,15 +184,11 @@ export function createSummaryRunRuntime({
     markdown: string;
     browserAi?: BrowserAiSummaryInput;
   }) => {
-    dispatch({
-      type: "pending-summary-run",
-      urlKey: normalizePanelUrl(payload.run.url),
-      value: {
-        type: "snapshot",
-        run: payload.run,
-        markdown: payload.markdown,
-        browserAi: payload.browserAi,
-      },
+    setPendingSummaryRun(panelState, normalizePanelUrl(payload.run.url), {
+      type: "snapshot",
+      run: payload.run,
+      markdown: payload.markdown,
+      browserAi: payload.browserAi,
     });
   };
 
@@ -210,7 +197,7 @@ export function createSummaryRunRuntime({
     const key = normalizePanelUrl(url);
     const pending = panelState.pendingRuns.summaryByUrl[key];
     if (!pending || summaryStream.isStreaming()) return false;
-    dispatch({ type: "pending-summary-run", urlKey: key, value: null });
+    setPendingSummaryRun(panelState, key, null);
     if (pending.type === "snapshot") {
       applySnapshot({
         run: pending.run,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summary-stream-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summary-stream-runtime.ts
@@ -1,5 +1,4 @@
 import { buildIdleSubtitle } from "../../lib/header";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
 import { createStreamController } from "./stream-controller";
 import type { PanelPhase, PanelState } from "./types";
 
@@ -17,7 +16,7 @@ export function createSummaryStreamRuntime({
   isStreaming,
   maybeApplyPendingSlidesSummary,
   panelState,
-  dispatchPanelState,
+
   queueSlidesRender,
   rebuildSlideDescriptions,
   refreshSummaryMetrics,
@@ -44,7 +43,7 @@ export function createSummaryStreamRuntime({
   isStreaming: () => boolean;
   maybeApplyPendingSlidesSummary: () => void;
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   queueSlidesRender: () => void;
   rebuildSlideDescriptions: () => void;
   refreshSummaryMetrics: (summary: string) => void;
@@ -58,13 +57,6 @@ export function createSummaryStreamRuntime({
   shouldRebuildSlideDescriptions: () => boolean;
   syncWithActiveTab: () => Promise<void>;
 }) {
-  const dispatch = (action: PanelStateAction) => {
-    if (dispatchPanelState) {
-      dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(panelState, action);
-    }
-  };
   let lastStreamError: string | null = null;
 
   return {
@@ -73,14 +65,11 @@ export function createSummaryStreamRuntime({
       onReset: () => {
         resetSummaryView({ clearRunId: false, stopSlides: false });
         const fallbackModel = getFallbackModel();
-        dispatch({
-          type: "meta",
-          meta: {
-            inputSummary: null,
-            model: fallbackModel,
-            modelLabel: fallbackModel,
-          },
-        });
+        panelState.lastMeta = {
+          inputSummary: null,
+          model: fallbackModel,
+          modelLabel: fallbackModel,
+        };
         lastStreamError = null;
         seedPlannedSlidesForPendingRun();
       },
@@ -110,20 +99,15 @@ export function createSummaryStreamRuntime({
         rememberUrl(url);
       },
       onMeta: (data) => {
-        dispatch({
-          type: "meta",
-          meta: {
-            model: typeof data.model === "string" ? data.model : panelState.lastMeta.model,
-            modelLabel:
-              typeof data.modelLabel === "string"
-                ? data.modelLabel
-                : panelState.lastMeta.modelLabel,
-            inputSummary:
-              typeof data.inputSummary === "string"
-                ? data.inputSummary
-                : panelState.lastMeta.inputSummary,
-          },
-        });
+        panelState.lastMeta = {
+          model: typeof data.model === "string" ? data.model : panelState.lastMeta.model,
+          modelLabel:
+            typeof data.modelLabel === "string" ? data.modelLabel : panelState.lastMeta.modelLabel,
+          inputSummary:
+            typeof data.inputSummary === "string"
+              ? data.inputSummary
+              : panelState.lastMeta.inputSummary,
+        };
         headerSetBaseSubtitle(
           buildIdleSubtitle({
             inputSummary: panelState.lastMeta.inputSummary,
@@ -135,7 +119,7 @@ export function createSummaryStreamRuntime({
       },
       onSlides: handleSlides,
       onSummaryFromCache: (value) => {
-        dispatch({ type: "summary-cache", value });
+        panelState.summaryFromCache = value;
         handleSummaryFromCache(value);
         schedulePanelCacheSync();
         if (value === true) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summary-view-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summary-view-runtime.ts
@@ -1,7 +1,7 @@
 import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import { buildIdleSubtitle } from "../../lib/header";
 import type { PanelCachePayload } from "./panel-cache";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState, resetPanelSummary, restorePanelSession } from "./panel-state-store";
 import { normalizeSlideImageUrl } from "./slide-images";
 import { normalizeSlidesPayload } from "./slides-payload";
 import { clearSummaryCopyButton } from "./summary-renderer";
@@ -31,7 +31,7 @@ type HeaderControllerLike = {
 
 type SummaryViewRuntimeOpts = {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   renderEl: HTMLElement;
   renderSlidesHostEl: HTMLElement;
   renderMarkdownHostEl: HTMLElement;
@@ -59,13 +59,6 @@ type SummaryViewRuntimeOpts = {
 };
 
 export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
-  const dispatch = (action: PanelStateAction) => {
-    if (opts.dispatchPanelState) {
-      opts.dispatchPanelState(action);
-    } else {
-      applyPanelStateAction(opts.panelState, action);
-    }
-  };
   const resolveActiveSlidesRunId = () => {
     if (opts.panelState.slidesRunId) return opts.panelState.slidesRunId;
     if (opts.panelState.slides && opts.panelState.runId) return opts.panelState.runId;
@@ -83,20 +76,17 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
     opts.renderMarkdownHostEl.innerHTML = "";
     clearSummaryCopyButton(opts.summaryCopyBtn);
     opts.metricsController.clearForMode("summary");
-    dispatch({ type: "reset-summary", clearRunId, clearSlides: stopSlides });
-    dispatch({
-      type: "slides-session-update",
-      value: {
-        slidesExpanded: true,
-        ...(stopSlides
-          ? {
-              slidesContextPending: false,
-              slidesContextUrl: null,
-              slidesSeededSourceId: null,
-              slidesAppliedRunId: null,
-            }
-          : {}),
-      },
+    resetPanelSummary(opts.panelState, { clearRunId, clearSlides: stopSlides });
+    patchPanelState(opts.panelState, "slidesSession", {
+      slidesExpanded: true,
+      ...(stopSlides
+        ? {
+            slidesContextPending: false,
+            slidesContextUrl: null,
+            slidesSeededSourceId: null,
+            slidesAppliedRunId: null,
+          }
+        : {}),
     });
     if (stopSlides) {
       opts.slidesRenderer.clear();
@@ -112,8 +102,7 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
     const slidesRunId =
       payload.slidesRunId ??
       (opts.panelState.slidesSession.slidesParallel ? null : (payload.runId ?? null));
-    dispatch({
-      type: "restore-session",
+    restorePanelSession(opts.panelState, {
       tabId: payload.tabId,
       runId: payload.runId ?? null,
       slidesRunId,
@@ -125,20 +114,17 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
       },
       summaryFromCache: payload.summaryFromCache ?? null,
     });
-    dispatch({
-      type: "slides-summary-update",
-      value: {
-        markdown: payload.slidesSummaryMarkdown ?? "",
-        complete:
-          payload.slidesSummaryComplete ?? Boolean((payload.slidesSummaryMarkdown ?? "").trim()),
-        model:
-          payload.slidesSummaryModel ??
-          opts.panelState.lastMeta.model ??
-          opts.panelState.ui?.settings.model ??
-          null,
-        pending: null,
-        hadError: false,
-      },
+    patchPanelState(opts.panelState, "slidesSummary", {
+      markdown: payload.slidesSummaryMarkdown ?? "",
+      complete:
+        payload.slidesSummaryComplete ?? Boolean((payload.slidesSummaryMarkdown ?? "").trim()),
+      model:
+        payload.slidesSummaryModel ??
+        opts.panelState.lastMeta.model ??
+        opts.panelState.ui?.settings.model ??
+        null,
+      pending: null,
+      hadError: false,
     });
     opts.headerController.setBaseTitle(payload.title || payload.url || "Summarize");
     opts.headerController.setBaseSubtitle(
@@ -152,26 +138,16 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
     const normalizedSlides = normalizeSlidesPayload(payload.slides);
     const hasNormalizedSlides = Boolean(normalizedSlides && normalizedSlides.slides.length > 0);
     if (normalizedSlides && hasNormalizedSlides) {
-      dispatch({
-        type: "slides",
-        slides: {
-          ...normalizedSlides,
-          slides: normalizedSlides.slides.map((slide) => ({
-            ...slide,
-            imageUrl: normalizeSlideImageUrl(
-              slide.imageUrl,
-              normalizedSlides.sourceId,
-              slide.index,
-            ),
-          })),
-        },
-      });
-      dispatch({
-        type: "slides-session-update",
-        value: {
-          slidesContextPending: false,
-          slidesContextUrl: opts.slidesTextController.getTranscriptAvailable() ? payload.url : null,
-        },
+      opts.panelState.slides = {
+        ...normalizedSlides,
+        slides: normalizedSlides.slides.map((slide) => ({
+          ...slide,
+          imageUrl: normalizeSlideImageUrl(slide.imageUrl, normalizedSlides.sourceId, slide.index),
+        })),
+      };
+      patchPanelState(opts.panelState, "slidesSession", {
+        slidesContextPending: false,
+        slidesContextUrl: opts.slidesTextController.getTranscriptAvailable() ? payload.url : null,
       });
       opts.updateSlidesTextState();
       if (
@@ -181,19 +157,15 @@ export function createSummaryViewRuntime(opts: SummaryViewRuntimeOpts) {
       ) {
         void opts.requestSlidesContext();
       }
-      dispatch({
-        type: "slides-session-update",
-        value: { slidesAppliedRunId: resolveActiveSlidesRunId() },
+      patchPanelState(opts.panelState, "slidesSession", {
+        slidesAppliedRunId: resolveActiveSlidesRunId(),
       });
     } else {
-      dispatch({ type: "slides", slides: null });
-      dispatch({
-        type: "slides-session-update",
-        value: {
-          slidesContextPending: false,
-          slidesContextUrl: null,
-          slidesAppliedRunId: null,
-        },
+      opts.panelState.slides = null;
+      patchPanelState(opts.panelState, "slidesSession", {
+        slidesContextPending: false,
+        slidesContextUrl: null,
+        slidesAppliedRunId: null,
       });
       opts.updateSlidesTextState();
       if (payload.summaryMarkdown && payload.url && isYouTubeVideoUrl(payload.url)) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/test-hooks-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/test-hooks-runtime.ts
@@ -1,7 +1,7 @@
 import type { BgToPanel, UiState } from "../../lib/panel-contracts";
 import type { SidepanelDom } from "./dom";
 import { isPanelChatAvailable } from "./panel-capabilities";
-import type { PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import type { createSidepanelPresentationRuntime } from "./presentation-runtime";
 import { selectRetainedSlideSummaryMarkdown } from "./retained-slide-summary";
 import type { createSidepanelRunRuntime } from "./run-runtime";
@@ -17,14 +17,14 @@ type StateEffectsRuntime = ReturnType<typeof createSidepanelStateEffectsRuntime>
 export function registerSidepanelRuntimeTestHooks({
   dom,
   panelState,
-  dispatchPanelState,
+
   presentationRuntime,
   runRuntime,
   stateEffectsRuntime,
 }: {
   dom: SidepanelDom;
   panelState: PanelState;
-  dispatchPanelState: (action: PanelStateAction) => void;
+
   presentationRuntime: PresentationRuntime;
   runRuntime: RunRuntime;
   stateEffectsRuntime: StateEffectsRuntime;
@@ -85,7 +85,7 @@ export function registerSidepanelRuntimeTestHooks({
     }),
     renderSlidesNow: slidesViewRuntime.queueSlidesRender,
     applyUiState: (state: UiState) => {
-      dispatchPanelState({ type: "ui", ui: state });
+      panelState.ui = state;
       stateEffectsRuntime.applyUiState(state);
     },
     applyBgMessage: (message: BgToPanel) => {
@@ -104,13 +104,10 @@ export function registerSidepanelRuntimeTestHooks({
       setPhase("idle");
     },
     forceRenderSlides: () => {
-      dispatchPanelState({
-        type: "slides-session-update",
-        value: {
-          slidesEnabled: true,
-          inputMode: "video",
-          inputModeOverride: "video",
-        },
+      patchPanelState(panelState, "slidesSession", {
+        slidesEnabled: true,
+        inputMode: "video",
+        inputModeOverride: "video",
       });
       return slidesViewRuntime.slidesRenderer.forceRender();
     },

--- a/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/ui-state-runtime.ts
@@ -1,7 +1,7 @@
 import { isYouTubeVideoUrl, shouldPreferUrlMode } from "@steipete/summarize-core/content/url";
 import type { PanelCachePayload } from "./panel-cache";
 import { isPanelChatAvailable } from "./panel-capabilities";
-import { applyPanelStateAction, type PanelStateAction } from "./panel-state-store";
+import { patchPanelState } from "./panel-state-store";
 import {
   resolvePanelNavigationDecision,
   shouldIgnoreTransientPanelTabState,
@@ -43,7 +43,7 @@ type PanelCacheControllerLike = {
 
 type UiStateRuntimeOpts = {
   panelState: PanelState;
-  dispatchPanelState?: (action: PanelStateAction) => void;
+
   appearanceControls: AppearanceControlsLike;
   typographyController: TypographyControllerLike;
   navigationRuntime: NavigationRuntimeLike;
@@ -88,22 +88,10 @@ type UiStateRuntimeOpts = {
   onSlidesOcrChanged: () => void;
 };
 
-function dispatchPanelState(
-  opts: Pick<UiStateRuntimeOpts, "panelState" | "dispatchPanelState">,
-  action: PanelStateAction,
-) {
-  if (opts.dispatchPanelState) {
-    opts.dispatchPanelState(action);
-  } else {
-    applyPanelStateAction(opts.panelState, action);
-  }
-}
-
 function applyCachedOrReset(
   opts: Pick<
     UiStateRuntimeOpts,
     | "panelState"
-    | "dispatchPanelState"
     | "panelCacheController"
     | "applyPanelCache"
     | "requestSlidesCapture"
@@ -126,14 +114,14 @@ function applyCachedOrReset(
         opts.requestSlidesCapture();
       }
     } else {
-      dispatchPanelState(opts, { type: "source", source: null });
+      opts.panelState.currentSource = null;
       opts.resetSummaryView({ preserveChat });
       opts.panelCacheController.request(tabId, url, preserveChat);
     }
     return;
   }
 
-  dispatchPanelState(opts, { type: "source", source: null });
+  opts.panelState.currentSource = null;
   opts.resetSummaryView({ preserveChat });
 }
 
@@ -142,12 +130,9 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
     if (state.panelOpen && !opts.panelState.panelSession.lastPanelOpen) {
       opts.clearInlineError();
     }
-    dispatchPanelState(opts, {
-      type: "panel-session-update",
-      value: {
-        lastPanelOpen: state.panelOpen,
-        autoSummarize: state.settings.autoSummarize,
-      },
+    patchPanelState(opts.panelState, "panelSession", {
+      lastPanelOpen: state.panelOpen,
+      autoSummarize: state.settings.autoSummarize,
     });
     opts.appearanceControls.setAutoValue(state.settings.autoSummarize);
 
@@ -206,7 +191,10 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
         );
       }
       const previousTabId = activeTabId;
-      dispatchPanelState(opts, { type: "active-tab", tabId: nextTabId, url: nextTabUrl });
+      patchPanelState(opts.panelState, "navigation", {
+        activeTabId: nextTabId,
+        activeTabUrl: nextTabUrl,
+      });
       if (opts.panelState.chat.streaming && navigation.shouldAbortChatStream) {
         opts.requestAgentAbort("Tab changed");
       }
@@ -216,23 +204,17 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
         void opts.migrateChatHistory(previousTabId, nextTabId, nextTabUrl);
       }
       if (navigation.nextInputMode) {
-        dispatchPanelState(opts, {
-          type: "slides-session-update",
-          value: { inputMode: navigation.nextInputMode },
-        });
+        patchPanelState(opts.panelState, "slidesSession", { inputMode: navigation.nextInputMode });
       }
       if (navigation.resetInputModeOverride) {
-        dispatchPanelState(opts, {
-          type: "slides-session-update",
-          value: { inputModeOverride: null },
-        });
+        patchPanelState(opts.panelState, "slidesSession", { inputModeOverride: null });
       }
       opts.abortSummaryStream();
       if (!opts.maybeStartPendingSummaryRunForUrl(nextTabUrl)) {
         applyCachedOrReset(opts, nextTabId, nextTabUrl, navigation.preserveChat);
       }
     } else if (navigation.kind === "url") {
-      dispatchPanelState(opts, { type: "active-tab-url", url: nextTabUrl });
+      patchPanelState(opts.panelState, "navigation", { activeTabUrl: nextTabUrl });
       if (navigation.preserveChat) {
         opts.navigationRuntime.notePreserveChatForUrl(nextTabUrl);
       } else if (navigation.shouldClearChat) {
@@ -248,33 +230,24 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
         );
       }
       if (navigation.nextInputMode) {
-        dispatchPanelState(opts, {
-          type: "slides-session-update",
-          value: { inputMode: navigation.nextInputMode },
-        });
+        patchPanelState(opts.panelState, "slidesSession", { inputMode: navigation.nextInputMode });
       }
     }
 
-    dispatchPanelState(opts, {
-      type: "panel-session-update",
-      value: {
-        chatEnabled: state.settings.chatEnabled,
-        automationEnabled: state.settings.automationEnabled,
-        daemonFeaturesAvailable:
-          (state.settings.summaryRuntime === "direct" && state.settings.providerConfigured) ||
-          (state.settings.summaryRuntime === "daemon" && state.daemon.ok && state.daemon.authed),
-      },
+    patchPanelState(opts.panelState, "panelSession", {
+      chatEnabled: state.settings.chatEnabled,
+      automationEnabled: state.settings.automationEnabled,
+      daemonFeaturesAvailable:
+        (state.settings.summaryRuntime === "direct" && state.settings.providerConfigured) ||
+        (state.settings.summaryRuntime === "daemon" && state.daemon.ok && state.daemon.authed),
     });
     const nextSlidesOcrEnabled = Boolean(state.settings.slidesOcrEnabled);
     const slidesOcrChanged =
       nextSlidesOcrEnabled !== opts.panelState.slidesSession.slidesOcrEnabled;
-    dispatchPanelState(opts, {
-      type: "slides-session-update",
-      value: {
-        slidesEnabled: state.settings.slidesEnabled,
-        slidesParallel: state.settings.slidesParallel,
-        ...(slidesOcrChanged ? { slidesOcrEnabled: nextSlidesOcrEnabled } : {}),
-      },
+    patchPanelState(opts.panelState, "slidesSession", {
+      slidesEnabled: state.settings.slidesEnabled,
+      slidesParallel: state.settings.slidesParallel,
+      ...(slidesOcrChanged ? { slidesOcrEnabled: nextSlidesOcrEnabled } : {}),
     });
     if (slidesOcrChanged) {
       opts.onSlidesOcrChanged();
@@ -285,22 +258,16 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
       fallbackModel &&
       (!opts.panelState.lastMeta.model || !opts.panelState.lastMeta.model.trim())
     ) {
-      dispatchPanelState(opts, {
-        type: "meta",
-        meta: {
-          ...opts.panelState.lastMeta,
-          model: fallbackModel,
-          modelLabel: fallbackModel,
-        },
-      });
+      opts.panelState.lastMeta = {
+        ...opts.panelState.lastMeta,
+        model: fallbackModel,
+        modelLabel: fallbackModel,
+      };
     }
     if (opts.panelState.slidesSession.slidesEnabled && nextMediaAvailable) {
-      dispatchPanelState(opts, {
-        type: "slides-session-update",
-        value: {
-          inputMode: "video",
-          inputModeOverride: "video",
-        },
+      patchPanelState(opts.panelState, "slidesSession", {
+        inputMode: "video",
+        inputModeOverride: "video",
       });
     }
     if (state.settings.slidesLayout && state.settings.slidesLayout !== slidesLayoutValue) {
@@ -363,28 +330,22 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
         if (preserveChat) {
           opts.navigationRuntime.notePreserveChatForUrl(nextTabUrl);
         }
-        dispatchPanelState(opts, { type: "source", source: null });
+        opts.panelState.currentSource = null;
         if (opts.isStreaming()) {
           opts.abortSummaryStream();
         }
         opts.resetSummaryView({ preserveChat });
       } else if (nextTabTitle && nextTabTitle !== opts.panelState.currentSource.title) {
-        dispatchPanelState(opts, {
-          type: "source",
-          source: {
-            ...opts.panelState.currentSource,
-            title: nextTabTitle,
-          },
-        });
+        opts.panelState.currentSource = {
+          ...opts.panelState.currentSource,
+          title: nextTabTitle,
+        };
         opts.headerController.setBaseTitle(nextTabTitle);
       }
     }
     if (!opts.panelState.currentSource) {
       if (!ignoreTransientTabState) {
-        dispatchPanelState(opts, {
-          type: "meta",
-          meta: { inputSummary: null, model: null, modelLabel: null },
-        });
+        opts.panelState.lastMeta = { inputSummary: null, model: null, modelLabel: null };
         opts.headerController.setBaseTitle(nextTabTitle || nextTabUrl || "Summarize");
         opts.headerController.setBaseSubtitle("");
       }
@@ -393,22 +354,16 @@ export function createUiStateRuntime(opts: UiStateRuntimeOpts) {
       opts.headerController.setStatus(state.status);
     }
     if (!nextMediaAvailable && hasMediaInfo) {
-      dispatchPanelState(opts, {
-        type: "slides-session-update",
-        value: {
-          inputMode: "page",
-          inputModeOverride: null,
-        },
+      patchPanelState(opts.panelState, "slidesSession", {
+        inputMode: "page",
+        inputModeOverride: null,
       });
     }
-    dispatchPanelState(opts, {
-      type: "slides-session-update",
-      value: {
-        mediaAvailable: nextMediaAvailable,
-        summarizeVideoLabel: nextVideoLabel,
-        summarizePageWords: state.stats.pageWords,
-        summarizeVideoDurationSeconds: state.stats.videoDurationSeconds,
-      },
+    patchPanelState(opts.panelState, "slidesSession", {
+      mediaAvailable: nextMediaAvailable,
+      summarizeVideoLabel: nextVideoLabel,
+      summarizePageWords: state.stats.pageWords,
+      summarizeVideoDurationSeconds: state.stats.videoDurationSeconds,
     });
     opts.maybeSeedPlannedSlidesForPendingRun();
     opts.refreshSummarizeControl();

--- a/apps/chrome-extension/tests/extension.spec.ts
+++ b/apps/chrome-extension/tests/extension.spec.ts
@@ -3,7 +3,7 @@ import { createServer as createHttpServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { runDaemonServer } from "../../../src/daemon/server.js";
 import {
   ALWAYS_ON_CONTENT_SCRIPT_EXCLUDE_MATCHES,
@@ -34,19 +34,16 @@ import {
   startDaemonSummaryRun,
   waitForSlidesSnapshot,
 } from "./helpers/daemon-fixtures";
+import { test } from "./helpers/extension-fixtures";
 import {
   activateTabByUrl,
-  assertNoErrors,
   buildAgentStream,
   buildUiState,
-  closeExtension,
   getActiveTabId,
   getActiveTabUrl,
   getBackground,
-  getBrowserFromProject,
   getSettings,
   injectContentScript,
-  launchExtension,
   maybeBringToFront,
   openExtensionPage,
   seedSettings,
@@ -111,22 +108,17 @@ test("Chromium manifest grants visible-tab capture and keeps companion access op
 });
 
 test("fresh Chromium install has no optional companion or automation grants", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-  try {
-    const background = await getBackground(harness);
-    const grants = await background.evaluate(async () => {
-      return {
-        nativeMessaging: await chrome.permissions.contains({ permissions: ["nativeMessaging"] }),
-        userScripts: await chrome.permissions.contains({ permissions: ["userScripts"] }),
-        debugger: await chrome.permissions.contains({ permissions: ["debugger"] }),
-      };
-    });
-    expect(grants).toEqual({ nativeMessaging: false, userScripts: false, debugger: false });
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  harness,
+}) => {
+  const background = await getBackground(harness);
+  const grants = await background.evaluate(async () => {
+    return {
+      nativeMessaging: await chrome.permissions.contains({ permissions: ["nativeMessaging"] }),
+      userScripts: await chrome.permissions.contains({ permissions: ["userScripts"] }),
+      debugger: await chrome.permissions.contains({ permissions: ["debugger"] }),
+    };
+  });
+  expect(grants).toEqual({ nativeMessaging: false, userScripts: false, debugger: false });
 });
 
 test("Chromium summary manifest keeps User Scripts optional and omits debugger", () => {
@@ -148,452 +140,388 @@ test("Chromium summary manifest keeps User Scripts optional and omits debugger",
 });
 
 test("sidepanel shows a ready state instead of going blank when switching tabs manually", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: false,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: false,
+  const sseBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
+    );
+  await page.route("http://127.0.0.1:8787/v1/summarize/run-a/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody("Summary A"),
     });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
+  });
 
-    const sseBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-    await page.route("http://127.0.0.1:8787/v1/summarize/run-a/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody("Summary A"),
-      });
-    });
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
+      settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
+      status: "",
+    }),
+  });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-a",
+      url: "https://www.youtube.com/watch?v=alpha123",
+      title: "Alpha Tab",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+  await expect(page.locator("#render")).toContainText("Summary A");
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
-        settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
-        status: "",
-      }),
-    });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-a",
-        url: "https://www.youtube.com/watch?v=alpha123",
-        title: "Alpha Tab",
-        model: "auto",
-        reason: "manual",
-      },
-    });
-    await expect(page.locator("#render")).toContainText("Summary A");
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
+      settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
+      status: "",
+    }),
+  });
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
-        settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
-        status: "",
-      }),
-    });
-
-    await expect(page.locator("#render")).toContainText("Click Summarize to start.");
-    await expect(page.locator("#render")).toContainText("Bravo Tab");
-    await expect(page.locator("#render")).not.toContainText("Summary A");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect(page.locator("#render")).toContainText("Click Summarize to start.");
+  await expect(page.locator("#render")).toContainText("Bravo Tab");
+  await expect(page.locator("#render")).not.toContainText("Summary A");
 });
 
 test("sidepanel shows a loading state instead of going blank while waiting for auto summarize", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, { token: "test-token", autoSummarize: true, slidesEnabled: false });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
 
-  try {
-    await seedSettings(harness, { token: "test-token", autoSummarize: true, slidesEnabled: false });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
+      settings: { autoSummarize: true, tokenPresent: true, slidesEnabled: false },
+      status: "",
+    }),
+  });
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
-        settings: { autoSummarize: true, tokenPresent: true, slidesEnabled: false },
-        status: "",
-      }),
-    });
-
-    await expect(page.locator("#render")).toContainText("Preparing summary");
-    await expect(page.locator(".renderEmpty__label")).toHaveText("Loading");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect(page.locator("#render")).toContainText("Preparing summary");
+  await expect(page.locator(".renderEmpty__label")).toHaveText("Loading");
 });
 
 test("sidepanel drops an active summary stream when the active tab changes before content arrives", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: false,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: false,
+  const delay = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
+  const sseBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
+    );
+  await page.route("http://127.0.0.1:8787/v1/summarize/run-a/events", async (route) => {
+    await delay(250);
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody("Stale Summary A"),
     });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
+  });
 
-    const delay = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
-    const sseBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-    await page.route("http://127.0.0.1:8787/v1/summarize/run-a/events", async (route) => {
-      await delay(250);
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody("Stale Summary A"),
-      });
-    });
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
+      settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
+      status: "",
+    }),
+  });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-a",
+      url: "https://www.youtube.com/watch?v=alpha123",
+      title: "Alpha Tab",
+      model: "auto",
+      reason: "manual",
+    },
+  });
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
-        settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
-        status: "",
-      }),
-    });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-a",
-        url: "https://www.youtube.com/watch?v=alpha123",
-        title: "Alpha Tab",
-        model: "auto",
-        reason: "manual",
-      },
-    });
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
+      settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
+      status: "",
+    }),
+  });
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
-        settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
-        status: "",
-      }),
-    });
-
-    await expect(page.locator("#render")).toContainText("Click Summarize to start.");
-    await page.waitForTimeout(350);
-    await expect(page.locator("#title")).toHaveText("Bravo Tab");
-    await expect(page.locator("#render")).not.toContainText("Stale Summary A");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect(page.locator("#render")).toContainText("Click Summarize to start.");
+  await page.waitForTimeout(350);
+  await expect(page.locator("#title")).toHaveText("Bravo Tab");
+  await expect(page.locator("#render")).not.toContainText("Stale Summary A");
 });
 
 test("sidepanel starts a queued pending run after aborting a previous tab stream", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: false,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: false,
+  const delay = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
+  const sseBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
+    );
+  await page.route("http://127.0.0.1:8787/v1/summarize/run-a/events", async (route) => {
+    await delay(500);
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody("Stale Summary A"),
     });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/run-b/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody("Summary B"),
+    });
+  });
 
-    const delay = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
-    const sseBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-    await page.route("http://127.0.0.1:8787/v1/summarize/run-a/events", async (route) => {
-      await delay(500);
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody("Stale Summary A"),
-      });
-    });
-    await page.route("http://127.0.0.1:8787/v1/summarize/run-b/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody("Summary B"),
-      });
-    });
+  const tabAState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
+    settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
+    status: "",
+  });
+  const tabBState = buildUiState({
+    tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
+    settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
+    status: "",
+  });
 
-    const tabAState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
-      settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
-      status: "",
-    });
-    const tabBState = buildUiState({
-      tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
-      settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
-      status: "",
-    });
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-a",
+      url: "https://www.youtube.com/watch?v=alpha123",
+      title: "Alpha Tab",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+  await page.waitForTimeout(50);
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-b",
+      url: "https://www.youtube.com/watch?v=bravo456",
+      title: "Bravo Tab",
+      model: "auto",
+      reason: "manual",
+    },
+  });
 
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-a",
-        url: "https://www.youtube.com/watch?v=alpha123",
-        title: "Alpha Tab",
-        model: "auto",
-        reason: "manual",
-      },
-    });
-    await page.waitForTimeout(50);
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-b",
-        url: "https://www.youtube.com/watch?v=bravo456",
-        title: "Bravo Tab",
-        model: "auto",
-        reason: "manual",
-      },
-    });
+  await sendBgMessage(harness, { type: "ui:state", state: tabBState });
 
-    await sendBgMessage(harness, { type: "ui:state", state: tabBState });
-
-    await expect(page.locator("#title")).toHaveText("Bravo Tab");
-    await expect(page.locator("#render")).toContainText("Summary B");
-    await expect(page.locator("#render")).not.toContainText("Stale Summary A");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect(page.locator("#title")).toHaveText("Bravo Tab");
+  await expect(page.locator("#render")).toContainText("Summary B");
+  await expect(page.locator("#render")).not.toContainText("Stale Summary A");
 });
 
 test("sidepanel resumes a pending summary run when returning to the original tab", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: false,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: false,
+  const sseBody = [
+    "event: chunk",
+    `data: ${JSON.stringify({ text: "Summary A" })}`,
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await page.route("http://127.0.0.1:8787/v1/summarize/run-a/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody,
     });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
+  });
 
-    const sseBody = [
-      "event: chunk",
-      `data: ${JSON.stringify({ text: "Summary A" })}`,
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await page.route("http://127.0.0.1:8787/v1/summarize/run-a/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody,
-      });
-    });
+  const tabAState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
+    settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
+    status: "",
+  });
+  const tabBState = buildUiState({
+    tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
+    settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
+    status: "",
+  });
 
-    const tabAState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
-      settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
-      status: "",
-    });
-    const tabBState = buildUiState({
-      tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
-      settings: { autoSummarize: false, tokenPresent: true, slidesEnabled: false },
-      status: "",
-    });
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await sendBgMessage(harness, { type: "ui:state", state: tabBState });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-a",
+      url: "https://www.youtube.com/watch?v=alpha123",
+      title: "Alpha Tab",
+      model: "auto",
+      reason: "manual",
+    },
+  });
 
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await sendBgMessage(harness, { type: "ui:state", state: tabBState });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-a",
-        url: "https://www.youtube.com/watch?v=alpha123",
-        title: "Alpha Tab",
-        model: "auto",
-        reason: "manual",
-      },
-    });
+  await expect(page.locator("#render")).toContainText("Click Summarize to start.");
+  await expect(page.locator("#render")).toContainText("Bravo Tab");
+  await expect(page.locator("#render")).not.toContainText("Summary A");
 
-    await expect(page.locator("#render")).toContainText("Click Summarize to start.");
-    await expect(page.locator("#render")).toContainText("Bravo Tab");
-    await expect(page.locator("#render")).not.toContainText("Summary A");
-
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await expect(page.locator("#render")).toContainText("Summary A");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await expect(page.locator("#render")).toContainText("Summary A");
 });
 
-test("sidepanel switches between page, video, and slides modes", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel switches between page, video, and slides modes", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: false,
+    slidesLayout: "gallery",
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await page.evaluate(() => {
+    const global = window as typeof globalThis & {
+      __summarizePanelPort?: { disconnect?: () => void } | undefined;
+    };
+    global.__summarizePanelPort?.disconnect?.();
+    global.__summarizePanelPort = undefined;
+  });
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
+  await page.route("http://127.0.0.1:8787/v1/tools", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ok: true,
+        tools: {
+          ytDlp: { available: true },
+          ffmpeg: { available: true },
+          tesseract: { available: true },
+        },
+      }),
+    });
+  });
+
+  const sseBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
+    );
+  await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
+    const url = route.request().url();
+    const match = url.match(/summarize\/([^/]+)\/events/);
+    const runId = match ? (match[1] ?? "") : "";
+    const text =
+      runId === "run-page"
+        ? "Page summary"
+        : runId === "run-video"
+          ? "Video summary"
+          : runId === "run-slides"
+            ? "Slides summary"
+            : "Back summary";
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody(text),
+    });
+  });
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "x-summarize-slide-ready": "1",
+      },
+      body: placeholderPng,
+    });
+  });
+
+  const uiState = buildUiState({
+    tab: { id: 1, url: "https://example.com/video", title: "Example Video" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: false },
+    stats: { pageWords: 120, videoDurationSeconds: 120 },
+    settings: {
       autoSummarize: false,
       slidesEnabled: false,
+      slidesParallel: true,
       slidesLayout: "gallery",
       slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await page.evaluate(() => {
-      const global = window as typeof globalThis & {
-        __summarizePanelPort?: { disconnect?: () => void } | undefined;
-      };
-      global.__summarizePanelPort?.disconnect?.();
-      global.__summarizePanelPort = undefined;
-    });
+      tokenPresent: true,
+    },
+    status: "",
+  });
+  const summarizeButton = page.locator(".summarizeButton");
+  await expect(summarizeButton).toBeVisible();
 
-    await page.route("http://127.0.0.1:8787/v1/tools", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          ok: true,
-          tools: {
-            ytDlp: { available: true },
-            ffmpeg: { available: true },
-            tesseract: { available: true },
-          },
-        }),
-      });
-    });
-
-    const sseBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
+  await page.waitForFunction(
+    () => {
+      const hooks = (
+        window as typeof globalThis & {
+          __summarizeTestHooks?: {
+            setSummarizeMode?: unknown;
+            applyUiState?: unknown;
+          };
+        }
+      ).__summarizeTestHooks;
+      return (
+        typeof hooks?.setSummarizeMode === "function" && typeof hooks?.applyUiState === "function"
       );
-    await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
-      const url = route.request().url();
-      const match = url.match(/summarize\/([^/]+)\/events/);
-      const runId = match ? (match[1] ?? "") : "";
-      const text =
-        runId === "run-page"
-          ? "Page summary"
-          : runId === "run-video"
-            ? "Video summary"
-            : runId === "run-slides"
-              ? "Slides summary"
-              : "Back summary";
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody(text),
-      });
-    });
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
-    );
-    await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "content-type": "image/png",
-          "x-summarize-slide-ready": "1",
-        },
-        body: placeholderPng,
-      });
-    });
+    },
+    null,
+    { timeout: 5_000 },
+  );
 
-    const uiState = buildUiState({
-      tab: { id: 1, url: "https://example.com/video", title: "Example Video" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: false },
-      stats: { pageWords: 120, videoDurationSeconds: 120 },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: false,
-        slidesParallel: true,
-        slidesLayout: "gallery",
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-      status: "",
-    });
-    const summarizeButton = page.locator(".summarizeButton");
-    await expect(summarizeButton).toBeVisible();
-
-    await page.waitForFunction(
-      () => {
+  const setSummarizeMode = async (mode: "page" | "video", slides: boolean) => {
+    await page.evaluate(
+      async (payload) => {
         const hooks = (
           window as typeof globalThis & {
             __summarizeTestHooks?: {
-              setSummarizeMode?: unknown;
-              applyUiState?: unknown;
-            };
-          }
-        ).__summarizeTestHooks;
-        return (
-          typeof hooks?.setSummarizeMode === "function" && typeof hooks?.applyUiState === "function"
-        );
-      },
-      null,
-      { timeout: 5_000 },
-    );
-
-    const setSummarizeMode = async (mode: "page" | "video", slides: boolean) => {
-      await page.evaluate(
-        async (payload) => {
-          const hooks = (
-            window as typeof globalThis & {
-              __summarizeTestHooks?: {
-                setSummarizeMode?: (payload: {
-                  mode: "page" | "video";
-                  slides: boolean;
-                }) => Promise<void>;
-                getSummarizeMode?: () => {
-                  mode: "page" | "video";
-                  slides: boolean;
-                  mediaAvailable: boolean;
-                };
-              };
-            }
-          ).__summarizeTestHooks;
-          await hooks?.setSummarizeMode?.(payload);
-        },
-        { mode, slides },
-      );
-    };
-
-    const getSummarizeMode = async () =>
-      await page.evaluate(() => {
-        const hooks = (
-          window as typeof globalThis & {
-            __summarizeTestHooks?: {
+              setSummarizeMode?: (payload: {
+                mode: "page" | "video";
+                slides: boolean;
+              }) => Promise<void>;
               getSummarizeMode?: () => {
                 mode: "page" | "video";
                 slides: boolean;
@@ -602,143 +530,147 @@ test("sidepanel switches between page, video, and slides modes", async ({
             };
           }
         ).__summarizeTestHooks;
-        return hooks?.getSummarizeMode?.() ?? null;
-      });
-
-    const expectSummarizeMode = async (mode: "page" | "video", slides: boolean) => {
-      await expect
-        .poll(async () => {
-          const current = await getSummarizeMode();
-          return current ? { mode: current.mode, slides: current.slides } : null;
-        })
-        .toEqual({ mode, slides });
-    };
-
-    const applyUiState = async (state: UiState) => {
-      await page.evaluate((payload) => {
-        const hooks = (
-          window as typeof globalThis & {
-            __summarizeTestHooks?: { applyUiState?: (state: UiState) => void };
-          }
-        ).__summarizeTestHooks;
-        hooks?.applyUiState?.(payload);
-      }, state);
-    };
-
-    const ensureMediaAvailable = async (slidesEnabled: boolean) => {
-      const state = buildUiState({
-        ...uiState,
-        settings: { ...uiState.settings, slidesEnabled },
-      });
-      await applyUiState(state);
-      await expect.poll(async () => (await getSummarizeMode())?.mediaAvailable ?? false).toBe(true);
-    };
-
-    await ensureMediaAvailable(false);
-    await expect(summarizeButton).toHaveAttribute("aria-label", /Page(?: · 120 words)?/);
-
-    await setSummarizeMode("page", false);
-    await expectSummarizeMode("page", false);
-    await expect(summarizeButton).toHaveAttribute("aria-label", /Page/);
-    await expect(
-      page.locator("img.slideStrip__thumbImage, img.slideInline__thumbImage"),
-    ).toHaveCount(0);
-
-    await ensureMediaAvailable(false);
-    await setSummarizeMode("video", false);
-    await expectSummarizeMode("video", false);
-    await expect(summarizeButton).toHaveAttribute("aria-label", /Video/);
-    await expect(
-      page.locator("img.slideStrip__thumbImage, img.slideInline__thumbImage"),
-    ).toHaveCount(0);
-
-    await ensureMediaAvailable(true);
-    await setSummarizeMode("video", true);
-    await expectSummarizeMode("video", true);
-    await expect.poll(async () => (await getSummarizeMode())?.slides ?? false).toBe(true);
-    await expect(summarizeButton).toHaveAttribute("aria-label", /Slides/);
-
-    await ensureMediaAvailable(false);
-    await setSummarizeMode("page", false);
-    await expectSummarizeMode("page", false);
-    await expect(summarizeButton).toHaveAttribute("aria-label", /Page/);
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-back",
-        url: "https://example.com/video",
-        title: "Example Video",
-        model: "auto",
-        reason: "manual",
+        await hooks?.setSummarizeMode?.(payload);
       },
-    });
-    await expect(
-      page.locator("img.slideStrip__thumbImage, img.slideInline__thumbImage"),
-    ).toHaveCount(0);
+      { mode, slides },
+    );
+  };
 
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const getSummarizeMode = async () =>
+    await page.evaluate(() => {
+      const hooks = (
+        window as typeof globalThis & {
+          __summarizeTestHooks?: {
+            getSummarizeMode?: () => {
+              mode: "page" | "video";
+              slides: boolean;
+              mediaAvailable: boolean;
+            };
+          };
+        }
+      ).__summarizeTestHooks;
+      return hooks?.getSummarizeMode?.() ?? null;
+    });
+
+  const expectSummarizeMode = async (mode: "page" | "video", slides: boolean) => {
+    await expect
+      .poll(async () => {
+        const current = await getSummarizeMode();
+        return current ? { mode: current.mode, slides: current.slides } : null;
+      })
+      .toEqual({ mode, slides });
+  };
+
+  const applyUiState = async (state: UiState) => {
+    await page.evaluate((payload) => {
+      const hooks = (
+        window as typeof globalThis & {
+          __summarizeTestHooks?: { applyUiState?: (state: UiState) => void };
+        }
+      ).__summarizeTestHooks;
+      hooks?.applyUiState?.(payload);
+    }, state);
+  };
+
+  const ensureMediaAvailable = async (slidesEnabled: boolean) => {
+    const state = buildUiState({
+      ...uiState,
+      settings: { ...uiState.settings, slidesEnabled },
+    });
+    await applyUiState(state);
+    await expect.poll(async () => (await getSummarizeMode())?.mediaAvailable ?? false).toBe(true);
+  };
+
+  await ensureMediaAvailable(false);
+  await expect(summarizeButton).toHaveAttribute("aria-label", /Page(?: · 120 words)?/);
+
+  await setSummarizeMode("page", false);
+  await expectSummarizeMode("page", false);
+  await expect(summarizeButton).toHaveAttribute("aria-label", /Page/);
+  await expect(page.locator("img.slideStrip__thumbImage, img.slideInline__thumbImage")).toHaveCount(
+    0,
+  );
+
+  await ensureMediaAvailable(false);
+  await setSummarizeMode("video", false);
+  await expectSummarizeMode("video", false);
+  await expect(summarizeButton).toHaveAttribute("aria-label", /Video/);
+  await expect(page.locator("img.slideStrip__thumbImage, img.slideInline__thumbImage")).toHaveCount(
+    0,
+  );
+
+  await ensureMediaAvailable(true);
+  await setSummarizeMode("video", true);
+  await expectSummarizeMode("video", true);
+  await expect.poll(async () => (await getSummarizeMode())?.slides ?? false).toBe(true);
+  await expect(summarizeButton).toHaveAttribute("aria-label", /Slides/);
+
+  await ensureMediaAvailable(false);
+  await setSummarizeMode("page", false);
+  await expectSummarizeMode("page", false);
+  await expect(summarizeButton).toHaveAttribute("aria-label", /Page/);
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-back",
+      url: "https://example.com/video",
+      title: "Example Video",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+  await expect(page.locator("img.slideStrip__thumbImage, img.slideInline__thumbImage")).toHaveCount(
+    0,
+  );
 });
 
-test("sidepanel auto summarize toggle stays inline", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, { token: "test-token" });
-    await harness.context.route("http://127.0.0.1:8787/v1/models", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          ok: true,
-          options: [],
-          providers: {},
-          localModelsSource: null,
-        }),
-      });
+test("sidepanel auto summarize toggle stays inline", async ({ harness }) => {
+  await seedSettings(harness, { token: "test-token" });
+  await harness.context.route("http://127.0.0.1:8787/v1/models", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ok: true,
+        options: [],
+        providers: {},
+        localModelsSource: null,
+      }),
     });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await page.click("#drawerToggle");
-    await expect(page.locator("#drawer")).toBeVisible();
-    await page.click("#advancedSettings > summary");
-    await expect(page.locator("#advancedSettings")).toHaveJSProperty("open", true);
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await page.click("#drawerToggle");
+  await expect(page.locator("#drawer")).toBeVisible();
+  await page.click("#advancedSettings > summary");
+  await expect(page.locator("#advancedSettings")).toHaveJSProperty("open", true);
 
-    const label = page.locator("#autoToggle .checkboxRoot");
-    await expect(label).toBeVisible();
-    const layout = await label.evaluate((element) => {
-      const control = element.querySelector(".checkboxControl");
-      const text = element.querySelector(".checkboxLabel");
-      if (!(control instanceof HTMLElement) || !(text instanceof HTMLElement)) return null;
-      const labelRect = element.getBoundingClientRect();
-      const controlRect = control.getBoundingClientRect();
-      const textRect = text.getBoundingClientRect();
-      return {
-        labelTop: labelRect.top,
-        labelBottom: labelRect.bottom,
-        controlTop: controlRect.top,
-        controlBottom: controlRect.bottom,
-        controlCenter: controlRect.top + controlRect.height / 2,
-        textTop: textRect.top,
-        textBottom: textRect.bottom,
-        textCenter: textRect.top + textRect.height / 2,
-      };
-    });
+  const label = page.locator("#autoToggle .checkboxRoot");
+  await expect(label).toBeVisible();
+  const layout = await label.evaluate((element) => {
+    const control = element.querySelector(".checkboxControl");
+    const text = element.querySelector(".checkboxLabel");
+    if (!(control instanceof HTMLElement) || !(text instanceof HTMLElement)) return null;
+    const labelRect = element.getBoundingClientRect();
+    const controlRect = control.getBoundingClientRect();
+    const textRect = text.getBoundingClientRect();
+    return {
+      labelTop: labelRect.top,
+      labelBottom: labelRect.bottom,
+      controlTop: controlRect.top,
+      controlBottom: controlRect.bottom,
+      controlCenter: controlRect.top + controlRect.height / 2,
+      textTop: textRect.top,
+      textBottom: textRect.bottom,
+      textCenter: textRect.top + textRect.height / 2,
+    };
+  });
 
-    expect(layout).not.toBeNull();
-    if (layout) {
-      expect(layout.controlTop).toBeGreaterThanOrEqual(layout.labelTop - 1);
-      expect(layout.controlBottom).toBeLessThanOrEqual(layout.labelBottom + 1);
-      expect(layout.textTop).toBeGreaterThanOrEqual(layout.labelTop - 1);
-      expect(layout.textBottom).toBeLessThanOrEqual(layout.labelBottom + 1);
-      expect(Math.abs(layout.controlCenter - layout.textCenter)).toBeLessThanOrEqual(1);
-    }
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
+  expect(layout).not.toBeNull();
+  if (layout) {
+    expect(layout.controlTop).toBeGreaterThanOrEqual(layout.labelTop - 1);
+    expect(layout.controlBottom).toBeLessThanOrEqual(layout.labelBottom + 1);
+    expect(layout.textTop).toBeGreaterThanOrEqual(layout.labelTop - 1);
+    expect(layout.textBottom).toBeLessThanOrEqual(layout.labelBottom + 1);
+    expect(Math.abs(layout.controlCenter - layout.textCenter)).toBeLessThanOrEqual(1);
   }
 });

--- a/apps/chrome-extension/tests/helpers/extension-fixtures.ts
+++ b/apps/chrome-extension/tests/helpers/extension-fixtures.ts
@@ -1,0 +1,25 @@
+import { test as base } from "@playwright/test";
+import {
+  assertNoErrors,
+  closeExtension,
+  getBrowserFromProject,
+  launchExtension,
+  type ExtensionHarness,
+} from "./extension-harness";
+import { allowFirefoxExtensionTests } from "./extension-test-config";
+
+export const test = base.extend<{ harness: ExtensionHarness }>({
+  harness: async ({ browserName }, use, testInfo) => {
+    testInfo.skip(
+      browserName === "firefox" && !allowFirefoxExtensionTests,
+      "Firefox extension tests require ALLOW_FIREFOX_EXTENSION_TESTS=1.",
+    );
+    const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+    try {
+      await use(harness);
+      assertNoErrors(harness);
+    } finally {
+      await closeExtension(harness.context, harness.userDataDir);
+    }
+  },
+});

--- a/apps/chrome-extension/tests/hover.direct-provider.spec.ts
+++ b/apps/chrome-extension/tests/hover.direct-provider.spec.ts
@@ -1,16 +1,12 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "./helpers/extension-fixtures";
 import {
   activateTabByUrl,
-  assertNoErrors,
-  closeExtension,
-  getBrowserFromProject,
-  launchExtension,
   maybeBringToFront,
   seedSettings,
   trackErrors,
   waitForActiveTabUrl,
 } from "./helpers/extension-harness";
-import { allowFirefoxExtensionTests } from "./helpers/extension-test-config";
 
 function openAiStream(text: string) {
   return [
@@ -21,100 +17,87 @@ function openAiStream(text: string) {
   ].join("\n");
 }
 
-test.skip(
-  ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
-  "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
-);
-
 test("hover tooltip summarizes through a direct provider without a daemon token", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "",
+    hoverSummaries: true,
+    summaryRuntime: "direct",
+    provider: "openai",
+    providerApiKeys: { openai: "test-key" },
+    providerBaseUrls: { openai: "https://api.openai.test/v1" },
+    model: "openai/test-model",
+    maxChars: 60_000,
+  });
 
-  try {
-    await seedSettings(harness, {
-      token: "",
-      hoverSummaries: true,
-      summaryRuntime: "direct",
-      provider: "openai",
-      providerApiKeys: { openai: "test-key" },
-      providerBaseUrls: { openai: "https://api.openai.test/v1" },
-      model: "openai/test-model",
-      maxChars: 60_000,
-    });
-
-    let articleFetches = 0;
-    await harness.context.route("https://example.com/hover-proof", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/html" },
-        body: `
+  let articleFetches = 0;
+  await harness.context.route("https://example.com/hover-proof", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: `
           <main>
             <h1>Hover proof page</h1>
             <a id="target" href="https://example.com/hover-proof-target">Summarize target</a>
           </main>
         `,
-      });
     });
-    await harness.context.route("https://example.com/hover-proof-target", async (route) => {
-      articleFetches += 1;
+  });
+  await harness.context.route("https://example.com/hover-proof-target", async (route) => {
+    articleFetches += 1;
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: `<article><h1>Target article</h1><p>${"Direct provider hover content. ".repeat(
+        80,
+      )}</p></article>`,
+    });
+  });
+
+  let providerCalls = 0;
+  let daemonSummarizeCalls = 0;
+  const requestBodies: Array<Record<string, unknown>> = [];
+  await harness.context.route("https://api.openai.test/v1/chat/completions", async (route) => {
+    providerCalls += 1;
+    requestBodies.push(route.request().postDataJSON() as Record<string, unknown>);
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: openAiStream("Direct hover proof without daemon token."),
+    });
+  });
+  await harness.context.route(
+    /http:\/\/127\.0\.0\.1:8787\/v1\/summarize(?:\/.*)?$/,
+    async (route) => {
+      daemonSummarizeCalls += 1;
       await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/html" },
-        body: `<article><h1>Target article</h1><p>${"Direct provider hover content. ".repeat(
-          80,
-        )}</p></article>`,
+        status: 500,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ok: false, error: "daemon should not be called" }),
       });
-    });
+    },
+  );
 
-    let providerCalls = 0;
-    let daemonSummarizeCalls = 0;
-    const requestBodies: Array<Record<string, unknown>> = [];
-    await harness.context.route("https://api.openai.test/v1/chat/completions", async (route) => {
-      providerCalls += 1;
-      requestBodies.push(route.request().postDataJSON() as Record<string, unknown>);
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: openAiStream("Direct hover proof without daemon token."),
-      });
-    });
-    await harness.context.route(
-      /http:\/\/127\.0\.0\.1:8787\/v1\/summarize(?:\/.*)?$/,
-      async (route) => {
-        daemonSummarizeCalls += 1;
-        await route.fulfill({
-          status: 500,
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ ok: false, error: "daemon should not be called" }),
-        });
-      },
-    );
+  const page = await harness.context.newPage();
+  trackErrors(page, harness.pageErrors, harness.consoleErrors);
+  await page.goto("https://example.com/hover-proof", { waitUntil: "domcontentloaded" });
+  await maybeBringToFront(page);
+  await activateTabByUrl(harness, "https://example.com/hover-proof");
+  await waitForActiveTabUrl(harness, "https://example.com/hover-proof");
 
-    const page = await harness.context.newPage();
-    trackErrors(page, harness.pageErrors, harness.consoleErrors);
-    await page.goto("https://example.com/hover-proof", { waitUntil: "domcontentloaded" });
-    await maybeBringToFront(page);
-    await activateTabByUrl(harness, "https://example.com/hover-proof");
-    await waitForActiveTabUrl(harness, "https://example.com/hover-proof");
+  await page.locator("#target").hover();
 
-    await page.locator("#target").hover();
+  const tooltip = page.locator('#__summarize_hover_tooltip__[data-visible="true"] .summary');
+  await expect(tooltip).toContainText("Direct hover proof without daemon token.");
+  await expect.poll(() => articleFetches).toBe(1);
+  await expect.poll(() => providerCalls).toBe(1);
+  await expect.poll(() => daemonSummarizeCalls).toBe(0);
+  expect(requestBodies[0]?.model).toBe("test-model");
+  expect(JSON.stringify(requestBodies[0]?.messages)).toContain("Direct provider hover content");
 
-    const tooltip = page.locator('#__summarize_hover_tooltip__[data-visible="true"] .summary');
-    await expect(tooltip).toContainText("Direct hover proof without daemon token.");
-    await expect.poll(() => articleFetches).toBe(1);
-    await expect.poll(() => providerCalls).toBe(1);
-    await expect.poll(() => daemonSummarizeCalls).toBe(0);
-    expect(requestBodies[0]?.model).toBe("test-model");
-    expect(JSON.stringify(requestBodies[0]?.messages)).toContain("Direct provider hover content");
-
-    const screenshotPath = process.env.HOVER_PROOF_SCREENSHOT;
-    if (screenshotPath) {
-      await page.screenshot({ path: screenshotPath, fullPage: true });
-    }
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
+  const screenshotPath = process.env.HOVER_PROOF_SCREENSHOT;
+  if (screenshotPath) {
+    await page.screenshot({ path: screenshotPath, fullPage: true });
   }
 });

--- a/apps/chrome-extension/tests/options.spec.ts
+++ b/apps/chrome-extension/tests/options.spec.ts
@@ -1,600 +1,439 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "./helpers/extension-fixtures";
 import {
-  assertNoErrors,
-  closeExtension,
-  getBrowserFromProject,
   getExtensionUrl,
   getOpenPickerList,
   getSettings,
-  launchExtension,
   openExtensionPage,
   seedSettings,
   trackErrors,
 } from "./helpers/extension-harness";
-import { allowFirefoxExtensionTests } from "./helpers/extension-test-config";
 
-test.skip(
-  ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
-  "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
-);
+test("options pickers apply overlay selection", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await page.click("#tab-ui");
+  await expect(page.locator("#panel-ui")).toBeVisible();
 
-test("options pickers apply overlay selection", async ({ browserName: _browserName }, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  const schemeLabel = page.locator("label.scheme");
+  const schemeTrigger = schemeLabel.locator(".pickerTrigger");
 
-  try {
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    await page.click("#tab-ui");
-    await expect(page.locator("#panel-ui")).toBeVisible();
+  await schemeTrigger.focus();
+  await schemeTrigger.press("Enter");
+  const schemeList = getOpenPickerList(page);
+  await expect(schemeList).toBeVisible();
+  await schemeList.locator('[role="option"]').nth(2).click();
 
-    const schemeLabel = page.locator("label.scheme");
-    const schemeTrigger = schemeLabel.locator(".pickerTrigger");
+  await expect(schemeTrigger.locator(".scheme-label")).toHaveText("Mint");
 
-    await schemeTrigger.focus();
-    await schemeTrigger.press("Enter");
-    const schemeList = getOpenPickerList(page);
-    await expect(schemeList).toBeVisible();
-    await schemeList.locator('[role="option"]').nth(2).click();
+  const modeLabel = page.locator("label.mode");
+  const modeTrigger = modeLabel.locator(".pickerTrigger");
 
-    await expect(schemeTrigger.locator(".scheme-label")).toHaveText("Mint");
+  await modeTrigger.focus();
+  await modeTrigger.press("Enter");
+  const modeList = getOpenPickerList(page);
+  await expect(modeList).toBeVisible();
+  await modeList.locator('[role="option"]').nth(1).click();
 
-    const modeLabel = page.locator("label.mode");
-    const modeTrigger = modeLabel.locator(".pickerTrigger");
-
-    await modeTrigger.focus();
-    await modeTrigger.press("Enter");
-    const modeList = getOpenPickerList(page);
-    await expect(modeList).toBeVisible();
-    await modeList.locator('[role="option"]').nth(1).click();
-
-    await expect(modeTrigger).toHaveText("Light");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect(modeTrigger).toHaveText("Light");
 });
 
-test("options restores the active tab from browser local storage", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("options restores the active tab from browser local storage", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await page.click("#tab-runtime");
+  await expect(page.locator("#panel-runtime")).toBeVisible();
 
-  try {
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    await page.click("#tab-runtime");
-    await expect(page.locator("#panel-runtime")).toBeVisible();
-
-    await page.reload();
-    await expect(page.locator("#tab-runtime")).toHaveAttribute("aria-selected", "true");
-    await expect(page.locator("#panel-runtime")).toBeVisible();
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await page.reload();
+  await expect(page.locator("#tab-runtime")).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#panel-runtime")).toBeVisible();
 });
 
-test("options restores the Logs tab without aborting startup", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("options restores the Logs tab without aborting startup", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await page.click("#tab-logs");
+  await expect(page.locator("#panel-logs")).toBeVisible();
 
-  try {
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    await page.click("#tab-logs");
-    await expect(page.locator("#panel-logs")).toBeVisible();
-
-    await page.reload();
-    await expect(page.locator("#tab-logs")).toHaveAttribute("aria-selected", "true");
-    await expect(page.locator("#panel-logs")).toBeVisible();
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await page.reload();
+  await expect(page.locator("#tab-logs")).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#panel-logs")).toBeVisible();
 });
 
-test("options themes password and URL fields like the provider control", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("options themes password and URL fields like the provider control", async ({ harness }) => {
+  await seedSettings(harness, {
+    colorMode: "dark",
+    colorScheme: "slate",
+    provider: "openai",
+    summaryRuntime: "daemon",
+  });
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await page.click("#tab-runtime");
+  await expect(page.locator("#panel-runtime")).toBeVisible();
+  await expect(page.locator("html")).toHaveAttribute("data-mode", "dark");
 
-  try {
-    await seedSettings(harness, {
-      colorMode: "dark",
-      colorScheme: "slate",
-      provider: "openai",
-      summaryRuntime: "daemon",
-    });
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    await page.click("#tab-runtime");
-    await expect(page.locator("#panel-runtime")).toBeVisible();
-    await expect(page.locator("html")).toHaveAttribute("data-mode", "dark");
-
-    const readControlStyle = (selector: string) =>
-      page.locator(selector).evaluate((element) => {
-        const style = getComputedStyle(element);
-        return {
-          backgroundColor: style.backgroundColor,
-          borderColor: style.borderColor,
-          borderRadius: style.borderRadius,
-          borderStyle: style.borderStyle,
-          borderWidth: style.borderWidth,
-          color: style.color,
-          fontFamily: style.fontFamily,
-          fontSize: style.fontSize,
-        };
-      });
-
-    const [providerStyle, apiKeyStyle, baseUrlStyle] = await Promise.all([
-      readControlStyle("#provider"),
-      readControlStyle("#providerApiKey"),
-      readControlStyle("#providerBaseUrl"),
-    ]);
-
-    expect(apiKeyStyle).toEqual(providerStyle);
-    expect(baseUrlStyle).toEqual(providerStyle);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("options keeps custom model selected while presets refresh", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, { token: "test-token", model: "auto" });
-    let modelCalls = 0;
-    let releaseSecond: (() => void) | null = null;
-    const secondGate = new Promise<void>((resolve) => {
-      releaseSecond = resolve;
+  const readControlStyle = (selector: string) =>
+    page.locator(selector).evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        backgroundColor: style.backgroundColor,
+        borderColor: style.borderColor,
+        borderRadius: style.borderRadius,
+        borderStyle: style.borderStyle,
+        borderWidth: style.borderWidth,
+        color: style.color,
+        fontFamily: style.fontFamily,
+        fontSize: style.fontSize,
+      };
     });
 
-    await harness.context.route("http://127.0.0.1:8787/v1/models", async (route) => {
-      modelCalls += 1;
-      if (modelCalls === 2) await secondGate;
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          ok: true,
-          options: [{ id: "auto", label: "" }],
-          providers: { openrouter: true },
-        }),
-      });
-    });
-    await harness.context.route("http://127.0.0.1:8787/health", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: true, version: "0.0.0" }),
-      });
-    });
-    await harness.context.route("http://127.0.0.1:8787/v1/ping", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: true }),
-      });
-    });
+  const [providerStyle, apiKeyStyle, baseUrlStyle] = await Promise.all([
+    readControlStyle("#provider"),
+    readControlStyle("#providerApiKey"),
+    readControlStyle("#providerBaseUrl"),
+  ]);
 
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    await page.click("#tab-model");
-    await expect(page.locator("#panel-model")).toBeVisible();
-    await expect.poll(() => modelCalls).toBeGreaterThanOrEqual(1);
-    await expect(page.locator("#modelPreset")).toHaveValue("auto");
-
-    await page.evaluate(() => {
-      const preset = document.getElementById("modelPreset") as HTMLSelectElement | null;
-      if (!preset) return;
-      preset.value = "custom";
-      preset.dispatchEvent(new Event("change", { bubbles: true }));
-    });
-    await expect(page.locator("#modelCustom")).toBeVisible();
-
-    await page.locator("#modelCustom").focus();
-    await expect.poll(() => modelCalls).toBe(2);
-    releaseSecond?.();
-
-    await expect(page.locator("#modelPreset")).toHaveValue("custom");
-    await expect(page.locator("#modelCustom")).toBeVisible();
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  expect(apiKeyStyle).toEqual(providerStyle);
+  expect(baseUrlStyle).toEqual(providerStyle);
 });
 
-test("options defers automation skills until Skills tab opens", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("options keeps custom model selected while presets refresh", async ({ harness }) => {
+  await seedSettings(harness, { token: "test-token", model: "auto" });
+  let modelCalls = 0;
+  let releaseSecond: (() => void) | null = null;
+  const secondGate = new Promise<void>((resolve) => {
+    releaseSecond = resolve;
+  });
 
-  try {
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    await page.waitForLoadState("networkidle");
-
-    await expect(page.locator("#panel-general")).toBeVisible();
-    await expect(page.locator("#skillsList .skillCard")).toHaveCount(0);
-
-    await page.click("#tab-skills");
-    await expect(page.locator("#panel-skills")).toBeVisible();
-    await expect
-      .poll(async () => page.locator("#skillsList .skillCard").count())
-      .toBeGreaterThan(0);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("options persists automation toggle without save", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, { automationEnabled: false });
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    await page.waitForFunction(() => document.documentElement.dataset.settingsReady === "true");
-
-    const toggle = page.locator("#automationToggle .checkboxRoot");
-    await toggle.click();
-
-    await expect
-      .poll(async () => {
-        const settings = await getSettings(harness);
-        return settings.automationEnabled;
-      })
-      .toBe(true);
-
-    await page.close();
-
-    const reopened = await openExtensionPage(harness, "options.html", "#tabs");
-    const checked = await reopened.evaluate(() => {
-      const input = document.querySelector("#automationToggle input") as HTMLInputElement | null;
-      return input?.checked ?? false;
+  await harness.context.route("http://127.0.0.1:8787/v1/models", async (route) => {
+    modelCalls += 1;
+    if (modelCalls === 2) await secondGate;
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ok: true,
+        options: [{ id: "auto", label: "" }],
+        providers: { openrouter: true },
+      }),
     });
-    expect(checked).toBe(true);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  });
+  await harness.context.route("http://127.0.0.1:8787/health", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true, version: "0.0.0" }),
+    });
+  });
+  await harness.context.route("http://127.0.0.1:8787/v1/ping", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await page.click("#tab-model");
+  await expect(page.locator("#panel-model")).toBeVisible();
+  await expect.poll(() => modelCalls).toBeGreaterThanOrEqual(1);
+  await expect(page.locator("#modelPreset")).toHaveValue("auto");
+
+  await page.evaluate(() => {
+    const preset = document.getElementById("modelPreset") as HTMLSelectElement | null;
+    if (!preset) return;
+    preset.value = "custom";
+    preset.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await expect(page.locator("#modelCustom")).toBeVisible();
+
+  await page.locator("#modelCustom").focus();
+  await expect.poll(() => modelCalls).toBe(2);
+  releaseSecond?.();
+
+  await expect(page.locator("#modelPreset")).toHaveValue("custom");
+  await expect(page.locator("#modelCustom")).toBeVisible();
 });
 
-test("options exposes two AI connections and independent slide runtimes", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("options defers automation skills until Skills tab opens", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await page.waitForLoadState("networkidle");
 
-  try {
-    await seedSettings(harness, { summaryRuntime: "direct", slideRuntime: "browser" });
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await expect(page.locator("#panel-general")).toBeVisible();
+  await expect(page.locator("#skillsList .skillCard")).toHaveCount(0);
 
-    await expect(page.locator("#daemonStatus")).toContainText("Local companion permission missing");
-    await expect(page.locator("#panel-general")).not.toContainText("Token");
-
-    await page.click("#tab-runtime");
-    await expect(page.locator("#panel-runtime")).toBeVisible();
-    await expect(page.locator("#panel-runtime")).toContainText("Direct");
-    await expect(page.locator("#panel-runtime")).toContainText("Daemon");
-    await expect(page.locator("#summaryRuntimeMode .runtimeModeCard")).toHaveCount(2);
-    await expect(page.locator("#panel-runtime")).not.toContainText("On-device");
-    await page.click("#tab-advanced");
-    await expect(page.locator("#modelPreset")).toContainText("Gemini Nano (on-device)");
-    await page.click("#tab-runtime");
-    await expect(page.locator("#panel-runtime")).toContainText("Browser cache");
-    await expect(page.locator("#panel-runtime #daemonPort")).toBeVisible();
-    await expect(page.locator("#panel-runtime #token")).toBeVisible();
-    await expect(page.locator("#daemonPermissionEnable")).toBeVisible();
-    await expect(page.locator("#panel-runtime")).not.toContainText("Show summary first");
-    await expect(page.locator("#browserCacheStatus")).toContainText(/entries? · /);
-    await page.locator("#browserCacheClear").click();
-    await expect(page.locator("#browserCacheStatus")).toContainText("0 entries");
-
-    const aiMode = page.locator("#summaryRuntimeMode");
-    await expect(aiMode.locator('input[value="direct"]')).toBeChecked();
-    const slideMode = page.locator("#slideRuntimeMode");
-    await expect(slideMode.locator('input[value="browser"]')).toBeChecked();
-
-    await page.click("#tab-advanced");
-    await expect(page.locator("#panel-advanced")).toContainText("Show summary first");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await page.click("#tab-skills");
+  await expect(page.locator("#panel-skills")).toBeVisible();
+  await expect.poll(async () => page.locator("#skillsList .skillCard").count()).toBeGreaterThan(0);
 });
 
-test("options opens the requested runtime tab from the URL", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("options persists automation toggle without save", async ({ harness }) => {
+  await seedSettings(harness, { automationEnabled: false });
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await page.waitForFunction(() => document.documentElement.dataset.settingsReady === "true");
 
-  try {
-    const page = await openExtensionPage(harness, "options.html?tab=runtime", "#tabs");
+  const toggle = page.locator("#automationToggle .checkboxRoot");
+  await toggle.click();
 
-    await expect(page.locator("#tab-runtime")).toHaveAttribute("aria-selected", "true");
-    await expect(page.locator("#panel-runtime")).toBeVisible();
+  await expect
+    .poll(async () => {
+      const settings = await getSettings(harness);
+      return settings.automationEnabled;
+    })
+    .toBe(true);
 
-    await page.click("#tab-general");
-    await expect(page).not.toHaveURL(/tab=runtime/);
-    await expect(page.locator("#tab-general")).toHaveAttribute("aria-selected", "true");
+  await page.close();
 
-    await page.reload({ waitUntil: "domcontentloaded" });
-    await page.waitForSelector("#tabs");
-    await expect(page.locator("#tab-general")).toHaveAttribute("aria-selected", "true");
-    await expect(page.locator("#panel-general")).toBeVisible();
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const reopened = await openExtensionPage(harness, "options.html", "#tabs");
+  const checked = await reopened.evaluate(() => {
+    const input = document.querySelector("#automationToggle input") as HTMLInputElement | null;
+    return input?.checked ?? false;
+  });
+  expect(checked).toBe(true);
+});
+
+test("options exposes two AI connections and independent slide runtimes", async ({ harness }) => {
+  await seedSettings(harness, { summaryRuntime: "direct", slideRuntime: "browser" });
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+
+  await expect(page.locator("#daemonStatus")).toContainText("Local companion permission missing");
+  await expect(page.locator("#panel-general")).not.toContainText("Token");
+
+  await page.click("#tab-runtime");
+  await expect(page.locator("#panel-runtime")).toBeVisible();
+  await expect(page.locator("#panel-runtime")).toContainText("Direct");
+  await expect(page.locator("#panel-runtime")).toContainText("Daemon");
+  await expect(page.locator("#summaryRuntimeMode .runtimeModeCard")).toHaveCount(2);
+  await expect(page.locator("#panel-runtime")).not.toContainText("On-device");
+  await page.click("#tab-advanced");
+  await expect(page.locator("#modelPreset")).toContainText("Gemini Nano (on-device)");
+  await page.click("#tab-runtime");
+  await expect(page.locator("#panel-runtime")).toContainText("Browser cache");
+  await expect(page.locator("#panel-runtime #daemonPort")).toBeVisible();
+  await expect(page.locator("#panel-runtime #token")).toBeVisible();
+  await expect(page.locator("#daemonPermissionEnable")).toBeVisible();
+  await expect(page.locator("#panel-runtime")).not.toContainText("Show summary first");
+  await expect(page.locator("#browserCacheStatus")).toContainText(/entries? · /);
+  await page.locator("#browserCacheClear").click();
+  await expect(page.locator("#browserCacheStatus")).toContainText("0 entries");
+
+  const aiMode = page.locator("#summaryRuntimeMode");
+  await expect(aiMode.locator('input[value="direct"]')).toBeChecked();
+  const slideMode = page.locator("#slideRuntimeMode");
+  await expect(slideMode.locator('input[value="browser"]')).toBeChecked();
+
+  await page.click("#tab-advanced");
+  await expect(page.locator("#panel-advanced")).toContainText("Show summary first");
+});
+
+test("options opens the requested runtime tab from the URL", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "options.html?tab=runtime", "#tabs");
+
+  await expect(page.locator("#tab-runtime")).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#panel-runtime")).toBeVisible();
+
+  await page.click("#tab-general");
+  await expect(page).not.toHaveURL(/tab=runtime/);
+  await expect(page.locator("#tab-general")).toHaveAttribute("aria-selected", "true");
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#tabs");
+  await expect(page.locator("#tab-general")).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#panel-general")).toBeVisible();
 });
 
 test("options stores an OpenAI key for direct mode without requiring the daemon", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    summaryRuntime: "daemon",
+    slideRuntime: "daemon",
+    provider: "openrouter",
+    providerApiKeys: {},
+  });
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
 
-  try {
-    await seedSettings(harness, {
-      summaryRuntime: "daemon",
-      slideRuntime: "daemon",
-      provider: "openrouter",
-      providerApiKeys: {},
-    });
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await expect(page.locator("#daemonStatus")).toContainText("Local companion permission missing");
+  await page.click("#tab-runtime");
+  await page.locator('#summaryRuntimeMode input[value="direct"]').click();
+  await page.locator('#slideRuntimeMode input[value="browser"]').click();
+  await expect
+    .poll(async () => {
+      const settings = await getSettings(harness);
+      return { summaryRuntime: settings.summaryRuntime, slideRuntime: settings.slideRuntime };
+    })
+    .toEqual({ summaryRuntime: "direct", slideRuntime: "browser" });
+  await page.locator("#provider").selectOption("openai");
+  await expect.poll(async () => (await getSettings(harness)).provider).toBe("openai");
+  await page.locator("#providerApiKey").fill("sk-test-direct-openai");
 
-    await expect(page.locator("#daemonStatus")).toContainText("Local companion permission missing");
-    await page.click("#tab-runtime");
-    await page.locator('#summaryRuntimeMode input[value="direct"]').click();
-    await page.locator('#slideRuntimeMode input[value="browser"]').click();
-    await expect
-      .poll(async () => {
-        const settings = await getSettings(harness);
-        return { summaryRuntime: settings.summaryRuntime, slideRuntime: settings.slideRuntime };
-      })
-      .toEqual({ summaryRuntime: "direct", slideRuntime: "browser" });
-    await page.locator("#provider").selectOption("openai");
-    await expect.poll(async () => (await getSettings(harness)).provider).toBe("openai");
-    await page.locator("#providerApiKey").fill("sk-test-direct-openai");
-
-    await expect
-      .poll(async () => {
-        const settings = await getSettings(harness);
-        return {
-          summaryRuntime: settings.summaryRuntime,
-          slideRuntime: settings.slideRuntime,
-          provider: settings.provider,
-          key: settings.providerApiKeys?.openai,
-        };
-      })
-      .toEqual({
-        summaryRuntime: "direct",
-        slideRuntime: "browser",
-        provider: "openai",
-        key: "sk-test-direct-openai",
-      });
-
-    await page.reload();
-    await page.click("#tab-runtime");
-    await expect(page.locator('#summaryRuntimeMode input[value="direct"]')).toBeChecked();
-    await expect(page.locator('#slideRuntimeMode input[value="browser"]')).toBeChecked();
-    await expect(page.locator("#provider")).toHaveValue("openai");
-    await expect(page.locator("#providerApiKey")).toHaveValue("sk-test-direct-openai");
-    await expect(page.locator("#daemonStatus")).toContainText("Local companion permission missing");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("managed daemon disable locks the UI to Direct and Browser", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
-      token: "saved-daemon-token",
-      summaryRuntime: "daemon",
-      slideRuntime: "daemon",
-      autoCliFallback: true,
-    });
-    const page = await harness.context.newPage();
-    trackErrors(page, harness.pageErrors, harness.consoleErrors);
-    await page.addInitScript(() => {
-      Object.defineProperty(chrome.storage, "managed", {
-        configurable: true,
-        value: {
-          get: async () => ({ daemonAllowed: false }),
-          setAccessLevel: async () => undefined,
-        },
-      });
-    });
-    await page.goto(getExtensionUrl(harness, "options.html"), { waitUntil: "domcontentloaded" });
-    await page.waitForSelector("#tabs");
-
-    await expect(page.locator("#daemonStatus")).toContainText("Disabled by administrator");
-    await page.click("#tab-runtime");
-    await expect(page.locator("#daemonCapabilityStatus")).toHaveText("Disabled by administrator");
-    await expect(page.locator('#summaryRuntimeMode input[value="direct"]')).toBeChecked();
-    await expect(page.locator('#slideRuntimeMode input[value="browser"]')).toBeChecked();
-    await expect(page.locator('#summaryRuntimeMode input[value="daemon"]')).toBeDisabled();
-    await expect(page.locator('#slideRuntimeMode input[value="daemon"]')).toBeDisabled();
-    await expect(page.locator("#daemonPermissionEnable")).toBeHidden();
-    await expect(page.locator("#token")).toBeDisabled();
-    await expect(page.locator("#token")).toHaveValue("");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("options persists direct provider credentials per provider", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
+  await expect
+    .poll(async () => {
+      const settings = await getSettings(harness);
+      return {
+        summaryRuntime: settings.summaryRuntime,
+        slideRuntime: settings.slideRuntime,
+        provider: settings.provider,
+        key: settings.providerApiKeys?.openai,
+      };
+    })
+    .toEqual({
       summaryRuntime: "direct",
+      slideRuntime: "browser",
       provider: "openai",
-      providerApiKeys: { openai: "openai-key" },
-      providerBaseUrls: {},
+      key: "sk-test-direct-openai",
     });
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    await page.click("#tab-runtime");
-    await expect(page.locator("#provider")).toHaveValue("openai");
-    await expect(page.locator("#providerApiKey")).toHaveValue("openai-key");
 
-    await page.locator("#provider").selectOption("anthropic");
-    await expect(page.locator("#providerApiKey")).toHaveValue("");
-    await expect(page.locator("#providerBaseUrl")).toHaveValue("");
-    await page.locator("#providerApiKey").fill("anthropic-key");
-    await page.locator("#providerBaseUrl").fill("https://anthropic.test");
-
-    await expect
-      .poll(async () => {
-        const settings = await getSettings(harness);
-        return (settings.providerApiKeys as Record<string, string> | undefined)?.anthropic;
-      })
-      .toBe("anthropic-key");
-
-    await page.locator("#provider").selectOption("openai");
-    await expect(page.locator("#providerApiKey")).toHaveValue("openai-key");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await page.reload();
+  await page.click("#tab-runtime");
+  await expect(page.locator('#summaryRuntimeMode input[value="direct"]')).toBeChecked();
+  await expect(page.locator('#slideRuntimeMode input[value="browser"]')).toBeChecked();
+  await expect(page.locator("#provider")).toHaveValue("openai");
+  await expect(page.locator("#providerApiKey")).toHaveValue("sk-test-direct-openai");
+  await expect(page.locator("#daemonStatus")).toContainText("Local companion permission missing");
 });
 
-test("options labels unavailable automation permissions as optional", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, { automationEnabled: true });
-    const page = await harness.context.newPage();
-    trackErrors(page, harness.pageErrors, harness.consoleErrors);
-    await page.addInitScript(() => {
-      Object.defineProperty(chrome, "permissions", {
-        configurable: true,
-        value: {
-          contains: async () => false,
-          request: async () => true,
-        },
-      });
-      Object.defineProperty(chrome, "userScripts", {
-        configurable: true,
-        value: undefined,
-      });
+test("managed daemon disable locks the UI to Direct and Browser", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "saved-daemon-token",
+    summaryRuntime: "daemon",
+    slideRuntime: "daemon",
+    autoCliFallback: true,
+  });
+  const page = await harness.context.newPage();
+  trackErrors(page, harness.pageErrors, harness.consoleErrors);
+  await page.addInitScript(() => {
+    Object.defineProperty(chrome.storage, "managed", {
+      configurable: true,
+      value: {
+        get: async () => ({ daemonAllowed: false }),
+        setAccessLevel: async () => undefined,
+      },
     });
-    await page.goto(getExtensionUrl(harness, "options.html"), {
-      waitUntil: "domcontentloaded",
+  });
+  await page.goto(getExtensionUrl(harness, "options.html"), { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#tabs");
+
+  await expect(page.locator("#daemonStatus")).toContainText("Disabled by administrator");
+  await page.click("#tab-runtime");
+  await expect(page.locator("#daemonCapabilityStatus")).toHaveText("Disabled by administrator");
+  await expect(page.locator('#summaryRuntimeMode input[value="direct"]')).toBeChecked();
+  await expect(page.locator('#slideRuntimeMode input[value="browser"]')).toBeChecked();
+  await expect(page.locator('#summaryRuntimeMode input[value="daemon"]')).toBeDisabled();
+  await expect(page.locator('#slideRuntimeMode input[value="daemon"]')).toBeDisabled();
+  await expect(page.locator("#daemonPermissionEnable")).toBeHidden();
+  await expect(page.locator("#token")).toBeDisabled();
+  await expect(page.locator("#token")).toHaveValue("");
+});
+
+test("options persists direct provider credentials per provider", async ({ harness }) => {
+  await seedSettings(harness, {
+    summaryRuntime: "direct",
+    provider: "openai",
+    providerApiKeys: { openai: "openai-key" },
+    providerBaseUrls: {},
+  });
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await page.click("#tab-runtime");
+  await expect(page.locator("#provider")).toHaveValue("openai");
+  await expect(page.locator("#providerApiKey")).toHaveValue("openai-key");
+
+  await page.locator("#provider").selectOption("anthropic");
+  await expect(page.locator("#providerApiKey")).toHaveValue("");
+  await expect(page.locator("#providerBaseUrl")).toHaveValue("");
+  await page.locator("#providerApiKey").fill("anthropic-key");
+  await page.locator("#providerBaseUrl").fill("https://anthropic.test");
+
+  await expect
+    .poll(async () => {
+      const settings = await getSettings(harness);
+      return (settings.providerApiKeys as Record<string, string> | undefined)?.anthropic;
+    })
+    .toBe("anthropic-key");
+
+  await page.locator("#provider").selectOption("openai");
+  await expect(page.locator("#providerApiKey")).toHaveValue("openai-key");
+});
+
+test("options labels unavailable automation permissions as optional", async ({ harness }) => {
+  await seedSettings(harness, { automationEnabled: true });
+  const page = await harness.context.newPage();
+  trackErrors(page, harness.pageErrors, harness.consoleErrors);
+  await page.addInitScript(() => {
+    Object.defineProperty(chrome, "permissions", {
+      configurable: true,
+      value: {
+        contains: async () => false,
+        request: async () => true,
+      },
     });
-    await page.waitForSelector("#tabs");
+    Object.defineProperty(chrome, "userScripts", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+  await page.goto(getExtensionUrl(harness, "options.html"), {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForSelector("#tabs");
 
-    await expect(page.locator("#automationPermissions")).toBeEnabled();
-    await expect(page.locator("#automationPermissions")).toHaveText(
-      "Enable automation permissions",
-    );
-    await expect(page.locator(".permissionHint")).toContainText("Optional for summarization");
-    await expect(page.locator(".permissionHint")).toContainText("userScripts");
-    await expect(page.locator(".permissionHint")).toContainText("debugger");
-    await expect(page.locator("#userScriptsNotice")).toBeVisible();
-    await expect(page.locator("#userScriptsNotice")).toContainText(/User Scripts|chrome:\/\//);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect(page.locator("#automationPermissions")).toBeEnabled();
+  await expect(page.locator("#automationPermissions")).toHaveText("Enable automation permissions");
+  await expect(page.locator(".permissionHint")).toContainText("Optional for summarization");
+  await expect(page.locator(".permissionHint")).toContainText("userScripts");
+  await expect(page.locator(".permissionHint")).toContainText("debugger");
+  await expect(page.locator("#userScriptsNotice")).toBeVisible();
+  await expect(page.locator("#userScriptsNotice")).toContainText(/User Scripts|chrome:\/\//);
 });
 
 test("options grants User Scripts only after the explicit automation action", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, { automationEnabled: true });
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  const hasUserScripts = () =>
+    page.evaluate(() => chrome.permissions.contains({ permissions: ["userScripts"] }));
 
-  try {
-    await seedSettings(harness, { automationEnabled: true });
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    const hasUserScripts = () =>
-      page.evaluate(() => chrome.permissions.contains({ permissions: ["userScripts"] }));
-
-    await expect.poll(hasUserScripts).toBe(false);
-    await page.locator("#automationPermissions").click();
-    await expect.poll(hasUserScripts).toBe(true);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect.poll(hasUserScripts).toBe(false);
+  await page.locator("#automationPermissions").click();
+  await expect.poll(hasUserScripts).toBe(true);
 });
 
-test("options scheme list renders chips", async ({ browserName: _browserName }, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("options scheme list renders chips", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await page.click("#tab-ui");
+  await expect(page.locator("#panel-ui")).toBeVisible();
 
-  try {
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    await page.click("#tab-ui");
-    await expect(page.locator("#panel-ui")).toBeVisible();
+  const schemeLabel = page.locator("label.scheme");
+  const schemeTrigger = schemeLabel.locator(".pickerTrigger");
 
-    const schemeLabel = page.locator("label.scheme");
-    const schemeTrigger = schemeLabel.locator(".pickerTrigger");
+  await schemeTrigger.focus();
+  await schemeTrigger.press("Enter");
+  const schemeList = getOpenPickerList(page);
+  await expect(schemeList).toBeVisible();
 
-    await schemeTrigger.focus();
-    await schemeTrigger.press("Enter");
-    const schemeList = getOpenPickerList(page);
-    await expect(schemeList).toBeVisible();
-
-    const options = schemeList.locator(".pickerOption");
-    await expect(options).toHaveCount(6);
-    await expect(options.first().locator(".scheme-chips span")).toHaveCount(4);
-    await expect(options.nth(1).locator(".scheme-chips span")).toHaveCount(4);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const options = schemeList.locator(".pickerOption");
+  await expect(options).toHaveCount(6);
+  await expect(options.first().locator(".scheme-chips span")).toHaveCount(4);
+  await expect(options.nth(1).locator(".scheme-chips span")).toHaveCount(4);
 });
 
-test("options footer links to summarize site", async ({ browserName: _browserName }, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    const summarizeLink = page.locator(".pageFooter a", { hasText: "Summarize" });
-    await expect(summarizeLink).toHaveAttribute("href", /summarize\.sh/);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+test("options footer links to summarize site", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  const summarizeLink = page.locator(".pageFooter a", { hasText: "Summarize" });
+  await expect(summarizeLink).toHaveAttribute("href", /summarize\.sh/);
 });
 
-test("options persists a custom daemon port", async ({ browserName: _browserName }, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, { daemonPort: "9931" });
-    const page = await openExtensionPage(harness, "options.html", "#tabs");
-    await page.click("#tab-runtime");
-    await expect(page.locator("#daemonPort")).toHaveValue("9931");
-    await page.locator("#daemonPort").fill("8788");
-    await expect
-      .poll(async () => {
-        const settings = await getSettings(harness);
-        return settings.daemonPort;
-      })
-      .toBe("8788");
-    await page.locator("#daemonPort").fill("65536");
-    await expect(page.locator("#daemonPort")).toHaveValue("8787");
-    await expect.poll(async () => (await getSettings(harness)).daemonPort).toBe("8787");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+test("options persists a custom daemon port", async ({ harness }) => {
+  await seedSettings(harness, { daemonPort: "9931" });
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await page.click("#tab-runtime");
+  await expect(page.locator("#daemonPort")).toHaveValue("9931");
+  await page.locator("#daemonPort").fill("8788");
+  await expect
+    .poll(async () => {
+      const settings = await getSettings(harness);
+      return settings.daemonPort;
+    })
+    .toBe("8788");
+  await page.locator("#daemonPort").fill("65536");
+  await expect(page.locator("#daemonPort")).toHaveValue("8787");
+  await expect.poll(async () => (await getSettings(harness)).daemonPort).toBe("8787");
 });

--- a/apps/chrome-extension/tests/sidepanel.browser-ai.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.browser-ai.spec.ts
@@ -1,10 +1,7 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "./helpers/extension-fixtures";
 import {
-  assertNoErrors,
   buildUiState,
-  closeExtension,
-  getBrowserFromProject,
-  launchExtension,
   openExtensionPage,
   sendBgMessage,
   trackErrors,
@@ -20,261 +17,242 @@ import {
   getPanelSummaryMarkdown,
 } from "./helpers/panel-hooks";
 
-test("browser AI keeps the native session receiver", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      const session = {
-        inputQuota: 10_000,
-        async measureInputUsage(this: unknown, input: string) {
-          if (this !== session) throw new TypeError("Illegal invocation");
-          return input.length;
-        },
-        async summarize(this: unknown) {
-          if (this !== session) throw new TypeError("Illegal invocation");
-          return "* Native summary point\n* Another native point";
-        },
-      };
-      Object.defineProperty(globalThis, "Summarizer", {
-        configurable: true,
-        value: {
-          availability: async () => "available",
-          create: async () => session,
-        },
-      });
-    });
-    trackErrors(page, harness.pageErrors, harness.consoleErrors);
-    await waitForPanelPort(page);
-
-    await sendBgMessage(harness, {
-      type: "run:snapshot",
-      run: {
-        id: "browser-ai-test",
-        url: "https://example.com/article",
-        title: "Native summary",
-        model: "Browser",
-        reason: "manual",
+test("browser AI keeps the native session receiver", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    const session = {
+      inputQuota: 10_000,
+      async measureInputUsage(this: unknown, input: string) {
+        if (this !== session) throw new TypeError("Illegal invocation");
+        return input.length;
       },
-      markdown: "## Native summary\n\nFallback summary.",
-      browserAi: {
-        text: "A sufficiently detailed article for the native summarizer.",
-        length: "long",
-        keyMoments: [],
+      async summarize(this: unknown) {
+        if (this !== session) throw new TypeError("Illegal invocation");
+        return "* Native summary point\n* Another native point";
+      },
+    };
+    Object.defineProperty(globalThis, "Summarizer", {
+      configurable: true,
+      value: {
+        availability: async () => "available",
+        create: async () => session,
       },
     });
+  });
+  trackErrors(page, harness.pageErrors, harness.consoleErrors);
+  await waitForPanelPort(page);
 
-    await expect.poll(() => getPanelModel(page)).toBe("Gemini Nano");
-    await expect.poll(() => getPanelSummaryMarkdown(page)).toContain("- Native summary point");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await sendBgMessage(harness, {
+    type: "run:snapshot",
+    run: {
+      id: "browser-ai-test",
+      url: "https://example.com/article",
+      title: "Native summary",
+      model: "Browser",
+      reason: "manual",
+    },
+    markdown: "## Native summary\n\nFallback summary.",
+    browserAi: {
+      text: "A sufficiently detailed article for the native summarizer.",
+      length: "long",
+      keyMoments: [],
+    },
+  });
+
+  await expect.poll(() => getPanelModel(page)).toBe("Gemini Nano");
+  await expect.poll(() => getPanelSummaryMarkdown(page)).toContain("- Native summary point");
 });
 
-test("browser AI creates distinct summaries for browser-extracted slides", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      (
-        globalThis as typeof globalThis & {
-          __browserAiPromptCalls?: number;
-          __browserAiPromptImageInputs?: number;
-          __browserAiSlideSummarizerCalls?: number;
-        }
-      ).__browserAiPromptCalls = 0;
-      (
-        globalThis as typeof globalThis & {
-          __browserAiPromptImageInputs?: number;
-        }
-      ).__browserAiPromptImageInputs = 0;
-      (
-        globalThis as typeof globalThis & {
-          __browserAiSlideSummarizerCalls?: number;
-        }
-      ).__browserAiSlideSummarizerCalls = 0;
-      Object.defineProperty(globalThis, "LanguageModel", {
-        configurable: true,
-        value: {
-          availability: async () => "available",
-          create: async (createOptions?: { expectedInputs?: Array<{ type?: string }> }) => ({
-            contextWindow: 9_216,
-            async measureContextUsage() {
-              return 500;
-            },
-            async prompt(
-              input:
-                | string
-                | Array<{
-                    content?: Array<{ type?: string; value?: unknown }>;
-                  }>,
-              options?: { responseConstraint?: RegExp },
-            ) {
-              const scope = globalThis as typeof globalThis & {
-                __browserAiPromptCalls?: number;
-                __browserAiPromptImageInputs?: number;
-              };
-              scope.__browserAiPromptCalls = (scope.__browserAiPromptCalls ?? 0) + 1;
-              scope.__browserAiPromptImageInputs =
-                typeof input === "string"
-                  ? 0
-                  : input
-                      .flatMap((message) => message.content ?? [])
-                      .filter(
-                        (content) => content.type === "image" && content.value instanceof Blob,
-                      ).length;
-              if (!createOptions?.expectedInputs?.some((expected) => expected.type === "image")) {
-                throw new DOMException("Missing image modality", "NotSupportedError");
-              }
-              const result =
-                "[slide:1] Linear classifiers learn a decision boundary between labeled examples.\n" +
-                "[slide:2] The sigmoid converts model scores into class probabilities.";
-              if (!options?.responseConstraint?.test(result)) {
-                throw new DOMException("Constraint mismatch", "SyntaxError");
-              }
-              return result;
-            },
-            destroy() {},
-          }),
-        },
-      });
-      Object.defineProperty(globalThis, "Summarizer", {
-        configurable: true,
-        value: {
-          availability: async () => "available",
-          create: async () => ({
-            async summarize(input: string, options?: { context?: string }) {
-              if (options?.context?.includes("slide 1 of 2")) {
-                const scope = globalThis as typeof globalThis & {
-                  __browserAiSlideSummarizerCalls?: number;
-                };
-                scope.__browserAiSlideSummarizerCalls =
-                  (scope.__browserAiSlideSummarizerCalls ?? 0) + 1;
-                return "Linear classifiers learn a decision boundary between labeled examples.";
-              }
-              if (options?.context?.includes("slide 2 of 2")) {
-                const scope = globalThis as typeof globalThis & {
-                  __browserAiSlideSummarizerCalls?: number;
-                };
-                scope.__browserAiSlideSummarizerCalls =
-                  (scope.__browserAiSlideSummarizerCalls ?? 0) + 1;
-                return "The sigmoid converts model scores into class probabilities.";
-              }
-              return `Overall summary of ${input.slice(0, 20)}.`;
-            },
-          }),
-        },
-      });
-    });
-    trackErrors(page, harness.pageErrors, harness.consoleErrors);
-    await waitForPanelPort(page);
-    const url = "https://www.youtube.com/watch?v=browser-ai-slides";
-    const uiState = buildUiState({
-      tab: { id: 1, url, title: "Machine Learning Lecture" },
-    });
-    Object.assign(uiState.settings, {
-      slideRuntime: "browser",
-      summaryRuntime: "direct",
-      providerConfigured: false,
-      model: "auto",
-    });
-
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: uiState,
-    });
-    await sendBgMessage(harness, {
-      type: "run:snapshot",
-      run: {
-        id: "browser-ai-slides-summary",
-        url,
-        title: "Machine Learning Lecture",
-        model: "Browser",
-        reason: "manual",
-      },
-      markdown: "## Machine Learning Lecture\n\nFallback summary.",
-      browserAi: {
-        text: "The lecture introduces classification and logistic regression.",
-        length: "long",
-        keyMoments: [],
-      },
-    });
-    await applySlidesPayload(page, {
-      sourceUrl: url,
-      sourceId: "browser-ai-slide-source",
-      sourceKind: "youtube",
-      slideRuntime: "browser",
-      ocrAvailable: false,
-      transcriptTimedText:
-        "[00:00] The first section explains linear decision boundaries and labeled examples.\n" +
-        "[01:00] The second section derives the sigmoid and probability interpretation.",
-      slides: [
-        {
-          index: 1,
-          timestamp: 0,
-          imageUrl:
-            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2xZkAAAAASUVORK5CYII=",
-        },
-        {
-          index: 2,
-          timestamp: 60,
-          imageUrl:
-            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2xZkAAAAASUVORK5CYII=",
-        },
-      ],
-    });
-
-    await expect.poll(() => getPanelSlidesSummaryComplete(page)).toBe(true);
-    await expect.poll(() => getPanelSlidesSummaryModel(page)).toBe("Gemini Nano");
-    const markdown = await getPanelSlidesSummaryMarkdown(page);
-    expect(markdown).toContain("[slide:1]");
-    expect(markdown).toContain("Linear classifiers learn a decision boundary");
-    expect(markdown).toContain("[slide:2]");
-    expect(markdown).toContain("The sigmoid converts model scores");
-    expect(markdown).not.toContain("The first section explains");
-    expect(await getPanelSlideDescriptions(page)).toEqual([
-      [1, "Linear classifiers learn a decision boundary between labeled examples."],
-      [2, "The sigmoid converts model scores into class probabilities."],
-    ]);
-    await expect
-      .poll(() =>
-        page.evaluate(
-          () =>
-            (
-              globalThis as typeof globalThis & {
-                __browserAiPromptCalls?: number;
-              }
-            ).__browserAiPromptCalls ?? 0,
-        ),
-      )
-      .toBe(1);
-    expect(
-      await page.evaluate(
-        () =>
-          (
-            globalThis as typeof globalThis & {
+test("browser AI creates distinct summaries for browser-extracted slides", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    (
+      globalThis as typeof globalThis & {
+        __browserAiPromptCalls?: number;
+        __browserAiPromptImageInputs?: number;
+        __browserAiSlideSummarizerCalls?: number;
+      }
+    ).__browserAiPromptCalls = 0;
+    (
+      globalThis as typeof globalThis & {
+        __browserAiPromptImageInputs?: number;
+      }
+    ).__browserAiPromptImageInputs = 0;
+    (
+      globalThis as typeof globalThis & {
+        __browserAiSlideSummarizerCalls?: number;
+      }
+    ).__browserAiSlideSummarizerCalls = 0;
+    Object.defineProperty(globalThis, "LanguageModel", {
+      configurable: true,
+      value: {
+        availability: async () => "available",
+        create: async (createOptions?: { expectedInputs?: Array<{ type?: string }> }) => ({
+          contextWindow: 9_216,
+          async measureContextUsage() {
+            return 500;
+          },
+          async prompt(
+            input:
+              | string
+              | Array<{
+                  content?: Array<{ type?: string; value?: unknown }>;
+                }>,
+            options?: { responseConstraint?: RegExp },
+          ) {
+            const scope = globalThis as typeof globalThis & {
+              __browserAiPromptCalls?: number;
               __browserAiPromptImageInputs?: number;
+            };
+            scope.__browserAiPromptCalls = (scope.__browserAiPromptCalls ?? 0) + 1;
+            scope.__browserAiPromptImageInputs =
+              typeof input === "string"
+                ? 0
+                : input
+                    .flatMap((message) => message.content ?? [])
+                    .filter((content) => content.type === "image" && content.value instanceof Blob)
+                    .length;
+            if (!createOptions?.expectedInputs?.some((expected) => expected.type === "image")) {
+              throw new DOMException("Missing image modality", "NotSupportedError");
             }
-          ).__browserAiPromptImageInputs ?? 0,
-      ),
-    ).toBe(2);
-    expect(
-      await page.evaluate(
+            const result =
+              "[slide:1] Linear classifiers learn a decision boundary between labeled examples.\n" +
+              "[slide:2] The sigmoid converts model scores into class probabilities.";
+            if (!options?.responseConstraint?.test(result)) {
+              throw new DOMException("Constraint mismatch", "SyntaxError");
+            }
+            return result;
+          },
+          destroy() {},
+        }),
+      },
+    });
+    Object.defineProperty(globalThis, "Summarizer", {
+      configurable: true,
+      value: {
+        availability: async () => "available",
+        create: async () => ({
+          async summarize(input: string, options?: { context?: string }) {
+            if (options?.context?.includes("slide 1 of 2")) {
+              const scope = globalThis as typeof globalThis & {
+                __browserAiSlideSummarizerCalls?: number;
+              };
+              scope.__browserAiSlideSummarizerCalls =
+                (scope.__browserAiSlideSummarizerCalls ?? 0) + 1;
+              return "Linear classifiers learn a decision boundary between labeled examples.";
+            }
+            if (options?.context?.includes("slide 2 of 2")) {
+              const scope = globalThis as typeof globalThis & {
+                __browserAiSlideSummarizerCalls?: number;
+              };
+              scope.__browserAiSlideSummarizerCalls =
+                (scope.__browserAiSlideSummarizerCalls ?? 0) + 1;
+              return "The sigmoid converts model scores into class probabilities.";
+            }
+            return `Overall summary of ${input.slice(0, 20)}.`;
+          },
+        }),
+      },
+    });
+  });
+  trackErrors(page, harness.pageErrors, harness.consoleErrors);
+  await waitForPanelPort(page);
+  const url = "https://www.youtube.com/watch?v=browser-ai-slides";
+  const uiState = buildUiState({
+    tab: { id: 1, url, title: "Machine Learning Lecture" },
+  });
+  Object.assign(uiState.settings, {
+    slideRuntime: "browser",
+    summaryRuntime: "direct",
+    providerConfigured: false,
+    model: "auto",
+  });
+
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: uiState,
+  });
+  await sendBgMessage(harness, {
+    type: "run:snapshot",
+    run: {
+      id: "browser-ai-slides-summary",
+      url,
+      title: "Machine Learning Lecture",
+      model: "Browser",
+      reason: "manual",
+    },
+    markdown: "## Machine Learning Lecture\n\nFallback summary.",
+    browserAi: {
+      text: "The lecture introduces classification and logistic regression.",
+      length: "long",
+      keyMoments: [],
+    },
+  });
+  await applySlidesPayload(page, {
+    sourceUrl: url,
+    sourceId: "browser-ai-slide-source",
+    sourceKind: "youtube",
+    slideRuntime: "browser",
+    ocrAvailable: false,
+    transcriptTimedText:
+      "[00:00] The first section explains linear decision boundaries and labeled examples.\n" +
+      "[01:00] The second section derives the sigmoid and probability interpretation.",
+    slides: [
+      {
+        index: 1,
+        timestamp: 0,
+        imageUrl:
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2xZkAAAAASUVORK5CYII=",
+      },
+      {
+        index: 2,
+        timestamp: 60,
+        imageUrl:
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2xZkAAAAASUVORK5CYII=",
+      },
+    ],
+  });
+
+  await expect.poll(() => getPanelSlidesSummaryComplete(page)).toBe(true);
+  await expect.poll(() => getPanelSlidesSummaryModel(page)).toBe("Gemini Nano");
+  const markdown = await getPanelSlidesSummaryMarkdown(page);
+  expect(markdown).toContain("[slide:1]");
+  expect(markdown).toContain("Linear classifiers learn a decision boundary");
+  expect(markdown).toContain("[slide:2]");
+  expect(markdown).toContain("The sigmoid converts model scores");
+  expect(markdown).not.toContain("The first section explains");
+  expect(await getPanelSlideDescriptions(page)).toEqual([
+    [1, "Linear classifiers learn a decision boundary between labeled examples."],
+    [2, "The sigmoid converts model scores into class probabilities."],
+  ]);
+  await expect
+    .poll(() =>
+      page.evaluate(
         () =>
           (
             globalThis as typeof globalThis & {
-              __browserAiSlideSummarizerCalls?: number;
+              __browserAiPromptCalls?: number;
             }
-          ).__browserAiSlideSummarizerCalls ?? 0,
+          ).__browserAiPromptCalls ?? 0,
       ),
-    ).toBe(0);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+    )
+    .toBe(1);
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          globalThis as typeof globalThis & {
+            __browserAiPromptImageInputs?: number;
+          }
+        ).__browserAiPromptImageInputs ?? 0,
+    ),
+  ).toBe(2);
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          globalThis as typeof globalThis & {
+            __browserAiSlideSummarizerCalls?: number;
+          }
+        ).__browserAiSlideSummarizerCalls ?? 0,
+    ),
+  ).toBe(0);
 });

--- a/apps/chrome-extension/tests/sidepanel.cache-navigation.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.cache-navigation.spec.ts
@@ -1,17 +1,14 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import {
   getSummarizeBodies,
   getSummarizeCallTimes,
   getSummarizeCalls,
   mockDaemonSummarize,
 } from "./helpers/daemon-fixtures";
+import { test } from "./helpers/extension-fixtures";
 import {
   activateTabByUrl,
-  assertNoErrors,
-  closeExtension,
-  getBrowserFromProject,
   injectContentScript,
-  launchExtension,
   maybeBringToFront,
   openExtensionPage,
   seedSettings,
@@ -21,110 +18,100 @@ import {
   waitForPanelPort,
 } from "./helpers/extension-harness";
 
-test("sidepanel auto summarizes quickly when switching YouTube tabs", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: true,
-      slidesEnabled: false,
-      slideRuntime: "daemon",
+test("sidepanel auto summarizes quickly when switching YouTube tabs", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: true,
+    slidesEnabled: false,
+    slideRuntime: "daemon",
+  });
+  await harness.context.route("https://www.youtube.com/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: "<html><body><article>YouTube placeholder</article></body></html>",
     });
-    await harness.context.route("https://www.youtube.com/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/html" },
-        body: "<html><body><article>YouTube placeholder</article></body></html>",
-      });
+  });
+
+  const videoA = "https://www.youtube.com/watch?v=videoA12345";
+  const videoB = "https://www.youtube.com/watch?v=videoB67890";
+
+  const pageA = await harness.context.newPage();
+  await pageA.goto(videoA, { waitUntil: "domcontentloaded" });
+  const pageB = await harness.context.newPage();
+  await pageB.goto(videoB, { waitUntil: "domcontentloaded" });
+
+  await activateTabByUrl(harness, videoA);
+  await waitForActiveTabUrl(harness, videoA);
+  await injectContentScript(harness, "content-scripts/extract.js", videoA);
+  await injectContentScript(harness, "content-scripts/extract.js", videoB);
+
+  const sseBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
+    );
+  await harness.context.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
+    const url = route.request().url();
+    const match = url.match(/summarize\/([^/]+)\/events/);
+    const runId = match ? (match[1] ?? "") : "";
+    const runIndex = Number.parseInt(runId.replace("run-", ""), 10);
+    const summaryText = runIndex % 2 === 1 ? "Video A summary" : "Video B summary";
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody(summaryText),
     });
+  });
+  const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(panel);
+  await maybeBringToFront(pageA);
+  await activateTabByUrl(harness, videoA);
+  await waitForActiveTabUrl(harness, videoA);
+  await mockDaemonSummarize(harness);
 
-    const videoA = "https://www.youtube.com/watch?v=videoA12345";
-    const videoB = "https://www.youtube.com/watch?v=videoB67890";
-
-    const pageA = await harness.context.newPage();
-    await pageA.goto(videoA, { waitUntil: "domcontentloaded" });
-    const pageB = await harness.context.newPage();
-    await pageB.goto(videoB, { waitUntil: "domcontentloaded" });
-
-    await activateTabByUrl(harness, videoA);
-    await waitForActiveTabUrl(harness, videoA);
-    await injectContentScript(harness, "content-scripts/extract.js", videoA);
-    await injectContentScript(harness, "content-scripts/extract.js", videoB);
-
-    const sseBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-    await harness.context.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
-      const url = route.request().url();
-      const match = url.match(/summarize\/([^/]+)\/events/);
-      const runId = match ? (match[1] ?? "") : "";
-      const runIndex = Number.parseInt(runId.replace("run-", ""), 10);
-      const summaryText = runIndex % 2 === 1 ? "Video A summary" : "Video B summary";
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody(summaryText),
-      });
-    });
-    const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(panel);
-    await maybeBringToFront(pageA);
-    await activateTabByUrl(harness, videoA);
-    await waitForActiveTabUrl(harness, videoA);
-    await mockDaemonSummarize(harness);
-
-    const maxPromptSummarizeDelayMs = 6_000;
-    const waitForSummarizeCall = async (sinceCount: number, startedAt: number) => {
-      await expect
-        .poll(async () => await getSummarizeCalls(harness), { timeout: maxPromptSummarizeDelayMs })
-        .toBeGreaterThan(sinceCount);
-      const callTimes = await getSummarizeCallTimes(harness);
-      const callTime = callTimes[sinceCount] ?? callTimes.at(-1) ?? Date.now();
-      expect(callTime - startedAt).toBeLessThan(maxPromptSummarizeDelayMs);
-    };
-
-    const callsBeforeReady = await getSummarizeCalls(harness);
-    const startA = Date.now();
-    await sendPanelMessage(panel, { type: "panel:ready" });
-    await waitForSummarizeCall(callsBeforeReady, startA);
+  const maxPromptSummarizeDelayMs = 6_000;
+  const waitForSummarizeCall = async (sinceCount: number, startedAt: number) => {
     await expect
-      .poll(async () => {
-        const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
-        return bodies.some((body) => body?.url === videoA);
-      })
-      .toBe(true);
+      .poll(async () => await getSummarizeCalls(harness), { timeout: maxPromptSummarizeDelayMs })
+      .toBeGreaterThan(sinceCount);
+    const callTimes = await getSummarizeCallTimes(harness);
+    const callTime = callTimes[sinceCount] ?? callTimes.at(-1) ?? Date.now();
+    expect(callTime - startedAt).toBeLessThan(maxPromptSummarizeDelayMs);
+  };
 
-    const callsBeforeB = await getSummarizeCalls(harness);
-    const startB = Date.now();
-    await activateTabByUrl(harness, videoB);
-    await waitForActiveTabUrl(harness, videoB);
-    await waitForSummarizeCall(callsBeforeB, startB);
-    await expect
-      .poll(async () => {
-        const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
-        return bodies.some((body) => body?.url === videoB);
-      })
-      .toBe(true);
+  const callsBeforeReady = await getSummarizeCalls(harness);
+  const startA = Date.now();
+  await sendPanelMessage(panel, { type: "panel:ready" });
+  await waitForSummarizeCall(callsBeforeReady, startA);
+  await expect
+    .poll(async () => {
+      const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
+      return bodies.some((body) => body?.url === videoA);
+    })
+    .toBe(true);
 
-    const callsBeforeReturn = await getSummarizeCalls(harness);
-    const startA2 = Date.now();
-    await activateTabByUrl(harness, videoA);
-    await waitForActiveTabUrl(harness, videoA);
+  const callsBeforeB = await getSummarizeCalls(harness);
+  const startB = Date.now();
+  await activateTabByUrl(harness, videoB);
+  await waitForActiveTabUrl(harness, videoB);
+  await waitForSummarizeCall(callsBeforeB, startB);
+  await expect
+    .poll(async () => {
+      const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
+      return bodies.some((body) => body?.url === videoB);
+    })
+    .toBe(true);
 
-    const callsAfterReturn = await getSummarizeCalls(harness);
-    if (callsAfterReturn > callsBeforeReturn) {
-      const callTimes = await getSummarizeCallTimes(harness);
-      const callTime = callTimes[callsAfterReturn - 1] ?? callTimes.at(-1) ?? Date.now();
-      expect(callTime - startA2).toBeLessThan(maxPromptSummarizeDelayMs);
-    }
+  const callsBeforeReturn = await getSummarizeCalls(harness);
+  const startA2 = Date.now();
+  await activateTabByUrl(harness, videoA);
+  await waitForActiveTabUrl(harness, videoA);
 
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
+  const callsAfterReturn = await getSummarizeCalls(harness);
+  if (callsAfterReturn > callsBeforeReturn) {
+    const callTimes = await getSummarizeCallTimes(harness);
+    const callTime = callTimes[callsAfterReturn - 1] ?? callTimes.at(-1) ?? Date.now();
+    expect(callTime - startA2).toBeLessThan(maxPromptSummarizeDelayMs);
   }
 });

--- a/apps/chrome-extension/tests/sidepanel.cache-state.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.cache-state.spec.ts
@@ -1,17 +1,14 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import {
   buildSlidesPayload,
   mockDaemonSummarize,
   routePlaceholderSlideImages,
 } from "./helpers/daemon-fixtures";
+import { test } from "./helpers/extension-fixtures";
 import {
   activateTabByUrl,
-  assertNoErrors,
   buildUiState,
-  closeExtension,
-  getBrowserFromProject,
   getActiveTabId,
-  launchExtension,
   openExtensionPage,
   seedSettings,
   sendBgMessage,
@@ -28,753 +25,719 @@ import {
   waitForSlidesRuntimeHooks,
 } from "./helpers/panel-hooks";
 
-test("sidepanel restores cached state when switching YouTube tabs", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel restores cached state when switching YouTube tabs", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    (
+      window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
+    ).__summarizeTestHooks = {};
+  });
+  await waitForPanelPort(page);
 
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
+  const sseBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
+    );
+  await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
+    const url = route.request().url();
+    const match = url.match(/summarize\/([^/]+)\/events/);
+    const runId = match ? (match[1] ?? "") : "";
+    const body = runId === "run-a" ? sseBody("Summary A") : sseBody("Summary B");
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body,
+    });
+  });
+
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "x-summarize-slide-ready": "1",
+      },
+      body: placeholderPng,
+    });
+  });
+
+  const tabAState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
+    settings: {
       autoSummarize: false,
       slidesEnabled: true,
       slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      (
-        window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
-      ).__summarizeTestHooks = {};
-    });
-    await waitForPanelPort(page);
+      tokenPresent: true,
+    },
+    status: "",
+  });
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-a",
+      url: "https://www.youtube.com/watch?v=alpha123",
+      title: "Alpha Tab",
+      model: "auto",
+      reason: "manual",
+      slides: false,
+    },
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
 
-    const sseBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-    await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
-      const url = route.request().url();
-      const match = url.match(/summarize\/([^/]+)\/events/);
-      const runId = match ? (match[1] ?? "") : "";
-      const body = runId === "run-a" ? sseBody("Summary A") : sseBody("Summary B");
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body,
-      });
-    });
-
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
-    );
-    await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "content-type": "image/png",
-          "x-summarize-slide-ready": "1",
-        },
-        body: placeholderPng,
-      });
-    });
-
-    const tabAState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-      status: "",
-    });
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-a",
-        url: "https://www.youtube.com/watch?v=alpha123",
-        title: "Alpha Tab",
-        model: "auto",
-        reason: "manual",
-        slides: false,
-      },
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
-
-    await page.waitForFunction(
-      () => {
-        const hooks = (
-          window as typeof globalThis & {
-            __summarizeTestHooks?: { applySlidesPayload?: (payload: unknown) => void };
-          }
-        ).__summarizeTestHooks;
-        return Boolean(hooks?.applySlidesPayload);
-      },
-      null,
-      { timeout: 5_000 },
-    );
-    const slidesPayloadA = {
-      sourceUrl: "https://www.youtube.com/watch?v=alpha123",
-      sourceId: "alpha",
-      sourceKind: "url",
-      ocrAvailable: true,
-      slides: [
-        {
-          index: 1,
-          timestamp: 0,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/alpha/1?v=1",
-          ocrText: "Alpha slide one.",
-        },
-        {
-          index: 2,
-          timestamp: 12,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/alpha/2?v=1",
-          ocrText: "Alpha slide two.",
-        },
-      ],
-    };
-    await page.evaluate((payload) => {
+  await page.waitForFunction(
+    () => {
       const hooks = (
         window as typeof globalThis & {
           __summarizeTestHooks?: { applySlidesPayload?: (payload: unknown) => void };
         }
       ).__summarizeTestHooks;
-      hooks?.applySlidesPayload?.(payload);
-    }, slidesPayloadA);
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(2);
-    const slidesA = await getPanelSlideDescriptions(page);
-    expect(slidesA[0]?.[1] ?? "").toContain("Alpha");
-
-    const tabBState = buildUiState({
-      tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
+      return Boolean(hooks?.applySlidesPayload);
+    },
+    null,
+    { timeout: 5_000 },
+  );
+  const slidesPayloadA = {
+    sourceUrl: "https://www.youtube.com/watch?v=alpha123",
+    sourceId: "alpha",
+    sourceKind: "url",
+    ocrAvailable: true,
+    slides: [
+      {
+        index: 1,
+        timestamp: 0,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/alpha/1?v=1",
+        ocrText: "Alpha slide one.",
       },
-      status: "",
-    });
-    await sendBgMessage(harness, { type: "ui:state", state: tabBState });
-    await expect(page.locator("#title")).toHaveText("Bravo Tab");
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-b",
-        url: "https://www.youtube.com/watch?v=bravo456",
-        title: "Bravo Tab",
-        model: "auto",
-        reason: "manual",
-        slides: false,
+      {
+        index: 2,
+        timestamp: 12,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/alpha/2?v=1",
+        ocrText: "Alpha slide two.",
       },
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary B");
+    ],
+  };
+  await page.evaluate((payload) => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: { applySlidesPayload?: (payload: unknown) => void };
+      }
+    ).__summarizeTestHooks;
+    hooks?.applySlidesPayload?.(payload);
+  }, slidesPayloadA);
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(2);
+  const slidesA = await getPanelSlideDescriptions(page);
+  expect(slidesA[0]?.[1] ?? "").toContain("Alpha");
 
-    const slidesPayloadB = {
-      sourceUrl: "https://www.youtube.com/watch?v=bravo456",
-      sourceId: "bravo",
-      sourceKind: "url",
-      ocrAvailable: true,
-      slides: [
-        {
-          index: 1,
-          timestamp: 0,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/bravo/1?v=1",
-          ocrText: "Bravo slide one.",
-        },
-      ],
-    };
-    await page.evaluate((payload) => {
-      const hooks = (
-        window as typeof globalThis & {
-          __summarizeTestHooks?: { applySlidesPayload?: (payload: unknown) => void };
-        }
-      ).__summarizeTestHooks;
-      hooks?.applySlidesPayload?.(payload);
-    }, slidesPayloadB);
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(1);
-    const slidesB = await getPanelSlideDescriptions(page);
-    expect(slidesB[0]?.[1] ?? "").toContain("Bravo");
+  const tabBState = buildUiState({
+    tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+    status: "",
+  });
+  await sendBgMessage(harness, { type: "ui:state", state: tabBState });
+  await expect(page.locator("#title")).toHaveText("Bravo Tab");
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-b",
+      url: "https://www.youtube.com/watch?v=bravo456",
+      title: "Bravo Tab",
+      model: "auto",
+      reason: "manual",
+      slides: false,
+    },
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary B");
 
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await expect(page.locator("#title")).toHaveText("Alpha Tab");
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
-    const restoredSlides = await getPanelSlideDescriptions(page);
-    expect(restoredSlides[0]?.[1] ?? "").toContain("Alpha");
-    expect(restoredSlides.some((entry) => entry[1].includes("Bravo"))).toBe(false);
+  const slidesPayloadB = {
+    sourceUrl: "https://www.youtube.com/watch?v=bravo456",
+    sourceId: "bravo",
+    sourceKind: "url",
+    ocrAvailable: true,
+    slides: [
+      {
+        index: 1,
+        timestamp: 0,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/bravo/1?v=1",
+        ocrText: "Bravo slide one.",
+      },
+    ],
+  };
+  await page.evaluate((payload) => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: { applySlidesPayload?: (payload: unknown) => void };
+      }
+    ).__summarizeTestHooks;
+    hooks?.applySlidesPayload?.(payload);
+  }, slidesPayloadB);
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(1);
+  const slidesB = await getPanelSlideDescriptions(page);
+  expect(slidesB[0]?.[1] ?? "").toContain("Bravo");
 
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await expect(page.locator("#title")).toHaveText("Alpha Tab");
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
+  const restoredSlides = await getPanelSlideDescriptions(page);
+  expect(restoredSlides[0]?.[1] ?? "").toContain("Alpha");
+  expect(restoredSlides.some((entry) => entry[1].includes("Bravo"))).toBe(false);
 });
 
 test("sidepanel clears cached slides when switching from a cached YouTube video to an uncached one", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    (
+      window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
+    ).__summarizeTestHooks = {};
+  });
+  await waitForPanelPort(page);
 
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      (
-        window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
-      ).__summarizeTestHooks = {};
-    });
-    await waitForPanelPort(page);
-
-    const sseBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-    await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
-      const runId =
-        route
-          .request()
-          .url()
-          .match(/summarize\/([^/]+)\/events/)?.[1] ?? "";
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: runId === "run-a" ? sseBody("Summary A") : sseBody("Summary B"),
-      });
-    });
-    await routePlaceholderSlideImages(page);
-
-    const tabAState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-    });
-    const tabBState = buildUiState({
-      tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-    });
-
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await expect(page.locator("#title")).toHaveText("Alpha Tab");
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-a",
-        url: "https://www.youtube.com/watch?v=alpha123",
-        title: "Alpha Tab",
-        model: "auto",
-        reason: "manual",
-        slides: false,
-      },
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
-    await waitForApplySlidesHook(page);
-    await applySlidesPayload(
-      page,
-      buildSlidesPayload({
-        sourceUrl: "https://www.youtube.com/watch?v=alpha123",
-        sourceId: "youtube-alpha123",
-        count: 2,
-        textPrefix: "Alpha",
-      }),
+  const sseBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
     );
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(2);
-    expect((await getPanelSlideDescriptions(page))[0]?.[1] ?? "").toContain("Alpha");
+  await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
+    const runId =
+      route
+        .request()
+        .url()
+        .match(/summarize\/([^/]+)\/events/)?.[1] ?? "";
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: runId === "run-a" ? sseBody("Summary A") : sseBody("Summary B"),
+    });
+  });
+  await routePlaceholderSlideImages(page);
 
-    await sendBgMessage(harness, { type: "ui:state", state: tabBState });
-    await expect(page.locator("#title")).toHaveText("Bravo Tab");
-    const emptyState = page.locator('#render [data-empty-state="true"]');
-    await expect(emptyState).toContainText("Click Summarize to start.");
-    await expect(emptyState).toContainText("Bravo Tab");
-    await expect(page.locator("#render")).not.toContainText("Summary A");
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(0);
-
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await expect(page.locator("#title")).toHaveText("Alpha Tab");
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
-    const restoredSlides = await getPanelSlideDescriptions(page);
-    expect(restoredSlides).toHaveLength(2);
-    expect(restoredSlides.every(([, text]) => text.includes("Alpha"))).toBe(true);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel keeps cached slides isolated while a different YouTube video resumes uncached slides", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
+  const tabAState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
+    settings: {
       autoSummarize: false,
       slidesEnabled: true,
       slidesParallel: true,
       slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      (
-        window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
-      ).__summarizeTestHooks = {};
-    });
-    await waitForPanelPort(page);
+      tokenPresent: true,
+    },
+  });
+  const tabBState = buildUiState({
+    tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
 
-    const summaryBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-    await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
-      const runId =
-        route
-          .request()
-          .url()
-          .match(/summarize\/([^/]+)\/events/)?.[1] ?? "";
-      let body = summaryBody("Summary");
-      if (runId === "run-a") body = summaryBody("Summary A");
-      if (runId === "run-b") body = summaryBody("Summary B");
-      if (runId === "slides-a") body = summaryBody("Slides summary A");
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body,
-      });
-    });
-
-    const alphaPayload = buildSlidesPayload({
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await expect(page.locator("#title")).toHaveText("Alpha Tab");
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-a",
+      url: "https://www.youtube.com/watch?v=alpha123",
+      title: "Alpha Tab",
+      model: "auto",
+      reason: "manual",
+      slides: false,
+    },
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
+  await waitForApplySlidesHook(page);
+  await applySlidesPayload(
+    page,
+    buildSlidesPayload({
       sourceUrl: "https://www.youtube.com/watch?v=alpha123",
       sourceId: "youtube-alpha123",
       count: 2,
       textPrefix: "Alpha",
+    }),
+  );
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(2);
+  expect((await getPanelSlideDescriptions(page))[0]?.[1] ?? "").toContain("Alpha");
+
+  await sendBgMessage(harness, { type: "ui:state", state: tabBState });
+  await expect(page.locator("#title")).toHaveText("Bravo Tab");
+  const emptyState = page.locator('#render [data-empty-state="true"]');
+  await expect(emptyState).toContainText("Click Summarize to start.");
+  await expect(emptyState).toContainText("Bravo Tab");
+  await expect(page.locator("#render")).not.toContainText("Summary A");
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(0);
+
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await expect(page.locator("#title")).toHaveText("Alpha Tab");
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
+  const restoredSlides = await getPanelSlideDescriptions(page);
+  expect(restoredSlides).toHaveLength(2);
+  expect(restoredSlides.every(([, text]) => text.includes("Alpha"))).toBe(true);
+});
+
+test("sidepanel keeps cached slides isolated while a different YouTube video resumes uncached slides", async ({
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    (
+      window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
+    ).__summarizeTestHooks = {};
+  });
+  await waitForPanelPort(page);
+
+  const summaryBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
+    );
+  await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
+    const runId =
+      route
+        .request()
+        .url()
+        .match(/summarize\/([^/]+)\/events/)?.[1] ?? "";
+    let body = summaryBody("Summary");
+    if (runId === "run-a") body = summaryBody("Summary A");
+    if (runId === "run-b") body = summaryBody("Summary B");
+    if (runId === "slides-a") body = summaryBody("Slides summary A");
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body,
     });
-    await page.route("http://127.0.0.1:8787/v1/summarize/**/slides", async (route) => {
-      const url = route.request().url();
-      if (url.includes("/slides-a/slides")) {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ ok: true, slides: alphaPayload }),
-        });
-        return;
-      }
+  });
+
+  const alphaPayload = buildSlidesPayload({
+    sourceUrl: "https://www.youtube.com/watch?v=alpha123",
+    sourceId: "youtube-alpha123",
+    count: 2,
+    textPrefix: "Alpha",
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/**/slides", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/slides-a/slides")) {
       await route.fulfill({
         status: 200,
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: false, error: "not found" }),
+        body: JSON.stringify({ ok: true, slides: alphaPayload }),
       });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: false, error: "not found" }),
     });
-    await page.route("http://127.0.0.1:8787/v1/summarize/slides-a/slides/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: [
-          "event: slides",
-          `data: ${JSON.stringify(alphaPayload)}`,
-          "",
-          "event: done",
-          "data: {}",
-          "",
-        ].join("\n"),
-      });
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/slides-a/slides/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: [
+        "event: slides",
+        `data: ${JSON.stringify(alphaPayload)}`,
+        "",
+        "event: done",
+        "data: {}",
+        "",
+      ].join("\n"),
     });
-    await routePlaceholderSlideImages(page);
+  });
+  await routePlaceholderSlideImages(page);
 
-    const tabAState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-    });
-    const tabBState = buildUiState({
-      tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-    });
+  const tabAState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=alpha123", title: "Alpha Tab" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
+  const tabBState = buildUiState({
+    tab: { id: 2, url: "https://www.youtube.com/watch?v=bravo456", title: "Bravo Tab" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
 
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-a",
-        url: "https://www.youtube.com/watch?v=alpha123",
-        title: "Alpha Tab",
-        model: "auto",
-        reason: "manual",
-      },
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
-
-    await sendBgMessage(harness, { type: "ui:state", state: tabBState });
-    await expect(page.locator("#title")).toHaveText("Bravo Tab");
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-b",
-        url: "https://www.youtube.com/watch?v=bravo456",
-        title: "Bravo Tab",
-        model: "auto",
-        reason: "manual",
-      },
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary B");
-    await waitForApplySlidesHook(page);
-    await applySlidesPayload(
-      page,
-      buildSlidesPayload({
-        sourceUrl: "https://www.youtube.com/watch?v=bravo456",
-        sourceId: "youtube-bravo456",
-        count: 1,
-        textPrefix: "Bravo",
-      }),
-    );
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(1);
-    expect((await getPanelSlideDescriptions(page))[0]?.[1] ?? "").toContain("Bravo");
-
-    await sendBgMessage(harness, {
-      type: "slides:run",
-      ok: true,
-      runId: "slides-a",
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-a",
       url: "https://www.youtube.com/watch?v=alpha123",
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary B");
-    await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(1);
+      title: "Alpha Tab",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
 
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await sendBgMessage(harness, { type: "ui:state", state: tabBState });
+  await expect(page.locator("#title")).toHaveText("Bravo Tab");
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-b",
+      url: "https://www.youtube.com/watch?v=bravo456",
+      title: "Bravo Tab",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary B");
+  await waitForApplySlidesHook(page);
+  await applySlidesPayload(
+    page,
+    buildSlidesPayload({
+      sourceUrl: "https://www.youtube.com/watch?v=bravo456",
+      sourceId: "youtube-bravo456",
+      count: 1,
+      textPrefix: "Bravo",
+    }),
+  );
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(1);
+  expect((await getPanelSlideDescriptions(page))[0]?.[1] ?? "").toContain("Bravo");
+
+  await sendBgMessage(harness, {
+    type: "slides:run",
+    ok: true,
+    runId: "slides-a",
+    url: "https://www.youtube.com/watch?v=alpha123",
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary B");
+  await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(1);
 });
 
 test("sidepanel keeps slide summaries isolated when switching YouTube videos mid-analysis", async ({
-  browserName: _browserName,
+  harness,
 }, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+    slidesLayout: "gallery",
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    (
+      window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
+    ).__summarizeTestHooks = {};
+  });
+  await waitForPanelPort(page);
+  await waitForSlidesRuntimeHooks(page);
+  await waitForSettingsHydratedHook(page);
+  await routePlaceholderSlideImages(page);
+  const applyBgMessage = async (message: object) => {
+    await page.evaluate((payload) => {
+      const hooks = (
+        window as typeof globalThis & {
+          __summarizeTestHooks?: { applyBgMessage?: (value: object) => void };
+        }
+      ).__summarizeTestHooks;
+      hooks?.applyBgMessage?.(payload);
+    }, message);
+  };
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
+  const delay = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
+  const sseBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
+    );
+  const alphaSlidesMarkdown = [
+    "### Slides",
+    "Slide 1 · 0:00",
+    "Alpha briefing",
+    "Alpha summary body one polished from the scene, not raw OCR.",
+    "",
+    "Slide 2 · 0:10",
+    "Alpha fallout",
+    "Alpha summary body two explains the fallout after the poisoned drink lands.",
+  ].join("\n");
+  const bravoSlidesMarkdown = [
+    "### Slides",
+    "Slide 1 · 0:00",
+    "Bravo arrival",
+    "Bravo summary body one captures the new plan after switching videos.",
+    "",
+    "Slide 2 · 0:10",
+    "Bravo twist",
+    "Bravo summary body two explains the twist in the second scene.",
+  ].join("\n");
+  await harness.context.route("https://www.youtube.com/**", async (route) => {
+    const url = route.request().url();
+    const title = url.includes("alpha123")
+      ? "Alpha Tab"
+      : url.includes("bravo456")
+        ? "Bravo Tab"
+        : "YouTube placeholder";
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: `<html><head><title>${title}</title></head><body><article>${title}</article></body></html>`,
+    });
+  });
+
+  await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
+    const runId =
+      route
+        .request()
+        .url()
+        .match(/summarize\/([^/]+)\/events/)?.[1] ?? "";
+    if (runId === "run-a") await delay(250);
+    if (runId === "slides-a") await delay(900);
+    if (runId === "run-b") await delay(60);
+    if (runId === "slides-b") await delay(120);
+
+    let body = sseBody("Summary");
+    if (runId === "run-a") body = sseBody("Alpha overall summary.");
+    if (runId === "run-b") body = sseBody("Bravo overall summary.");
+    if (runId === "slides-a") body = sseBody(alphaSlidesMarkdown);
+    if (runId === "slides-b") body = sseBody(bravoSlidesMarkdown);
+
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body,
+    });
+  });
+
+  const alphaUrl = "https://www.youtube.com/watch?v=alpha123";
+  const bravoUrl = "https://www.youtube.com/watch?v=bravo456";
+  await (await harness.context.newPage()).goto(alphaUrl, { waitUntil: "domcontentloaded" });
+  await (await harness.context.newPage()).goto(bravoUrl, { waitUntil: "domcontentloaded" });
+  await activateTabByUrl(harness, alphaUrl);
+  await waitForActiveTabUrl(harness, alphaUrl);
+  const alphaTabId = await getActiveTabId(harness);
+  await activateTabByUrl(harness, bravoUrl);
+  await waitForActiveTabUrl(harness, bravoUrl);
+  const bravoTabId = await getActiveTabId(harness);
+  expect(alphaTabId).not.toBeNull();
+  expect(bravoTabId).not.toBeNull();
+  await activateTabByUrl(harness, alphaUrl);
+  await waitForActiveTabUrl(harness, alphaUrl);
+  const alphaPayload = {
+    sourceUrl: alphaUrl,
+    sourceId: "youtube-alpha123",
+    sourceKind: "youtube",
+    ocrAvailable: true,
+    slides: [
+      {
+        index: 1,
+        timestamp: 0,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-alpha123/1?v=1",
+        ocrText: "alpha raw ocr line one that should be replaced by summary text",
+      },
+      {
+        index: 2,
+        timestamp: 10,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-alpha123/2?v=1",
+        ocrText: "alpha raw ocr line two that should be replaced by summary text",
+      },
+    ],
+  };
+  const bravoPayload = {
+    sourceUrl: bravoUrl,
+    sourceId: "youtube-bravo456",
+    sourceKind: "youtube",
+    ocrAvailable: true,
+    slides: [
+      {
+        index: 1,
+        timestamp: 0,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-bravo456/1?v=1",
+        ocrText: "bravo raw ocr line one that should be replaced by summary text",
+      },
+      {
+        index: 2,
+        timestamp: 10,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-bravo456/2?v=1",
+        ocrText: "bravo raw ocr line two that should be replaced by summary text",
+      },
+    ],
+  };
+
+  await page.route("http://127.0.0.1:8787/v1/summarize/*/slides/events", async (route) => {
+    const runId =
+      route
+        .request()
+        .url()
+        .match(/summarize\/([^/]+)\/slides\/events/)?.[1] ?? "";
+    const payload =
+      runId === "slides-a" ? alphaPayload : runId === "slides-b" ? bravoPayload : null;
+    if (!payload) {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: ["event: done", "data: {}", ""].join("\n"),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: [
+        "event: slides",
+        `data: ${JSON.stringify(payload)}`,
+        "",
+        "event: done",
+        "data: {}",
+        "",
+      ].join("\n"),
+    });
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/*/slides", async (route) => {
+    const runId =
+      route
+        .request()
+        .url()
+        .match(/summarize\/([^/]+)\/slides(?:\\?.*)?$/)?.[1] ?? "";
+    const payload =
+      runId === "slides-a" ? alphaPayload : runId === "slides-b" ? bravoPayload : null;
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload ? { ok: true, slides: payload } : { ok: true, slides: null }),
+    });
+  });
+
+  const tabAState = buildUiState({
+    tab: { id: alphaTabId, url: alphaUrl, title: "Alpha Tab" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+    settings: {
       autoSummarize: false,
       slidesEnabled: true,
       slidesParallel: true,
       slidesOcrEnabled: true,
       slidesLayout: "gallery",
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      (
-        window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
-      ).__summarizeTestHooks = {};
-    });
-    await waitForPanelPort(page);
-    await waitForSlidesRuntimeHooks(page);
-    await waitForSettingsHydratedHook(page);
-    await routePlaceholderSlideImages(page);
-    const applyBgMessage = async (message: object) => {
-      await page.evaluate((payload) => {
-        const hooks = (
-          window as typeof globalThis & {
-            __summarizeTestHooks?: { applyBgMessage?: (value: object) => void };
-          }
-        ).__summarizeTestHooks;
-        hooks?.applyBgMessage?.(payload);
-      }, message);
-    };
+      tokenPresent: true,
+    },
+  });
+  const tabBState = buildUiState({
+    tab: { id: bravoTabId, url: bravoUrl, title: "Bravo Tab" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      slidesLayout: "gallery",
+      tokenPresent: true,
+    },
+  });
 
-    const delay = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
-    const sseBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-    const alphaSlidesMarkdown = [
-      "### Slides",
-      "Slide 1 · 0:00",
-      "Alpha briefing",
-      "Alpha summary body one polished from the scene, not raw OCR.",
-      "",
-      "Slide 2 · 0:10",
-      "Alpha fallout",
-      "Alpha summary body two explains the fallout after the poisoned drink lands.",
-    ].join("\n");
-    const bravoSlidesMarkdown = [
-      "### Slides",
-      "Slide 1 · 0:00",
-      "Bravo arrival",
-      "Bravo summary body one captures the new plan after switching videos.",
-      "",
-      "Slide 2 · 0:10",
-      "Bravo twist",
-      "Bravo summary body two explains the twist in the second scene.",
-    ].join("\n");
-    await harness.context.route("https://www.youtube.com/**", async (route) => {
-      const url = route.request().url();
-      const title = url.includes("alpha123")
-        ? "Alpha Tab"
-        : url.includes("bravo456")
-          ? "Bravo Tab"
-          : "YouTube placeholder";
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/html" },
-        body: `<html><head><title>${title}</title></head><body><article>${title}</article></body></html>`,
-      });
-    });
-
-    await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
-      const runId =
-        route
-          .request()
-          .url()
-          .match(/summarize\/([^/]+)\/events/)?.[1] ?? "";
-      if (runId === "run-a") await delay(250);
-      if (runId === "slides-a") await delay(900);
-      if (runId === "run-b") await delay(60);
-      if (runId === "slides-b") await delay(120);
-
-      let body = sseBody("Summary");
-      if (runId === "run-a") body = sseBody("Alpha overall summary.");
-      if (runId === "run-b") body = sseBody("Bravo overall summary.");
-      if (runId === "slides-a") body = sseBody(alphaSlidesMarkdown);
-      if (runId === "slides-b") body = sseBody(bravoSlidesMarkdown);
-
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body,
-      });
-    });
-
-    const alphaUrl = "https://www.youtube.com/watch?v=alpha123";
-    const bravoUrl = "https://www.youtube.com/watch?v=bravo456";
-    await (await harness.context.newPage()).goto(alphaUrl, { waitUntil: "domcontentloaded" });
-    await (await harness.context.newPage()).goto(bravoUrl, { waitUntil: "domcontentloaded" });
-    await activateTabByUrl(harness, alphaUrl);
-    await waitForActiveTabUrl(harness, alphaUrl);
-    const alphaTabId = await getActiveTabId(harness);
-    await activateTabByUrl(harness, bravoUrl);
-    await waitForActiveTabUrl(harness, bravoUrl);
-    const bravoTabId = await getActiveTabId(harness);
-    expect(alphaTabId).not.toBeNull();
-    expect(bravoTabId).not.toBeNull();
-    await activateTabByUrl(harness, alphaUrl);
-    await waitForActiveTabUrl(harness, alphaUrl);
-    const alphaPayload = {
-      sourceUrl: alphaUrl,
-      sourceId: "youtube-alpha123",
-      sourceKind: "youtube",
-      ocrAvailable: true,
-      slides: [
-        {
-          index: 1,
-          timestamp: 0,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-alpha123/1?v=1",
-          ocrText: "alpha raw ocr line one that should be replaced by summary text",
-        },
-        {
-          index: 2,
-          timestamp: 10,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-alpha123/2?v=1",
-          ocrText: "alpha raw ocr line two that should be replaced by summary text",
-        },
-      ],
-    };
-    const bravoPayload = {
-      sourceUrl: bravoUrl,
-      sourceId: "youtube-bravo456",
-      sourceKind: "youtube",
-      ocrAvailable: true,
-      slides: [
-        {
-          index: 1,
-          timestamp: 0,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-bravo456/1?v=1",
-          ocrText: "bravo raw ocr line one that should be replaced by summary text",
-        },
-        {
-          index: 2,
-          timestamp: 10,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-bravo456/2?v=1",
-          ocrText: "bravo raw ocr line two that should be replaced by summary text",
-        },
-      ],
-    };
-
-    await page.route("http://127.0.0.1:8787/v1/summarize/*/slides/events", async (route) => {
-      const runId =
-        route
-          .request()
-          .url()
-          .match(/summarize\/([^/]+)\/slides\/events/)?.[1] ?? "";
-      const payload =
-        runId === "slides-a" ? alphaPayload : runId === "slides-b" ? bravoPayload : null;
-      if (!payload) {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: ["event: done", "data: {}", ""].join("\n"),
-        });
-        return;
-      }
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: [
-          "event: slides",
-          `data: ${JSON.stringify(payload)}`,
-          "",
-          "event: done",
-          "data: {}",
-          "",
-        ].join("\n"),
-      });
-    });
-    await page.route("http://127.0.0.1:8787/v1/summarize/*/slides", async (route) => {
-      const runId =
-        route
-          .request()
-          .url()
-          .match(/summarize\/([^/]+)\/slides(?:\\?.*)?$/)?.[1] ?? "";
-      const payload =
-        runId === "slides-a" ? alphaPayload : runId === "slides-b" ? bravoPayload : null;
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(payload ? { ok: true, slides: payload } : { ok: true, slides: null }),
-      });
-    });
-
-    const tabAState = buildUiState({
-      tab: { id: alphaTabId, url: alphaUrl, title: "Alpha Tab" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        slidesLayout: "gallery",
-        tokenPresent: true,
-      },
-    });
-    const tabBState = buildUiState({
-      tab: { id: bravoTabId, url: bravoUrl, title: "Bravo Tab" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        slidesLayout: "gallery",
-        tokenPresent: true,
-      },
-    });
-
-    await applyBgMessage({ type: "ui:state", state: tabAState });
-    await expect(page.locator("#title")).toHaveText("Alpha Tab");
-    await applyBgMessage({
-      type: "run:start",
-      run: {
-        id: "run-a",
-        url: alphaUrl,
-        title: "Alpha Tab",
-        model: "auto",
-        reason: "manual",
-      },
-    });
-    await applyBgMessage({
-      type: "slides:run",
-      ok: true,
-      runId: "slides-a",
+  await applyBgMessage({ type: "ui:state", state: tabAState });
+  await expect(page.locator("#title")).toHaveText("Alpha Tab");
+  await applyBgMessage({
+    type: "run:start",
+    run: {
+      id: "run-a",
       url: alphaUrl,
-    });
+      title: "Alpha Tab",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+  await applyBgMessage({
+    type: "slides:run",
+    ok: true,
+    runId: "slides-a",
+    url: alphaUrl,
+  });
 
-    await activateTabByUrl(harness, bravoUrl);
-    await waitForActiveTabUrl(harness, bravoUrl);
-    await applyBgMessage({ type: "ui:state", state: tabBState });
-    await applyBgMessage({
-      type: "run:start",
-      run: {
-        id: "run-b",
-        url: bravoUrl,
-        title: "Bravo Tab",
-        model: "auto",
-        reason: "manual",
-      },
-    });
-    await applyBgMessage({
-      type: "slides:run",
-      ok: true,
-      runId: "slides-b",
+  await activateTabByUrl(harness, bravoUrl);
+  await waitForActiveTabUrl(harness, bravoUrl);
+  await applyBgMessage({ type: "ui:state", state: tabBState });
+  await applyBgMessage({
+    type: "run:start",
+    run: {
+      id: "run-b",
       url: bravoUrl,
-    });
+      title: "Bravo Tab",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+  await applyBgMessage({
+    type: "slides:run",
+    ok: true,
+    runId: "slides-b",
+    url: bravoUrl,
+  });
 
-    await expect
-      .poll(
-        async () => {
-          await page.evaluate(() => {
-            const hooks = (
-              window as typeof globalThis & {
-                __summarizeTestHooks?: { forceRenderSlides?: () => number | void };
-              }
-            ).__summarizeTestHooks;
-            hooks?.forceRenderSlides?.();
-          });
-          const descriptions = (await getPanelSlideDescriptions(page)).map(([, text]) =>
-            text.toLowerCase(),
-          );
-          return (
-            descriptions.length === 2 &&
-            descriptions.every((text) => text.includes("bravo")) &&
-            descriptions.every((text) => !text.includes("alpha"))
-          );
-        },
-        { timeout: 20_000 },
-      )
-      .toBe(true);
+  await expect
+    .poll(
+      async () => {
+        await page.evaluate(() => {
+          const hooks = (
+            window as typeof globalThis & {
+              __summarizeTestHooks?: { forceRenderSlides?: () => number | void };
+            }
+          ).__summarizeTestHooks;
+          hooks?.forceRenderSlides?.();
+        });
+        const descriptions = (await getPanelSlideDescriptions(page)).map(([, text]) =>
+          text.toLowerCase(),
+        );
+        return (
+          descriptions.length === 2 &&
+          descriptions.every((text) => text.includes("bravo")) &&
+          descriptions.every((text) => !text.includes("alpha"))
+        );
+      },
+      { timeout: 20_000 },
+    )
+    .toBe(true);
 
-    const bravoDescriptions = await getPanelSlideDescriptions(page);
-    expect((bravoDescriptions[0]?.[1] ?? "").toLowerCase()).toContain("bravo");
-    expect((bravoDescriptions[1]?.[1] ?? "").toLowerCase()).toContain("bravo");
-    await expect(page.locator(".slideGallery__thumb img")).toHaveCount(2);
+  const bravoDescriptions = await getPanelSlideDescriptions(page);
+  expect((bravoDescriptions[0]?.[1] ?? "").toLowerCase()).toContain("bravo");
+  expect((bravoDescriptions[1]?.[1] ?? "").toLowerCase()).toContain("bravo");
+  await expect(page.locator(".slideGallery__thumb img")).toHaveCount(2);
 
-    await page.waitForTimeout(1_200);
-    const stillBravoDescriptions = await getPanelSlideDescriptions(page);
-    expect(stillBravoDescriptions).toHaveLength(2);
-    expect(stillBravoDescriptions.some(([, text]) => /alpha/i.test(text))).toBe(false);
-    await page.screenshot({
-      path: testInfo.outputPath("youtube-switch-mid-analysis-bravo.png"),
-      fullPage: true,
-    });
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await page.waitForTimeout(1_200);
+  const stillBravoDescriptions = await getPanelSlideDescriptions(page);
+  expect(stillBravoDescriptions).toHaveLength(2);
+  expect(stillBravoDescriptions.some(([, text]) => /alpha/i.test(text))).toBe(false);
+  await page.screenshot({
+    path: testInfo.outputPath("youtube-switch-mid-analysis-bravo.png"),
+    fullPage: true,
+  });
 });

--- a/apps/chrome-extension/tests/sidepanel.chat-errors.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.chat-errors.spec.ts
@@ -1,14 +1,11 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { mockDaemonSummarize } from "./helpers/daemon-fixtures";
+import { test } from "./helpers/extension-fixtures";
 import {
   activateTabByUrl,
-  assertNoErrors,
   buildUiState,
-  closeExtension,
   getActiveTabId,
-  getBrowserFromProject,
   injectContentScript,
-  launchExtension,
   maybeBringToFront,
   openExtensionPage,
   seedSettings,
@@ -17,262 +14,220 @@ import {
   waitForExtractReady,
   waitForPanelPort,
 } from "./helpers/extension-harness";
-import { allowFirefoxExtensionTests } from "./helpers/extension-test-config";
 import { waitForSettingsHydratedHook } from "./helpers/panel-hooks";
 
-test.skip(
-  ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
-  "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
-);
+test("sidepanel shows an error when agent request fails", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    summaryRuntime: "daemon",
+    autoSummarize: false,
+    chatEnabled: true,
+  });
+  const contentPage = await harness.context.newPage();
+  await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
+  await contentPage.evaluate(() => {
+    document.body.innerHTML = `<article><p>${"Agent error test. ".repeat(12)}</p></article>`;
+  });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
+  await waitForExtractReady(harness, "https://example.com");
 
-test("sidepanel shows an error when agent request fails", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      summaryRuntime: "daemon",
-      autoSummarize: false,
-      chatEnabled: true,
+  let agentCalls = 0;
+  await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
+    agentCalls += 1;
+    await route.fulfill({
+      status: 500,
+      headers: { "content-type": "text/plain" },
+      body: "Boom",
     });
-    const contentPage = await harness.context.newPage();
-    await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
-    await contentPage.evaluate(() => {
-      document.body.innerHTML = `<article><p>${"Agent error test. ".repeat(12)}</p></article>`;
-    });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
-    await waitForExtractReady(harness, "https://example.com");
+  });
 
-    let agentCalls = 0;
-    await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
-      agentCalls += 1;
-      await route.fulfill({
-        status: 500,
-        headers: { "content-type": "text/plain" },
-        body: "Boom",
-      });
-    });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  const activeTabId = await getActiveTabId(harness);
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: activeTabId, url: "https://example.com", title: "Example" },
+      settings: {
+        chatEnabled: true,
+        summaryRuntime: "daemon",
+        tokenPresent: true,
+      },
+    }),
+  });
 
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    const activeTabId = await getActiveTabId(harness);
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: activeTabId, url: "https://example.com", title: "Example" },
-        settings: {
-          chatEnabled: true,
-          summaryRuntime: "daemon",
-          tokenPresent: true,
-        },
-      }),
-    });
+  await expect(page.locator("#chatSend")).toBeEnabled();
+  await page.evaluate((value) => {
+    const input = document.getElementById("chatInput") as HTMLTextAreaElement | null;
+    const send = document.getElementById("chatSend") as HTMLButtonElement | null;
+    if (!input || !send) return;
+    input.value = value;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    send.click();
+  }, "Trigger agent error");
 
-    await expect(page.locator("#chatSend")).toBeEnabled();
-    await page.evaluate((value) => {
-      const input = document.getElementById("chatInput") as HTMLTextAreaElement | null;
-      const send = document.getElementById("chatSend") as HTMLButtonElement | null;
-      if (!input || !send) return;
-      input.value = value;
-      input.dispatchEvent(new Event("input", { bubbles: true }));
-      send.click();
-    }, "Trigger agent error");
-
-    await expect.poll(() => agentCalls).toBe(1);
-    await expect(page.locator("#inlineError")).toBeVisible();
-    await expect(page.locator("#inlineErrorMessage")).toContainText(
-      "Daemon chat request failed: Boom",
-    );
-    await expect(page.locator(".chatMessage.assistant.streaming")).toHaveCount(0);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect.poll(() => agentCalls).toBe(1);
+  await expect(page.locator("#inlineError")).toBeVisible();
+  await expect(page.locator("#inlineErrorMessage")).toContainText(
+    "Daemon chat request failed: Boom",
+  );
+  await expect(page.locator(".chatMessage.assistant.streaming")).toHaveCount(0);
 });
 
-test("sidepanel hides inline error when message is empty", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel hides inline error when message is empty", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    (
+      window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
+    ).__summarizeTestHooks = {};
+  });
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await page.evaluate(() => {
+    const global = window as typeof globalThis & {
+      __summarizePanelPort?: { disconnect?: () => void };
+    };
+    global.__summarizePanelPort?.disconnect?.();
+    global.__summarizePanelPort = undefined;
+  });
 
-  try {
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      (
-        window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
-      ).__summarizeTestHooks = {};
-    });
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await page.evaluate(() => {
-      const global = window as typeof globalThis & {
-        __summarizePanelPort?: { disconnect?: () => void };
-      };
-      global.__summarizePanelPort?.disconnect?.();
-      global.__summarizePanelPort = undefined;
-    });
-
-    const shown = await page.evaluate(
-      (state) => {
-        const hooks = (
-          window as typeof globalThis & {
-            __summarizeTestHooks?: {
-              applyUiState?: (state: unknown) => void;
-              showInlineError?: (message: string) => void;
-              isInlineErrorVisible?: () => boolean;
-              getInlineErrorMessage?: () => string;
-            };
-          }
-        ).__summarizeTestHooks;
-        hooks?.applyUiState?.(state);
-        hooks?.showInlineError?.("Boom");
-        return {
-          visible: hooks?.isInlineErrorVisible?.() ?? false,
-          message: hooks?.getInlineErrorMessage?.() ?? "",
-        };
-      },
-      buildUiState({ daemon: { ok: false, authed: false } }),
-    );
-    expect(shown).toEqual({ visible: true, message: "Boom" });
-
-    const hidden = await page.evaluate(() => {
+  const shown = await page.evaluate(
+    (state) => {
       const hooks = (
         window as typeof globalThis & {
           __summarizeTestHooks?: {
+            applyUiState?: (state: unknown) => void;
             showInlineError?: (message: string) => void;
             isInlineErrorVisible?: () => boolean;
             getInlineErrorMessage?: () => string;
           };
         }
       ).__summarizeTestHooks;
-      hooks?.showInlineError?.("   ");
+      hooks?.applyUiState?.(state);
+      hooks?.showInlineError?.("Boom");
       return {
         visible: hooks?.isInlineErrorVisible?.() ?? false,
         message: hooks?.getInlineErrorMessage?.() ?? "",
       };
-    });
+    },
+    buildUiState({ daemon: { ok: false, authed: false } }),
+  );
+  expect(shown).toEqual({ visible: true, message: "Boom" });
 
-    expect(hidden).toEqual({ visible: false, message: "" });
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const hidden = await page.evaluate(() => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: {
+          showInlineError?: (message: string) => void;
+          isInlineErrorVisible?: () => boolean;
+          getInlineErrorMessage?: () => string;
+        };
+      }
+    ).__summarizeTestHooks;
+    hooks?.showInlineError?.("   ");
+    return {
+      visible: hooks?.isInlineErrorVisible?.() ?? false,
+      message: hooks?.getInlineErrorMessage?.() ?? "",
+    };
+  });
+
+  expect(hidden).toEqual({ visible: false, message: "" });
 });
 
-test("sidepanel shows daemon upgrade hint when /v1/agent is missing", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel shows daemon upgrade hint when /v1/agent is missing", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    summaryRuntime: "daemon",
+    autoSummarize: false,
+    chatEnabled: true,
+  });
+  const contentPage = await harness.context.newPage();
+  await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
+  await contentPage.evaluate(() => {
+    document.body.innerHTML = `<article><p>${"Agent 404 test. ".repeat(12)}</p></article>`;
+  });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
+  await waitForExtractReady(harness, "https://example.com");
 
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      summaryRuntime: "daemon",
-      autoSummarize: false,
-      chatEnabled: true,
+  let agentCalls = 0;
+  await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
+    agentCalls += 1;
+    await route.fulfill({
+      status: 404,
+      headers: { "content-type": "text/plain" },
+      body: "Not Found",
     });
-    const contentPage = await harness.context.newPage();
-    await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
-    await contentPage.evaluate(() => {
-      document.body.innerHTML = `<article><p>${"Agent 404 test. ".repeat(12)}</p></article>`;
-    });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
-    await waitForExtractReady(harness, "https://example.com");
+  });
 
-    let agentCalls = 0;
-    await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
-      agentCalls += 1;
-      await route.fulfill({
-        status: 404,
-        headers: { "content-type": "text/plain" },
-        body: "Not Found",
-      });
-    });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  const activeTabId = await getActiveTabId(harness);
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: activeTabId, url: "https://example.com", title: "Example" },
+      settings: {
+        chatEnabled: true,
+        summaryRuntime: "daemon",
+        tokenPresent: true,
+      },
+    }),
+  });
 
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    const activeTabId = await getActiveTabId(harness);
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: activeTabId, url: "https://example.com", title: "Example" },
-        settings: {
-          chatEnabled: true,
-          summaryRuntime: "daemon",
-          tokenPresent: true,
+  await expect(page.locator("#chatSend")).toBeEnabled();
+  await page.locator("#chatInput").fill("Trigger agent 404");
+  await page.locator("#chatSend").click();
+
+  await expect.poll(() => agentCalls).toBe(1);
+  await expect(page.locator("#inlineError")).toBeVisible();
+  await expect(page.locator("#inlineErrorMessage")).toContainText(
+    "Daemon does not support /v1/agent",
+  );
+});
+
+test("sidepanel shows automation notice when permission event fires", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await page.evaluate(() => {
+    const global = window as typeof globalThis & {
+      __summarizePanelPort?: { disconnect?: () => void };
+    };
+    global.__summarizePanelPort?.disconnect?.();
+    global.__summarizePanelPort = undefined;
+  });
+  const notice = await page.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent("summarize:automation-permissions", {
+        detail: {
+          title: "User Scripts required",
+          message: "Enable User Scripts to use automation.",
+          ctaLabel: "Open extension details",
         },
       }),
-    });
-
-    await expect(page.locator("#chatSend")).toBeEnabled();
-    await page.locator("#chatInput").fill("Trigger agent 404");
-    await page.locator("#chatSend").click();
-
-    await expect.poll(() => agentCalls).toBe(1);
-    await expect(page.locator("#inlineError")).toBeVisible();
-    await expect(page.locator("#inlineErrorMessage")).toContainText(
-      "Daemon does not support /v1/agent",
     );
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
+    const noticeEl = document.getElementById("automationNotice");
+    return {
+      visible: !noticeEl?.classList.contains("hidden"),
+      message: document.getElementById("automationNoticeMessage")?.textContent ?? "",
+    };
+  });
 
-test("sidepanel shows automation notice when permission event fires", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await page.evaluate(() => {
-      const global = window as typeof globalThis & {
-        __summarizePanelPort?: { disconnect?: () => void };
-      };
-      global.__summarizePanelPort?.disconnect?.();
-      global.__summarizePanelPort = undefined;
-    });
-    const notice = await page.evaluate(() => {
-      window.dispatchEvent(
-        new CustomEvent("summarize:automation-permissions", {
-          detail: {
-            title: "User Scripts required",
-            message: "Enable User Scripts to use automation.",
-            ctaLabel: "Open extension details",
-          },
-        }),
-      );
-      const noticeEl = document.getElementById("automationNotice");
-      return {
-        visible: !noticeEl?.classList.contains("hidden"),
-        message: document.getElementById("automationNoticeMessage")?.textContent ?? "",
-      };
-    });
-
-    expect(notice.visible).toBe(true);
-    expect(notice.message).toContain("Enable User Scripts");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  expect(notice.visible).toBe(true);
+  expect(notice.message).toContain("Enable User Scripts");
 });

--- a/apps/chrome-extension/tests/sidepanel.chat.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.chat.spec.ts
@@ -1,16 +1,13 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { getSummarizeCalls, mockDaemonSummarize } from "./helpers/daemon-fixtures";
+import { test } from "./helpers/extension-fixtures";
 import {
   activateTabByUrl,
-  assertNoErrors,
   buildAgentStream,
   buildUiState,
-  closeExtension,
   getActiveTabId,
   getBackground,
-  getBrowserFromProject,
   injectContentScript,
-  launchExtension,
   maybeBringToFront,
   openExtensionPage,
   seedSettings,
@@ -21,324 +18,46 @@ import {
   waitForExtractReady,
   waitForPanelPort,
 } from "./helpers/extension-harness";
-import { allowFirefoxExtensionTests } from "./helpers/extension-test-config";
 
-test.skip(
-  ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
-  "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
-);
+test("sidepanel chat queue sends next message after stream completes", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    summaryRuntime: "daemon",
+    autoSummarize: false,
+    chatEnabled: true,
+  });
+  const contentPage = await harness.context.newPage();
+  await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
+  await contentPage.evaluate(() => {
+    document.body.innerHTML = `<article><p>${"Hello ".repeat(40)}</p><p>More text for chat.</p></article>`;
+  });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
+  await waitForExtractReady(harness, "https://example.com");
 
-test("sidepanel chat queue sends next message after stream completes", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
 
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      summaryRuntime: "daemon",
-      autoSummarize: false,
-      chatEnabled: true,
+  let agentRequestCount = 0;
+  let releaseFirst: (() => void) | null = null;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+
+  await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
+    agentRequestCount += 1;
+    if (agentRequestCount === 1) await firstGate;
+    const body = buildAgentStream(`Reply ${agentRequestCount}`);
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body,
     });
-    const contentPage = await harness.context.newPage();
-    await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
-    await contentPage.evaluate(() => {
-      document.body.innerHTML = `<article><p>${"Hello ".repeat(40)}</p><p>More text for chat.</p></article>`;
-    });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
-    await waitForExtractReady(harness, "https://example.com");
+  });
 
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-
-    let agentRequestCount = 0;
-    let releaseFirst: (() => void) | null = null;
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-
-    await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
-      agentRequestCount += 1;
-      if (agentRequestCount === 1) await firstGate;
-      const body = buildAgentStream(`Reply ${agentRequestCount}`);
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body,
-      });
-    });
-
-    const sendChat = async (text: string) => {
-      await page.evaluate((value) => {
-        const input = document.getElementById("chatInput") as HTMLTextAreaElement | null;
-        const send = document.getElementById("chatSend") as HTMLButtonElement | null;
-        if (!input || !send) return;
-        input.value = value;
-        input.dispatchEvent(new Event("input", { bubbles: true }));
-        send.click();
-      }, text);
-    };
-
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await sendChat("First question");
-    await expect.poll(() => agentRequestCount).toBe(1);
-    await sendChat("Second question");
-    await expect.poll(() => agentRequestCount, { timeout: 1_000 }).toBe(1);
-
-    releaseFirst?.();
-
-    await expect.poll(() => agentRequestCount).toBe(2);
-    await expect(page.locator("#chatMessages")).toContainText("Second question");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel chat sends mixed OCR and transcript slide text to the bot", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      summaryRuntime: "daemon",
-      autoSummarize: false,
-      chatEnabled: true,
-      slidesOcrEnabled: true,
-      length: "xl",
-    });
-    const contentPage = await harness.context.newPage();
-    await contentPage.goto("https://example.com/slides", { waitUntil: "domcontentloaded" });
-    await contentPage.evaluate(() => {
-      document.body.innerHTML = `<article><p>${"Deck context ".repeat(40)}</p></article>`;
-    });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com/slides");
-    await waitForActiveTabUrl(harness, "https://example.com/slides");
-    await injectContentScript(harness, "content-scripts/extract.js", "https://example.com/slides");
-    await waitForExtractReady(harness, "https://example.com/slides");
-    const activeTabId = await getActiveTabId(harness);
-
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    const transcriptTimedText = [
-      "[0:00] First slide transcript context.",
-      "[0:30] More first slide detail.",
-      "[0:42] Second slide transcript should be replaced by OCR.",
-      "[1:28] Lead-in near the third slide.",
-      "[1:32] Third slide transcript context.",
-    ].join("\n");
-    await sendPanelMessage(page, {
-      type: "panel:cache",
-      cache: {
-        tabId: activeTabId,
-        url: "https://example.com/slides",
-        title: "Slides",
-        runId: "summary-run",
-        slidesRunId: "slides-run",
-        summaryMarkdown: "Summary text.",
-        summaryFromCache: false,
-        slidesSummaryMarkdown: null,
-        slidesSummaryComplete: null,
-        slidesSummaryModel: null,
-        lastMeta: { inputSummary: null, model: "test", modelLabel: "Test" },
-        transcriptTimedText,
-        slides: {
-          sourceUrl: "https://example.com/slides",
-          sourceId: "local-slides",
-          sourceKind: "browser-capture",
-          ocrAvailable: false,
-          transcriptTimedText,
-          slides: [
-            { index: 1, timestamp: 1, imageUrl: "", ocrText: null, ocrConfidence: null },
-            {
-              index: 2,
-              timestamp: 40,
-              imageUrl: "",
-              ocrText: "Second slide visual OCR.",
-              ocrConfidence: null,
-            },
-            { index: 3, timestamp: 90, imageUrl: "", ocrText: null, ocrConfidence: null },
-          ],
-        },
-      },
-    });
-
-    let agentPageContent = "";
-    await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
-      const body = route.request().postDataJSON() as { pageContent?: string };
-      agentPageContent = body.pageContent ?? "";
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: buildAgentStream("Slide-aware reply"),
-      });
-    });
-
-    await page.locator("#chatInput").fill("What is on each slide?");
-    await page.locator("#chatSend").click();
-
-    await expect.poll(() => agentPageContent).toContain("Slide timeline:");
-    expect(agentPageContent).toContain("Slide 1 @ 0:01");
-    expect(agentPageContent).toContain("First slide transcript context.");
-    expect(agentPageContent).toContain("Slide 2 @ 0:40");
-    expect(agentPageContent).toContain("Second slide visual OCR.");
-    expect(agentPageContent).toContain("Slide 3 @ 1:30");
-    expect(agentPageContent).toContain("Third slide transcript context.");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel chat queue drains messages after stream completes", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      summaryRuntime: "daemon",
-      autoSummarize: false,
-      chatEnabled: true,
-    });
-    const contentPage = await harness.context.newPage();
-    await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
-    await contentPage.evaluate(() => {
-      document.body.innerHTML = `<article><p>${"Hello ".repeat(40)}</p><p>More text for chat.</p></article>`;
-    });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
-    await waitForExtractReady(harness, "https://example.com");
-
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-
-    let agentRequestCount = 0;
-    let releaseFirst: (() => void) | null = null;
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-
-    await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
-      agentRequestCount += 1;
-      if (agentRequestCount === 1) await firstGate;
-      const body = buildAgentStream(`Reply ${agentRequestCount}`);
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body,
-      });
-    });
-
-    const sendChat = async (text: string) => {
-      await page.evaluate((value) => {
-        const input = document.getElementById("chatInput") as HTMLTextAreaElement | null;
-        const send = document.getElementById("chatSend") as HTMLButtonElement | null;
-        if (!input || !send) return;
-        input.value = value;
-        input.dispatchEvent(new Event("input", { bubbles: true }));
-        send.click();
-      }, text);
-    };
-
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await sendChat("First question");
-    await expect.poll(() => agentRequestCount).toBe(1);
-
-    const enqueueChat = async (text: string) => {
-      await page.evaluate((value) => {
-        const input = document.getElementById("chatInput") as HTMLTextAreaElement | null;
-        if (!input) return;
-        input.value = value;
-        input.dispatchEvent(new Event("input", { bubbles: true }));
-        input.dispatchEvent(
-          new KeyboardEvent("keydown", {
-            key: "Enter",
-            code: "Enter",
-            bubbles: true,
-            cancelable: true,
-          }),
-        );
-      }, text);
-    };
-
-    await enqueueChat("Second question");
-    await enqueueChat("Third question");
-
-    releaseFirst?.();
-
-    await expect.poll(() => agentRequestCount).toBeGreaterThanOrEqual(3);
-    await expect(page.locator("#chatMessages")).toContainText("Second question");
-    await expect(page.locator("#chatMessages")).toContainText("Third question");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel clears chat on user navigation", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      summaryRuntime: "daemon",
-      autoSummarize: false,
-      chatEnabled: true,
-    });
-    const contentPage = await harness.context.newPage();
-    await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
-    await contentPage.evaluate(() => {
-      document.body.innerHTML = `<article><p>${"Chat navigation context. ".repeat(20)}</p></article>`;
-    });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
-    await waitForExtractReady(harness, "https://example.com");
-    const activeTabId = await getActiveTabId(harness);
-
-    await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
-      const body = buildAgentStream("Ack");
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body,
-      });
-    });
-
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: activeTabId, url: "https://example.com", title: "Example" },
-        settings: {
-          chatEnabled: true,
-          summaryRuntime: "daemon",
-          tokenPresent: true,
-        },
-      }),
-    });
-
+  const sendChat = async (text: string) => {
     await page.evaluate((value) => {
       const input = document.getElementById("chatInput") as HTMLTextAreaElement | null;
       const send = document.getElementById("chatSend") as HTMLButtonElement | null;
@@ -346,246 +65,446 @@ test("sidepanel clears chat on user navigation", async ({
       input.value = value;
       input.dispatchEvent(new Event("input", { bubbles: true }));
       send.click();
-    }, "Hello");
+    }, text);
+  };
 
-    await expect(page.locator("#chatMessages")).toContainText("Hello");
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await sendChat("First question");
+  await expect.poll(() => agentRequestCount).toBe(1);
+  await sendChat("Second question");
+  await expect.poll(() => agentRequestCount, { timeout: 1_000 }).toBe(1);
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: activeTabId, url: "https://example.com/next", title: "Next" },
-        settings: {
-          chatEnabled: true,
-          summaryRuntime: "daemon",
-          tokenPresent: true,
-        },
-      }),
-    });
+  releaseFirst?.();
 
-    await expect(page.locator(".chatMessage")).toHaveCount(0);
-    await expect(page.locator("#chatMessages")).not.toContainText("Tool result: navigation");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect.poll(() => agentRequestCount).toBe(2);
+  await expect(page.locator("#chatMessages")).toContainText("Second question");
 });
 
-test("auto summarize reruns after panel reopen", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel chat sends mixed OCR and transcript slide text to the bot", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    summaryRuntime: "daemon",
+    autoSummarize: false,
+    chatEnabled: true,
+    slidesOcrEnabled: true,
+    length: "xl",
+  });
+  const contentPage = await harness.context.newPage();
+  await contentPage.goto("https://example.com/slides", { waitUntil: "domcontentloaded" });
+  await contentPage.evaluate(() => {
+    document.body.innerHTML = `<article><p>${"Deck context ".repeat(40)}</p></article>`;
+  });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com/slides");
+  await waitForActiveTabUrl(harness, "https://example.com/slides");
+  await injectContentScript(harness, "content-scripts/extract.js", "https://example.com/slides");
+  await waitForExtractReady(harness, "https://example.com/slides");
+  const activeTabId = await getActiveTabId(harness);
 
-  try {
-    await mockDaemonSummarize(harness);
-
-    const sseBody = [
-      "event: chunk",
-      'data: {"text":"First chunk"}',
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await harness.context.route(
-      /http:\/\/127\.0\.0\.1:8787\/v1\/summarize\/[^/]+\/events/,
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: sseBody,
-        });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  const transcriptTimedText = [
+    "[0:00] First slide transcript context.",
+    "[0:30] More first slide detail.",
+    "[0:42] Second slide transcript should be replaced by OCR.",
+    "[1:28] Lead-in near the third slide.",
+    "[1:32] Third slide transcript context.",
+  ].join("\n");
+  await sendPanelMessage(page, {
+    type: "panel:cache",
+    cache: {
+      tabId: activeTabId,
+      url: "https://example.com/slides",
+      title: "Slides",
+      runId: "summary-run",
+      slidesRunId: "slides-run",
+      summaryMarkdown: "Summary text.",
+      summaryFromCache: false,
+      slidesSummaryMarkdown: null,
+      slidesSummaryComplete: null,
+      slidesSummaryModel: null,
+      lastMeta: { inputSummary: null, model: "test", modelLabel: "Test" },
+      transcriptTimedText,
+      slides: {
+        sourceUrl: "https://example.com/slides",
+        sourceId: "local-slides",
+        sourceKind: "browser-capture",
+        ocrAvailable: false,
+        transcriptTimedText,
+        slides: [
+          { index: 1, timestamp: 1, imageUrl: "", ocrText: null, ocrConfidence: null },
+          {
+            index: 2,
+            timestamp: 40,
+            imageUrl: "",
+            ocrText: "Second slide visual OCR.",
+            ocrConfidence: null,
+          },
+          { index: 3, timestamp: 90, imageUrl: "", ocrText: null, ocrConfidence: null },
+        ],
       },
-    );
+    },
+  });
 
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: true,
-      slideRuntime: "daemon",
+  let agentPageContent = "";
+  await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
+    const body = route.request().postDataJSON() as { pageContent?: string };
+    agentPageContent = body.pageContent ?? "";
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: buildAgentStream("Slide-aware reply"),
     });
+  });
 
-    const contentPage = await harness.context.newPage();
-    await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
-    const activeUrl = contentPage.url();
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
+  await page.locator("#chatInput").fill("What is on each slide?");
+  await page.locator("#chatSend").click();
 
-    const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await mockDaemonSummarize(harness);
-    await sendPanelMessage(panel, { type: "panel:ready" });
-    await expect.poll(async () => await getSummarizeCalls(harness)).toBeGreaterThanOrEqual(1);
-    await sendPanelMessage(panel, { type: "panel:rememberUrl", url: activeUrl });
-
-    const callsBeforeClose = await getSummarizeCalls(harness);
-    await sendPanelMessage(panel, { type: "panel:closed" });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await mockDaemonSummarize(harness);
-    await sendPanelMessage(panel, { type: "panel:ready" });
-    await expect
-      .poll(async () => await getSummarizeCalls(harness))
-      .toBeGreaterThan(callsBeforeClose);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect.poll(() => agentPageContent).toContain("Slide timeline:");
+  expect(agentPageContent).toContain("Slide 1 @ 0:01");
+  expect(agentPageContent).toContain("First slide transcript context.");
+  expect(agentPageContent).toContain("Slide 2 @ 0:40");
+  expect(agentPageContent).toContain("Second slide visual OCR.");
+  expect(agentPageContent).toContain("Slide 3 @ 1:30");
+  expect(agentPageContent).toContain("Third slide transcript context.");
 });
 
-test("sidepanel updates title while streaming on same URL", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel chat queue drains messages after stream completes", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    summaryRuntime: "daemon",
+    autoSummarize: false,
+    chatEnabled: true,
+  });
+  const contentPage = await harness.context.newPage();
+  await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
+  await contentPage.evaluate(() => {
+    document.body.innerHTML = `<article><p>${"Hello ".repeat(40)}</p><p>More text for chat.</p></article>`;
+  });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
+  await waitForExtractReady(harness, "https://example.com");
 
-  try {
-    await mockDaemonSummarize(harness);
-    const sseBody = [
-      "event: chunk",
-      'data: {"text":"Hello"}',
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await harness.context.route(
-      /http:\/\/127\.0\.0\.1:8787\/v1\/summarize\/[^/]+\/events/,
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: sseBody,
-        });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+
+  let agentRequestCount = 0;
+  let releaseFirst: (() => void) | null = null;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+
+  await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
+    agentRequestCount += 1;
+    if (agentRequestCount === 1) await firstGate;
+    const body = buildAgentStream(`Reply ${agentRequestCount}`);
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body,
+    });
+  });
+
+  const sendChat = async (text: string) => {
+    await page.evaluate((value) => {
+      const input = document.getElementById("chatInput") as HTMLTextAreaElement | null;
+      const send = document.getElementById("chatSend") as HTMLButtonElement | null;
+      if (!input || !send) return;
+      input.value = value;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      send.click();
+    }, text);
+  };
+
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await sendChat("First question");
+  await expect.poll(() => agentRequestCount).toBe(1);
+
+  const enqueueChat = async (text: string) => {
+    await page.evaluate((value) => {
+      const input = document.getElementById("chatInput") as HTMLTextAreaElement | null;
+      if (!input) return;
+      input.value = value;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          code: "Enter",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    }, text);
+  };
+
+  await enqueueChat("Second question");
+  await enqueueChat("Third question");
+
+  releaseFirst?.();
+
+  await expect.poll(() => agentRequestCount).toBeGreaterThanOrEqual(3);
+  await expect(page.locator("#chatMessages")).toContainText("Second question");
+  await expect(page.locator("#chatMessages")).toContainText("Third question");
+});
+
+test("sidepanel clears chat on user navigation", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    summaryRuntime: "daemon",
+    autoSummarize: false,
+    chatEnabled: true,
+  });
+  const contentPage = await harness.context.newPage();
+  await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
+  await contentPage.evaluate(() => {
+    document.body.innerHTML = `<article><p>${"Chat navigation context. ".repeat(20)}</p></article>`;
+  });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
+  await waitForExtractReady(harness, "https://example.com");
+  const activeTabId = await getActiveTabId(harness);
+
+  await harness.context.route("http://127.0.0.1:8787/v1/agent", async (route) => {
+    const body = buildAgentStream("Ack");
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body,
+    });
+  });
+
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: activeTabId, url: "https://example.com", title: "Example" },
+      settings: {
+        chatEnabled: true,
+        summaryRuntime: "daemon",
+        tokenPresent: true,
       },
-    );
+    }),
+  });
 
-    await seedSettings(harness, { token: "test-token", autoSummarize: false });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
+  await page.evaluate((value) => {
+    const input = document.getElementById("chatInput") as HTMLTextAreaElement | null;
+    const send = document.getElementById("chatSend") as HTMLButtonElement | null;
+    if (!input || !send) return;
+    input.value = value;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    send.click();
+  }, "Hello");
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: "https://example.com/watch?v=1", title: "Old Title" },
-        settings: { autoSummarize: false, tokenPresent: true },
-        status: "",
-      }),
-    });
+  await expect(page.locator("#chatMessages")).toContainText("Hello");
 
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-1",
-        url: "https://example.com/watch?v=1",
-        title: "Old Title",
-        model: "auto",
-        reason: "manual",
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: activeTabId, url: "https://example.com/next", title: "Next" },
+      settings: {
+        chatEnabled: true,
+        summaryRuntime: "daemon",
+        tokenPresent: true,
       },
-    });
-    await expect(page.locator("#title")).toHaveText("Old Title");
+    }),
+  });
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { url: "https://example.com/watch?v=1", title: "New Title" },
-        settings: { autoSummarize: false, tokenPresent: true },
-        status: "",
-      }),
-    });
-    await expect(page.locator("#title")).toHaveText("New Title");
+  await expect(page.locator(".chatMessage")).toHaveCount(0);
+  await expect(page.locator("#chatMessages")).not.toContainText("Tool result: navigation");
+});
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+test("auto summarize reruns after panel reopen", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+
+  const sseBody = [
+    "event: chunk",
+    'data: {"text":"First chunk"}',
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await harness.context.route(
+    /http:\/\/127\.0\.0\.1:8787\/v1\/summarize\/[^/]+\/events/,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: sseBody,
+      });
+    },
+  );
+
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: true,
+    slideRuntime: "daemon",
+  });
+
+  const contentPage = await harness.context.newPage();
+  await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
+  const activeUrl = contentPage.url();
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+
+  const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await mockDaemonSummarize(harness);
+  await sendPanelMessage(panel, { type: "panel:ready" });
+  await expect.poll(async () => await getSummarizeCalls(harness)).toBeGreaterThanOrEqual(1);
+  await sendPanelMessage(panel, { type: "panel:rememberUrl", url: activeUrl });
+
+  const callsBeforeClose = await getSummarizeCalls(harness);
+  await sendPanelMessage(panel, { type: "panel:closed" });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await mockDaemonSummarize(harness);
+  await sendPanelMessage(panel, { type: "panel:ready" });
+  await expect.poll(async () => await getSummarizeCalls(harness)).toBeGreaterThan(callsBeforeClose);
+});
+
+test("sidepanel updates title while streaming on same URL", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  const sseBody = [
+    "event: chunk",
+    'data: {"text":"Hello"}',
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await harness.context.route(
+    /http:\/\/127\.0\.0\.1:8787\/v1\/summarize\/[^/]+\/events/,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: sseBody,
+      });
+    },
+  );
+
+  await seedSettings(harness, { token: "test-token", autoSummarize: false });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url: "https://example.com/watch?v=1", title: "Old Title" },
+      settings: { autoSummarize: false, tokenPresent: true },
+      status: "",
+    }),
+  });
+
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-1",
+      url: "https://example.com/watch?v=1",
+      title: "Old Title",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+  await expect(page.locator("#title")).toHaveText("Old Title");
+
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { url: "https://example.com/watch?v=1", title: "New Title" },
+      settings: { autoSummarize: false, tokenPresent: true },
+      status: "",
+    }),
+  });
+  await expect(page.locator("#title")).toHaveText("New Title");
+
+  await new Promise((resolve) => setTimeout(resolve, 200));
 });
 
 test("hover tooltip proxies daemon calls via background (no page-origin localhost fetch)", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    hoverSummaries: true,
+    summaryRuntime: "daemon",
+  });
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      hoverSummaries: true,
-      summaryRuntime: "daemon",
+  await harness.context.route("https://example.com/hover-daemon-proof", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: '<a id="target" href="https://example.com/next">Summarize target</a>',
     });
+  });
 
-    await harness.context.route("https://example.com/hover-daemon-proof", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/html" },
-        body: '<a id="target" href="https://example.com/next">Summarize target</a>',
-      });
+  const requestWorkerUrls: Array<string | null> = [];
+  await harness.context.route("http://127.0.0.1:8787/v1/summarize", async (route) => {
+    requestWorkerUrls.push(route.request().serviceWorker()?.url() ?? null);
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true, id: "hover-route-run" }),
     });
-
-    const requestWorkerUrls: Array<string | null> = [];
-    await harness.context.route("http://127.0.0.1:8787/v1/summarize", async (route) => {
+  });
+  const sseBody = [
+    "event: chunk",
+    'data: {"text":"Hello hover"}',
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await harness.context.route(
+    /http:\/\/127\.0\.0\.1:8787\/v1\/summarize\/[^/]+\/events/,
+    async (route) => {
       requestWorkerUrls.push(route.request().serviceWorker()?.url() ?? null);
       await route.fulfill({
         status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: true, id: "hover-route-run" }),
+        headers: { "content-type": "text/event-stream" },
+        body: sseBody,
       });
-    });
-    const sseBody = [
-      "event: chunk",
-      'data: {"text":"Hello hover"}',
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await harness.context.route(
-      /http:\/\/127\.0\.0\.1:8787\/v1\/summarize\/[^/]+\/events/,
-      async (route) => {
-        requestWorkerUrls.push(route.request().serviceWorker()?.url() ?? null);
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: sseBody,
-        });
-      },
-    );
+    },
+  );
 
-    const page = await harness.context.newPage();
-    trackErrors(page, harness.pageErrors, harness.consoleErrors);
-    await page.goto("https://example.com/hover-daemon-proof", {
-      waitUntil: "domcontentloaded",
-    });
-    await maybeBringToFront(page);
-    await activateTabByUrl(harness, "https://example.com/hover-daemon-proof");
-    await waitForActiveTabUrl(harness, "https://example.com/hover-daemon-proof");
+  const page = await harness.context.newPage();
+  trackErrors(page, harness.pageErrors, harness.consoleErrors);
+  await page.goto("https://example.com/hover-daemon-proof", {
+    waitUntil: "domcontentloaded",
+  });
+  await maybeBringToFront(page);
+  await activateTabByUrl(harness, "https://example.com/hover-daemon-proof");
+  await waitForActiveTabUrl(harness, "https://example.com/hover-daemon-proof");
 
-    await page.locator("#target").hover();
+  await page.locator("#target").hover();
 
-    const tooltip = page.locator('#__summarize_hover_tooltip__[data-visible="true"] .summary');
-    await expect(tooltip).toContainText("Hello hover");
-    await expect.poll(() => requestWorkerUrls).toHaveLength(2);
-    expect(requestWorkerUrls).toEqual([
-      expect.stringMatching(/^chrome-extension:\/\//),
-      expect.stringMatching(/^chrome-extension:\/\//),
-    ]);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const tooltip = page.locator('#__summarize_hover_tooltip__[data-visible="true"] .summary');
+  await expect(tooltip).toContainText("Hello hover");
+  await expect.poll(() => requestWorkerUrls).toHaveLength(2);
+  expect(requestWorkerUrls).toEqual([
+    expect.stringMatching(/^chrome-extension:\/\//),
+    expect.stringMatching(/^chrome-extension:\/\//),
+  ]);
 });
 
-test("content script extracts visible duration metadata", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    const page = await harness.context.newPage();
-    await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
-    await page.setContent(`
+test("content script extracts visible duration metadata", async ({ harness }) => {
+  const page = await harness.context.newPage();
+  await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+  await page.setContent(`
       <html>
         <head>
           <meta itemprop="duration" content="PT5M21S" />
@@ -599,20 +518,16 @@ test("content script extracts visible duration metadata", async ({
       </html>
     `);
 
-    await maybeBringToFront(page);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
-    const background = await getBackground(harness);
-    const result = await background.evaluate(async () => {
-      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      if (!tab?.id) return null;
-      return await chrome.tabs.sendMessage(tab.id, { type: "extract", maxChars: 1200 });
-    });
+  await maybeBringToFront(page);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
+  const background = await getBackground(harness);
+  const result = await background.evaluate(async () => {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) return null;
+    return await chrome.tabs.sendMessage(tab.id, { type: "extract", maxChars: 1200 });
+  });
 
-    expect(result).toEqual(expect.objectContaining({ mediaDurationSeconds: 321 }));
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  expect(result).toEqual(expect.objectContaining({ mediaDurationSeconds: 321 }));
 });

--- a/apps/chrome-extension/tests/sidepanel.core.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.core.spec.ts
@@ -1,14 +1,11 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { mockDaemonSummarize } from "./helpers/daemon-fixtures";
+import { test } from "./helpers/extension-fixtures";
 import {
-  assertNoErrors,
   buildUiState,
-  closeExtension,
-  getBrowserFromProject,
   getExtensionUrl,
   getSettings,
   getOpenPickerList,
-  launchExtension,
   openExtensionPage,
   seedSettings,
   sendBgMessage,
@@ -16,713 +13,573 @@ import {
   updateSettings,
   waitForPanelPort,
 } from "./helpers/extension-harness";
-import { allowFirefoxExtensionTests } from "./helpers/extension-test-config";
 import { waitForChatEnabled, waitForSettingsHydratedHook } from "./helpers/panel-hooks";
 
-test.skip(
-  ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
-  "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
-);
-
-test("sidepanel loads without runtime errors", async ({ browserName: _browserName }, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await openExtensionPage(harness, "sidepanel.html", "#title");
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+test("sidepanel loads without runtime errors", async ({ harness }) => {
+  await openExtensionPage(harness, "sidepanel.html", "#title");
+  await new Promise((resolve) => setTimeout(resolve, 500));
 });
 
-test("sidepanel hides chat dock when chat is disabled", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, { chatEnabled: false });
-    const page = await harness.context.newPage();
-    trackErrors(page, harness.pageErrors, harness.consoleErrors);
-    await page.addInitScript(() => {
-      (
-        window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
-      ).__summarizeTestHooks = {};
-    });
-    await page.goto(getExtensionUrl(harness, "sidepanel.html"), {
-      waitUntil: "domcontentloaded",
-    });
-    await page.waitForSelector("#title");
-    await waitForPanelPort(page);
-    await waitForPanelPort(page);
-    await expect(page.locator("#chatDock")).toBeHidden();
-    await expect(page.locator("#chatContainer")).toBeHidden();
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+test("sidepanel hides chat dock when chat is disabled", async ({ harness }) => {
+  await seedSettings(harness, { chatEnabled: false });
+  const page = await harness.context.newPage();
+  trackErrors(page, harness.pageErrors, harness.consoleErrors);
+  await page.addInitScript(() => {
+    (
+      window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
+    ).__summarizeTestHooks = {};
+  });
+  await page.goto(getExtensionUrl(harness, "sidepanel.html"), {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForSelector("#title");
+  await waitForPanelPort(page);
+  await waitForPanelPort(page);
+  await expect(page.locator("#chatDock")).toBeHidden();
+  await expect(page.locator("#chatContainer")).toBeHidden();
 });
 
-test("sidepanel updates chat visibility when settings change", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel updates chat visibility when settings change", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    chatEnabled: true,
+    summaryRuntime: "daemon",
+    token: "test-token",
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    (window as typeof globalThis & { IntersectionObserver?: unknown }).IntersectionObserver =
+      undefined;
+  });
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      daemon: { ok: true, authed: true },
+      settings: {
+        chatEnabled: true,
+        summaryRuntime: "daemon",
+        tokenPresent: true,
+      },
+    }),
+  });
+  await waitForChatEnabled(page, true);
+  await expect(page.locator("#chatDock")).toBeVisible();
 
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      chatEnabled: true,
-      summaryRuntime: "daemon",
-      token: "test-token",
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      (window as typeof globalThis & { IntersectionObserver?: unknown }).IntersectionObserver =
-        undefined;
-    });
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        daemon: { ok: true, authed: true },
-        settings: {
-          chatEnabled: true,
-          summaryRuntime: "daemon",
-          tokenPresent: true,
-        },
-      }),
-    });
-    await waitForChatEnabled(page, true);
-    await expect(page.locator("#chatDock")).toBeVisible();
-
-    await updateSettings(page, { chatEnabled: false });
-    await waitForChatEnabled(page, false);
-    await expect(page.locator("#chatDock")).toBeHidden();
-    await expect(page.locator("#chatContainer")).toBeHidden();
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await updateSettings(page, { chatEnabled: false });
+  await waitForChatEnabled(page, false);
+  await expect(page.locator("#chatDock")).toBeHidden();
+  await expect(page.locator("#chatContainer")).toBeHidden();
 });
 
-test("sidepanel hides daemon-backed chat when browser mode has no daemon", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel hides daemon-backed chat when browser mode has no daemon", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "",
+    chatEnabled: true,
+    slideRuntime: "browser",
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      daemon: { ok: false, authed: false },
+      settings: {
+        chatEnabled: true,
+        slideRuntime: "browser",
+        tokenPresent: false,
+      },
+    }),
+  });
 
-  try {
-    await seedSettings(harness, {
-      token: "",
-      chatEnabled: true,
-      slideRuntime: "browser",
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        daemon: { ok: false, authed: false },
-        settings: {
-          chatEnabled: true,
-          slideRuntime: "browser",
-          tokenPresent: false,
-        },
-      }),
-    });
-
-    await waitForChatEnabled(page, false);
-    await expect(page.locator("#chatDock")).toBeHidden();
-    await expect(page.locator("#chatContainer")).toBeHidden();
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await waitForChatEnabled(page, false);
+  await expect(page.locator("#chatDock")).toBeHidden();
+  await expect(page.locator("#chatContainer")).toBeHidden();
 });
 
-test("sidepanel default stays usable with a dismissible daemon hint", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel default stays usable with a dismissible daemon hint", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "",
+    summaryRuntime: "direct",
+    slideRuntime: "browser",
+    model: "auto",
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      daemon: { ok: false, authed: false },
+      settings: {
+        summaryRuntime: "direct",
+        slideRuntime: "browser",
+        providerConfigured: false,
+        daemonHintDismissed: false,
+        model: "auto",
+        tokenPresent: false,
+      },
+    }),
+  });
 
-  try {
-    await seedSettings(harness, {
-      token: "",
-      summaryRuntime: "direct",
-      slideRuntime: "browser",
-      model: "auto",
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        daemon: { ok: false, authed: false },
-        settings: {
-          summaryRuntime: "direct",
-          slideRuntime: "browser",
-          providerConfigured: false,
-          daemonHintDismissed: false,
-          model: "auto",
-          tokenPresent: false,
-        },
-      }),
-    });
+  await expect(page.locator("#daemonHint")).toBeVisible();
+  await expect(page.locator("#daemonHint")).toContainText("Works locally in Chrome");
+  await expect(page.locator("#setup")).toBeHidden();
+  const hintLayout = await page.locator("#daemonHint").evaluate((element) => ({
+    height: element.getBoundingClientRect().height,
+    overflows: element.scrollWidth > element.clientWidth,
+  }));
+  expect(hintLayout.height).toBeLessThan(72);
+  expect(hintLayout.overflows).toBe(false);
 
-    await expect(page.locator("#daemonHint")).toBeVisible();
-    await expect(page.locator("#daemonHint")).toContainText("Works locally in Chrome");
-    await expect(page.locator("#setup")).toBeHidden();
-    const hintLayout = await page.locator("#daemonHint").evaluate((element) => ({
-      height: element.getBoundingClientRect().height,
-      overflows: element.scrollWidth > element.clientWidth,
-    }));
-    expect(hintLayout.height).toBeLessThan(72);
-    expect(hintLayout.overflows).toBe(false);
-
-    await page.locator("#daemonHintClose").click();
-    await expect(page.locator("#daemonHint")).toBeHidden();
-    await expect.poll(async () => (await getSettings(harness)).daemonHintDismissed).toBe(true);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await page.locator("#daemonHintClose").click();
+  await expect(page.locator("#daemonHint")).toBeHidden();
+  await expect.poll(async () => (await getSettings(harness)).daemonHintDismissed).toBe(true);
 });
 
 test("sidepanel daemon Connect opens Runtime setup with permission diagnostics", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
-      token: "",
-      summaryRuntime: "direct",
-      slideRuntime: "browser",
-      model: "auto",
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        daemon: { ok: false, authed: false },
-        settings: {
-          summaryRuntime: "direct",
-          slideRuntime: "browser",
-          providerConfigured: false,
-          daemonHintDismissed: false,
-          model: "auto",
-          tokenPresent: false,
-        },
-      }),
-    });
-
-    await expect(page.locator("#daemonHint")).toBeVisible();
-    const optionsPromise = harness.context.waitForEvent("page");
-    await page.locator("#daemonHintAction").click();
-    const options = await optionsPromise;
-    trackErrors(options, harness.pageErrors, harness.consoleErrors);
-
-    await options.waitForSelector("#tabs");
-    await expect(options).toHaveURL(/options\.html\?tab=runtime/);
-    await expect(options.locator("#tab-runtime")).toHaveAttribute("aria-selected", "true");
-    await expect(options.locator("#panel-runtime")).toBeVisible();
-    await expect(options.locator("#daemonStatus")).toContainText(
-      "Local companion permission missing",
-    );
-    await expect(options.locator("#daemonStatus")).toContainText("Runtime settings");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel scheme picker applies overlay selection", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      (
-        window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
-      ).__summarizeTestHooks = {};
-    });
-    await waitForPanelPort(page);
-    await page.evaluate(() => {
-      const global = window as typeof globalThis & {
-        __summarizePanelPort?: { disconnect?: () => void } | undefined;
-      };
-      global.__summarizePanelPort?.disconnect?.();
-      global.__summarizePanelPort = undefined;
-    });
-    await page.click("#drawerToggle");
-    await expect(page.locator("#drawer")).toBeVisible();
-
-    const schemeLabel = page.locator("label.scheme");
-    const schemeTrigger = schemeLabel.locator(".pickerTrigger");
-
-    await schemeTrigger.focus();
-    await schemeTrigger.press("Enter");
-    const schemeList = getOpenPickerList(page);
-    await expect(schemeList).toBeVisible();
-    await schemeList.locator('[role="option"]').nth(1).click();
-
-    await expect(schemeTrigger.locator(".scheme-label")).toHaveText("Cedar");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel font picker truncates its value on narrow panels", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await page.setViewportSize({ width: 360, height: 640 });
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await page.click("#drawerToggle");
-    await expect(page.locator("#drawer")).toBeVisible();
-
-    const fontTrigger = page.locator("label.font .pickerTrigger");
-    await fontTrigger.evaluate((element) => {
-      element.style.width = "70px";
-    });
-    const fontValue = fontTrigger.locator(":scope > span");
-    await expect(fontValue).toHaveText("San Francisco");
-    const layout = await fontValue.evaluate((element) => {
-      const style = getComputedStyle(element);
-      return {
-        clientWidth: element.clientWidth,
-        overflow: style.overflow,
-        scrollWidth: element.scrollWidth,
-        textOverflow: style.textOverflow,
-        whiteSpace: style.whiteSpace,
-      };
-    });
-
-    expect(layout.whiteSpace).toBe("nowrap");
-    expect(layout.overflow).toBe("hidden");
-    expect(layout.textOverflow).toBe("ellipsis");
-    expect(layout.scrollWidth).toBeGreaterThan(layout.clientWidth);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel refresh free models from advanced settings", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, { token: "test-token", autoSummarize: false });
-
-    let modelCalls = 0;
-    await harness.context.route("http://127.0.0.1:8787/v1/models", async (route) => {
-      modelCalls += 1;
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          ok: true,
-          options: [
-            { id: "auto", label: "Auto" },
-            { id: "free", label: "Free (OpenRouter)" },
-          ],
-          providers: {
-            openrouter: true,
-            openai: false,
-            google: false,
-            anthropic: false,
-            xai: false,
-            zai: false,
-          },
-          openaiBaseUrl: null,
-          localModelsSource: null,
-        }),
-      });
-    });
-
-    await harness.context.route("http://127.0.0.1:8787/v1/refresh-free", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: true, id: "refresh-1" }),
-      });
-    });
-
-    const sseBody = [
-      "event: status",
-      'data: {"text":"Refresh free: scanning..."}',
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-
-    await harness.context.route(
-      "http://127.0.0.1:8787/v1/refresh-free/refresh-1/events",
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: sseBody,
-        });
-      },
-    );
-
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await page.click("#drawerToggle");
-    await expect(page.locator("#drawer")).toBeVisible();
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        status: "",
-        settings: { tokenPresent: true, autoSummarize: false, model: "free", length: "xl" },
-      }),
-    });
-
-    await page.locator("#advancedSettings summary").click();
-    await expect(page.locator("#modelRefresh")).toBeVisible();
-    await page.locator("#modelRefresh").click();
-    await expect(page.locator("#modelStatus")).toContainText("Free models updated.");
-    await expect.poll(() => modelCalls).toBeGreaterThanOrEqual(2);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel refresh free shows error on failure", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, { token: "test-token", autoSummarize: false });
-
-    await harness.context.route("http://127.0.0.1:8787/v1/models", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          ok: true,
-          options: [
-            { id: "auto", label: "Auto" },
-            { id: "free", label: "Free (OpenRouter)" },
-          ],
-          providers: {
-            openrouter: true,
-            openai: false,
-            google: false,
-            anthropic: false,
-            xai: false,
-            zai: false,
-          },
-          openaiBaseUrl: null,
-          localModelsSource: null,
-        }),
-      });
-    });
-
-    await harness.context.route("http://127.0.0.1:8787/v1/refresh-free", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: false, error: "nope" }),
-      });
-    });
-
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await page.click("#drawerToggle");
-    await expect(page.locator("#drawer")).toBeVisible();
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        status: "",
-        settings: { tokenPresent: true, autoSummarize: false, model: "free", length: "xl" },
-      }),
-    });
-
-    await page.locator("#advancedSettings summary").click();
-    await expect(page.locator("#modelRefresh")).toBeVisible();
-    await page.locator("#modelRefresh").click();
-    await expect(page.locator("#modelStatus")).toContainText("Refresh free failed");
-    await expect(page.locator("#modelStatus")).toHaveAttribute("data-state", "error");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel mode picker applies overlay selection", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await page.click("#drawerToggle");
-    await expect(page.locator("#drawer")).toBeVisible();
-
-    const modeLabel = page.locator("label.mode");
-    const modeTrigger = modeLabel.locator(".pickerTrigger");
-
-    await modeTrigger.focus();
-    await modeTrigger.press("Enter");
-    const modeList = getOpenPickerList(page);
-    await expect(modeList).toBeVisible();
-    const modeContent = page.locator(
-      '#summarize-overlay-root .pickerPositioner[data-picker="mode"] .pickerContent:not([hidden])',
-    );
-    const pickerAlpha = await modeContent.evaluate((element) => {
-      const background = getComputedStyle(element).backgroundColor;
-      const rgba = /^rgba?\(([^)]+)\)$/.exec(background);
-      if (!rgba) return 1;
-      const parts = rgba[1]
-        .split(",")
-        .map((part) => part.trim())
-        .filter(Boolean);
-      return parts.length >= 4 ? Number(parts[3]) : 1;
-    });
-    expect(pickerAlpha).toBeGreaterThanOrEqual(0.85);
-    await modeList.locator('[role="option"]').nth(2).click();
-
-    await expect(modeTrigger).toHaveText("Dark");
-    await expect(page.locator("html")).toHaveAttribute("data-mode", "dark");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel custom length input accepts typing", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await page.click("#drawerToggle");
-    await expect(page.locator("#drawer")).toBeVisible();
-
-    const lengthLabel = page.locator("label.length.mini");
-    const lengthTrigger = lengthLabel.locator(".pickerTrigger").first();
-
-    await lengthTrigger.click();
-    const lengthList = getOpenPickerList(page);
-    await expect(lengthList).toBeVisible();
-    await lengthList.locator(".pickerOption", { hasText: "Custom…" }).click();
-
-    const customInput = page.locator("#lengthCustom");
-    await expect(customInput).toBeVisible();
-    await customInput.click();
-    await customInput.fill("20k");
-    await expect(customInput).toHaveValue("20k");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel updates title after stream when tab title changes", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, { token: "test-token", autoSummarize: false });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    const sseBody = [
-      "event: meta",
-      'data: {"model":"test"}',
-      "",
-      "event: chunk",
-      'data: {"text":"Hello world"}',
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-
-    await harness.context.route(
-      /http:\/\/127\.0\.0\.1:8787\/v1\/summarize\/[^/]+\/events/,
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: sseBody,
-        });
-      },
-    );
-
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: "https://example.com/video", title: "Original Title" },
-        settings: { autoSummarize: false, tokenPresent: true },
-        status: "",
-      }),
-    });
-
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-1",
-        url: "https://example.com/video",
-        title: "Original Title",
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "",
+    summaryRuntime: "direct",
+    slideRuntime: "browser",
+    model: "auto",
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      daemon: { ok: false, authed: false },
+      settings: {
+        summaryRuntime: "direct",
+        slideRuntime: "browser",
+        providerConfigured: false,
+        daemonHintDismissed: false,
         model: "auto",
-        reason: "manual",
+        tokenPresent: false,
       },
-    });
+    }),
+  });
 
-    await expect(page.locator("#title")).toHaveText("Original Title");
-    await expect(page.locator("#render")).toContainText("Hello world");
+  await expect(page.locator("#daemonHint")).toBeVisible();
+  const optionsPromise = harness.context.waitForEvent("page");
+  await page.locator("#daemonHintAction").click();
+  const options = await optionsPromise;
+  trackErrors(options, harness.pageErrors, harness.consoleErrors);
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { url: "https://example.com/video", title: "Updated Title" },
-        status: "",
-      }),
-    });
-
-    await expect(page.locator("#title")).toHaveText("Updated Title");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await options.waitForSelector("#tabs");
+  await expect(options).toHaveURL(/options\.html\?tab=runtime/);
+  await expect(options.locator("#tab-runtime")).toHaveAttribute("aria-selected", "true");
+  await expect(options.locator("#panel-runtime")).toBeVisible();
+  await expect(options.locator("#daemonStatus")).toContainText(
+    "Local companion permission missing",
+  );
+  await expect(options.locator("#daemonStatus")).toContainText("Runtime settings");
 });
 
-test("sidepanel keeps scroll position while summary markdown streams", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, { autoSummarize: false });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await page.setViewportSize({ width: 430, height: 720 });
-
-    const makeMarkdown = (extraParagraphs = 0, tail = "") =>
-      Array.from(
-        { length: 90 + extraParagraphs },
-        (_, index) => `Paragraph ${index + 1}. ${"Readable streaming summary content ".repeat(12)}`,
-      ).join("\n\n") + tail;
-    const applyMarkdown = async (markdown: string) => {
-      await page.evaluate((value) => {
-        const hooks = (
-          window as typeof globalThis & {
-            __summarizeTestHooks?: { applySummaryMarkdown?: (markdown: string) => void };
-          }
-        ).__summarizeTestHooks;
-        hooks?.applySummaryMarkdown?.(value);
-      }, markdown);
+test("sidepanel scheme picker applies overlay selection", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    (
+      window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
+    ).__summarizeTestHooks = {};
+  });
+  await waitForPanelPort(page);
+  await page.evaluate(() => {
+    const global = window as typeof globalThis & {
+      __summarizePanelPort?: { disconnect?: () => void } | undefined;
     };
+    global.__summarizePanelPort?.disconnect?.();
+    global.__summarizePanelPort = undefined;
+  });
+  await page.click("#drawerToggle");
+  await expect(page.locator("#drawer")).toBeVisible();
 
-    await applyMarkdown(makeMarkdown());
-    await expect(page.locator(".render__markdownBody p")).toHaveCount(90);
+  const schemeLabel = page.locator("label.scheme");
+  const schemeTrigger = schemeLabel.locator(".pickerTrigger");
 
-    const before = await page.evaluate(() => {
-      const main = document.querySelector("main") as HTMLElement;
-      main.scrollTop = 640;
-      return main.scrollTop;
-    });
-    expect(before).toBeGreaterThan(0);
+  await schemeTrigger.focus();
+  await schemeTrigger.press("Enter");
+  const schemeList = getOpenPickerList(page);
+  await expect(schemeList).toBeVisible();
+  await schemeList.locator('[role="option"]').nth(1).click();
 
-    await applyMarkdown(makeMarkdown(0, "\n\nStreaming tail."));
-
-    await expect
-      .poll(async () => {
-        return await page.evaluate(() => {
-          const main = document.querySelector("main") as HTMLElement;
-          return main.scrollTop;
-        });
-      })
-      .toBeGreaterThanOrEqual(before - 24);
-
-    await page.evaluate(
-      () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
-    );
-    await page.evaluate(() => {
-      const main = document.querySelector("main") as HTMLElement;
-      main.scrollTop = main.scrollHeight;
-    });
-    await applyMarkdown(makeMarkdown(12, "\n\nMore streaming tail."));
-    await expect
-      .poll(async () => {
-        return await page.evaluate(() => {
-          const main = document.querySelector("main") as HTMLElement;
-          return main.scrollHeight - main.scrollTop - main.clientHeight;
-        });
-      })
-      .toBeLessThan(32);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect(schemeTrigger.locator(".scheme-label")).toHaveText("Cedar");
 });
 
-test("sidepanel clears summary when tab url changes", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel font picker truncates its value on narrow panels", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await page.setViewportSize({ width: 360, height: 640 });
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await page.click("#drawerToggle");
+  await expect(page.locator("#drawer")).toBeVisible();
 
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, { token: "test-token", autoSummarize: false });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  const fontTrigger = page.locator("label.font .pickerTrigger");
+  await fontTrigger.evaluate((element) => {
+    element.style.width = "70px";
+  });
+  const fontValue = fontTrigger.locator(":scope > span");
+  await expect(fontValue).toHaveText("San Francisco");
+  const layout = await fontValue.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      clientWidth: element.clientWidth,
+      overflow: style.overflow,
+      scrollWidth: element.scrollWidth,
+      textOverflow: style.textOverflow,
+      whiteSpace: style.whiteSpace,
+    };
+  });
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { url: "https://example.com/old", title: "Old Title" },
-        settings: { autoSummarize: false, tokenPresent: true },
-        status: "",
+  expect(layout.whiteSpace).toBe("nowrap");
+  expect(layout.overflow).toBe("hidden");
+  expect(layout.textOverflow).toBe("ellipsis");
+  expect(layout.scrollWidth).toBeGreaterThan(layout.clientWidth);
+});
+
+test("sidepanel refresh free models from advanced settings", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, { token: "test-token", autoSummarize: false });
+
+  let modelCalls = 0;
+  await harness.context.route("http://127.0.0.1:8787/v1/models", async (route) => {
+    modelCalls += 1;
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ok: true,
+        options: [
+          { id: "auto", label: "Auto" },
+          { id: "free", label: "Free (OpenRouter)" },
+        ],
+        providers: {
+          openrouter: true,
+          openai: false,
+          google: false,
+          anthropic: false,
+          xai: false,
+          zai: false,
+        },
+        openaiBaseUrl: null,
+        localModelsSource: null,
       }),
     });
+  });
 
-    await expect(page.locator("#title")).toHaveText("Old Title");
-    await page.evaluate(() => {
-      const host = document.querySelector(".render__markdownHost") as HTMLElement | null;
-      if (host) host.textContent = "Hello world";
+  await harness.context.route("http://127.0.0.1:8787/v1/refresh-free", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true, id: "refresh-1" }),
     });
-    await expect(page.locator(".render__markdownHost")).toContainText("Hello world");
+  });
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { url: "https://example.com/new", title: "New Title" },
-        settings: { autoSummarize: false },
-        status: "",
+  const sseBody = [
+    "event: status",
+    'data: {"text":"Refresh free: scanning..."}',
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+
+  await harness.context.route(
+    "http://127.0.0.1:8787/v1/refresh-free/refresh-1/events",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: sseBody,
+      });
+    },
+  );
+
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await page.click("#drawerToggle");
+  await expect(page.locator("#drawer")).toBeVisible();
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      status: "",
+      settings: { tokenPresent: true, autoSummarize: false, model: "free", length: "xl" },
+    }),
+  });
+
+  await page.locator("#advancedSettings summary").click();
+  await expect(page.locator("#modelRefresh")).toBeVisible();
+  await page.locator("#modelRefresh").click();
+  await expect(page.locator("#modelStatus")).toContainText("Free models updated.");
+  await expect.poll(() => modelCalls).toBeGreaterThanOrEqual(2);
+});
+
+test("sidepanel refresh free shows error on failure", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, { token: "test-token", autoSummarize: false });
+
+  await harness.context.route("http://127.0.0.1:8787/v1/models", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ok: true,
+        options: [
+          { id: "auto", label: "Auto" },
+          { id: "free", label: "Free (OpenRouter)" },
+        ],
+        providers: {
+          openrouter: true,
+          openai: false,
+          google: false,
+          anthropic: false,
+          xai: false,
+          zai: false,
+        },
+        openaiBaseUrl: null,
+        localModelsSource: null,
       }),
     });
+  });
 
-    await expect(page.locator("#title")).toHaveText("New Title");
-    await expect(page.locator("#render")).toContainText("Click Summarize to start.");
-    await expect(page.locator("#render")).toContainText("New Title");
-    await expect(page.locator("#render")).not.toContainText("Hello world");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await harness.context.route("http://127.0.0.1:8787/v1/refresh-free", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: false, error: "nope" }),
+    });
+  });
+
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await page.click("#drawerToggle");
+  await expect(page.locator("#drawer")).toBeVisible();
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      status: "",
+      settings: { tokenPresent: true, autoSummarize: false, model: "free", length: "xl" },
+    }),
+  });
+
+  await page.locator("#advancedSettings summary").click();
+  await expect(page.locator("#modelRefresh")).toBeVisible();
+  await page.locator("#modelRefresh").click();
+  await expect(page.locator("#modelStatus")).toContainText("Refresh free failed");
+  await expect(page.locator("#modelStatus")).toHaveAttribute("data-state", "error");
+});
+
+test("sidepanel mode picker applies overlay selection", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await page.click("#drawerToggle");
+  await expect(page.locator("#drawer")).toBeVisible();
+
+  const modeLabel = page.locator("label.mode");
+  const modeTrigger = modeLabel.locator(".pickerTrigger");
+
+  await modeTrigger.focus();
+  await modeTrigger.press("Enter");
+  const modeList = getOpenPickerList(page);
+  await expect(modeList).toBeVisible();
+  const modeContent = page.locator(
+    '#summarize-overlay-root .pickerPositioner[data-picker="mode"] .pickerContent:not([hidden])',
+  );
+  const pickerAlpha = await modeContent.evaluate((element) => {
+    const background = getComputedStyle(element).backgroundColor;
+    const rgba = /^rgba?\(([^)]+)\)$/.exec(background);
+    if (!rgba) return 1;
+    const parts = rgba[1]
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean);
+    return parts.length >= 4 ? Number(parts[3]) : 1;
+  });
+  expect(pickerAlpha).toBeGreaterThanOrEqual(0.85);
+  await modeList.locator('[role="option"]').nth(2).click();
+
+  await expect(modeTrigger).toHaveText("Dark");
+  await expect(page.locator("html")).toHaveAttribute("data-mode", "dark");
+});
+
+test("sidepanel custom length input accepts typing", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await page.click("#drawerToggle");
+  await expect(page.locator("#drawer")).toBeVisible();
+
+  const lengthLabel = page.locator("label.length.mini");
+  const lengthTrigger = lengthLabel.locator(".pickerTrigger").first();
+
+  await lengthTrigger.click();
+  const lengthList = getOpenPickerList(page);
+  await expect(lengthList).toBeVisible();
+  await lengthList.locator(".pickerOption", { hasText: "Custom…" }).click();
+
+  const customInput = page.locator("#lengthCustom");
+  await expect(customInput).toBeVisible();
+  await customInput.click();
+  await customInput.fill("20k");
+  await expect(customInput).toHaveValue("20k");
+});
+
+test("sidepanel updates title after stream when tab title changes", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, { token: "test-token", autoSummarize: false });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  const sseBody = [
+    "event: meta",
+    'data: {"model":"test"}',
+    "",
+    "event: chunk",
+    'data: {"text":"Hello world"}',
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+
+  await harness.context.route(
+    /http:\/\/127\.0\.0\.1:8787\/v1\/summarize\/[^/]+\/events/,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: sseBody,
+      });
+    },
+  );
+
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url: "https://example.com/video", title: "Original Title" },
+      settings: { autoSummarize: false, tokenPresent: true },
+      status: "",
+    }),
+  });
+
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-1",
+      url: "https://example.com/video",
+      title: "Original Title",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+
+  await expect(page.locator("#title")).toHaveText("Original Title");
+  await expect(page.locator("#render")).toContainText("Hello world");
+
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { url: "https://example.com/video", title: "Updated Title" },
+      status: "",
+    }),
+  });
+
+  await expect(page.locator("#title")).toHaveText("Updated Title");
+});
+
+test("sidepanel keeps scroll position while summary markdown streams", async ({ harness }) => {
+  await seedSettings(harness, { autoSummarize: false });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await page.setViewportSize({ width: 430, height: 720 });
+
+  const makeMarkdown = (extraParagraphs = 0, tail = "") =>
+    Array.from(
+      { length: 90 + extraParagraphs },
+      (_, index) => `Paragraph ${index + 1}. ${"Readable streaming summary content ".repeat(12)}`,
+    ).join("\n\n") + tail;
+  const applyMarkdown = async (markdown: string) => {
+    await page.evaluate((value) => {
+      const hooks = (
+        window as typeof globalThis & {
+          __summarizeTestHooks?: { applySummaryMarkdown?: (markdown: string) => void };
+        }
+      ).__summarizeTestHooks;
+      hooks?.applySummaryMarkdown?.(value);
+    }, markdown);
+  };
+
+  await applyMarkdown(makeMarkdown());
+  await expect(page.locator(".render__markdownBody p")).toHaveCount(90);
+
+  const before = await page.evaluate(() => {
+    const main = document.querySelector("main") as HTMLElement;
+    main.scrollTop = 640;
+    return main.scrollTop;
+  });
+  expect(before).toBeGreaterThan(0);
+
+  await applyMarkdown(makeMarkdown(0, "\n\nStreaming tail."));
+
+  await expect
+    .poll(async () => {
+      return await page.evaluate(() => {
+        const main = document.querySelector("main") as HTMLElement;
+        return main.scrollTop;
+      });
+    })
+    .toBeGreaterThanOrEqual(before - 24);
+
+  await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+  await page.evaluate(() => {
+    const main = document.querySelector("main") as HTMLElement;
+    main.scrollTop = main.scrollHeight;
+  });
+  await applyMarkdown(makeMarkdown(12, "\n\nMore streaming tail."));
+  await expect
+    .poll(async () => {
+      return await page.evaluate(() => {
+        const main = document.querySelector("main") as HTMLElement;
+        return main.scrollHeight - main.scrollTop - main.clientHeight;
+      });
+    })
+    .toBeLessThan(32);
+});
+
+test("sidepanel clears summary when tab url changes", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, { token: "test-token", autoSummarize: false });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { url: "https://example.com/old", title: "Old Title" },
+      settings: { autoSummarize: false, tokenPresent: true },
+      status: "",
+    }),
+  });
+
+  await expect(page.locator("#title")).toHaveText("Old Title");
+  await page.evaluate(() => {
+    const host = document.querySelector(".render__markdownHost") as HTMLElement | null;
+    if (host) host.textContent = "Hello world";
+  });
+  await expect(page.locator(".render__markdownHost")).toContainText("Hello world");
+
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { url: "https://example.com/new", title: "New Title" },
+      settings: { autoSummarize: false },
+      status: "",
+    }),
+  });
+
+  await expect(page.locator("#title")).toHaveText("New Title");
+  await expect(page.locator("#render")).toContainText("Click Summarize to start.");
+  await expect(page.locator("#render")).toContainText("New Title");
+  await expect(page.locator("#render")).not.toContainText("Hello world");
 });

--- a/apps/chrome-extension/tests/sidepanel.direct-provider.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.direct-provider.spec.ts
@@ -1,11 +1,8 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "./helpers/extension-fixtures";
 import {
   activateTabByUrl,
-  assertNoErrors,
-  closeExtension,
-  getBrowserFromProject,
   injectContentScript,
-  launchExtension,
   openExtensionPage,
   seedSettings,
   sendPanelMessage,
@@ -24,83 +21,73 @@ function openAiStream(text: string) {
 }
 
 test("sidepanel summarizes and chats through a local direct provider without daemon", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    summaryRuntime: "direct",
+    slideRuntime: "browser",
+    provider: "openai",
+    providerApiKeys: { openai: "test-key" },
+    providerBaseUrls: { openai: "http://127.0.0.1:11434/v1" },
+    model: "openai/test-model",
+    autoSummarize: false,
+    chatEnabled: true,
+    automationEnabled: true,
+  });
+  const contentPage = await harness.context.newPage();
+  await contentPage.goto("https://example.com/direct-provider", {
+    waitUntil: "domcontentloaded",
+  });
+  await contentPage.evaluate(() => {
+    document.title = "Direct provider article";
+    document.body.innerHTML = `<article><h1>Direct provider article</h1><p>${"Browser-local extraction content. ".repeat(
+      50,
+    )}</p></article>`;
+  });
+  await activateTabByUrl(harness, "https://example.com/direct-provider");
+  await waitForActiveTabUrl(harness, "https://example.com/direct-provider");
+  await injectContentScript(
+    harness,
+    "content-scripts/extract.js",
+    "https://example.com/direct-provider",
+  );
+  await waitForExtractReady(harness, "https://example.com/direct-provider");
 
-  try {
-    await seedSettings(harness, {
-      summaryRuntime: "direct",
-      slideRuntime: "browser",
-      provider: "openai",
-      providerApiKeys: { openai: "test-key" },
-      providerBaseUrls: { openai: "http://127.0.0.1:11434/v1" },
-      model: "openai/test-model",
-      autoSummarize: false,
-      chatEnabled: true,
-      automationEnabled: true,
+  let requestCount = 0;
+  const requestBodies: Array<Record<string, unknown>> = [];
+  await harness.context.route("http://127.0.0.1:11434/v1/chat/completions", async (route) => {
+    requestCount += 1;
+    requestBodies.push(route.request().postDataJSON() as Record<string, unknown>);
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: openAiStream(
+        requestCount === 1 ? "## Direct summary\n\nNo daemon used." : "Direct chat reply.",
+      ),
     });
-    const contentPage = await harness.context.newPage();
-    await contentPage.goto("https://example.com/direct-provider", {
-      waitUntil: "domcontentloaded",
-    });
-    await contentPage.evaluate(() => {
-      document.title = "Direct provider article";
-      document.body.innerHTML = `<article><h1>Direct provider article</h1><p>${"Browser-local extraction content. ".repeat(
-        50,
-      )}</p></article>`;
-    });
-    await activateTabByUrl(harness, "https://example.com/direct-provider");
-    await waitForActiveTabUrl(harness, "https://example.com/direct-provider");
-    await injectContentScript(
-      harness,
-      "content-scripts/extract.js",
-      "https://example.com/direct-provider",
-    );
-    await waitForExtractReady(harness, "https://example.com/direct-provider");
+  });
 
-    let requestCount = 0;
-    const requestBodies: Array<Record<string, unknown>> = [];
-    await harness.context.route("http://127.0.0.1:11434/v1/chat/completions", async (route) => {
-      requestCount += 1;
-      requestBodies.push(route.request().postDataJSON() as Record<string, unknown>);
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: openAiStream(
-          requestCount === 1 ? "## Direct summary\n\nNo daemon used." : "Direct chat reply.",
-        ),
-      });
-    });
+  const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await sendPanelMessage(panel, { type: "panel:summarize", refresh: true });
 
-    const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await sendPanelMessage(panel, { type: "panel:summarize", refresh: true });
+  await expect.poll(() => getPanelSummaryMarkdown(panel)).toContain("No daemon used");
+  expect(requestBodies[0]?.model).toBe("test-model");
+  expect(JSON.stringify(requestBodies[0]?.messages)).toContain("Browser-local extraction content");
 
-    await expect.poll(() => getPanelSummaryMarkdown(panel)).toContain("No daemon used");
-    expect(requestBodies[0]?.model).toBe("test-model");
-    expect(JSON.stringify(requestBodies[0]?.messages)).toContain(
-      "Browser-local extraction content",
-    );
+  await panel.locator("#chatInput").fill("What backend answered?");
+  await panel.locator("#chatSend").click();
+  await expect(panel.locator("#chatMessages")).toContainText("Direct chat reply");
+  await expect.poll(() => requestCount).toBe(2);
 
-    await panel.locator("#chatInput").fill("What backend answered?");
-    await panel.locator("#chatSend").click();
-    await expect(panel.locator("#chatMessages")).toContainText("Direct chat reply");
-    await expect.poll(() => requestCount).toBe(2);
-
-    const advertisedTools = requestBodies.flatMap((body) => {
-      if (!Array.isArray(body.tools)) return [];
-      return body.tools
-        .map((tool) => (tool as { function?: { name?: string } }).function?.name)
-        .filter((name): name is string => Boolean(name));
-    });
-    const debuggerEnabled = await panel.evaluate(() =>
-      chrome.runtime.getManifest().permissions?.includes("debugger"),
-    );
-    expect(advertisedTools).toContain("navigate");
-    expect(advertisedTools.includes("debugger")).toBe(debuggerEnabled);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const advertisedTools = requestBodies.flatMap((body) => {
+    if (!Array.isArray(body.tools)) return [];
+    return body.tools
+      .map((tool) => (tool as { function?: { name?: string } }).function?.name)
+      .filter((name): name is string => Boolean(name));
+  });
+  const debuggerEnabled = await panel.evaluate(() =>
+    chrome.runtime.getManifest().permissions?.includes("debugger"),
+  );
+  expect(advertisedTools).toContain("navigate");
+  expect(advertisedTools.includes("debugger")).toBe(debuggerEnabled);
 });

--- a/apps/chrome-extension/tests/sidepanel.media-selection.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.media-selection.spec.ts
@@ -1,18 +1,15 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import {
   getSummarizeBodies,
   getSummarizeCalls,
   getSummarizeLastBody,
   mockDaemonSummarize,
 } from "./helpers/daemon-fixtures";
+import { test } from "./helpers/extension-fixtures";
 import {
   activateTabByUrl,
-  assertNoErrors,
   buildUiState,
-  closeExtension,
-  getBrowserFromProject,
   injectContentScript,
-  launchExtension,
   maybeBringToFront,
   openExtensionPage,
   seedSettings,
@@ -23,328 +20,298 @@ import {
   waitForPanelPort,
 } from "./helpers/extension-harness";
 
-test("sidepanel video selection forces transcript mode", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: false,
-      slideRuntime: "daemon",
+test("sidepanel video selection forces transcript mode", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: false,
+    slideRuntime: "daemon",
+  });
+  const contentPage = await harness.context.newPage();
+  await contentPage.route("https://www.youtube.com/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: "<html><body><article>Video placeholder</article></body></html>",
     });
-    const contentPage = await harness.context.newPage();
-    await contentPage.route("https://www.youtube.com/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/html" },
-        body: "<html><body><article>Video placeholder</article></body></html>",
-      });
+  });
+  await contentPage.goto("https://www.youtube.com/watch?v=abc123", {
+    waitUntil: "domcontentloaded",
+  });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://www.youtube.com/watch?v=abc123");
+  await waitForActiveTabUrl(harness, "https://www.youtube.com/watch?v=abc123");
+  await injectContentScript(
+    harness,
+    "content-scripts/extract.js",
+    "https://www.youtube.com/watch?v=abc123",
+  );
+
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  const mediaState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=abc123", title: "Example" },
+    media: { hasVideo: true, hasAudio: false, hasCaptions: false },
+    stats: { pageWords: 120, videoDurationSeconds: 90 },
+    settings: { slidesEnabled: false },
+    status: "",
+  });
+  await expect
+    .poll(async () => {
+      await sendBgMessage(harness, { type: "ui:state", state: mediaState });
+      return await page.locator(".summarizeButton.isDropdown").count();
+    })
+    .toBe(1);
+
+  const sseBody = [
+    "event: chunk",
+    'data: {"text":"Hello world"}',
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody,
     });
-    await contentPage.goto("https://www.youtube.com/watch?v=abc123", {
-      waitUntil: "domcontentloaded",
-    });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://www.youtube.com/watch?v=abc123");
-    await waitForActiveTabUrl(harness, "https://www.youtube.com/watch?v=abc123");
-    await injectContentScript(
-      harness,
-      "content-scripts/extract.js",
-      "https://www.youtube.com/watch?v=abc123",
-    );
+  });
 
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    const mediaState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=abc123", title: "Example" },
-      media: { hasVideo: true, hasAudio: false, hasCaptions: false },
-      stats: { pageWords: 120, videoDurationSeconds: 90 },
-      settings: { slidesEnabled: false },
-      status: "",
-    });
-    await expect
-      .poll(async () => {
-        await sendBgMessage(harness, { type: "ui:state", state: mediaState });
-        return await page.locator(".summarizeButton.isDropdown").count();
-      })
-      .toBe(1);
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://www.youtube.com/watch?v=abc123");
+  await waitForActiveTabUrl(harness, "https://www.youtube.com/watch?v=abc123");
 
-    const sseBody = [
-      "event: chunk",
-      'data: {"text":"Hello world"}',
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody,
-      });
-    });
+  await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
+  await expect
+    .poll(async () => {
+      const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
+      return bodies.some((body) => body?.mode === "url" && !("videoMode" in body));
+    })
+    .toBe(true);
 
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://www.youtube.com/watch?v=abc123");
-    await waitForActiveTabUrl(harness, "https://www.youtube.com/watch?v=abc123");
-
-    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
-    await expect
-      .poll(async () => {
-        const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
-        return bodies.some((body) => body?.mode === "url" && !("videoMode" in body));
-      })
-      .toBe(true);
-
-    const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
-    const body = bodies.find((item) => item?.mode === "url" && !("videoMode" in item)) ?? null;
-    expect(body?.mode).toBe("url");
-    expect(body).not.toHaveProperty("videoMode");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
+  const body = bodies.find((item) => item?.mode === "url" && !("videoMode" in item)) ?? null;
+  expect(body?.mode).toBe("url");
+  expect(body).not.toHaveProperty("videoMode");
 });
 
 test("sidepanel page selection on YouTube uses page text instead of captions", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: false,
-      slideRuntime: "daemon",
-    });
-    const youtubeUrl = "https://www.youtube.com/watch?v=pageMode123";
-    const playerResponse = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [
-            {
-              baseUrl: "https://www.youtube.com/api/timedtext?v=pageMode123&lang=en",
-              languageCode: "en",
-              name: { simpleText: "English" },
-            },
-          ],
-        },
+  harness,
+}) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: false,
+    slideRuntime: "daemon",
+  });
+  const youtubeUrl = "https://www.youtube.com/watch?v=pageMode123";
+  const playerResponse = {
+    captions: {
+      playerCaptionsTracklistRenderer: {
+        captionTracks: [
+          {
+            baseUrl: "https://www.youtube.com/api/timedtext?v=pageMode123&lang=en",
+            languageCode: "en",
+            name: { simpleText: "English" },
+          },
+        ],
       },
-      videoDetails: { lengthSeconds: "90", videoId: "pageMode123" },
-    };
-    const contentPage = await harness.context.newPage();
-    await contentPage.route("https://www.youtube.com/**", async (route) => {
-      const url = route.request().url();
-      if (url.includes("/api/timedtext")) {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            events: [{ tStartMs: 0, segs: [{ utf8: "Caption text should not be used." }] }],
-          }),
-        });
-        return;
-      }
+    },
+    videoDetails: { lengthSeconds: "90", videoId: "pageMode123" },
+  };
+  const contentPage = await harness.context.newPage();
+  await contentPage.route("https://www.youtube.com/**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/api/timedtext")) {
       await route.fulfill({
         status: 200,
-        headers: { "content-type": "text/html" },
-        body: `<html><head><title>Page Mode Video</title></head><body>
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          events: [{ tStartMs: 0, segs: [{ utf8: "Caption text should not be used." }] }],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: `<html><head><title>Page Mode Video</title></head><body>
           <script>var ytInitialPlayerResponse = ${JSON.stringify(playerResponse)};</script>
           <article><h1>Video description</h1><p>Page description text should be used.</p></article>
         </body></html>`,
-      });
     });
-    await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, youtubeUrl);
-    await waitForActiveTabUrl(harness, youtubeUrl);
-    await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
+  });
+  await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, youtubeUrl);
+  await waitForActiveTabUrl(harness, youtubeUrl);
+  await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
 
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: ["event: done", "data: {}", ""].join("\n"),
-      });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ["event: done", "data: {}", ""].join("\n"),
     });
-    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "page", refresh: false });
+  });
+  await sendPanelMessage(page, { type: "panel:summarize", inputMode: "page", refresh: false });
 
-    await expect.poll(async () => await getSummarizeCalls(harness)).toBeGreaterThan(0);
-    const body = (await getSummarizeLastBody(harness)) as Record<string, unknown>;
-    expect(String(body.text ?? "")).toContain("Page description text should be used.");
-    expect(String(body.text ?? "")).not.toContain("Caption text should not be used.");
-    expect(body.videoMode).toBeUndefined();
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect.poll(async () => await getSummarizeCalls(harness)).toBeGreaterThan(0);
+  const body = (await getSummarizeLastBody(harness)) as Record<string, unknown>;
+  expect(String(body.text ?? "")).toContain("Page description text should be used.");
+  expect(String(body.text ?? "")).not.toContain("Caption text should not be used.");
+  expect(body.videoMode).toBeUndefined();
 });
 
-test("sidepanel includes browser-fetched YouTube transcript text", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: false,
-      slideRuntime: "daemon",
-    });
-    const youtubeUrl = "https://www.youtube.com/watch?v=browserTranscript123";
-    const stalePlayerResponse = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [
-            {
-              baseUrl: "https://www.youtube.com/api/timedtext?v=previousVideo&lang=en",
-              languageCode: "en",
-              name: { simpleText: "English" },
-            },
-          ],
-        },
+test("sidepanel includes browser-fetched YouTube transcript text", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: false,
+    slideRuntime: "daemon",
+  });
+  const youtubeUrl = "https://www.youtube.com/watch?v=browserTranscript123";
+  const stalePlayerResponse = {
+    captions: {
+      playerCaptionsTracklistRenderer: {
+        captionTracks: [
+          {
+            baseUrl: "https://www.youtube.com/api/timedtext?v=previousVideo&lang=en",
+            languageCode: "en",
+            name: { simpleText: "English" },
+          },
+        ],
       },
-      videoDetails: { lengthSeconds: "12", videoId: "previousVideo" },
-    };
-    const playerResponse = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [
-            {
-              baseUrl: "https://www.youtube.com/api/timedtext?v=browserTranscript123&lang=en",
-              languageCode: "en",
-              name: { simpleText: "English" },
-            },
-          ],
-        },
+    },
+    videoDetails: { lengthSeconds: "12", videoId: "previousVideo" },
+  };
+  const playerResponse = {
+    captions: {
+      playerCaptionsTracklistRenderer: {
+        captionTracks: [
+          {
+            baseUrl: "https://www.youtube.com/api/timedtext?v=browserTranscript123&lang=en",
+            languageCode: "en",
+            name: { simpleText: "English" },
+          },
+        ],
       },
-      videoDetails: { lengthSeconds: "90", videoId: "browserTranscript123" },
-    };
-    const contentPage = await harness.context.newPage();
-    await contentPage.route("https://www.youtube.com/**", async (route) => {
-      const url = route.request().url();
-      if (url.includes("/api/timedtext")) {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            events: [
-              { tStartMs: 0, segs: [{ utf8: "First caption line." }] },
-              { tStartMs: 2500, segs: [{ utf8: "Second caption line." }] },
-            ],
-          }),
-        });
-        return;
-      }
+    },
+    videoDetails: { lengthSeconds: "90", videoId: "browserTranscript123" },
+  };
+  const contentPage = await harness.context.newPage();
+  await contentPage.route("https://www.youtube.com/**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/api/timedtext")) {
       await route.fulfill({
         status: 200,
-        headers: { "content-type": "text/html" },
-        body: `<html><body>
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          events: [
+            { tStartMs: 0, segs: [{ utf8: "First caption line." }] },
+            { tStartMs: 2500, segs: [{ utf8: "Second caption line." }] },
+          ],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: `<html><body>
           <script>var ytInitialPlayerResponse = ${JSON.stringify(stalePlayerResponse)};</script>
           <ytd-watch-flexy id="watch"></ytd-watch-flexy>
           <script>document.getElementById("watch").playerResponse = ${JSON.stringify(playerResponse)};</script>
           <article>Video placeholder</article>
         </body></html>`,
-      });
     });
-    await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, youtubeUrl);
-    await waitForActiveTabUrl(harness, youtubeUrl);
-    await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
+  });
+  await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, youtubeUrl);
+  await waitForActiveTabUrl(harness, youtubeUrl);
+  await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
 
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: ["event: done", "data: {}", ""].join("\n"),
-      });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ["event: done", "data: {}", ""].join("\n"),
     });
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: youtubeUrl, title: "Example" },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        settings: { slidesEnabled: false },
-        status: "",
-      }),
-    });
+  });
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url: youtubeUrl, title: "Example" },
+      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+      settings: { slidesEnabled: false },
+      status: "",
+    }),
+  });
 
-    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
-    await expect
-      .poll(async () => {
-        const body = (await getSummarizeLastBody(harness)) as Record<string, unknown> | null;
-        return typeof body?.text === "string" ? body.text : "";
-      })
-      .toContain("First caption line");
+  await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
+  await expect
+    .poll(async () => {
+      const body = (await getSummarizeLastBody(harness)) as Record<string, unknown> | null;
+      return typeof body?.text === "string" ? body.text : "";
+    })
+    .toContain("First caption line");
 
-    const body = (await getSummarizeLastBody(harness)) as Record<string, unknown>;
-    expect(body.mode).toBe("page");
-    expect(body.text).toContain("[0:00] First caption line.");
-    expect(body.text).toContain("[0:02] Second caption line.");
-    expect(body).not.toHaveProperty("slides");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const body = (await getSummarizeLastBody(harness)) as Record<string, unknown>;
+  expect(body.mode).toBe("page");
+  expect(body.text).toContain("[0:00] First caption line.");
+  expect(body.text).toContain("[0:02] Second caption line.");
+  expect(body).not.toHaveProperty("slides");
 });
 
-test("sidepanel falls back to current YouTube transcript panel rows", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slideRuntime: "daemon",
-    });
-    const youtubeUrl = "https://www.youtube.com/watch?v=panelTranscript123";
-    const playerResponse = {
-      captions: {
-        playerCaptionsTracklistRenderer: {
-          captionTracks: [
-            {
-              baseUrl: "https://www.youtube.com/api/timedtext?v=panelTranscript123&lang=en",
-              languageCode: "en",
-              name: { simpleText: "English (auto-generated)" },
-              kind: "asr",
-            },
-          ],
-        },
+test("sidepanel falls back to current YouTube transcript panel rows", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slideRuntime: "daemon",
+  });
+  const youtubeUrl = "https://www.youtube.com/watch?v=panelTranscript123";
+  const playerResponse = {
+    captions: {
+      playerCaptionsTracklistRenderer: {
+        captionTracks: [
+          {
+            baseUrl: "https://www.youtube.com/api/timedtext?v=panelTranscript123&lang=en",
+            languageCode: "en",
+            name: { simpleText: "English (auto-generated)" },
+            kind: "asr",
+          },
+        ],
       },
-      videoDetails: { lengthSeconds: "90", videoId: "panelTranscript123" },
-    };
-    const contentPage = await harness.context.newPage();
-    await contentPage.route("https://www.youtube.com/**", async (route) => {
-      const url = route.request().url();
-      if (url.includes("/api/timedtext")) {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/html; charset=UTF-8" },
-          body: "",
-        });
-        return;
-      }
+    },
+    videoDetails: { lengthSeconds: "90", videoId: "panelTranscript123" },
+  };
+  const contentPage = await harness.context.newPage();
+  await contentPage.route("https://www.youtube.com/**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/api/timedtext")) {
       await route.fulfill({
         status: 200,
-        headers: { "content-type": "text/html" },
-        body: `<html><body>
+        headers: { "content-type": "text/html; charset=UTF-8" },
+        body: "",
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: `<html><body>
 	          <script>var ytInitialPlayerResponse = ${JSON.stringify(playerResponse)};</script>
 	          <ytd-watch-metadata></ytd-watch-metadata>
 	          <ytd-video-description-transcript-section-renderer>
@@ -361,403 +328,364 @@ test("sidepanel falls back to current YouTube transcript panel rows", async ({
             <span class="ytAttributedStringHost" role="text">Panel second caption.</span>
           </transcript-segment-view-model>
         </body></html>`,
-      });
     });
-    await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, youtubeUrl);
-    await waitForActiveTabUrl(harness, youtubeUrl);
-    await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
+  });
+  await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, youtubeUrl);
+  await waitForActiveTabUrl(harness, youtubeUrl);
+  await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
 
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: ["event: done", "data: {}", ""].join("\n"),
-      });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ["event: done", "data: {}", ""].join("\n"),
     });
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: youtubeUrl, title: "Example" },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        settings: { slidesEnabled: true },
-        status: "",
-      }),
-    });
+  });
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url: youtubeUrl, title: "Example" },
+      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+      settings: { slidesEnabled: true },
+      status: "",
+    }),
+  });
 
-    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
-    await expect
-      .poll(async () => {
-        const body = (await getSummarizeLastBody(harness)) as Record<string, unknown> | null;
-        return typeof body?.text === "string" ? body.text : "";
-      })
-      .toContain("Panel first caption");
+  await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
+  await expect
+    .poll(async () => {
+      const body = (await getSummarizeLastBody(harness)) as Record<string, unknown> | null;
+      return typeof body?.text === "string" ? body.text : "";
+    })
+    .toContain("Panel first caption");
 
-    const body = (await getSummarizeLastBody(harness)) as Record<string, unknown>;
-    expect(body.mode).toBe("url");
-    expect(body.slides).toBe(true);
-    expect(body.text).toContain("[0:00] Panel first caption.");
-    expect(body.text).toContain("[0:02] Panel second caption.");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const body = (await getSummarizeLastBody(harness)) as Record<string, unknown>;
+  expect(body.mode).toBe("url");
+  expect(body.slides).toBe(true);
+  expect(body.text).toContain("[0:00] Panel first caption.");
+  expect(body.text).toContain("[0:02] Panel second caption.");
 });
 
 test("sidepanel video selection requests daemon slides when daemon extraction is enabled", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slideRuntime: "daemon",
+  harness,
+}) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slideRuntime: "daemon",
+  });
+  const contentPage = await harness.context.newPage();
+  await contentPage.route("https://www.youtube.com/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: "<html><body><article>Video placeholder</article></body></html>",
     });
-    const contentPage = await harness.context.newPage();
-    await contentPage.route("https://www.youtube.com/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/html" },
-        body: "<html><body><article>Video placeholder</article></body></html>",
-      });
+  });
+  await contentPage.goto("https://www.youtube.com/watch?v=dQw4w9WgXcQ", {
+    waitUntil: "domcontentloaded",
+  });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+  await waitForActiveTabUrl(harness, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+  await injectContentScript(
+    harness,
+    "content-scripts/extract.js",
+    "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  );
+
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  const mediaState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", title: "Example" },
+    media: { hasVideo: true, hasAudio: false, hasCaptions: false },
+    stats: { pageWords: 120, videoDurationSeconds: 90 },
+    settings: { slidesEnabled: true },
+    status: "",
+  });
+  await expect
+    .poll(async () => {
+      await sendBgMessage(harness, { type: "ui:state", state: mediaState });
+      return await page.locator(".summarizeButton.isDropdown").count();
+    })
+    .toBe(1);
+
+  const sseBody = [
+    "event: chunk",
+    'data: {"text":"Hello world"}',
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody,
     });
-    await contentPage.goto("https://www.youtube.com/watch?v=dQw4w9WgXcQ", {
-      waitUntil: "domcontentloaded",
-    });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
-    await waitForActiveTabUrl(harness, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
-    await injectContentScript(
-      harness,
-      "content-scripts/extract.js",
-      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-    );
+  });
 
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    const mediaState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", title: "Example" },
-      media: { hasVideo: true, hasAudio: false, hasCaptions: false },
-      stats: { pageWords: 120, videoDurationSeconds: 90 },
-      settings: { slidesEnabled: true },
-      status: "",
-    });
-    await expect
-      .poll(async () => {
-        await sendBgMessage(harness, { type: "ui:state", state: mediaState });
-        return await page.locator(".summarizeButton.isDropdown").count();
-      })
-      .toBe(1);
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+  await waitForActiveTabUrl(harness, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
 
-    const sseBody = [
-      "event: chunk",
-      'data: {"text":"Hello world"}',
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody,
-      });
-    });
+  await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
+  await expect
+    .poll(async () => {
+      const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
+      return bodies.some(
+        (body) => body?.mode === "url" && body?.slides === true && !("videoMode" in body),
+      );
+    })
+    .toBe(true);
 
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
-    await waitForActiveTabUrl(harness, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
-
-    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
-    await expect
-      .poll(async () => {
-        const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
-        return bodies.some(
-          (body) => body?.mode === "url" && body?.slides === true && !("videoMode" in body),
-        );
-      })
-      .toBe(true);
-
-    const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
-    const body =
-      bodies.find(
-        (item) => item?.mode === "url" && item?.slides === true && !("videoMode" in item),
-      ) ?? null;
-    expect(body?.mode).toBe("url");
-    expect(body).not.toHaveProperty("videoMode");
-    expect(body?.slides).toBe(true);
-    expect(body?.slidesOcr).toBeUndefined();
-    expect(body).not.toHaveProperty("slidesMax");
-    expect(body).not.toHaveProperty("slidesMinDuration");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
+  const body =
+    bodies.find(
+      (item) => item?.mode === "url" && item?.slides === true && !("videoMode" in item),
+    ) ?? null;
+  expect(body?.mode).toBe("url");
+  expect(body).not.toHaveProperty("videoMode");
+  expect(body?.slides).toBe(true);
+  expect(body?.slidesOcr).toBeUndefined();
+  expect(body).not.toHaveProperty("slidesMax");
+  expect(body).not.toHaveProperty("slidesMinDuration");
 });
 
 test("sidepanel coalesces duplicate YouTube daemon slide summarize requests", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slideRuntime: "daemon",
+  harness,
+}) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slideRuntime: "daemon",
+  });
+  const youtubeUrl = "https://www.youtube.com/watch?v=coalesce123";
+  const contentPage = await harness.context.newPage();
+  await contentPage.route("https://www.youtube.com/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/html" },
+      body: "<html><body><article>Video placeholder</article></body></html>",
     });
-    const youtubeUrl = "https://www.youtube.com/watch?v=coalesce123";
-    const contentPage = await harness.context.newPage();
-    await contentPage.route("https://www.youtube.com/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/html" },
-        body: "<html><body><article>Video placeholder</article></body></html>",
-      });
-    });
-    await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, youtubeUrl);
-    await waitForActiveTabUrl(harness, youtubeUrl);
-    await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
+  });
+  await contentPage.goto(youtubeUrl, { waitUntil: "domcontentloaded" });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, youtubeUrl);
+  await waitForActiveTabUrl(harness, youtubeUrl);
+  await injectContentScript(harness, "content-scripts/extract.js", youtubeUrl);
 
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: ["event: done", "data: {}", ""].join("\n"),
-      });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ["event: done", "data: {}", ""].join("\n"),
     });
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: youtubeUrl, title: "Example" },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        settings: { slidesEnabled: true },
-        status: "",
-      }),
-    });
-
-    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
-    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
-
-    await expect
-      .poll(async () => {
-        const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
-        return bodies.filter((body) => body?.mode === "url" && body?.slides === true).length;
-      })
-      .toBe(1);
-    const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
-    expect(bodies.filter((body) => body?.mode === "url" && body?.slides === true)).toHaveLength(1);
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel video selection does not request slides when disabled", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: false,
-      slideRuntime: "daemon",
-    });
-    const contentPage = await harness.context.newPage();
-    await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
-    await contentPage.evaluate(() => {
-      document.body.innerHTML = `<article><p>${"Hello ".repeat(40)}</p></article>`;
-    });
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-    await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
-    await waitForExtractReady(harness, "https://example.com");
-
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      (window as typeof globalThis & { IntersectionObserver?: unknown }).IntersectionObserver =
-        undefined;
-    });
-    const mediaState = buildUiState({
-      tab: { id: 1, url: "https://example.com", title: "Example" },
-      media: { hasVideo: true, hasAudio: false, hasCaptions: false },
-      stats: { pageWords: 120, videoDurationSeconds: 90 },
+  });
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url: youtubeUrl, title: "Example" },
+      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
       settings: { slidesEnabled: true },
       status: "",
-    });
-    await expect
-      .poll(async () => {
-        await sendBgMessage(harness, { type: "ui:state", state: mediaState });
-        return await page.locator(".summarizeButton.isDropdown").count();
-      })
-      .toBe(1);
+    }),
+  });
 
-    const sseBody = [
-      "event: chunk",
-      'data: {"text":"Hello world"}',
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody,
-      });
-    });
+  await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
+  await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
 
-    await maybeBringToFront(contentPage);
-    await activateTabByUrl(harness, "https://example.com");
-    await waitForActiveTabUrl(harness, "https://example.com");
-
-    await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
-    await expect.poll(() => getSummarizeCalls(harness)).toBe(1);
-
-    const body = (await getSummarizeLastBody(harness)) as Record<string, unknown> | null;
-    expect(body?.mode).toBe("url");
-    expect(body?.videoMode).toBe("transcript");
-    expect(body?.slides).toBeUndefined();
-    expect(body?.slidesOcr).toBeUndefined();
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect
+    .poll(async () => {
+      const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
+      return bodies.filter((body) => body?.mode === "url" && body?.slides === true).length;
+    })
+    .toBe(1);
+  const bodies = (await getSummarizeBodies(harness)) as Array<Record<string, unknown>>;
+  expect(bodies.filter((body) => body?.mode === "url" && body?.slides === true)).toHaveLength(1);
 });
 
-test("sidepanel loads slide images after they become ready", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel video selection does not request slides when disabled", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: false,
+    slideRuntime: "daemon",
+  });
+  const contentPage = await harness.context.newPage();
+  await contentPage.goto("https://example.com", { waitUntil: "domcontentloaded" });
+  await contentPage.evaluate(() => {
+    document.body.innerHTML = `<article><p>${"Hello ".repeat(40)}</p></article>`;
+  });
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+  await injectContentScript(harness, "content-scripts/extract.js", "https://example.com");
+  await waitForExtractReady(harness, "https://example.com");
 
-  try {
-    await mockDaemonSummarize(harness);
-    await seedSettings(harness, { token: "test-token", autoSummarize: false, slidesEnabled: true });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
-      (
-        window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
-      ).__summarizeTestHooks = {};
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    (window as typeof globalThis & { IntersectionObserver?: unknown }).IntersectionObserver =
+      undefined;
+  });
+  const mediaState = buildUiState({
+    tab: { id: 1, url: "https://example.com", title: "Example" },
+    media: { hasVideo: true, hasAudio: false, hasCaptions: false },
+    stats: { pageWords: 120, videoDurationSeconds: 90 },
+    settings: { slidesEnabled: true },
+    status: "",
+  });
+  await expect
+    .poll(async () => {
+      await sendBgMessage(harness, { type: "ui:state", state: mediaState });
+      return await page.locator(".summarizeButton.isDropdown").count();
+    })
+    .toBe(1);
+
+  const sseBody = [
+    "event: chunk",
+    'data: {"text":"Hello world"}',
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await page.route("http://127.0.0.1:8787/v1/summarize/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody,
     });
-    await waitForPanelPort(page);
-    const youtubeUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
-    const mediaState = buildUiState({
-      tab: { id: 1, url: youtubeUrl, title: "Example Video" },
-      media: { hasVideo: true, hasAudio: false, hasCaptions: false },
-      stats: { pageWords: 120, videoDurationSeconds: 90 },
-      status: "",
-    });
-    await expect
-      .poll(async () => {
-        await sendBgMessage(harness, { type: "ui:state", state: mediaState });
-        return await page.locator(".summarizeButton.isDropdown").count();
-      })
-      .toBe(1);
+  });
 
-    const slidesPayload = {
-      sourceUrl: youtubeUrl,
-      sourceId: "dQw4w9WgXcQ",
-      sourceKind: "youtube",
-      ocrAvailable: false,
-      slides: [
-        {
-          index: 1,
-          timestamp: 0,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/dQw4w9WgXcQ/1?v=1",
-        },
-      ],
-    };
-    await page.waitForFunction(
-      () => {
-        const hooks = (
-          window as typeof globalThis & {
-            __summarizeTestHooks?: { applySlidesPayload?: (payload: unknown) => void };
-          }
-        ).__summarizeTestHooks;
-        return Boolean(hooks?.applySlidesPayload);
+  await maybeBringToFront(contentPage);
+  await activateTabByUrl(harness, "https://example.com");
+  await waitForActiveTabUrl(harness, "https://example.com");
+
+  await sendPanelMessage(page, { type: "panel:summarize", inputMode: "video", refresh: false });
+  await expect.poll(() => getSummarizeCalls(harness)).toBe(1);
+
+  const body = (await getSummarizeLastBody(harness)) as Record<string, unknown> | null;
+  expect(body?.mode).toBe("url");
+  expect(body?.videoMode).toBe("transcript");
+  expect(body?.slides).toBeUndefined();
+  expect(body?.slidesOcr).toBeUndefined();
+});
+
+test("sidepanel loads slide images after they become ready", async ({ harness }) => {
+  await mockDaemonSummarize(harness);
+  await seedSettings(harness, { token: "test-token", autoSummarize: false, slidesEnabled: true });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title", () => {
+    (
+      window as typeof globalThis & { __summarizeTestHooks?: Record<string, unknown> }
+    ).__summarizeTestHooks = {};
+  });
+  await waitForPanelPort(page);
+  const youtubeUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+  const mediaState = buildUiState({
+    tab: { id: 1, url: youtubeUrl, title: "Example Video" },
+    media: { hasVideo: true, hasAudio: false, hasCaptions: false },
+    stats: { pageWords: 120, videoDurationSeconds: 90 },
+    status: "",
+  });
+  await expect
+    .poll(async () => {
+      await sendBgMessage(harness, { type: "ui:state", state: mediaState });
+      return await page.locator(".summarizeButton.isDropdown").count();
+    })
+    .toBe(1);
+
+  const slidesPayload = {
+    sourceUrl: youtubeUrl,
+    sourceId: "dQw4w9WgXcQ",
+    sourceKind: "youtube",
+    ocrAvailable: false,
+    slides: [
+      {
+        index: 1,
+        timestamp: 0,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/dQw4w9WgXcQ/1?v=1",
       },
-      { timeout: 10_000 },
-    );
-
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
-    );
-    let imageCalls = 0;
-    await harness.context.route(
-      "http://127.0.0.1:8787/v1/slides/dQw4w9WgXcQ/1**",
-      async (route) => {
-        imageCalls += 1;
-        if (imageCalls < 2) {
-          await route.fulfill({
-            status: 200,
-            headers: {
-              "content-type": "image/png",
-              "access-control-allow-origin": "*",
-              "access-control-expose-headers": "x-summarize-slide-ready",
-              "x-summarize-slide-ready": "0",
-            },
-            body: placeholderPng,
-          });
-          return;
-        }
-        await route.fulfill({
-          status: 200,
-          headers: {
-            "content-type": "image/png",
-            "access-control-allow-origin": "*",
-            "access-control-expose-headers": "x-summarize-slide-ready",
-            "x-summarize-slide-ready": "1",
-          },
-          body: placeholderPng,
-        });
-      },
-    );
-
-    await page.evaluate((payload) => {
+    ],
+  };
+  await page.waitForFunction(
+    () => {
       const hooks = (
         window as typeof globalThis & {
-          __summarizeTestHooks?: {
-            applySlidesPayload?: (payload: unknown) => void;
-            forceRenderSlides?: () => number;
-          };
+          __summarizeTestHooks?: { applySlidesPayload?: (payload: unknown) => void };
         }
       ).__summarizeTestHooks;
-      hooks?.applySlidesPayload?.(payload);
-      hooks?.forceRenderSlides?.();
-    }, slidesPayload);
+      return Boolean(hooks?.applySlidesPayload);
+    },
+    { timeout: 10_000 },
+  );
 
-    const img = page.locator("img.slideStrip__thumbImage, img.slideInline__thumbImage");
-    await expect(img).toHaveCount(1, { timeout: 10_000 });
-    await expect.poll(() => imageCalls, { timeout: 10_000 }).toBeGreaterThan(0);
-    await expect.poll(() => imageCalls, { timeout: 10_000 }).toBeGreaterThan(1);
-    await expect
-      .poll(
-        async () => {
-          return await img.evaluate((node) => node.src);
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  let imageCalls = 0;
+  await harness.context.route("http://127.0.0.1:8787/v1/slides/dQw4w9WgXcQ/1**", async (route) => {
+    imageCalls += 1;
+    if (imageCalls < 2) {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "content-type": "image/png",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "x-summarize-slide-ready",
+          "x-summarize-slide-ready": "0",
         },
-        { timeout: 10_000 },
-      )
-      .toContain("blob:");
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+        body: placeholderPng,
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "access-control-allow-origin": "*",
+        "access-control-expose-headers": "x-summarize-slide-ready",
+        "x-summarize-slide-ready": "1",
+      },
+      body: placeholderPng,
+    });
+  });
+
+  await page.evaluate((payload) => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: {
+          applySlidesPayload?: (payload: unknown) => void;
+          forceRenderSlides?: () => number;
+        };
+      }
+    ).__summarizeTestHooks;
+    hooks?.applySlidesPayload?.(payload);
+    hooks?.forceRenderSlides?.();
+  }, slidesPayload);
+
+  const img = page.locator("img.slideStrip__thumbImage, img.slideInline__thumbImage");
+  await expect(img).toHaveCount(1, { timeout: 10_000 });
+  await expect.poll(() => imageCalls, { timeout: 10_000 }).toBeGreaterThan(0);
+  await expect.poll(() => imageCalls, { timeout: 10_000 }).toBeGreaterThan(1);
+  await expect
+    .poll(
+      async () => {
+        return await img.evaluate((node) => node.src);
+      },
+      { timeout: 10_000 },
+    )
+    .toContain("blob:");
 });

--- a/apps/chrome-extension/tests/sidepanel.slides-restore.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.slides-restore.spec.ts
@@ -1,17 +1,13 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { buildSlidesPayload } from "./helpers/daemon-fixtures";
+import { test } from "./helpers/extension-fixtures";
 import {
-  assertNoErrors,
   buildUiState,
-  closeExtension,
-  getBrowserFromProject,
-  launchExtension,
   openExtensionPage,
   seedSettings,
   sendBgMessage,
   waitForPanelPort,
 } from "./helpers/extension-harness";
-import { allowFirefoxExtensionTests } from "./helpers/extension-test-config";
 import {
   getPanelSlideDescriptions,
   getPanelSlidesTimeline,
@@ -20,434 +16,398 @@ import {
   waitForSettingsHydratedHook,
 } from "./helpers/panel-hooks";
 
-test.skip(
-  ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
-  "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
-);
+test("sidepanel resumes slides when returning to a tab", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
 
-test("sidepanel resumes slides when returning to a tab", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  const slidesPayload = {
+    sourceUrl: "https://www.youtube.com/watch?v=abc123",
+    sourceId: "alpha",
+    sourceKind: "youtube",
+    ocrAvailable: true,
+    slides: [
+      {
+        index: 1,
+        timestamp: 0,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/alpha/1?v=1",
+        ocrText: "Alpha slide one.",
+      },
+    ],
+  };
+  await page.route("http://127.0.0.1:8787/v1/summarize/**/slides", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true, slides: slidesPayload }),
+    });
+  });
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
+  const slidesStreamBody = [
+    "event: slides",
+    `data: ${JSON.stringify(slidesPayload)}`,
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await page.route("http://127.0.0.1:8787/v1/summarize/slides-a/slides/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: slidesStreamBody,
+    });
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/slides-a/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ["event: done", "data: {}", ""].join("\n"),
+    });
+  });
+
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "x-summarize-slide-ready": "1",
+      },
+      body: placeholderPng,
+    });
+  });
+
+  const tabAState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=abc123", title: "Alpha Video" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+    settings: {
       autoSummarize: false,
       slidesEnabled: true,
       slidesParallel: true,
       slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
+      tokenPresent: true,
+    },
+  });
+  const tabBState = buildUiState({
+    tab: { id: 2, url: "https://example.com", title: "Bravo Tab" },
+    media: { hasVideo: false, hasAudio: false, hasCaptions: false },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await sendBgMessage(harness, { type: "ui:state", state: tabBState });
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(0);
+  await sendBgMessage(harness, {
+    type: "slides:run",
+    ok: true,
+    runId: "slides-a",
+    url: "https://www.youtube.com/watch?v=abc123",
+  });
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await expect(page.locator("#title")).toHaveText("Alpha Video");
 
-    const slidesPayload = {
-      sourceUrl: "https://www.youtube.com/watch?v=abc123",
-      sourceId: "alpha",
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(1);
+  const slides = await getPanelSlideDescriptions(page);
+  expect(slides[0]?.[1] ?? "").toContain("Alpha");
+});
+
+test("sidepanel replaces stale slides when rerunning the same video", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: false,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+
+  await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/slides/events")) {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: ["event: done", "data: {}", ""].join("\n"),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: [
+        "event: chunk",
+        `data: ${JSON.stringify({ text: "Summary" })}`,
+        "",
+        "event: done",
+        "data: {}",
+        "",
+      ].join("\n"),
+    });
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/**/slides", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: false, error: "not found" }),
+    });
+  });
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "x-summarize-slide-ready": "1",
+      },
+      body: placeholderPng,
+    });
+  });
+
+  const uiState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=rerun123", title: "Rerun Video" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: false,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
+  await sendBgMessage(harness, { type: "ui:state", state: uiState });
+
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-1",
+      url: "https://www.youtube.com/watch?v=rerun123",
+      title: "Rerun Video",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary");
+
+  await page.evaluate(
+    (payload) => {
+      const hooks = (
+        window as typeof globalThis & {
+          __summarizeTestHooks?: { applySlidesPayload?: (value: unknown) => void };
+        }
+      ).__summarizeTestHooks;
+      hooks?.applySlidesPayload?.(payload);
+    },
+    {
+      sourceUrl: "https://www.youtube.com/watch?v=rerun123",
+      sourceId: "youtube-rerun",
       sourceKind: "youtube",
       ocrAvailable: true,
       slides: [
         {
           index: 1,
           timestamp: 0,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/alpha/1?v=1",
-          ocrText: "Alpha slide one.",
+          imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-rerun/1?v=1",
+          ocrText: "First run slide one.",
+        },
+        {
+          index: 2,
+          timestamp: 20,
+          imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-rerun/2?v=1",
+          ocrText: "First run slide two.",
+        },
+        {
+          index: 3,
+          timestamp: 40,
+          imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-rerun/3?v=1",
+          ocrText: "First run slide three.",
         },
       ],
-    };
-    await page.route("http://127.0.0.1:8787/v1/summarize/**/slides", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: true, slides: slidesPayload }),
-      });
-    });
+    },
+  );
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(3);
 
-    const slidesStreamBody = [
-      "event: slides",
-      `data: ${JSON.stringify(slidesPayload)}`,
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await page.route("http://127.0.0.1:8787/v1/summarize/slides-a/slides/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: slidesStreamBody,
-      });
-    });
-    await page.route("http://127.0.0.1:8787/v1/summarize/slides-a/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: ["event: done", "data: {}", ""].join("\n"),
-      });
-    });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-2",
+      url: "https://www.youtube.com/watch?v=rerun123",
+      title: "Rerun Video",
+      model: "auto",
+      reason: "manual",
+    },
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary");
 
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
-    );
-    await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "content-type": "image/png",
-          "x-summarize-slide-ready": "1",
+  await page.evaluate(
+    (payload) => {
+      const hooks = (
+        window as typeof globalThis & {
+          __summarizeTestHooks?: { applySlidesPayload?: (value: unknown) => void };
+        }
+      ).__summarizeTestHooks;
+      hooks?.applySlidesPayload?.(payload);
+    },
+    {
+      sourceUrl: "https://www.youtube.com/watch?v=rerun123",
+      sourceId: "youtube-rerun",
+      sourceKind: "youtube",
+      ocrAvailable: true,
+      slides: [
+        {
+          index: 1,
+          timestamp: 5,
+          imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-rerun/1?v=2",
+          ocrText: "Second run only slide.",
         },
-        body: placeholderPng,
-      });
-    });
+      ],
+    },
+  );
 
-    const tabAState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=abc123", title: "Alpha Video" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-    });
-    const tabBState = buildUiState({
-      tab: { id: 2, url: "https://example.com", title: "Bravo Tab" },
-      media: { hasVideo: false, hasAudio: false, hasCaptions: false },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-    });
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await sendBgMessage(harness, { type: "ui:state", state: tabBState });
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(0);
-    await sendBgMessage(harness, {
-      type: "slides:run",
-      ok: true,
-      runId: "slides-a",
-      url: "https://www.youtube.com/watch?v=abc123",
-    });
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await expect(page.locator("#title")).toHaveText("Alpha Video");
-
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(1);
-    const slides = await getPanelSlideDescriptions(page);
-    expect(slides[0]?.[1] ?? "").toContain("Alpha");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel replaces stale slides when rerunning the same video", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: false,
-      slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-
-    await page.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
-      const url = route.request().url();
-      if (url.includes("/slides/events")) {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: ["event: done", "data: {}", ""].join("\n"),
-        });
-        return;
-      }
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: [
-          "event: chunk",
-          `data: ${JSON.stringify({ text: "Summary" })}`,
-          "",
-          "event: done",
-          "data: {}",
-          "",
-        ].join("\n"),
-      });
-    });
-    await page.route("http://127.0.0.1:8787/v1/summarize/**/slides", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: false, error: "not found" }),
-      });
-    });
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
-    );
-    await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "content-type": "image/png",
-          "x-summarize-slide-ready": "1",
-        },
-        body: placeholderPng,
-      });
-    });
-
-    const uiState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=rerun123", title: "Rerun Video" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: false,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-    });
-    await sendBgMessage(harness, { type: "ui:state", state: uiState });
-
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-1",
-        url: "https://www.youtube.com/watch?v=rerun123",
-        title: "Rerun Video",
-        model: "auto",
-        reason: "manual",
-      },
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary");
-
-    await page.evaluate(
-      (payload) => {
-        const hooks = (
-          window as typeof globalThis & {
-            __summarizeTestHooks?: { applySlidesPayload?: (value: unknown) => void };
-          }
-        ).__summarizeTestHooks;
-        hooks?.applySlidesPayload?.(payload);
-      },
-      {
-        sourceUrl: "https://www.youtube.com/watch?v=rerun123",
-        sourceId: "youtube-rerun",
-        sourceKind: "youtube",
-        ocrAvailable: true,
-        slides: [
-          {
-            index: 1,
-            timestamp: 0,
-            imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-rerun/1?v=1",
-            ocrText: "First run slide one.",
-          },
-          {
-            index: 2,
-            timestamp: 20,
-            imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-rerun/2?v=1",
-            ocrText: "First run slide two.",
-          },
-          {
-            index: 3,
-            timestamp: 40,
-            imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-rerun/3?v=1",
-            ocrText: "First run slide three.",
-          },
-        ],
-      },
-    );
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(3);
-
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-2",
-        url: "https://www.youtube.com/watch?v=rerun123",
-        title: "Rerun Video",
-        model: "auto",
-        reason: "manual",
-      },
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary");
-
-    await page.evaluate(
-      (payload) => {
-        const hooks = (
-          window as typeof globalThis & {
-            __summarizeTestHooks?: { applySlidesPayload?: (value: unknown) => void };
-          }
-        ).__summarizeTestHooks;
-        hooks?.applySlidesPayload?.(payload);
-      },
-      {
-        sourceUrl: "https://www.youtube.com/watch?v=rerun123",
-        sourceId: "youtube-rerun",
-        sourceKind: "youtube",
-        ocrAvailable: true,
-        slides: [
-          {
-            index: 1,
-            timestamp: 5,
-            imageUrl: "http://127.0.0.1:8787/v1/slides/youtube-rerun/1?v=2",
-            ocrText: "Second run only slide.",
-          },
-        ],
-      },
-    );
-
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(1);
-    const slides = await getPanelSlideDescriptions(page);
-    expect(slides[0]?.[1] ?? "").toContain("Second run only slide");
-    expect(slides.some(([, text]) => text.includes("First run slide two"))).toBe(false);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(1);
+  const slides = await getPanelSlideDescriptions(page);
+  expect(slides[0]?.[1] ?? "").toContain("Second run only slide");
+  expect(slides.some(([, text]) => text.includes("First run slide two"))).toBe(false);
 });
 
 test("sidepanel starts pending slides after returning to a tab with seeded placeholders", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await waitForApplySlidesHook(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
+  const targetUrl = "https://www.youtube.com/watch?v=abc123";
+  const slidesPayload = buildSlidesPayload({
+    sourceUrl: targetUrl,
+    sourceId: "youtube-abc123",
+    count: 1,
+    textPrefix: "Alpha",
+  });
+
+  const summaryBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
+    );
+
+  await page.route("http://127.0.0.1:8787/v1/summarize/summary-a/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: summaryBody("Summary A"),
+    });
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/**/slides", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true, slides: slidesPayload }),
+    });
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/summary-a/slides/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: [
+        "event: slides",
+        `data: ${JSON.stringify(slidesPayload)}`,
+        "",
+        "event: done",
+        "data: {}",
+        "",
+      ].join("\n"),
+    });
+  });
+
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "x-summarize-slide-ready": "1",
+      },
+      body: placeholderPng,
+    });
+  });
+
+  const tabAState = buildUiState({
+    tab: { id: 1, url: targetUrl, title: "Alpha Video" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+    stats: { pageWords: 120, videoDurationSeconds: 120 },
+    settings: {
       autoSummarize: false,
       slidesEnabled: true,
       slidesParallel: true,
       slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await waitForApplySlidesHook(page);
+      tokenPresent: true,
+    },
+  });
+  const tabBState = buildUiState({
+    tab: { id: 2, url: "https://example.com", title: "Bravo Tab" },
+    media: { hasVideo: false, hasAudio: false, hasCaptions: false },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await expect(page.locator("#title")).toHaveText("Alpha Video");
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "summary-a",
+      url: targetUrl,
+      title: "Alpha Video",
+      model: "auto",
+      reason: "manual",
+      slides: true,
+    },
+  });
+  await expect
+    .poll(async () => (await getPanelSlidesTimeline(page)).length, { timeout: 10_000 })
+    .toBe(1);
 
-    const targetUrl = "https://www.youtube.com/watch?v=abc123";
-    const slidesPayload = buildSlidesPayload({
-      sourceUrl: targetUrl,
-      sourceId: "youtube-abc123",
-      count: 1,
-      textPrefix: "Alpha",
-    });
+  await sendBgMessage(harness, { type: "ui:state", state: tabBState });
+  await expect(page.locator("#title")).toHaveText("Bravo Tab");
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await expect(page.locator("#title")).toHaveText("Alpha Video");
 
-    const summaryBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-
-    await page.route("http://127.0.0.1:8787/v1/summarize/summary-a/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: summaryBody("Summary A"),
-      });
-    });
-    await page.route("http://127.0.0.1:8787/v1/summarize/**/slides", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: true, slides: slidesPayload }),
-      });
-    });
-    await page.route(
-      "http://127.0.0.1:8787/v1/summarize/summary-a/slides/events",
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: [
-            "event: slides",
-            `data: ${JSON.stringify(slidesPayload)}`,
-            "",
-            "event: done",
-            "data: {}",
-            "",
-          ].join("\n"),
-        });
-      },
-    );
-
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
-    );
-    await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "content-type": "image/png",
-          "x-summarize-slide-ready": "1",
-        },
-        body: placeholderPng,
-      });
-    });
-
-    const tabAState = buildUiState({
-      tab: { id: 1, url: targetUrl, title: "Alpha Video" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-      stats: { pageWords: 120, videoDurationSeconds: 120 },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-    });
-    const tabBState = buildUiState({
-      tab: { id: 2, url: "https://example.com", title: "Bravo Tab" },
-      media: { hasVideo: false, hasAudio: false, hasCaptions: false },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-    });
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await expect(page.locator("#title")).toHaveText("Alpha Video");
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "summary-a",
-        url: targetUrl,
-        title: "Alpha Video",
-        model: "auto",
-        reason: "manual",
-        slides: true,
-      },
-    });
-    await expect
-      .poll(async () => (await getPanelSlidesTimeline(page)).length, { timeout: 10_000 })
-      .toBe(1);
-
-    await sendBgMessage(harness, { type: "ui:state", state: tabBState });
-    await expect(page.locator("#title")).toHaveText("Bravo Tab");
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await expect(page.locator("#title")).toHaveText("Alpha Video");
-
-    await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(1);
-    const slides = await getPanelSlideDescriptions(page);
-    expect(slides.some(([, text]) => text.includes("Alpha"))).toBe(true);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(1);
+  const slides = await getPanelSlideDescriptions(page);
+  expect(slides.some(([, text]) => text.includes("Alpha"))).toBe(true);
 });

--- a/apps/chrome-extension/tests/sidepanel.slides-stream.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.slides-stream.spec.ts
@@ -1,17 +1,13 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { buildSlidesPayload } from "./helpers/daemon-fixtures";
+import { test } from "./helpers/extension-fixtures";
 import {
-  assertNoErrors,
   buildUiState,
-  closeExtension,
-  getBrowserFromProject,
-  launchExtension,
   openExtensionPage,
   seedSettings,
   sendBgMessage,
   waitForPanelPort,
 } from "./helpers/extension-harness";
-import { allowFirefoxExtensionTests } from "./helpers/extension-test-config";
 import {
   getPanelSlideDescriptions,
   getPanelSlideTitleEntries,
@@ -21,603 +17,325 @@ import {
   waitForSettingsHydratedHook,
 } from "./helpers/panel-hooks";
 
-test.skip(
-  ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
-  "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
-);
+test("sidepanel reconnects cached slide runs after tab restore", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
 
-test("sidepanel reconnects cached slide runs after tab restore", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-
-    const sseBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-    await page.route("http://127.0.0.1:8787/v1/summarize/run-a/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody("Summary A"),
-      });
-    });
-
-    const slidesPayload = {
-      sourceUrl: "https://www.youtube.com/watch?v=cache123",
-      sourceId: "cache-run",
-      sourceKind: "youtube",
-      ocrAvailable: true,
-      slides: [
-        {
-          index: 1,
-          timestamp: 0,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/cache-run/1?v=1",
-          ocrText: "Cached slide one.",
-        },
-      ],
-    };
-    const slidesStreamBody = [
-      "event: slides",
-      `data: ${JSON.stringify(slidesPayload)}`,
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    let slidesEventsRequests = 0;
-    await page.route("http://127.0.0.1:8787/v1/summarize/run-a/slides/events", async (route) => {
-      slidesEventsRequests += 1;
-      if (slidesEventsRequests === 1) {
-        await new Promise((resolve) => setTimeout(resolve, 2_000));
-      }
-      try {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: slidesStreamBody,
-        });
-      } catch {
-        // First request is intentionally abandoned when the tab changes.
-      }
-    });
-
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
+  const sseBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
     );
-    await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "content-type": "image/png",
-          "x-summarize-slide-ready": "1",
-        },
-        body: placeholderPng,
-      });
+  await page.route("http://127.0.0.1:8787/v1/summarize/run-a/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody("Summary A"),
     });
+  });
 
-    const tabAState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=cache123", title: "Cached Video" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
+  const slidesPayload = {
+    sourceUrl: "https://www.youtube.com/watch?v=cache123",
+    sourceId: "cache-run",
+    sourceKind: "youtube",
+    ocrAvailable: true,
+    slides: [
+      {
+        index: 1,
+        timestamp: 0,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/cache-run/1?v=1",
+        ocrText: "Cached slide one.",
       },
-    });
-    const tabBState = buildUiState({
-      tab: { id: 2, url: "https://example.com", title: "Other Tab" },
-      media: { hasVideo: false, hasAudio: false, hasCaptions: false },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesParallel: true,
-        slidesOcrEnabled: true,
-        tokenPresent: true,
-      },
-    });
-
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-a",
-        url: "https://www.youtube.com/watch?v=cache123",
-        title: "Cached Video",
-        model: "auto",
-        reason: "manual",
-        slides: true,
-      },
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
-    await expect.poll(async () => slidesEventsRequests).toBe(1);
-
-    await sendBgMessage(harness, { type: "ui:state", state: tabBState });
-    await expect(page.locator("#title")).toHaveText("Other Tab");
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(0);
-
-    await sendBgMessage(harness, { type: "ui:state", state: tabAState });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
-    expect(slidesEventsRequests).toBeGreaterThanOrEqual(1);
-    await expect
-      .poll(async () => (await getPanelSlideDescriptions(page)).length)
-      .toBeGreaterThanOrEqual(1);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel retry restarts the active single-run slide stream", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-    });
-    const url = "https://www.youtube.com/watch?v=retry12345";
-    const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(panel);
-    await waitForSettingsHydratedHook(panel);
-
-    let slideEventsRequests = 0;
-    await panel.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
-      const requestUrl = route.request().url();
-      if (requestUrl.includes("/slides/events")) {
-        slideEventsRequests += 1;
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: ["event: done", "data: {}", ""].join("\n"),
-        });
-        return;
-      }
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: [
-          "event: chunk",
-          `data: ${JSON.stringify({ text: "Video summary" })}`,
-          "",
-          "event: done",
-          "data: {}",
-          "",
-        ].join("\n"),
-      });
-    });
-    await panel.route("http://127.0.0.1:8787/v1/summarize/**/slides", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: false, error: "No slides yet" }),
-      });
-    });
-
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url, title: "Retry Video" },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        settings: {
-          autoSummarize: false,
-          slidesEnabled: true,
-          slidesParallel: true,
-          tokenPresent: true,
-        },
-      }),
-    });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "summary-run",
-        url,
-        title: "Retry Video",
-        model: "auto",
-        reason: "manual",
-        slides: true,
-      },
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(panel)).toContain("Video summary");
-    await expect.poll(async () => slideEventsRequests).toBe(1);
-
-    await sendBgMessage(harness, {
-      type: "slides:run",
-      ok: false,
-      error: "Slides request failed",
-    });
-    await expect(panel.locator("#slideNotice")).toContainText("Slides request failed");
-    await expect(panel.locator("#slideNoticeRetry")).toBeVisible();
-    await panel.evaluate(() => {
-      const port = (
-        window as typeof globalThis & {
-          __summarizePanelPort?: { postMessage: (payload: object) => void };
-          __capturedPanelMessages?: object[];
-        }
-      ).__summarizePanelPort;
-      if (!port) throw new Error("Missing panel port");
-      const captured: object[] = [];
-      (
-        window as typeof globalThis & { __capturedPanelMessages?: object[] }
-      ).__capturedPanelMessages = captured;
-      port.postMessage = (payload: object) => {
-        captured.push(payload);
-      };
-    });
-    await panel.locator("#slideNoticeRetry").click();
-    await expect.poll(async () => slideEventsRequests).toBe(2);
-    const captured = await panel.evaluate(() => {
-      return (
-        (
-          window as typeof globalThis & {
-            __capturedPanelMessages?: Array<{ type?: string; refresh?: boolean }>;
-          }
-        ).__capturedPanelMessages ?? []
-      ).map((message) => ({
-        type: message.type ?? null,
-        refresh: message.refresh ?? null,
-      }));
-    });
-    expect(captured).not.toContainEqual({ type: "panel:summarize", refresh: true });
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel replaces transcript slide copy with slides LLM summaries", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-
-    const sourceUrl = "https://www.youtube.com/watch?v=llmSlides123";
-    const slidesPayload = buildSlidesPayload({
-      sourceUrl,
-      sourceId: "youtube-llmSlides123",
-      count: 2,
-      textPrefix: "Raw transcript fallback",
-    });
-    const slidesStreamBody = [
-      "event: slides",
-      `data: ${JSON.stringify(slidesPayload)}`,
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await page.route(
-      "http://127.0.0.1:8787/v1/summarize/slides-llm/slides/events",
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: slidesStreamBody,
-        });
-      },
-    );
-
-    const llmMarkdown = [
-      "The video argues that the movie works because the premise stays emotionally grounded.",
-      "",
-      "[slide:1]",
-      "## Blockbuster setup",
-      "The LLM-written card frames the opening amnesia and spacecraft mystery without quoting the transcript.",
-      "",
-      "[slide:2]",
-      "## Stakes and tone",
-      "The LLM-written card connects the science problem to the story's warmer buddy-movie rhythm.",
-    ].join("\n");
-    const summaryStreamBody = [
-      "event: chunk",
-      `data: ${JSON.stringify({ text: llmMarkdown })}`,
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await page.route("http://127.0.0.1:8787/v1/summarize/slides-llm/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: summaryStreamBody,
-      });
-    });
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
-    );
-    await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "content-type": "image/png",
-          "x-summarize-slide-ready": "1",
-        },
-        body: placeholderPng,
-      });
-    });
-
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: sourceUrl, title: "LLM Slides" },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        settings: {
-          autoSummarize: false,
-          slidesEnabled: true,
-          slidesParallel: true,
-          slidesOcrEnabled: true,
-          tokenPresent: true,
-        },
-      }),
-    });
-    await sendBgMessage(harness, {
-      type: "slides:run",
-      ok: true,
-      runId: "slides-llm",
-      url: sourceUrl,
-    });
-
-    await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(2);
-    await expect
-      .poll(
-        async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"),
-        { timeout: 10_000 },
-      )
-      .toContain("LLM-written card");
-    const descriptions = await getPanelSlideDescriptions(page);
-    expect(descriptions).toHaveLength(2);
-    expect(descriptions.every(([, text]) => !text.includes("Raw transcript fallback"))).toBe(true);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel streams split slide summary chunks into gallery cards", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-
-    const sourceUrl = "https://www.youtube.com/watch?v=chunkedSlides123";
-    const slidesPayload = buildSlidesPayload({
-      sourceUrl,
-      sourceId: "youtube-chunkedSlides123",
-      count: 2,
-      textPrefix: "Raw transcript fallback",
-    });
-    await page.route(
-      "http://127.0.0.1:8787/v1/summarize/chunked-slides/slides/events",
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: [
-            "event: slides",
-            `data: ${JSON.stringify(slidesPayload)}`,
-            "",
-            "event: done",
-            "data: {}",
-            "",
-          ].join("\n"),
-        });
-      },
-    );
-    await page.route("http://127.0.0.1:8787/v1/summarize/chunked-slides/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: [
-          "event: chunk",
-          `data: ${JSON.stringify({ text: "Intro paragraph.\n\n[slide:1]\n## First shared title\n" })}`,
-          "",
-          "event: chunk",
-          `data: ${JSON.stringify({ text: "First shared card body arrives after the marker.\n\n[slide:2]\n## Second shared title\nSecond shared card body streams too." })}`,
-          "",
-          "event: done",
-          "data: {}",
-          "",
-        ].join("\n"),
-      });
-    });
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
-    );
-    await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "content-type": "image/png",
-          "x-summarize-slide-ready": "1",
-        },
-        body: placeholderPng,
-      });
-    });
-
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: sourceUrl, title: "Chunked Slides" },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        settings: {
-          autoSummarize: false,
-          slidesEnabled: true,
-          slidesParallel: true,
-          slidesOcrEnabled: true,
-          tokenPresent: true,
-        },
-      }),
-    });
-    await sendBgMessage(harness, {
-      type: "slides:run",
-      ok: true,
-      runId: "chunked-slides",
-      url: sourceUrl,
-    });
-
-    await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(2);
-    await expect
-      .poll(
-        async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"),
-        { timeout: 10_000 },
-      )
-      .toContain("First shared card body arrives");
-    const titles = await getPanelSlideTitleEntries(page);
-    expect(titles).toContainEqual([1, "First shared title"]);
-    expect(titles).toContainEqual([2, "Second shared title"]);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("daemon slides use the configured port and never leak the token off-origin", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      daemonPort: "8799",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-
-    const sseBody = (text: string) =>
-      ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
-        "\n",
-      );
-
-    // Summary + slides streams are served only from the CONFIGURED port (8799): if the
-    // extension still hardcoded 8787 these routes would never be hit and the run would stall.
-    await page.route("http://127.0.0.1:8799/v1/summarize/run-x/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: sseBody("Summary X"),
-      });
-    });
-
-    const slidesPayload = {
-      sourceUrl: "https://www.youtube.com/watch?v=port123",
-      sourceId: "port-run",
-      sourceKind: "youtube",
-      ocrAvailable: true,
-      slides: [
-        {
-          index: 1,
-          timestamp: 0,
-          imageUrl: "http://127.0.0.1:8799/v1/slides/port-run/1?v=1",
-          ocrText: "Daemon slide one has enough OCR text to pass thresholds.",
-        },
-        {
-          index: 2,
-          timestamp: 10,
-          // Hostile daemon-shaped URL on a foreign origin: must never receive the token.
-          imageUrl: "http://evil.test/v1/summarize/port-run/2?v=1",
-          ocrText: "Foreign slide two has enough OCR text to pass thresholds.",
-        },
-      ],
-    };
-    const slidesStreamBody = [
-      "event: slides",
-      `data: ${JSON.stringify(slidesPayload)}`,
-      "",
-      "event: done",
-      "data: {}",
-      "",
-    ].join("\n");
-    await page.route("http://127.0.0.1:8799/v1/summarize/run-x/slides/events", async (route) => {
+    ],
+  };
+  const slidesStreamBody = [
+    "event: slides",
+    `data: ${JSON.stringify(slidesPayload)}`,
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  let slidesEventsRequests = 0;
+  await page.route("http://127.0.0.1:8787/v1/summarize/run-a/slides/events", async (route) => {
+    slidesEventsRequests += 1;
+    if (slidesEventsRequests === 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+    }
+    try {
       await route.fulfill({
         status: 200,
         headers: { "content-type": "text/event-stream" },
         body: slidesStreamBody,
       });
-    });
+    } catch {
+      // First request is intentionally abandoned when the tab changes.
+    }
+  });
 
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
-    );
-    let daemonImageRequests = 0;
-    let daemonImageAuth: string | null = null;
-    await page.route("http://127.0.0.1:8799/v1/slides/**", async (route) => {
-      daemonImageRequests += 1;
-      daemonImageAuth = route.request().headers().authorization ?? null;
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "x-summarize-slide-ready": "1",
+      },
+      body: placeholderPng,
+    });
+  });
+
+  const tabAState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=cache123", title: "Cached Video" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
+  const tabBState = buildUiState({
+    tab: { id: 2, url: "https://example.com", title: "Other Tab" },
+    media: { hasVideo: false, hasAudio: false, hasCaptions: false },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
+
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-a",
+      url: "https://www.youtube.com/watch?v=cache123",
+      title: "Cached Video",
+      model: "auto",
+      reason: "manual",
+      slides: true,
+    },
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
+  await expect.poll(async () => slidesEventsRequests).toBe(1);
+
+  await sendBgMessage(harness, { type: "ui:state", state: tabBState });
+  await expect(page.locator("#title")).toHaveText("Other Tab");
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(0);
+
+  await sendBgMessage(harness, { type: "ui:state", state: tabAState });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary A");
+  expect(slidesEventsRequests).toBeGreaterThanOrEqual(1);
+  await expect
+    .poll(async () => (await getPanelSlideDescriptions(page)).length)
+    .toBeGreaterThanOrEqual(1);
+});
+
+test("sidepanel retry restarts the active single-run slide stream", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+  });
+  const url = "https://www.youtube.com/watch?v=retry12345";
+  const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(panel);
+  await waitForSettingsHydratedHook(panel);
+
+  let slideEventsRequests = 0;
+  await panel.route("http://127.0.0.1:8787/v1/summarize/**/events", async (route) => {
+    const requestUrl = route.request().url();
+    if (requestUrl.includes("/slides/events")) {
+      slideEventsRequests += 1;
       await route.fulfill({
         status: 200,
-        headers: { "content-type": "image/png", "x-summarize-slide-ready": "1" },
-        body: placeholderPng,
+        headers: { "content-type": "text/event-stream" },
+        body: ["event: done", "data: {}", ""].join("\n"),
       });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: [
+        "event: chunk",
+        `data: ${JSON.stringify({ text: "Video summary" })}`,
+        "",
+        "event: done",
+        "data: {}",
+        "",
+      ].join("\n"),
     });
-    let foreignImageRequests = 0;
-    let foreignImageAuth: string | null = null;
-    await page.route("http://evil.test/**", async (route) => {
-      foreignImageRequests += 1;
-      foreignImageAuth = route.request().headers().authorization ?? null;
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "image/png", "x-summarize-slide-ready": "1" },
-        body: placeholderPng,
-      });
+  });
+  await panel.route("http://127.0.0.1:8787/v1/summarize/**/slides", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: false, error: "No slides yet" }),
     });
+  });
 
-    const tabState = buildUiState({
-      tab: { id: 1, url: "https://www.youtube.com/watch?v=port123", title: "Port Video" },
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url, title: "Retry Video" },
+      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+      settings: {
+        autoSummarize: false,
+        slidesEnabled: true,
+        slidesParallel: true,
+        tokenPresent: true,
+      },
+    }),
+  });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "summary-run",
+      url,
+      title: "Retry Video",
+      model: "auto",
+      reason: "manual",
+      slides: true,
+    },
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(panel)).toContain("Video summary");
+  await expect.poll(async () => slideEventsRequests).toBe(1);
+
+  await sendBgMessage(harness, {
+    type: "slides:run",
+    ok: false,
+    error: "Slides request failed",
+  });
+  await expect(panel.locator("#slideNotice")).toContainText("Slides request failed");
+  await expect(panel.locator("#slideNoticeRetry")).toBeVisible();
+  await panel.evaluate(() => {
+    const port = (
+      window as typeof globalThis & {
+        __summarizePanelPort?: { postMessage: (payload: object) => void };
+        __capturedPanelMessages?: object[];
+      }
+    ).__summarizePanelPort;
+    if (!port) throw new Error("Missing panel port");
+    const captured: object[] = [];
+    (window as typeof globalThis & { __capturedPanelMessages?: object[] }).__capturedPanelMessages =
+      captured;
+    port.postMessage = (payload: object) => {
+      captured.push(payload);
+    };
+  });
+  await panel.locator("#slideNoticeRetry").click();
+  await expect.poll(async () => slideEventsRequests).toBe(2);
+  const captured = await panel.evaluate(() => {
+    return (
+      (
+        window as typeof globalThis & {
+          __capturedPanelMessages?: Array<{ type?: string; refresh?: boolean }>;
+        }
+      ).__capturedPanelMessages ?? []
+    ).map((message) => ({
+      type: message.type ?? null,
+      refresh: message.refresh ?? null,
+    }));
+  });
+  expect(captured).not.toContainEqual({ type: "panel:summarize", refresh: true });
+});
+
+test("sidepanel replaces transcript slide copy with slides LLM summaries", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+
+  const sourceUrl = "https://www.youtube.com/watch?v=llmSlides123";
+  const slidesPayload = buildSlidesPayload({
+    sourceUrl,
+    sourceId: "youtube-llmSlides123",
+    count: 2,
+    textPrefix: "Raw transcript fallback",
+  });
+  const slidesStreamBody = [
+    "event: slides",
+    `data: ${JSON.stringify(slidesPayload)}`,
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await page.route("http://127.0.0.1:8787/v1/summarize/slides-llm/slides/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: slidesStreamBody,
+    });
+  });
+
+  const llmMarkdown = [
+    "The video argues that the movie works because the premise stays emotionally grounded.",
+    "",
+    "[slide:1]",
+    "## Blockbuster setup",
+    "The LLM-written card frames the opening amnesia and spacecraft mystery without quoting the transcript.",
+    "",
+    "[slide:2]",
+    "## Stakes and tone",
+    "The LLM-written card connects the science problem to the story's warmer buddy-movie rhythm.",
+  ].join("\n");
+  const summaryStreamBody = [
+    "event: chunk",
+    `data: ${JSON.stringify({ text: llmMarkdown })}`,
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await page.route("http://127.0.0.1:8787/v1/summarize/slides-llm/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: summaryStreamBody,
+    });
+  });
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "x-summarize-slide-ready": "1",
+      },
+      body: placeholderPng,
+    });
+  });
+
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url: sourceUrl, title: "LLM Slides" },
       media: { hasVideo: true, hasAudio: true, hasCaptions: true },
       settings: {
         autoSummarize: false,
@@ -626,35 +344,254 @@ test("daemon slides use the configured port and never leak the token off-origin"
         slidesOcrEnabled: true,
         tokenPresent: true,
       },
+    }),
+  });
+  await sendBgMessage(harness, {
+    type: "slides:run",
+    ok: true,
+    runId: "slides-llm",
+    url: sourceUrl,
+  });
+
+  await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(2);
+  await expect
+    .poll(async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"), {
+      timeout: 10_000,
+    })
+    .toContain("LLM-written card");
+  const descriptions = await getPanelSlideDescriptions(page);
+  expect(descriptions).toHaveLength(2);
+  expect(descriptions.every(([, text]) => !text.includes("Raw transcript fallback"))).toBe(true);
+});
+
+test("sidepanel streams split slide summary chunks into gallery cards", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+
+  const sourceUrl = "https://www.youtube.com/watch?v=chunkedSlides123";
+  const slidesPayload = buildSlidesPayload({
+    sourceUrl,
+    sourceId: "youtube-chunkedSlides123",
+    count: 2,
+    textPrefix: "Raw transcript fallback",
+  });
+  await page.route(
+    "http://127.0.0.1:8787/v1/summarize/chunked-slides/slides/events",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: [
+          "event: slides",
+          `data: ${JSON.stringify(slidesPayload)}`,
+          "",
+          "event: done",
+          "data: {}",
+          "",
+        ].join("\n"),
+      });
+    },
+  );
+  await page.route("http://127.0.0.1:8787/v1/summarize/chunked-slides/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: [
+        "event: chunk",
+        `data: ${JSON.stringify({ text: "Intro paragraph.\n\n[slide:1]\n## First shared title\n" })}`,
+        "",
+        "event: chunk",
+        `data: ${JSON.stringify({ text: "First shared card body arrives after the marker.\n\n[slide:2]\n## Second shared title\nSecond shared card body streams too." })}`,
+        "",
+        "event: done",
+        "data: {}",
+        "",
+      ].join("\n"),
     });
-    await sendBgMessage(harness, { type: "ui:state", state: tabState });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "run-x",
-        url: "https://www.youtube.com/watch?v=port123",
-        title: "Port Video",
-        model: "auto",
-        reason: "manual",
-        slides: true,
+  });
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "x-summarize-slide-ready": "1",
       },
+      body: placeholderPng,
     });
+  });
 
-    // Custom-port proof: the run streams from 8799 and renders both slides.
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary X");
-    await expect
-      .poll(async () => (await getPanelSlideDescriptions(page)).length)
-      .toBeGreaterThanOrEqual(2);
-    await expect.poll(() => daemonImageRequests).toBeGreaterThanOrEqual(1);
-    expect(daemonImageAuth).toBe("Bearer test-token");
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url: sourceUrl, title: "Chunked Slides" },
+      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+      settings: {
+        autoSummarize: false,
+        slidesEnabled: true,
+        slidesParallel: true,
+        slidesOcrEnabled: true,
+        tokenPresent: true,
+      },
+    }),
+  });
+  await sendBgMessage(harness, {
+    type: "slides:run",
+    ok: true,
+    runId: "chunked-slides",
+    url: sourceUrl,
+  });
 
-    // Security: the daemon token never follows a foreign-origin slide URL.
-    await page.waitForTimeout(500);
-    expect(foreignImageRequests).toBe(0);
-    expect(foreignImageAuth).toBeNull();
+  await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(2);
+  await expect
+    .poll(async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"), {
+      timeout: 10_000,
+    })
+    .toContain("First shared card body arrives");
+  const titles = await getPanelSlideTitleEntries(page);
+  expect(titles).toContainEqual([1, "First shared title"]);
+  expect(titles).toContainEqual([2, "Second shared title"]);
+});
 
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+test("daemon slides use the configured port and never leak the token off-origin", async ({
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    daemonPort: "8799",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+
+  const sseBody = (text: string) =>
+    ["event: chunk", `data: ${JSON.stringify({ text })}`, "", "event: done", "data: {}", ""].join(
+      "\n",
+    );
+
+  // Summary + slides streams are served only from the CONFIGURED port (8799): if the
+  // extension still hardcoded 8787 these routes would never be hit and the run would stall.
+  await page.route("http://127.0.0.1:8799/v1/summarize/run-x/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: sseBody("Summary X"),
+    });
+  });
+
+  const slidesPayload = {
+    sourceUrl: "https://www.youtube.com/watch?v=port123",
+    sourceId: "port-run",
+    sourceKind: "youtube",
+    ocrAvailable: true,
+    slides: [
+      {
+        index: 1,
+        timestamp: 0,
+        imageUrl: "http://127.0.0.1:8799/v1/slides/port-run/1?v=1",
+        ocrText: "Daemon slide one has enough OCR text to pass thresholds.",
+      },
+      {
+        index: 2,
+        timestamp: 10,
+        // Hostile daemon-shaped URL on a foreign origin: must never receive the token.
+        imageUrl: "http://evil.test/v1/summarize/port-run/2?v=1",
+        ocrText: "Foreign slide two has enough OCR text to pass thresholds.",
+      },
+    ],
+  };
+  const slidesStreamBody = [
+    "event: slides",
+    `data: ${JSON.stringify(slidesPayload)}`,
+    "",
+    "event: done",
+    "data: {}",
+    "",
+  ].join("\n");
+  await page.route("http://127.0.0.1:8799/v1/summarize/run-x/slides/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: slidesStreamBody,
+    });
+  });
+
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  let daemonImageRequests = 0;
+  let daemonImageAuth: string | null = null;
+  await page.route("http://127.0.0.1:8799/v1/slides/**", async (route) => {
+    daemonImageRequests += 1;
+    daemonImageAuth = route.request().headers().authorization ?? null;
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "image/png", "x-summarize-slide-ready": "1" },
+      body: placeholderPng,
+    });
+  });
+  let foreignImageRequests = 0;
+  let foreignImageAuth: string | null = null;
+  await page.route("http://evil.test/**", async (route) => {
+    foreignImageRequests += 1;
+    foreignImageAuth = route.request().headers().authorization ?? null;
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "image/png", "x-summarize-slide-ready": "1" },
+      body: placeholderPng,
+    });
+  });
+
+  const tabState = buildUiState({
+    tab: { id: 1, url: "https://www.youtube.com/watch?v=port123", title: "Port Video" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
+  await sendBgMessage(harness, { type: "ui:state", state: tabState });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "run-x",
+      url: "https://www.youtube.com/watch?v=port123",
+      title: "Port Video",
+      model: "auto",
+      reason: "manual",
+      slides: true,
+    },
+  });
+
+  // Custom-port proof: the run streams from 8799 and renders both slides.
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toContain("Summary X");
+  await expect
+    .poll(async () => (await getPanelSlideDescriptions(page)).length)
+    .toBeGreaterThanOrEqual(2);
+  await expect.poll(() => daemonImageRequests).toBeGreaterThanOrEqual(1);
+  expect(daemonImageAuth).toBe("Bearer test-token");
+
+  // Security: the daemon token never follows a foreign-origin slide URL.
+  await page.waitForTimeout(500);
+  expect(foreignImageRequests).toBe(0);
+  expect(foreignImageAuth).toBeNull();
 });

--- a/apps/chrome-extension/tests/sidepanel.slides.spec.ts
+++ b/apps/chrome-extension/tests/sidepanel.slides.spec.ts
@@ -1,17 +1,13 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { buildSlidesPayload, routePlaceholderSlideImages } from "./helpers/daemon-fixtures";
+import { test } from "./helpers/extension-fixtures";
 import {
-  assertNoErrors,
   buildUiState,
-  closeExtension,
-  getBrowserFromProject,
-  launchExtension,
   openExtensionPage,
   seedSettings,
   sendBgMessage,
   waitForPanelPort,
 } from "./helpers/extension-harness";
-import { allowFirefoxExtensionTests } from "./helpers/extension-test-config";
 import {
   applySlidesPayload,
   getPanelSlideDescriptions,
@@ -25,188 +21,32 @@ import {
   waitForTranscriptTimedTextHook,
 } from "./helpers/panel-hooks";
 
-test.skip(
-  ({ browserName }) => browserName === "firefox" && !allowFirefoxExtensionTests,
-  "Firefox extension tests are blocked by Playwright limitations. Set ALLOW_FIREFOX_EXTENSION_TESTS=1 to run.",
-);
-
 test("sidepanel replaces placeholder slides with the final smaller payload", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await waitForSlidesRuntimeHooks(page);
+  await waitForTranscriptTimedTextHook(page);
+  await routePlaceholderSlideImages(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await waitForSlidesRuntimeHooks(page);
-    await waitForTranscriptTimedTextHook(page);
-    await routePlaceholderSlideImages(page);
-
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: {
-          id: 1,
-          url: "https://www.youtube.com/watch?v=helia123",
-          title: "Helia Video",
-        },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        settings: {
-          autoSummarize: false,
-          slidesEnabled: true,
-          slidesParallel: true,
-          slidesOcrEnabled: true,
-          tokenPresent: true,
-        },
-      }),
-    });
-
-    await applySlidesPayload(page, {
-      sourceUrl: "https://www.youtube.com/watch?v=helia123",
-      sourceId: "youtube-helia123",
-      sourceKind: "youtube",
-      ocrAvailable: false,
-      slides: [
-        { index: 1, timestamp: 2, imageUrl: "", ocrText: null },
-        { index: 2, timestamp: 63, imageUrl: "", ocrText: null },
-      ],
-    });
-
-    await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(2);
-
-    await applySlidesPayload(
-      page,
-      buildSlidesPayload({
-        sourceUrl: "https://www.youtube.com/watch?v=helia123",
-        sourceId: "youtube-helia123",
-        count: 1,
-        textPrefix: "Final",
-      }),
-    );
-
-    await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(1);
-    await expect(
-      page.locator("img.slideStrip__thumbImage, img.slideInline__thumbImage"),
-    ).toHaveCount(1);
-    await expect(
-      page.locator(
-        'img.slideStrip__thumbImage[data-loaded="true"], img.slideInline__thumbImage[data-loaded="true"]',
-      ),
-    ).toHaveCount(1);
-    const slides = await getPanelSlideDescriptions(page);
-    expect(slides[0]?.[1] ?? "").toContain("Final slide 1");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
-});
-
-test("sidepanel shows planned slide placeholders before daemon slides arrive", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await waitForSlidesRuntimeHooks(page);
-
-    await page.route("http://127.0.0.1:8787/v1/summarize/planned-run/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: [
-          "event: status",
-          `data: ${JSON.stringify({ text: "Slides: downloading video 8%" })}`,
-          "",
-          "event: chunk",
-          `data: ${JSON.stringify({ text: "Transcript summary arrives before slide images." })}`,
-          "",
-          "event: done",
-          "data: {}",
-          "",
-        ].join("\n"),
-      });
-    });
-    await page.route("http://127.0.0.1:8787/v1/summarize/planned-run/slides", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: false, error: "not ready" }),
-      });
-    });
-    await page.route(
-      "http://127.0.0.1:8787/v1/summarize/planned-run/slides/events",
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: [
-            "event: status",
-            `data: ${JSON.stringify({ text: "Slides: downloading video 8%" })}`,
-            "",
-            "event: done",
-            "data: {}",
-            "",
-          ].join("\n"),
-        });
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: {
+        id: 1,
+        url: "https://www.youtube.com/watch?v=helia123",
+        title: "Helia Video",
       },
-    );
-
-    const targetUrl = "https://www.youtube.com/watch?v=planned123";
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: { id: 1, url: targetUrl, title: "Planned Video" },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        stats: { pageWords: 0, videoDurationSeconds: null },
-        settings: {
-          autoSummarize: false,
-          slidesEnabled: true,
-          slidesParallel: true,
-          slidesOcrEnabled: true,
-          tokenPresent: true,
-        },
-      }),
-    });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "planned-run",
-        url: targetUrl,
-        title: "Planned Video",
-        model: "auto",
-        reason: "manual",
-        slides: true,
-      },
-    });
-
-    await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(6);
-    await expect(page.locator(".renderEmpty")).toHaveCount(0);
-    await expect(page.locator(".slideGallery__item")).toHaveCount(6);
-    await expect(page.locator("#render")).not.toContainText("Preparing summary");
-
-    const durationState = buildUiState({
-      tab: { id: 1, url: targetUrl, title: "Planned Video" },
       media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-      stats: { pageWords: 0, videoDurationSeconds: 1200 },
       settings: {
         autoSummarize: false,
         slidesEnabled: true,
@@ -214,47 +54,87 @@ test("sidepanel shows planned slide placeholders before daemon slides arrive", a
         slidesOcrEnabled: true,
         tokenPresent: true,
       },
-    });
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: durationState,
-    });
+    }),
+  });
 
-    await expect
-      .poll(async () => {
-        const timeline = await getPanelSlidesTimeline(page);
-        return {
-          count: timeline.length,
-          finiteTimestamps: timeline.filter((slide) => slide.timestamp !== null).length,
-        };
-      })
-      .toEqual({ count: 7, finiteTimestamps: 7 });
+  await applySlidesPayload(page, {
+    sourceUrl: "https://www.youtube.com/watch?v=helia123",
+    sourceId: "youtube-helia123",
+    sourceKind: "youtube",
+    ocrAvailable: false,
+    slides: [
+      { index: 1, timestamp: 2, imageUrl: "", ocrText: null },
+      { index: 2, timestamp: 63, imageUrl: "", ocrText: null },
+    ],
+  });
 
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(2);
+
+  await applySlidesPayload(
+    page,
+    buildSlidesPayload({
+      sourceUrl: "https://www.youtube.com/watch?v=helia123",
+      sourceId: "youtube-helia123",
+      count: 1,
+      textPrefix: "Final",
+    }),
+  );
+
+  await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(1);
+  await expect(page.locator("img.slideStrip__thumbImage, img.slideInline__thumbImage")).toHaveCount(
+    1,
+  );
+  await expect(
+    page.locator(
+      'img.slideStrip__thumbImage[data-loaded="true"], img.slideInline__thumbImage[data-loaded="true"]',
+    ),
+  ).toHaveCount(1);
+  const slides = await getPanelSlideDescriptions(page);
+  expect(slides[0]?.[1] ?? "").toContain("Final slide 1");
 });
 
-test("sidepanel does not reseed planned slides over resolved direct video slides", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel shows planned slide placeholders before daemon slides arrive", async ({
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await waitForSlidesRuntimeHooks(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
+  await page.route("http://127.0.0.1:8787/v1/summarize/planned-run/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: [
+        "event: status",
+        `data: ${JSON.stringify({ text: "Slides: downloading video 8%" })}`,
+        "",
+        "event: chunk",
+        `data: ${JSON.stringify({ text: "Transcript summary arrives before slide images." })}`,
+        "",
+        "event: done",
+        "data: {}",
+        "",
+      ].join("\n"),
     });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await waitForSlidesRuntimeHooks(page);
-
-    await page.route("http://127.0.0.1:8787/v1/summarize/direct-run/events", async (route) => {
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/planned-run/slides", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: false, error: "not ready" }),
+    });
+  });
+  await page.route(
+    "http://127.0.0.1:8787/v1/summarize/planned-run/slides/events",
+    async (route) => {
       await route.fulfill({
         status: 200,
         headers: { "content-type": "text/event-stream" },
@@ -262,37 +142,20 @@ test("sidepanel does not reseed planned slides over resolved direct video slides
           "event: status",
           `data: ${JSON.stringify({ text: "Slides: downloading video 8%" })}`,
           "",
-          "event: chunk",
-          `data: ${JSON.stringify({ text: "Direct video summary." })}`,
-          "",
           "event: done",
           "data: {}",
           "",
         ].join("\n"),
       });
-    });
-    await page.route("http://127.0.0.1:8787/v1/summarize/direct-run/slides", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ok: false, error: "not ready" }),
-      });
-    });
-    await page.route(
-      "http://127.0.0.1:8787/v1/summarize/direct-run/slides/events",
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-          body: ["event: done", "data: {}", ""].join("\n"),
-        });
-      },
-    );
+    },
+  );
 
-    const targetUrl = "https://cdn.example.com/video.mp4";
-    const stateWithoutDuration = buildUiState({
-      tab: { id: 1, url: targetUrl, title: "Direct Video" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: false },
+  const targetUrl = "https://www.youtube.com/watch?v=planned123";
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: { id: 1, url: targetUrl, title: "Planned Video" },
+      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
       stats: { pageWords: 0, videoDurationSeconds: null },
       settings: {
         autoSummarize: false,
@@ -301,374 +164,404 @@ test("sidepanel does not reseed planned slides over resolved direct video slides
         slidesOcrEnabled: true,
         tokenPresent: true,
       },
+    }),
+  });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "planned-run",
+      url: targetUrl,
+      title: "Planned Video",
+      model: "auto",
+      reason: "manual",
+      slides: true,
+    },
+  });
+
+  await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(6);
+  await expect(page.locator(".renderEmpty")).toHaveCount(0);
+  await expect(page.locator(".slideGallery__item")).toHaveCount(6);
+  await expect(page.locator("#render")).not.toContainText("Preparing summary");
+
+  const durationState = buildUiState({
+    tab: { id: 1, url: targetUrl, title: "Planned Video" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+    stats: { pageWords: 0, videoDurationSeconds: 1200 },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: durationState,
+  });
+
+  await expect
+    .poll(async () => {
+      const timeline = await getPanelSlidesTimeline(page);
+      return {
+        count: timeline.length,
+        finiteTimestamps: timeline.filter((slide) => slide.timestamp !== null).length,
+      };
+    })
+    .toEqual({ count: 7, finiteTimestamps: 7 });
+});
+
+test("sidepanel does not reseed planned slides over resolved direct video slides", async ({
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await waitForSlidesRuntimeHooks(page);
+
+  await page.route("http://127.0.0.1:8787/v1/summarize/direct-run/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: [
+        "event: status",
+        `data: ${JSON.stringify({ text: "Slides: downloading video 8%" })}`,
+        "",
+        "event: chunk",
+        `data: ${JSON.stringify({ text: "Direct video summary." })}`,
+        "",
+        "event: done",
+        "data: {}",
+        "",
+      ].join("\n"),
     });
-    await sendBgMessage(harness, { type: "ui:state", state: stateWithoutDuration });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "direct-run",
-        url: targetUrl,
-        title: "Direct Video",
-        model: "auto",
-        reason: "manual",
-        slides: true,
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/direct-run/slides", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: false, error: "not ready" }),
+    });
+  });
+  await page.route("http://127.0.0.1:8787/v1/summarize/direct-run/slides/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ["event: done", "data: {}", ""].join("\n"),
+    });
+  });
+
+  const targetUrl = "https://cdn.example.com/video.mp4";
+  const stateWithoutDuration = buildUiState({
+    tab: { id: 1, url: targetUrl, title: "Direct Video" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: false },
+    stats: { pageWords: 0, videoDurationSeconds: null },
+    settings: {
+      autoSummarize: false,
+      slidesEnabled: true,
+      slidesParallel: true,
+      slidesOcrEnabled: true,
+      tokenPresent: true,
+    },
+  });
+  await sendBgMessage(harness, { type: "ui:state", state: stateWithoutDuration });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "direct-run",
+      url: targetUrl,
+      title: "Direct Video",
+      model: "auto",
+      reason: "manual",
+      slides: true,
+    },
+  });
+
+  await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(6);
+  await routePlaceholderSlideImages(page);
+
+  await applySlidesPayload(page, {
+    sourceUrl: targetUrl,
+    sourceId: "cdn-example-video-deadbeef",
+    sourceKind: "direct",
+    ocrAvailable: false,
+    slides: [
+      {
+        index: 1,
+        timestamp: 12,
+        imageUrl: "http://127.0.0.1:8787/v1/slides/cdn-example-video-deadbeef/1?v=1",
+        ocrText: null,
+        ocrConfidence: null,
       },
-    });
+    ],
+  });
 
-    await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(6);
-    await routePlaceholderSlideImages(page);
-
-    await applySlidesPayload(page, {
-      sourceUrl: targetUrl,
-      sourceId: "cdn-example-video-deadbeef",
-      sourceKind: "direct",
-      ocrAvailable: false,
-      slides: [
-        {
-          index: 1,
-          timestamp: 12,
-          imageUrl: "http://127.0.0.1:8787/v1/slides/cdn-example-video-deadbeef/1?v=1",
-          ocrText: null,
-          ocrConfidence: null,
-        },
-      ],
-    });
-
-    await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(1);
-    await sendBgMessage(harness, { type: "ui:state", state: stateWithoutDuration });
-    await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(1);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(1);
+  await sendBgMessage(harness, { type: "ui:state", state: stateWithoutDuration });
+  await expect.poll(async () => (await getPanelSlidesTimeline(page)).length).toBe(1);
 });
 
 test("sidepanel shows gallery before intro and hides gallery heading in slide mode", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+    slidesLayout: "strip",
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await waitForSlidesRuntimeHooks(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
-      slidesLayout: "strip",
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await waitForSlidesRuntimeHooks(page);
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: {
+        id: 1,
+        url: "https://www.youtube.com/watch?v=heliafast",
+        title: "Helia Video",
+      },
+      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+      stats: { pageWords: 120, videoDurationSeconds: 120 },
+      settings: {
+        autoSummarize: false,
+        slidesEnabled: true,
+        slidesParallel: true,
+        slidesOcrEnabled: true,
+        slidesLayout: "strip",
+        tokenPresent: true,
+      },
+    }),
+  });
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: {
-          id: 1,
-          url: "https://www.youtube.com/watch?v=heliafast",
-          title: "Helia Video",
-        },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        stats: { pageWords: 120, videoDurationSeconds: 120 },
-        settings: {
-          autoSummarize: false,
-          slidesEnabled: true,
-          slidesParallel: true,
-          slidesOcrEnabled: true,
-          slidesLayout: "strip",
-          tokenPresent: true,
-        },
-      }),
-    });
+  await applySlidesPayload(page, {
+    sourceUrl: "https://www.youtube.com/watch?v=heliafast",
+    sourceId: "youtube-heliafast",
+    sourceKind: "youtube",
+    ocrAvailable: false,
+    slides: [
+      { index: 1, timestamp: 2, imageUrl: "", ocrText: "Helia returns to command." },
+      { index: 2, timestamp: 60, imageUrl: "", ocrText: null },
+    ],
+  });
 
-    await applySlidesPayload(page, {
-      sourceUrl: "https://www.youtube.com/watch?v=heliafast",
-      sourceId: "youtube-heliafast",
-      sourceKind: "youtube",
-      ocrAvailable: false,
-      slides: [
-        { index: 1, timestamp: 2, imageUrl: "", ocrText: "Helia returns to command." },
-        { index: 2, timestamp: 60, imageUrl: "", ocrText: null },
-      ],
-    });
+  await expect
+    .poll(async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"), {
+      timeout: 10_000,
+    })
+    .toContain("Helia returns to command.");
+  await page.evaluate(() => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: { forceRenderSlides?: () => number };
+      }
+    ).__summarizeTestHooks;
+    hooks?.forceRenderSlides?.();
+  });
+  await expect(page.locator(".slideGallery")).toHaveCount(1);
+  await expect(page.locator(".slideStrip")).toHaveCount(0);
 
-    await expect
-      .poll(
-        async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"),
-        { timeout: 10_000 },
-      )
-      .toContain("Helia returns to command.");
-    await page.evaluate(() => {
-      const hooks = (
-        window as typeof globalThis & {
-          __summarizeTestHooks?: { forceRenderSlides?: () => number };
-        }
-      ).__summarizeTestHooks;
-      hooks?.forceRenderSlides?.();
-    });
-    await expect(page.locator(".slideGallery")).toHaveCount(1);
-    await expect(page.locator(".slideStrip")).toHaveCount(0);
+  await page.evaluate((markdown) => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: {
+          applySummaryMarkdown?: (value: string) => void;
+        };
+      }
+    ).__summarizeTestHooks;
+    hooks?.applySummaryMarkdown?.(markdown);
+  }, "Overall summary that should stay hidden in slide mode.");
 
-    await page.evaluate((markdown) => {
-      const hooks = (
-        window as typeof globalThis & {
-          __summarizeTestHooks?: {
-            applySummaryMarkdown?: (value: string) => void;
-          };
-        }
-      ).__summarizeTestHooks;
-      hooks?.applySummaryMarkdown?.(markdown);
-    }, "Overall summary that should stay hidden in slide mode.");
+  await expect(page.locator("#render")).not.toContainText(
+    "Overall summary that should stay hidden in slide mode.",
+  );
 
-    await expect(page.locator("#render")).not.toContainText(
-      "Overall summary that should stay hidden in slide mode.",
-    );
+  await page.evaluate((markdown) => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: {
+          applySummaryMarkdown?: (value: string) => void;
+          forceRenderSlides?: () => number;
+        };
+      }
+    ).__summarizeTestHooks;
+    hooks?.applySummaryMarkdown?.(markdown);
+    hooks?.forceRenderSlides?.();
+  }, ["Intro before the first slide.", "", "[slide:1]", "## First card", "First card body.", "", "[slide:2]", "## Second card", "Second card body."].join("\n"));
 
-    await page.evaluate((markdown) => {
-      const hooks = (
-        window as typeof globalThis & {
-          __summarizeTestHooks?: {
-            applySummaryMarkdown?: (value: string) => void;
-            forceRenderSlides?: () => number;
-          };
-        }
-      ).__summarizeTestHooks;
-      hooks?.applySummaryMarkdown?.(markdown);
-      hooks?.forceRenderSlides?.();
-    }, ["Intro before the first slide.", "", "[slide:1]", "## First card", "First card body.", "", "[slide:2]", "## Second card", "Second card body."].join("\n"));
+  await expect(page.locator(".render__markdownHost")).toContainText(
+    "Intro before the first slide.",
+  );
+  await expect(page.locator("#render")).not.toContainText("Slides (2)");
+  await expect(page.locator(".slideGallery__title")).toHaveCount(0);
+  const renderOrder = await page
+    .locator("#render")
+    .evaluate((el) => Array.from(el.children).map((child) => child.className));
+  expect(renderOrder).toEqual(["render__slidesHost", "render__markdownHost"]);
 
-    await expect(page.locator(".render__markdownHost")).toContainText(
-      "Intro before the first slide.",
-    );
-    await expect(page.locator("#render")).not.toContainText("Slides (2)");
-    await expect(page.locator(".slideGallery__title")).toHaveCount(0);
-    const renderOrder = await page
-      .locator("#render")
-      .evaluate((el) => Array.from(el.children).map((child) => child.className));
-    expect(renderOrder).toEqual(["render__slidesHost", "render__markdownHost"]);
-
-    await expect(
-      page.locator(
-        'img.slideStrip__thumbImage[data-loaded="true"], img.slideInline__thumbImage[data-loaded="true"]',
-      ),
-    ).toHaveCount(0);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect(
+    page.locator(
+      'img.slideStrip__thumbImage[data-loaded="true"], img.slideInline__thumbImage[data-loaded="true"]',
+    ),
+  ).toHaveCount(0);
 });
 
 test("sidepanel replaces partial slide-stream fragments with the final slide summary", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+    slidesLayout: "gallery",
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await waitForSlidesRuntimeHooks(page);
+  await waitForTranscriptTimedTextHook(page);
+  await routePlaceholderSlideImages(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
-      slidesLayout: "gallery",
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await waitForSlidesRuntimeHooks(page);
-    await waitForTranscriptTimedTextHook(page);
-    await routePlaceholderSlideImages(page);
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: {
+        id: 1,
+        url: "https://www.youtube.com/watch?v=delenn123",
+        title: "Delenn Explains",
+      },
+      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+      settings: {
+        autoSummarize: false,
+        slidesEnabled: true,
+        slidesParallel: true,
+        slidesOcrEnabled: true,
+        slidesLayout: "gallery",
+        tokenPresent: true,
+      },
+    }),
+  });
 
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: {
-          id: 1,
-          url: "https://www.youtube.com/watch?v=delenn123",
-          title: "Delenn Explains",
-        },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        settings: {
-          autoSummarize: false,
-          slidesEnabled: true,
-          slidesParallel: true,
-          slidesOcrEnabled: true,
-          slidesLayout: "gallery",
-          tokenPresent: true,
-        },
-      }),
-    });
+  await applySlidesPayload(page, {
+    sourceUrl: "https://www.youtube.com/watch?v=delenn123",
+    sourceId: "youtube-delenn123",
+    sourceKind: "youtube",
+    ocrAvailable: false,
+    slides: [
+      { index: 1, timestamp: 3, imageUrl: "", ocrText: null },
+      { index: 2, timestamp: 47, imageUrl: "", ocrText: null },
+    ],
+  });
+  await page.evaluate(() => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: {
+          setTranscriptTimedText?: (value: string | null) => void;
+          applySlidesSummaryMarkdown?: (markdown: string) => void;
+          forceRenderSlides?: () => number | void;
+        };
+      }
+    ).__summarizeTestHooks;
+    hooks?.setTranscriptTimedText?.(
+      "[00:03] Raw transcript line that must not remain visible.\n[00:47] More raw transcript that should be replaced.",
+    );
+    hooks?.applySlidesSummaryMarkdown?.("[slide:1]\n##");
+    hooks?.forceRenderSlides?.();
+  });
 
-    await applySlidesPayload(page, {
-      sourceUrl: "https://www.youtube.com/watch?v=delenn123",
-      sourceId: "youtube-delenn123",
-      sourceKind: "youtube",
-      ocrAvailable: false,
-      slides: [
-        { index: 1, timestamp: 3, imageUrl: "", ocrText: null },
-        { index: 2, timestamp: 47, imageUrl: "", ocrText: null },
-      ],
-    });
-    await page.evaluate(() => {
-      const hooks = (
-        window as typeof globalThis & {
-          __summarizeTestHooks?: {
-            setTranscriptTimedText?: (value: string | null) => void;
-            applySlidesSummaryMarkdown?: (markdown: string) => void;
-            forceRenderSlides?: () => number | void;
-          };
-        }
-      ).__summarizeTestHooks;
-      hooks?.setTranscriptTimedText?.(
-        "[00:03] Raw transcript line that must not remain visible.\n[00:47] More raw transcript that should be replaced.",
-      );
-      hooks?.applySlidesSummaryMarkdown?.("[slide:1]\n##");
-      hooks?.forceRenderSlides?.();
-    });
+  await expect
+    .poll(async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"), {
+      timeout: 10_000,
+    })
+    .toContain("Raw transcript line");
 
-    await expect
-      .poll(
-        async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"),
-        { timeout: 10_000 },
-      )
-      .toContain("Raw transcript line");
+  await page.evaluate((markdown) => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: {
+          applySummaryMarkdown?: (value: string) => void;
+          forceRenderSlides?: () => number | void;
+        };
+      }
+    ).__summarizeTestHooks;
+    hooks?.applySummaryMarkdown?.(markdown);
+    hooks?.forceRenderSlides?.();
+  }, ["A compact scene summary.", "", "[slide:1]", "## Ancient enemy returns", "Delenn explains that the Shadows are an ancient enemy returning after millennia.", "", "[slide:2]", "## Kosh's hidden identity", "Kosh is framed as the remaining guardian watching for signs of the Shadows."].join("\n"));
 
-    await page.evaluate((markdown) => {
-      const hooks = (
-        window as typeof globalThis & {
-          __summarizeTestHooks?: {
-            applySummaryMarkdown?: (value: string) => void;
-            forceRenderSlides?: () => number | void;
-          };
-        }
-      ).__summarizeTestHooks;
-      hooks?.applySummaryMarkdown?.(markdown);
-      hooks?.forceRenderSlides?.();
-    }, ["A compact scene summary.", "", "[slide:1]", "## Ancient enemy returns", "Delenn explains that the Shadows are an ancient enemy returning after millennia.", "", "[slide:2]", "## Kosh's hidden identity", "Kosh is framed as the remaining guardian watching for signs of the Shadows."].join("\n"));
-
-    await expect
-      .poll(
-        async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"),
-        { timeout: 10_000 },
-      )
-      .toContain("ancient enemy returning");
-    const slides = await getPanelSlideDescriptions(page);
-    expect(slides[0]?.[1] ?? "").not.toBe("##");
-    expect(slides.some(([, text]) => text.includes("Raw transcript"))).toBe(false);
-    expect(slides[1]?.[1] ?? "").toContain("remaining guardian");
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  await expect
+    .poll(async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"), {
+      timeout: 10_000,
+    })
+    .toContain("ancient enemy returning");
+  const slides = await getPanelSlideDescriptions(page);
+  expect(slides[0]?.[1] ?? "").not.toBe("##");
+  expect(slides.some(([, text]) => text.includes("Raw transcript"))).toBe(false);
+  expect(slides[1]?.[1] ?? "").toContain("remaining guardian");
 });
 
 test("sidepanel applies existing summary text when local slides arrive after the summary", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+  harness,
+}) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesParallel: true,
+    slidesOcrEnabled: true,
+    slidesLayout: "gallery",
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
+  await waitForSlidesRuntimeHooks(page);
+  await waitForTranscriptTimedTextHook(page);
+  await routePlaceholderSlideImages(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
-      autoSummarize: false,
-      slidesEnabled: true,
-      slidesParallel: true,
-      slidesOcrEnabled: true,
-      slidesLayout: "gallery",
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
-    await waitForSlidesRuntimeHooks(page);
-    await waitForTranscriptTimedTextHook(page);
-    await routePlaceholderSlideImages(page);
-
-    const targetUrl = "https://www.youtube.com/watch?v=localrace123";
-    await sendBgMessage(harness, {
-      type: "ui:state",
-      state: buildUiState({
-        tab: {
-          id: 1,
-          url: targetUrl,
-          title: "Local Race Video",
-        },
-        media: { hasVideo: true, hasAudio: true, hasCaptions: true },
-        settings: {
-          autoSummarize: false,
-          slidesEnabled: true,
-          slidesParallel: true,
-          slidesOcrEnabled: true,
-          slidesLayout: "gallery",
-          tokenPresent: true,
-        },
-      }),
-    });
-
-    await page.evaluate((markdown) => {
-      const hooks = (
-        window as typeof globalThis & {
-          __summarizeTestHooks?: {
-            applySummaryMarkdown?: (value: string) => void;
-            setTranscriptTimedText?: (value: string | null) => void;
-          };
-        }
-      ).__summarizeTestHooks;
-      hooks?.setTranscriptTimedText?.(
-        [
-          "[00:00] raw transcript one should not become the slide card copy.",
-          "[01:03] raw transcript two should not become the slide card copy.",
-          "[02:07] raw transcript three should not become the slide card copy.",
-          "[03:05] raw transcript four should not become the slide card copy.",
-          "[04:12] raw transcript five should not become the slide card copy.",
-          "[05:01] raw transcript six should not become the slide card copy.",
-        ].join("\n"),
-      );
-      hooks?.applySummaryMarkdown?.(markdown);
-    }, ["This scene contrasts the family's chaotic defensiveness with Dr. Wong's calm patience.", "", "Rick arrives transformed and uses the spectacle to dodge emotional accountability.", "", "Dr. Wong reframes the room as a place for boring, repetitive repair rather than heroics."].join("\n"));
-
-    await page.route("http://127.0.0.1:8787/v1/summarize/localrace-run/events", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-        body: ["event: done", "data: {}", ""].join("\n"),
-      });
-    });
-    await sendBgMessage(harness, {
-      type: "run:start",
-      run: {
-        id: "localrace-run",
+  const targetUrl = "https://www.youtube.com/watch?v=localrace123";
+  await sendBgMessage(harness, {
+    type: "ui:state",
+    state: buildUiState({
+      tab: {
+        id: 1,
         url: targetUrl,
         title: "Local Race Video",
-        model: "auto",
-        reason: "manual",
-        slides: false,
       },
-    });
-    await expect.poll(async () => await getPanelSummaryMarkdown(page)).toBe("");
-    await expect
-      .poll(async () =>
-        page.evaluate(() => {
-          const hooks = (
-            window as typeof globalThis & {
-              __summarizeTestHooks?: { getRetainedSlideSummaryMarkdown?: () => string };
-            }
-          ).__summarizeTestHooks;
-          return hooks?.getRetainedSlideSummaryMarkdown?.() ?? "";
-        }),
-      )
-      .toContain("transformed and uses the spectacle");
+      media: { hasVideo: true, hasAudio: true, hasCaptions: true },
+      settings: {
+        autoSummarize: false,
+        slidesEnabled: true,
+        slidesParallel: true,
+        slidesOcrEnabled: true,
+        slidesLayout: "gallery",
+        tokenPresent: true,
+      },
+    }),
+  });
 
-    await applySlidesPayload(page, {
-      sourceUrl: targetUrl,
-      sourceId: "youtube-localrace123",
-      sourceKind: "youtube",
-      ocrAvailable: false,
-      transcriptTimedText: [
+  await page.evaluate((markdown) => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: {
+          applySummaryMarkdown?: (value: string) => void;
+          setTranscriptTimedText?: (value: string | null) => void;
+        };
+      }
+    ).__summarizeTestHooks;
+    hooks?.setTranscriptTimedText?.(
+      [
         "[00:00] raw transcript one should not become the slide card copy.",
         "[01:03] raw transcript two should not become the slide card copy.",
         "[02:07] raw transcript three should not become the slide card copy.",
@@ -676,151 +569,184 @@ test("sidepanel applies existing summary text when local slides arrive after the
         "[04:12] raw transcript five should not become the slide card copy.",
         "[05:01] raw transcript six should not become the slide card copy.",
       ].join("\n"),
-      slides: [
-        { index: 1, timestamp: 0, imageUrl: "", ocrText: null },
-        { index: 2, timestamp: 63, imageUrl: "", ocrText: null },
-        { index: 3, timestamp: 127, imageUrl: "", ocrText: null },
-        { index: 4, timestamp: 185, imageUrl: "", ocrText: null },
-        { index: 5, timestamp: 252, imageUrl: "", ocrText: null },
-        { index: 6, timestamp: 301, imageUrl: "", ocrText: null },
-      ],
+    );
+    hooks?.applySummaryMarkdown?.(markdown);
+  }, ["This scene contrasts the family's chaotic defensiveness with Dr. Wong's calm patience.", "", "Rick arrives transformed and uses the spectacle to dodge emotional accountability.", "", "Dr. Wong reframes the room as a place for boring, repetitive repair rather than heroics."].join("\n"));
+
+  await page.route("http://127.0.0.1:8787/v1/summarize/localrace-run/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ["event: done", "data: {}", ""].join("\n"),
     });
+  });
+  await sendBgMessage(harness, {
+    type: "run:start",
+    run: {
+      id: "localrace-run",
+      url: targetUrl,
+      title: "Local Race Video",
+      model: "auto",
+      reason: "manual",
+      slides: false,
+    },
+  });
+  await expect.poll(async () => await getPanelSummaryMarkdown(page)).toBe("");
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const hooks = (
+          window as typeof globalThis & {
+            __summarizeTestHooks?: { getRetainedSlideSummaryMarkdown?: () => string };
+          }
+        ).__summarizeTestHooks;
+        return hooks?.getRetainedSlideSummaryMarkdown?.() ?? "";
+      }),
+    )
+    .toContain("transformed and uses the spectacle");
 
-    await expect
-      .poll(
-        async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"),
-        { timeout: 10_000 },
-      )
-      .toContain("transformed and uses the spectacle");
+  await applySlidesPayload(page, {
+    sourceUrl: targetUrl,
+    sourceId: "youtube-localrace123",
+    sourceKind: "youtube",
+    ocrAvailable: false,
+    transcriptTimedText: [
+      "[00:00] raw transcript one should not become the slide card copy.",
+      "[01:03] raw transcript two should not become the slide card copy.",
+      "[02:07] raw transcript three should not become the slide card copy.",
+      "[03:05] raw transcript four should not become the slide card copy.",
+      "[04:12] raw transcript five should not become the slide card copy.",
+      "[05:01] raw transcript six should not become the slide card copy.",
+    ].join("\n"),
+    slides: [
+      { index: 1, timestamp: 0, imageUrl: "", ocrText: null },
+      { index: 2, timestamp: 63, imageUrl: "", ocrText: null },
+      { index: 3, timestamp: 127, imageUrl: "", ocrText: null },
+      { index: 4, timestamp: 185, imageUrl: "", ocrText: null },
+      { index: 5, timestamp: 252, imageUrl: "", ocrText: null },
+      { index: 6, timestamp: 301, imageUrl: "", ocrText: null },
+    ],
+  });
 
-    const slides = await getPanelSlideDescriptions(page);
-    expect(slides).toHaveLength(6);
-    expect(slides.some(([, text]) => text.includes("raw transcript"))).toBe(false);
-    expect(slides[0]?.[1] ?? "").toContain("chaotic defensiveness");
-    expect(slides[1]?.[1] ?? "").toContain("chaotic defensiveness");
-    expect(slides[2]?.[1] ?? "").toContain("transformed and uses the spectacle");
-    expect(slides[4]?.[1] ?? "").toContain("boring, repetitive repair");
+  await expect
+    .poll(async () => (await getPanelSlideDescriptions(page)).map(([, text]) => text).join("\n"), {
+      timeout: 10_000,
+    })
+    .toContain("transformed and uses the spectacle");
 
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const slides = await getPanelSlideDescriptions(page);
+  expect(slides).toHaveLength(6);
+  expect(slides.some(([, text]) => text.includes("raw transcript"))).toBe(false);
+  expect(slides[0]?.[1] ?? "").toContain("chaotic defensiveness");
+  expect(slides[1]?.[1] ?? "").toContain("chaotic defensiveness");
+  expect(slides[2]?.[1] ?? "").toContain("transformed and uses the spectacle");
+  expect(slides[4]?.[1] ?? "").toContain("boring, repetitive repair");
 });
 
-test("sidepanel scrolls YouTube slides and shows text for each slide", async ({
-  browserName: _browserName,
-}, testInfo) => {
-  const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
+test("sidepanel scrolls YouTube slides and shows text for each slide", async ({ harness }) => {
+  await seedSettings(harness, {
+    token: "test-token",
+    autoSummarize: false,
+    slidesEnabled: true,
+    slidesLayout: "gallery",
+    slidesOcrEnabled: true,
+  });
+  const page = await openExtensionPage(harness, "sidepanel.html", "#title");
+  await waitForPanelPort(page);
+  await waitForSettingsHydratedHook(page);
 
-  try {
-    await seedSettings(harness, {
-      token: "test-token",
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
+    "base64",
+  );
+  await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "x-summarize-slide-ready": "1",
+      },
+      body: placeholderPng,
+    });
+  });
+
+  const sourceUrl = "https://www.youtube.com/watch?v=scrollTest123";
+  const uiState = buildUiState({
+    tab: { id: 1, url: sourceUrl, title: "Scroll Test" },
+    media: { hasVideo: true, hasAudio: true, hasCaptions: false },
+    stats: { pageWords: 120, videoDurationSeconds: 600 },
+    settings: {
       autoSummarize: false,
       slidesEnabled: true,
-      slidesLayout: "gallery",
       slidesOcrEnabled: true,
-    });
-    const page = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await waitForPanelPort(page);
-    await waitForSettingsHydratedHook(page);
+      slidesLayout: "gallery",
+      tokenPresent: true,
+    },
+    status: "",
+  });
+  await sendBgMessage(harness, { type: "ui:state", state: uiState });
 
-    const placeholderPng = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3kq0cAAAAASUVORK5CYII=",
-      "base64",
-    );
-    await page.route("http://127.0.0.1:8787/v1/slides/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "content-type": "image/png",
-          "x-summarize-slide-ready": "1",
-        },
-        body: placeholderPng,
-      });
-    });
+  await waitForApplySlidesHook(page);
 
-    const sourceUrl = "https://www.youtube.com/watch?v=scrollTest123";
-    const uiState = buildUiState({
-      tab: { id: 1, url: sourceUrl, title: "Scroll Test" },
-      media: { hasVideo: true, hasAudio: true, hasCaptions: false },
-      stats: { pageWords: 120, videoDurationSeconds: 600 },
-      settings: {
-        autoSummarize: false,
-        slidesEnabled: true,
-        slidesOcrEnabled: true,
-        slidesLayout: "gallery",
-        tokenPresent: true,
-      },
-      status: "",
-    });
-    await sendBgMessage(harness, { type: "ui:state", state: uiState });
+  const slidesPayload = buildSlidesPayload({
+    sourceUrl,
+    sourceId: "yt-scroll",
+    count: 12,
+    textPrefix: "YouTube",
+  });
+  await page.evaluate((payload) => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: {
+          applySlidesPayload?: (payload: unknown) => void;
+        };
+      }
+    ).__summarizeTestHooks;
+    hooks?.applySlidesPayload?.(payload);
+  }, slidesPayload);
 
-    await waitForApplySlidesHook(page);
+  await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(12);
+  const renderedCount = await page.evaluate(() => {
+    const hooks = (
+      window as typeof globalThis & {
+        __summarizeTestHooks?: { forceRenderSlides?: () => number };
+      }
+    ).__summarizeTestHooks;
+    return hooks?.forceRenderSlides?.() ?? 0;
+  });
+  expect(renderedCount).toBeGreaterThan(0);
 
-    const slidesPayload = buildSlidesPayload({
-      sourceUrl,
-      sourceId: "yt-scroll",
-      count: 12,
-      textPrefix: "YouTube",
-    });
-    await page.evaluate((payload) => {
-      const hooks = (
-        window as typeof globalThis & {
-          __summarizeTestHooks?: {
-            applySlidesPayload?: (payload: unknown) => void;
-          };
-        }
-      ).__summarizeTestHooks;
-      hooks?.applySlidesPayload?.(payload);
-    }, slidesPayload);
+  const slideItems = page.locator(".slideGallery__item");
+  await expect(slideItems).toHaveCount(12);
 
-    await expect.poll(async () => (await getPanelSlideDescriptions(page)).length).toBe(12);
-    const renderedCount = await page.evaluate(() => {
-      const hooks = (
-        window as typeof globalThis & {
-          __summarizeTestHooks?: { forceRenderSlides?: () => number };
-        }
-      ).__summarizeTestHooks;
-      return hooks?.forceRenderSlides?.() ?? 0;
-    });
-    expect(renderedCount).toBeGreaterThan(0);
+  const galleryList = page.locator(".slideGallery__list");
+  await expect(galleryList).toBeVisible();
+  await galleryList.evaluate((node) => {
+    node.scrollTop = node.scrollHeight;
+  });
+  await expect(slideItems.nth(11)).toBeVisible();
 
-    const slideItems = page.locator(".slideGallery__item");
-    await expect(slideItems).toHaveCount(12);
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        Array.from(
+          document.querySelectorAll<HTMLImageElement>("img.slideInline__thumbImage"),
+        ).every((img) => (img.dataset.slideImageUrl ?? "").trim().length > 0),
+      ),
+    )
+    .toBe(true);
 
-    const galleryList = page.locator(".slideGallery__list");
-    await expect(galleryList).toBeVisible();
-    await galleryList.evaluate((node) => {
-      node.scrollTop = node.scrollHeight;
-    });
-    await expect(slideItems.nth(11)).toBeVisible();
-
-    await expect
-      .poll(async () =>
-        page.evaluate(() =>
-          Array.from(
-            document.querySelectorAll<HTMLImageElement>("img.slideInline__thumbImage"),
-          ).every((img) => (img.dataset.slideImageUrl ?? "").trim().length > 0),
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        Array.from(document.querySelectorAll<HTMLElement>(".slideGallery__text")).every(
+          (el) => (el.textContent ?? "").trim().length > 0,
         ),
-      )
-      .toBe(true);
+      ),
+    )
+    .toBe(true);
 
-    await expect
-      .poll(async () =>
-        page.evaluate(() =>
-          Array.from(document.querySelectorAll<HTMLElement>(".slideGallery__text")).every(
-            (el) => (el.textContent ?? "").trim().length > 0,
-          ),
-        ),
-      )
-      .toBe(true);
-
-    const slideDescriptions = await getPanelSlideDescriptions(page);
-    expect(slideDescriptions).toHaveLength(12);
-    expect(slideDescriptions.every(([, text]) => text.trim().length > 0)).toBe(true);
-
-    assertNoErrors(harness);
-  } finally {
-    await closeExtension(harness.context, harness.userDataDir);
-  }
+  const slideDescriptions = await getPanelSlideDescriptions(page);
+  expect(slideDescriptions).toHaveLength(12);
+  expect(slideDescriptions.every(([, text]) => text.trim().length > 0)).toBe(true);
 });

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -90,6 +90,8 @@ Dev (repo checkout):
 
 ## Architecture
 
+The sidepanel owns one plain `PanelState` object. Simple fields update directly; phase, run attachment, restoration, and reset use named transitions in `panel-state-store.ts`. Nested-slice updates replace the slice so previously captured navigation/chat/slide snapshots remain unchanged. There is no secondary action bus or optional dispatch path.
+
 - **Extension (MV3, WXT)**
   - Side Panel UI: length + typography controls (font family + size), auto/manual toggle.
   - Background service worker: tab + navigation tracking, content extraction, starts summarize runs.

--- a/tests/cli-main.integration.test.ts
+++ b/tests/cli-main.integration.test.ts
@@ -1,20 +1,9 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { runCliMain } from "../src/cli-main.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 async function run(argv: string[]) {
   const stdout = collectStream();

--- a/tests/cli.asset.audio-file-errors.test.ts
+++ b/tests/cli.asset.audio-file-errors.test.ts
@@ -1,15 +1,14 @@
+import { mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 /**
  * Phase 4.5: Error scenario tests for media file transcription
  * Tests edge cases and error conditions to ensure robust error handling
  */
-
-import { mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),
@@ -34,18 +33,6 @@ vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   getModel: mocks.getModel,
 }));
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-
-  return { stream, getText: () => text };
-}
 
 describe("Media file error handling", () => {
   it("handles non-existent audio files gracefully", async () => {

--- a/tests/cli.asset.audio-file.test.ts
+++ b/tests/cli.asset.audio-file.test.ts
@@ -1,21 +1,10 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.asset.local-file.test.ts
+++ b/tests/cli.asset.local-file.test.ts
@@ -2,22 +2,11 @@ import type { ChildProcess } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import type { ExecFileFn } from "../src/markitdown.js";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.asset.local-pdf-extract.test.ts
+++ b/tests/cli.asset.local-pdf-extract.test.ts
@@ -2,21 +2,10 @@ import type { ChildProcess } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import type { ExecFileFn } from "../src/markitdown.js";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.asset.local-pdf-ocr-fallback.test.ts
+++ b/tests/cli.asset.local-pdf-ocr-fallback.test.ts
@@ -2,22 +2,11 @@ import type { ChildProcess } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import type { ExecFileFn } from "../src/markitdown.js";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.asset.media-api-key.test.ts
+++ b/tests/cli.asset.media-api-key.test.ts
@@ -1,21 +1,13 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import type { createUrlExtractionSession as createUrlExtractionSessionType } from "../src/run/flows/url/extraction-session.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+import { discardStream as noopStream } from "./helpers/streams.js";
 
 type CreateUrlExtractionSessionArgs = Parameters<typeof createUrlExtractionSessionType>[0];
-
-function noopStream(): Writable {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
 
 type CapturedCtx = {
   model: {

--- a/tests/cli.asset.media-path-cache.test.ts
+++ b/tests/cli.asset.media-path-cache.test.ts
@@ -1,9 +1,9 @@
 import { mkdirSync, mkdtempSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const createLinkPreviewClient = vi.hoisted(() => vi.fn());
 const fetchLinkContent = vi.hoisted(() => vi.fn());
@@ -14,17 +14,6 @@ vi.mock("../src/content/index.js", () => ({
 }));
 
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("cli media file path and cache wiring", () => {
   beforeEach(() => {

--- a/tests/cli.asset.unsupported.test.ts
+++ b/tests/cli.asset.unsupported.test.ts
@@ -1,17 +1,10 @@
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
+import { discardStream as noopStream } from "./helpers/streams.js";
 
-function noopStream() {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),
   completeSimple: vi.fn(),

--- a/tests/cli.auto.fallback.test.ts
+++ b/tests/cli.auto.fallback.test.ts
@@ -6,6 +6,7 @@ import type { Api } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage } from "./helpers/pi-ai-mock.js";
+import { discardStream as noopStream } from "./helpers/streams.js";
 
 type MockModel = { provider: string; id: string; api: Api };
 
@@ -32,14 +33,6 @@ vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));
-
-function noopStream(): Writable {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
 
 function collectStdout() {
   let text = "";

--- a/tests/cli.auto.no-model-footer.test.ts
+++ b/tests/cli.auto.no-model-footer.test.ts
@@ -1,20 +1,9 @@
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 describe("--model auto no-model footer", () => {
   it("does not print a via footer when no extractor ran", async () => {

--- a/tests/cli.auto.no-model-json.test.ts
+++ b/tests/cli.auto.no-model-json.test.ts
@@ -1,17 +1,6 @@
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {

--- a/tests/cli.auto.no-model-needed.test.ts
+++ b/tests/cli.auto.no-model-needed.test.ts
@@ -1,20 +1,9 @@
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(() => {

--- a/tests/cli.cache-stats.test.ts
+++ b/tests/cli.cache-stats.test.ts
@@ -1,29 +1,10 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { createCacheStore } from "../src/cache.js";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
-
-function noopStream(): Writable {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
+import { discardStream as noopStream, captureStream as collectStream } from "./helpers/streams.js";
 
 describe("--cache-stats", () => {
   it("prints cache entry counts", async () => {

--- a/tests/cli.cache.auto-preset-selection.test.ts
+++ b/tests/cli.cache.auto-preset-selection.test.ts
@@ -1,9 +1,9 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   weakFails: false,
@@ -15,17 +15,6 @@ vi.mock("../src/llm/generate-text.js", () => ({
   generateTextWithModelId: mocks.generateTextWithModelId,
   streamTextWithModelId: mocks.streamTextWithModelId,
 }));
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("auto preset summary cache", () => {
   it("prefers the preset-level cached winner over older per-candidate cache entries", async () => {

--- a/tests/cli.cache.no-cache.test.ts
+++ b/tests/cli.cache.no-cache.test.ts
@@ -1,10 +1,10 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const TARGET_URL = "https://example.com";
 
@@ -13,17 +13,6 @@ const htmlResponse = (html: string, status = 200) =>
     status,
     headers: { "Content-Type": "text/html" },
   });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 function requestUrl(input: RequestInfo | URL): string {
   return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;

--- a/tests/cli.cache.summary.test.ts
+++ b/tests/cli.cache.summary.test.ts
@@ -1,10 +1,10 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {
@@ -16,17 +16,6 @@ const PNG_1X1 = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
   "base64",
 );
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.clear-cache.test.ts
+++ b/tests/cli.clear-cache.test.ts
@@ -1,23 +1,15 @@
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
+import { discardStream as noopStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {
     status,
     headers: { "Content-Type": "text/html" },
   });
-
-function noopStream(): Writable {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
 
 describe("--clear-cache", () => {
   it("clears the cache database and exits", async () => {

--- a/tests/cli.command-lifecycle.test.ts
+++ b/tests/cli.command-lifecycle.test.ts
@@ -1,5 +1,5 @@
-import { Writable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { discardStream as noopStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   close: vi.fn(),
@@ -32,14 +32,6 @@ vi.mock("../src/run/cli-summarize-execution.js", () => ({
 }));
 
 import { runCli } from "../src/run.js";
-
-function noopStream() {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
 
 describe("CLI summarize command lifecycle", () => {
   beforeEach(() => {

--- a/tests/cli.config-apikeys-legacy.test.ts
+++ b/tests/cli.config-apikeys-legacy.test.ts
@@ -1,11 +1,11 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import type { Api } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStdout, discardStream as noopStream } from "./helpers/streams.js";
 
 type MockModel = { provider: string; id: string; api: Api };
 
@@ -32,25 +32,6 @@ vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));
-
-function noopStream(): Writable {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
-
-function collectStdout() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("cli config legacy apiKeys", () => {
   it("maps config apiKeys to env fallback when process env is missing", async () => {

--- a/tests/cli.config-env.test.ts
+++ b/tests/cli.config-env.test.ts
@@ -1,11 +1,11 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import type { Api } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStdout, discardStream as noopStream } from "./helpers/streams.js";
 
 type MockModel = { provider: string; id: string; api: Api };
 
@@ -32,25 +32,6 @@ vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));
-
-function noopStream(): Writable {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
-
-function collectStdout() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("cli config env", () => {
   it("uses API keys from config env when process env is missing", async () => {

--- a/tests/cli.config-precedence.test.ts
+++ b/tests/cli.config-precedence.test.ts
@@ -1,11 +1,11 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import type { Api } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage } from "./helpers/pi-ai-mock.js";
+import { captureStream, discardStream as noopStream } from "./helpers/streams.js";
 
 type MockModel = { provider: string; id: string; api: Api };
 
@@ -32,25 +32,6 @@ vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));
-
-function noopStream(): Writable {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
-
-function captureStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 function resolveFetchUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") return input;

--- a/tests/cli.cost.finish-line.test.ts
+++ b/tests/cli.cost.finish-line.test.ts
@@ -1,27 +1,16 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {
     status,
     headers: { "Content-Type": "text/html" },
   });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.diarize.media.e2e.test.ts
+++ b/tests/cli.diarize.media.e2e.test.ts
@@ -1,10 +1,10 @@
 import { copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 vi.mock("../packages/core/src/transcription/whisper/ffmpeg.js", async (importOriginal) => {
   const actual =
@@ -14,17 +14,6 @@ vi.mock("../packages/core/src/transcription/whisper/ffmpeg.js", async (importOri
     probeMediaDurationSecondsWithFfprobe: vi.fn(async () => 2),
   };
 });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("CLI media diarization integration", () => {
   afterEach(() => {

--- a/tests/cli.extract.length-warning.test.ts
+++ b/tests/cli.extract.length-warning.test.ts
@@ -1,26 +1,15 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {
     status,
     headers: { "Content-Type": "text/html" },
   });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("--extract warnings", () => {
   it("warns when --length is explicitly set with --extract (TTY stderr, non-JSON)", async () => {

--- a/tests/cli.extract.llm-model.finish-line.test.ts
+++ b/tests/cli.extract.llm-model.finish-line.test.ts
@@ -1,9 +1,9 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 vi.mock("../src/llm/generate-text.js", () => ({
   generateTextWithModelId: vi.fn(async ({ modelId }: { modelId: string }) => {
@@ -16,17 +16,6 @@ vi.mock("../src/llm/generate-text.js", () => ({
     };
   }),
 }));
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("cli --extract finish line includes model when LLM ran", () => {
   it("prints extraction label + model id when markdown conversion uses an LLM", async () => {

--- a/tests/cli.free.no-allowed-providers-beats-timeout.test.ts
+++ b/tests/cli.free.no-allowed-providers-beats-timeout.test.ts
@@ -1,20 +1,9 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 vi.mock("../src/llm/generate-text.js", () => ({
   generateTextWithModelId: vi.fn(async ({ modelId }: { modelId: string }) => {

--- a/tests/cli.free.no-silent-fallback.test.ts
+++ b/tests/cli.free.no-silent-fallback.test.ts
@@ -1,20 +1,9 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 vi.mock("../src/llm/generate-text.js", () => ({
   generateTextWithModelId: vi.fn(async () => {

--- a/tests/cli.free.openrouter-no-provider.test.ts
+++ b/tests/cli.free.openrouter-no-provider.test.ts
@@ -1,20 +1,9 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 vi.mock("../src/llm/generate-text.js", () => ({
   generateTextWithModelId: vi.fn(async () => {

--- a/tests/cli.google.streaming-fallback.test.ts
+++ b/tests/cli.google.streaming-fallback.test.ts
@@ -2,11 +2,11 @@ import type { ChildProcess } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import type { ExecFileFn } from "../src/markitdown.js";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   completeSimple: vi.fn(),
@@ -46,17 +46,6 @@ mocks.streamSimple.mockImplementation(() => {
   });
   throw error;
 });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 const execFileMock: ExecFileFn = ((file, args, _options, callback) => {
   void file;

--- a/tests/cli.language.test.ts
+++ b/tests/cli.language.test.ts
@@ -1,27 +1,16 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {
     status,
     headers: { "Content-Type": "text/html" },
   });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.metrics.openrouter-label.test.ts
+++ b/tests/cli.metrics.openrouter-label.test.ts
@@ -1,11 +1,11 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import type { Api } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 type MockModel = { provider: string; id: string; api: Api };
 
@@ -32,17 +32,6 @@ vi.mock("@earendil-works/pi-ai/compat", () => ({
   streamSimple: mocks.streamSimple,
   getModel: mocks.getModel,
 }));
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("metrics model label", () => {
   it("keeps openrouter/… prefix in the finish line", async () => {

--- a/tests/cli.model-presets.free.test.ts
+++ b/tests/cli.model-presets.free.test.ts
@@ -1,20 +1,9 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 vi.mock("../src/llm/generate-text.js", () => ({
   generateTextWithModelId: vi.fn(async () => ({ text: "OK" })),

--- a/tests/cli.model.cli-provider.test.ts
+++ b/tests/cli.model.cli-provider.test.ts
@@ -1,5 +1,5 @@
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => {
   const createLinkPreviewClient = vi.fn(() => {
@@ -69,17 +69,6 @@ vi.mock("../src/llm/cli.js", () => ({
 }));
 
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("cli run.ts CLI provider model path", () => {
   it("summarizes via cli/<provider> and includes metrics finish line", async () => {

--- a/tests/cli.model.free.failure-branches.test.ts
+++ b/tests/cli.model.free.failure-branches.test.ts
@@ -1,20 +1,9 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => {
   const createLinkPreviewClient = vi.fn(() => {

--- a/tests/cli.preprocess.test.ts
+++ b/tests/cli.preprocess.test.ts
@@ -1,30 +1,11 @@
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import type { ExecFileFn } from "../src/markitdown.js";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
-
-function noopStream() {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream, discardStream as noopStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.prompt-config.test.ts
+++ b/tests/cli.prompt-config.test.ts
@@ -1,27 +1,16 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {
     status,
     headers: { "Content-Type": "text/html" },
   });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.refresh-free.test.ts
+++ b/tests/cli.refresh-free.test.ts
@@ -1,20 +1,9 @@
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 vi.mock("../src/llm/generate-text.js", () => ({
   generateTextWithModelId: vi.fn(async () => ({ text: "OK" })),

--- a/tests/cli.render.hyperlinks.test.ts
+++ b/tests/cli.render.hyperlinks.test.ts
@@ -1,11 +1,11 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import type { Api } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 type MockModel = { provider: string; id: string; api: Api };
 
@@ -30,17 +30,6 @@ mocks.completeSimple.mockImplementation(async (model: MockModel) =>
     usage: { input: 1, output: 1, totalTokens: 2 },
   }),
 );
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("cli markdown hyperlinks", () => {
   it("uses OSC-8 hyperlinks for markdown links on a TTY", async () => {

--- a/tests/cli.render.md.reference-links.test.ts
+++ b/tests/cli.render.md.reference-links.test.ts
@@ -1,27 +1,16 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {
     status,
     headers: { "Content-Type": "text/html" },
   });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.run.arg-branches.test.ts
+++ b/tests/cli.run.arg-branches.test.ts
@@ -1,23 +1,12 @@
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {
     status,
     headers: { "Content-Type": "text/html" },
   });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 const mocks = vi.hoisted(() => ({
   resolveTranscriptForLink: vi.fn(async () => ({

--- a/tests/cli.run.validation-branches.test.ts
+++ b/tests/cli.run.validation-branches.test.ts
@@ -1,20 +1,9 @@
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 describe("cli run.ts validation branches", () => {
   it("rejects --markdown-mode without --format md", async () => {

--- a/tests/cli.slides-warning.test.ts
+++ b/tests/cli.slides-warning.test.ts
@@ -1,20 +1,9 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => {
   const extracted = {

--- a/tests/cli.status.test.ts
+++ b/tests/cli.status.test.ts
@@ -1,20 +1,9 @@
 import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 function makeExecutable(dir: string, name: string): string {
   const file = join(dir, name);

--- a/tests/cli.stream-fallback.test.ts
+++ b/tests/cli.stream-fallback.test.ts
@@ -1,20 +1,9 @@
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   generateTextWithModelId: vi.fn(async () => ({

--- a/tests/cli.stream.auto-model.test.ts
+++ b/tests/cli.stream.auto-model.test.ts
@@ -1,26 +1,15 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {
     status,
     headers: { "Content-Type": "text/html" },
   });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 function createTextStream(chunks: string[]): AsyncIterable<string> {
   return {

--- a/tests/cli.streamed-markdown-render.test.ts
+++ b/tests/cli.streamed-markdown-render.test.ts
@@ -1,27 +1,16 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
 import { makeAssistantMessage, makeTextDeltaStream } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const htmlResponse = (html: string, status = 200) =>
   new Response(html, {
     status,
     headers: { "Content-Type": "text/html" },
   });
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 const mocks = vi.hoisted(() => ({
   streamSimple: vi.fn(),

--- a/tests/cli.twitter.skip-summary.json.test.ts
+++ b/tests/cli.twitter.skip-summary.json.test.ts
@@ -1,6 +1,6 @@
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { makeAssistantMessage } from "./helpers/pi-ai-mock.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => {
   const completeSimple = vi.fn();
@@ -74,17 +74,6 @@ vi.mock("../src/content/index.js", () => ({
 }));
 
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("cli twitter skip-summary branches", () => {
   it("skips summarization for short tweet content in --json mode", async () => {

--- a/tests/cli.version.test.ts
+++ b/tests/cli.version.test.ts
@@ -1,20 +1,9 @@
 import fs, { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { runCli } from "../src/run.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 describe("cli --version", () => {
   it("prints package.json version", async () => {

--- a/tests/cli.youtube.ytdlp-auto-fallback.test.ts
+++ b/tests/cli.youtube.ytdlp-auto-fallback.test.ts
@@ -1,9 +1,9 @@
 import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/run.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 vi.mock("../packages/core/src/content/transcript/providers/youtube/yt-dlp.js", () => ({
   fetchMediaMetadataWithYtDlp: vi.fn(async () => null),
@@ -12,17 +12,6 @@ vi.mock("../packages/core/src/content/transcript/providers/youtube/yt-dlp.js", (
     return { text: "hello from ytdlp", provider: "cpp", error: null, notes: [] };
   }),
 }));
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("cli YouTube auto transcript yt-dlp fallback", () => {
   it("falls back to yt-dlp when captions are unavailable", async () => {

--- a/tests/daemon.launchd.test.ts
+++ b/tests/daemon.launchd.test.ts
@@ -1,8 +1,8 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { Writable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   execFile: vi.fn(),
@@ -16,17 +16,6 @@ import {
   resolveLaunchctlDomains,
   resolveLaunchctlTargetUid,
 } from "../src/daemon/launchd.js";
-
-function collectStream(): { stream: Writable; getText: () => string } {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("daemon/launchd domain resolution", () => {
   it("resolves target uid with sudo fallback for root", () => {

--- a/tests/daemon.schtasks.test.ts
+++ b/tests/daemon.schtasks.test.ts
@@ -1,8 +1,8 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { Writable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   execFile: vi.fn(),
@@ -41,17 +41,6 @@ import {
   restartScheduledTask,
   uninstallScheduledTask,
 } from "../src/daemon/schtasks.js";
-
-function collectStream(): { stream: Writable; getText: () => string } {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 function mockExecFileSuccess() {
   mocks.execFile.mockImplementation(

--- a/tests/helpers.streams.test.ts
+++ b/tests/helpers.streams.test.ts
@@ -1,0 +1,33 @@
+import { once } from "node:events";
+import { describe, expect, it } from "vitest";
+import { captureStream, discardStream } from "./helpers/streams.js";
+
+describe("test output streams", () => {
+  it("captures strings and buffers in order without inventing terminal properties", async () => {
+    const output = captureStream();
+    const finished = once(output.stream, "finish");
+    output.stream.write("Hello ");
+    output.stream.end(Buffer.from("世界"));
+    await finished;
+    expect(output.getText()).toBe("Hello 世界");
+    expect("isTTY" in output.stream).toBe(false);
+    expect("columns" in output.stream).toBe(false);
+  });
+
+  it("keeps captures isolated", () => {
+    const first = captureStream();
+    const second = captureStream();
+    first.stream.write("first");
+    second.stream.write("second");
+    expect(first.getText()).toBe("first");
+    expect(second.getText()).toBe("second");
+  });
+
+  it("drains discarded output and completes normally", async () => {
+    const output = discardStream();
+    const finished = once(output, "finish");
+    output.write("ignored");
+    output.end(Buffer.from("also ignored"));
+    await finished;
+  });
+});

--- a/tests/helpers/streams.ts
+++ b/tests/helpers/streams.ts
@@ -1,0 +1,20 @@
+import { Writable } from "node:stream";
+
+export function captureStream() {
+  let text = "";
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      text += chunk.toString();
+      callback();
+    },
+  });
+  return { stream, getText: () => text };
+}
+
+export function discardStream(): Writable {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+}

--- a/tests/refresh-free.permissions.test.ts
+++ b/tests/refresh-free.permissions.test.ts
@@ -1,9 +1,9 @@
 import { mkdirSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { refreshFree } from "../src/refresh-free.js";
+import { discardStream as sink } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   generateTextWithModelId: vi.fn(async () => ({
@@ -17,14 +17,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../src/llm/generate-text.js", () => ({
   generateTextWithModelId: mocks.generateTextWithModelId,
 }));
-
-function sink() {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
 
 describe("refresh-free config file permissions proof", () => {
   afterEach(() => vi.restoreAllMocks());

--- a/tests/run.cli-preflight.test.ts
+++ b/tests/run.cli-preflight.test.ts
@@ -1,5 +1,5 @@
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   refreshFree: vi.fn(async () => {}),
@@ -35,17 +35,6 @@ import {
   handleHelpRequest,
   handleRefreshFreeRequest,
 } from "../src/run/cli-preflight.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 describe("run/cli-preflight", () => {
   it("handleHelpRequest: returns false when not help", () => {

--- a/tests/run.summary-stream.test.ts
+++ b/tests/run.summary-stream.test.ts
@@ -1,17 +1,6 @@
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { createTerminalSummaryStream } from "../src/run/summary-stream.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 describe("terminal summary stream", () => {
   it("renders engine deltas through the plain output adapter", async () => {

--- a/tests/run.url-markdown-anthropic.test.ts
+++ b/tests/run.url-markdown-anthropic.test.ts
@@ -1,6 +1,6 @@
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { parseRequestedModelId } from "../src/model-spec.js";
+import { discardStream as sink } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   createHtmlToMarkdownConverter: vi.fn(() => async () => "# Converted"),
@@ -12,14 +12,6 @@ vi.mock("../src/llm/html-to-markdown.js", () => ({
 
 import { createMarkdownConverters } from "../src/run/flows/url/markdown.js";
 import type { UrlFlowContext } from "../src/run/flows/url/types.js";
-
-function sink() {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
 
 function buildCtx(opts: {
   openaiRequestOptions?: { reasoningEffort?: "high" };

--- a/tests/run.url-markdown-ollama.test.ts
+++ b/tests/run.url-markdown-ollama.test.ts
@@ -1,6 +1,6 @@
-import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { parseRequestedModelId } from "../src/model-spec.js";
+import { discardStream as sink } from "./helpers/streams.js";
 
 const mocks = vi.hoisted(() => ({
   createHtmlToMarkdownConverter: vi.fn(() => async () => "# Converted"),
@@ -12,14 +12,6 @@ vi.mock("../src/llm/html-to-markdown.js", () => ({
 
 import { createMarkdownConverters } from "../src/run/flows/url/markdown.js";
 import type { UrlFlowContext } from "../src/run/flows/url/types.js";
-
-function sink() {
-  return new Writable({
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-}
 
 describe("URL markdown Ollama routing", () => {
   it("allows llm markdown with fixed Ollama models and forwards the Ollama base URL", () => {

--- a/tests/run.url-summary-flow.test.ts
+++ b/tests/run.url-summary-flow.test.ts
@@ -1,4 +1,3 @@
-import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import type { CacheStore } from "../src/cache.js";
 import type { ExtractedLinkContent } from "../src/content/index.js";
@@ -9,17 +8,7 @@ import {
   presentExtractedUrlSummary,
 } from "../src/run/flows/url/summary.js";
 import type { UrlFlowContext } from "../src/run/flows/url/types.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const extracted: ExtractedLinkContent = {
   url: "https://www.youtube.com/watch?v=9pUWFJgBc5Q",

--- a/tests/runner-setup.test.ts
+++ b/tests/runner-setup.test.ts
@@ -1,7 +1,6 @@
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import {
   applyWidthOverride,
@@ -9,17 +8,7 @@ import {
   prepareRunEnvironment,
   resolvePromptOverride,
 } from "../src/run/runner-setup.js";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 describe("runner setup", () => {
   it("normalizes bare diarize URLs and honors --no-color", () => {

--- a/tests/sidepanel.bootstrap-runtime.test.ts
+++ b/tests/sidepanel.bootstrap-runtime.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 const bindingSpies = vi.hoisted(() => ({
   bindSettingsStorage: vi.fn(),
@@ -11,10 +12,6 @@ vi.mock("../apps/chrome-extension/src/entrypoints/sidepanel/bindings", () => ({
 }));
 
 import { bootstrapSidepanel } from "../apps/chrome-extension/src/entrypoints/sidepanel/bootstrap-runtime";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 describe("sidepanel bootstrap runtime", () => {
   beforeEach(() => {
@@ -31,7 +28,7 @@ describe("sidepanel bootstrap runtime", () => {
     const calls: string[] = [];
     const initialState = createInitialPanelState();
     initialState.panelSession.pendingSettingsSnapshot = { chatEnabled: true };
-    const panelStateStore = createPanelStateStore(initialState);
+    const panelStateStore = initialState;
     const loadedSettings = {
       autoSummarize: true,
       chatEnabled: false,
@@ -49,8 +46,8 @@ describe("sidepanel bootstrap runtime", () => {
         calls.push("ensure");
       },
       loadSettings: async () => loadedSettings,
-      panelState: panelStateStore.state,
-      dispatchPanelState: panelStateStore.dispatch,
+      panelState: panelStateStore,
+
       typographyController: {
         setCurrentFontSize: (value) => calls.push(`font:${value}`),
         setCurrentLineHeight: (value) => calls.push(`line:${value}`),
@@ -84,19 +81,19 @@ describe("sidepanel bootstrap runtime", () => {
     expect(calls).toContain("model-disabled:true");
     expect(calls).toContain("ready");
     expect(calls).toContain("ping");
-    expect(panelStateStore.state.panelSession).toMatchObject({
+    expect(panelStateStore.panelSession).toMatchObject({
       autoSummarize: true,
       chatEnabled: true,
       automationEnabled: false,
       settingsHydrated: true,
       pendingSettingsSnapshot: null,
     });
-    expect(panelStateStore.state.slidesSession.slidesLayout).toBe("gallery");
+    expect(panelStateStore.slidesSession.slidesLayout).toBe("gallery");
   });
 
   it("uses loaded settings directly when there is no pending snapshot", async () => {
     const calls: string[] = [];
-    const panelStateStore = createPanelStateStore();
+    const panelStateStore = createInitialPanelState();
 
     bootstrapSidepanel({
       ensurePanelPort: async () => {
@@ -113,8 +110,8 @@ describe("sidepanel bootstrap runtime", () => {
         model: "openai/gpt-5.4",
         token: "abc123",
       }),
-      panelState: panelStateStore.state,
-      dispatchPanelState: panelStateStore.dispatch,
+      panelState: panelStateStore,
+
       typographyController: {
         setCurrentFontSize: (value) => calls.push(`font:${value}`),
         setCurrentLineHeight: (value) => calls.push(`line:${value}`),
@@ -144,13 +141,13 @@ describe("sidepanel bootstrap runtime", () => {
 
     expect(calls).not.toContain("hide-automation");
     expect(calls).toContain("model-disabled:false");
-    expect(panelStateStore.state.panelSession).toMatchObject({
+    expect(panelStateStore.panelSession).toMatchObject({
       autoSummarize: false,
       chatEnabled: true,
       automationEnabled: true,
       settingsHydrated: true,
       pendingSettingsSnapshot: null,
     });
-    expect(panelStateStore.state.slidesSession.slidesLayout).toBe("strip");
+    expect(panelStateStore.slidesSession.slidesLayout).toBe("strip");
   });
 });

--- a/tests/sidepanel.browser-ai-snapshot-runtime.test.ts
+++ b/tests/sidepanel.browser-ai-snapshot-runtime.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createBrowserAiSnapshotRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime";
-import {
-  applyPanelStateAction,
-  createInitialPanelState,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 describe("sidepanel browser AI snapshot runtime", () => {
   it("upgrades the current extractive snapshot and records Gemini Nano metadata", async () => {
@@ -13,7 +10,7 @@ describe("sidepanel browser AI snapshot runtime", () => {
     const renderMarkdown = vi.fn();
     const runtime = createBrowserAiSnapshotRuntime({
       panelState,
-      dispatchPanelState: (action) => applyPanelStateAction(panelState, action),
+
       browserAi: {
         cancel: vi.fn(),
         summarize: vi.fn(async () => "- First point\n- Second point"),
@@ -55,7 +52,7 @@ describe("sidepanel browser AI snapshot runtime", () => {
     const renderMarkdown = vi.fn();
     const runtime = createBrowserAiSnapshotRuntime({
       panelState,
-      dispatchPanelState: (action) => applyPanelStateAction(panelState, action),
+
       browserAi: {
         cancel: vi.fn(),
         summarize: vi.fn(async () => await summaryPromise),

--- a/tests/sidepanel.chat-controller.test.ts
+++ b/tests/sidepanel.chat-controller.test.ts
@@ -1,22 +1,17 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatController } from "../apps/chrome-extension/src/entrypoints/sidepanel/chat-controller";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { ChatMessage } from "../apps/chrome-extension/src/entrypoints/sidepanel/types";
 
-function createHarness(options: { injectedDispatch?: boolean } = {}) {
+function createHarness() {
   const panelState = createInitialPanelState();
-  const store = createPanelStateStore(panelState);
   const messagesEl = document.createElement("div");
   const inputEl = document.createElement("textarea");
   const sendBtn = document.createElement("button");
   const contextEl = document.createElement("div");
   const scrollToBottom = vi.fn();
   const onNewContent = vi.fn();
-  const dispatchPanelState = vi.fn(store.dispatch);
   const controller = new ChatController({
     messagesEl,
     inputEl,
@@ -28,14 +23,14 @@ function createHarness(options: { injectedDispatch?: boolean } = {}) {
     } as never,
     limits: { maxMessages: 10, maxChars: 10 },
     panelState,
-    dispatchPanelState: options.injectedDispatch ? dispatchPanelState : undefined,
+
     scrollToBottom,
     onNewContent,
   });
   return {
     contextEl,
     controller,
-    dispatchPanelState,
+
     inputEl,
     messagesEl,
     onNewContent,
@@ -74,7 +69,7 @@ describe("sidepanel chat controller", () => {
   });
 
   it("sets, replaces, appends missing replacements, and removes canonical messages", () => {
-    const harness = createHarness({ injectedDispatch: true });
+    const harness = createHarness();
     const user = userMessage();
     const assistant = assistantMessage();
 
@@ -86,7 +81,6 @@ describe("sidepanel chat controller", () => {
 
     expect(harness.panelState.chat.messages).toEqual([assistantMessage("assistant-1", "Updated")]);
     expect(harness.messagesEl.textContent).toContain("Updated");
-    expect(harness.dispatchPanelState).toHaveBeenCalled();
     expect(harness.onNewContent).toHaveBeenCalledOnce();
     expect(harness.scrollToBottom).toHaveBeenCalledOnce();
   });

--- a/tests/sidepanel.chat-runtime.test.ts
+++ b/tests/sidepanel.chat-runtime.test.ts
@@ -1,11 +1,10 @@
-// @vitest-environment happy-dom
-
 import type { Message } from "@earendil-works/pi-ai";
+// @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSidepanelChatRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime";
 import {
   createInitialPanelState,
-  createPanelStateStore,
+  patchPanelState,
 } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 const agentLoopMock = vi.hoisted(() => ({
@@ -38,13 +37,13 @@ function setScrollMetrics(element: HTMLElement) {
 }
 
 function createHarness(options: { chatEnabled?: boolean } = {}) {
-  const store = createPanelStateStore(createInitialPanelState());
-  store.state.panelSession.chatEnabled = options.chatEnabled ?? true;
-  store.state.panelSession.automationEnabled = true;
-  store.state.panelSession.daemonFeaturesAvailable = true;
-  store.state.navigation.activeTabId = 7;
-  store.state.navigation.activeTabUrl = "https://example.com/current";
-  store.state.summaryMarkdown = "Current summary";
+  const store = createInitialPanelState();
+  store.panelSession.chatEnabled = options.chatEnabled ?? true;
+  store.panelSession.automationEnabled = true;
+  store.panelSession.daemonFeaturesAvailable = true;
+  store.navigation.activeTabId = 7;
+  store.navigation.activeTabUrl = "https://example.com/current";
+  store.summaryMarkdown = "Current summary";
 
   const mainEl = document.createElement("main");
   setScrollMetrics(mainEl);
@@ -125,8 +124,8 @@ function createHarness(options: { chatEnabled?: boolean } = {}) {
     markAgentNavigationResult: vi.fn(),
   };
   const runtime = createSidepanelChatRuntime({
-    panelState: store.state,
-    dispatchPanelState: store.dispatch,
+    panelState: store,
+
     markdown: { render: (value: string) => value } as never,
     mainEl,
     renderEl,
@@ -142,8 +141,8 @@ function createHarness(options: { chatEnabled?: boolean } = {}) {
     automationNoticeEl,
     automationNoticeMessageEl,
     automationNoticeTitleEl,
-    getActiveTabId: () => store.state.navigation.activeTabId,
-    getActiveTabUrl: () => store.state.navigation.activeTabUrl,
+    getActiveTabId: () => store.navigation.activeTabId,
+    getActiveTabUrl: () => store.navigation.activeTabUrl,
     navigationRuntime,
     send,
     setStatus,
@@ -193,9 +192,9 @@ describe("sidepanel chat runtime", () => {
     harness.runtime.startMessage("  hello  ");
 
     await vi.waitFor(() => expect(agentLoopMock.run).toHaveBeenCalledOnce());
-    await vi.waitFor(() => expect(harness.store.state.chat.streaming).toBe(false));
+    await vi.waitFor(() => expect(harness.store.chat.streaming).toBe(false));
 
-    expect(harness.store.state.chat.messages).toMatchObject([{ role: "user", content: "hello" }]);
+    expect(harness.store.chat.messages).toMatchObject([{ role: "user", content: "hello" }]);
     expect(harness.clearErrors).toHaveBeenCalledOnce();
     expect(harness.setChatMetricsMode).toHaveBeenCalledOnce();
     expect(harness.setLastActionChat).toHaveBeenCalledOnce();
@@ -213,20 +212,20 @@ describe("sidepanel chat runtime", () => {
 
   it("queues normalized messages while streaming and drains them afterward", async () => {
     const harness = createHarness();
-    harness.store.dispatch({ type: "chat-streaming", value: true });
+    patchPanelState(harness.store, "chat", { streaming: true });
 
     expect(harness.runtime.enqueueMessage("  queued \n message  ")).toBe(true);
     harness.runtime.maybeSendQueuedMessage();
     expect(harness.runtime.getQueueLength()).toBe(1);
-    expect(harness.store.state.chat.queue).toMatchObject([{ text: "queued message" }]);
+    expect(harness.store.chat.queue).toMatchObject([{ text: "queued message" }]);
 
-    harness.store.dispatch({ type: "chat-streaming", value: false });
+    patchPanelState(harness.store, "chat", { streaming: false });
     harness.runtime.maybeSendQueuedMessage();
 
     await vi.waitFor(() => expect(harness.runtime.getQueueLength()).toBe(0));
-    expect(harness.store.state.chat.queue).toEqual([]);
-    await vi.waitFor(() => expect(harness.store.state.chat.streaming).toBe(false));
-    expect(harness.store.state.chat.messages).toMatchObject([
+    expect(harness.store.chat.queue).toEqual([]);
+    await vi.waitFor(() => expect(harness.store.chat.streaming).toBe(false));
+    expect(harness.store.chat.messages).toMatchObject([
       { role: "user", content: "queued message" },
     ]);
     expect(harness.chatQueueEl.classList.contains("isHidden")).toBe(true);
@@ -252,9 +251,7 @@ describe("sidepanel chat runtime", () => {
     });
     await restore;
 
-    expect(harness.store.state.chat.messages).toMatchObject([
-      { role: "user", content: "restored" },
-    ]);
+    expect(harness.store.chat.messages).toMatchObject([{ role: "user", content: "restored" }]);
     expect(harness.storage.set).toHaveBeenCalled();
   });
 
@@ -298,9 +295,11 @@ describe("sidepanel chat runtime", () => {
 
   it("migrates non-empty history to the destination tab URL", async () => {
     const harness = createHarness();
-    harness.store.dispatch({
-      type: "chat-message-add",
-      message: { id: "1", role: "user", content: "keep", timestamp: 1 },
+    patchPanelState(harness.store, "chat", {
+      messages: [
+        ...harness.store.chat.messages,
+        { id: "1", role: "user", content: "keep", timestamp: 1 },
+      ],
     });
 
     await harness.runtime.migrateHistory(7, 8, "https://example.com/next");
@@ -333,10 +332,10 @@ describe("sidepanel chat runtime", () => {
     expect(harness.seekToTimestamp).toHaveBeenCalledWith(42);
 
     harness.runtime.startMessage("temporary");
-    await vi.waitFor(() => expect(harness.store.state.chat.messages.length).toBe(1));
-    harness.store.state.panelSession.chatEnabled = false;
+    await vi.waitFor(() => expect(harness.store.chat.messages.length).toBe(1));
+    harness.store.panelSession.chatEnabled = false;
     harness.runtime.applyEnabled();
-    expect(harness.store.state.chat.messages).toEqual([]);
+    expect(harness.store.chat.messages).toEqual([]);
     expect(harness.chatContainerEl.hasAttribute("hidden")).toBe(true);
     expect(harness.clearChatMetrics).toHaveBeenCalledOnce();
 

--- a/tests/sidepanel.feedback-runtime.test.ts
+++ b/tests/sidepanel.feedback-runtime.test.ts
@@ -1,15 +1,11 @@
-// @vitest-environment happy-dom
-
 import { beforeEach, describe, expect, it, vi } from "vitest";
+// @vitest-environment happy-dom
 import { createSidepanelFeedbackRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/feedback-runtime";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createPanelPhaseRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/phase-runtime";
 
 function createHarness(options: { storageThrows?: boolean } = {}) {
-  const store = createPanelStateStore(createInitialPanelState());
+  const store = createInitialPanelState();
   const headerEl = document.createElement("header");
   headerEl.getBoundingClientRect = () => ({ height: 64 }) as DOMRect;
   const titleEl = document.createElement("div");
@@ -56,7 +52,7 @@ function createHarness(options: { storageThrows?: boolean } = {}) {
       : vi.fn(),
   };
   const runtime = createSidepanelFeedbackRuntime({
-    panelState: store.state,
+    panelState: store,
     headerEl,
     titleEl,
     subtitleEl,
@@ -83,8 +79,8 @@ function createHarness(options: { storageThrows?: boolean } = {}) {
   });
   runtime.bindActions({ retryLastAction, retrySlidesStream });
   const phaseRuntime = createPanelPhaseRuntime({
-    panelState: store.state,
-    dispatchPanelState: store.dispatch,
+    panelState: store,
+
     errorController: runtime.errorController,
     headerController: runtime.headerController,
     setSlidesBusy,
@@ -153,21 +149,21 @@ describe("sidepanel feedback runtime", () => {
     const harness = createHarness();
 
     harness.phaseRuntime.setPhase("connecting");
-    expect(harness.store.state.phase).toBe("connecting");
+    expect(harness.store.phase).toBe("connecting");
     expect(harness.setSlidesBusy).not.toHaveBeenCalled();
 
     harness.phaseRuntime.setPhase("idle");
     expect(harness.setSlidesBusy).toHaveBeenCalledWith(false);
     expect(harness.rebuildSlideDescriptions).not.toHaveBeenCalled();
 
-    harness.store.state.slides = { slides: [] } as never;
+    harness.store.slides = { slides: [] } as never;
     harness.phaseRuntime.setPhase("streaming");
     harness.phaseRuntime.setPhase("idle");
     expect(harness.rebuildSlideDescriptions).toHaveBeenCalledOnce();
     expect(harness.queueSlidesRender).toHaveBeenCalledOnce();
 
     harness.phaseRuntime.setPhase("error", { error: "Failure" });
-    expect(harness.store.state.error).toBe("Failure");
+    expect(harness.store.error).toBe("Failure");
     expect(harness.panelErrorMessageEl.textContent).toBe("Failure");
     expect(harness.panelErrorEl.classList.contains("hidden")).toBe(false);
     expect(harness.setSlidesBusy).toHaveBeenLastCalledWith(false);
@@ -214,20 +210,20 @@ describe("sidepanel feedback runtime", () => {
         message: "fallback",
       }),
     );
-    expect(harness.store.state.phase).toBe("error");
-    expect(harness.store.state.error).toContain("window failure");
+    expect(harness.store.phase).toBe("error");
+    expect(harness.store.error).toContain("window failure");
     expect(harness.panelErrorMessageEl.textContent).toContain("window failure");
 
     errorListener?.(new ErrorEvent("error", { message: "message-only failure" }));
-    expect(harness.store.state.error).toBe("message-only failure");
+    expect(harness.store.error).toBe("message-only failure");
 
     rejectionListener?.({
       reason: new Error("promise failure"),
     } as PromiseRejectionEvent);
-    expect(harness.store.state.error).toContain("promise failure");
+    expect(harness.store.error).toContain("promise failure");
 
     rejectionListener?.({ reason: "rejected" } as PromiseRejectionEvent);
-    expect(harness.store.state.error).toBe("rejected");
+    expect(harness.store.error).toBe("rejected");
     expect(harness.panelErrorMessageEl.textContent).toBe("rejected");
   });
 });

--- a/tests/sidepanel.navigation-runtime.test.ts
+++ b/tests/sidepanel.navigation-runtime.test.ts
@@ -4,14 +4,17 @@ import {
   type PanelSource,
 } from "../apps/chrome-extension/src/entrypoints/sidepanel/active-tab-sync.js";
 import { createNavigationRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/navigation-runtime.js";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store.js";
+import {
+  createInitialPanelState,
+  patchPanelState,
+} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 function createRuntime(options: { ttlMs?: number } = {}) {
-  const store = createPanelStateStore();
+  const store = createInitialPanelState();
   return createNavigationRuntime({
-    getState: () => store.state.navigation,
+    getState: () => store.navigation,
     updateState: (value) => {
-      store.dispatch({ type: "navigation-policy-update", value });
+      patchPanelState(store, "navigation", value);
     },
     ...options,
   });

--- a/tests/sidepanel.panel-messaging.test.ts
+++ b/tests/sidepanel.panel-messaging.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPanelMessagingRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-messaging";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { SseSlidesData } from "../apps/chrome-extension/src/lib/runtime-contracts";
 
 describe("sidepanel panel messaging runtime", () => {
@@ -12,11 +9,11 @@ describe("sidepanel panel messaging runtime", () => {
   });
 
   it("tracks user actions only for normal sends", async () => {
-    const panelStateStore = createPanelStateStore();
+    const panelStateStore = createInitialPanelState();
     const send = vi.fn(async () => {});
     const runtime = createPanelMessagingRuntime({
-      panelState: panelStateStore.state,
-      dispatchPanelState: panelStateStore.dispatch,
+      panelState: panelStateStore,
+
       onMessage: vi.fn(),
       portRuntime: {
         ensure: async () => null,
@@ -25,7 +22,7 @@ describe("sidepanel panel messaging runtime", () => {
     });
 
     await runtime.send({ type: "panel:summarize", refresh: true });
-    expect(panelStateStore.state.panelSession.lastAction).toBe("summarize");
+    expect(panelStateStore.panelSession.lastAction).toBe("summarize");
 
     await runtime.sendRaw({
       type: "panel:agent",
@@ -33,7 +30,7 @@ describe("sidepanel panel messaging runtime", () => {
       messages: [],
       tools: [],
     });
-    expect(panelStateStore.state.panelSession.lastAction).toBe("summarize");
+    expect(panelStateStore.panelSession.lastAction).toBe("summarize");
     expect(send).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/sidepanel.panel-state-store.test.ts
+++ b/tests/sidepanel.panel-state-store.test.ts
@@ -1,27 +1,32 @@
 import { describe, expect, it } from "vitest";
 import {
-  createPanelStateStore,
-  reducePanelState,
+  attachPanelRun,
+  createInitialPanelState,
+  createInitialSlidesSummaryState,
+  createInitialSlidesTextState,
+  patchPanelState,
+  setPanelPhase,
+  replacePanelChatMessage,
+  resetPanelSummary,
+  restorePanelSession,
+  setPendingSlidesRun,
+  setPendingSummaryRun,
 } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 describe("sidepanel panel state store", () => {
   it("updates active tab identity as one navigation transition", () => {
-    const store = createPanelStateStore();
-    store.dispatch({
-      type: "active-tab",
-      tabId: 42,
-      url: "https://example.com",
-    });
+    const store = createInitialPanelState();
+    patchPanelState(store, "navigation", { activeTabId: 42, activeTabUrl: "https://example.com" });
 
-    expect(store.state.navigation).toEqual({
+    expect(store.navigation).toEqual({
       activeTabId: 42,
       activeTabUrl: "https://example.com",
       lastAgentNavigation: null,
       pendingPreserveChatForUrl: null,
     });
 
-    store.dispatch({ type: "active-tab-url", url: "https://example.com/next" });
-    expect(store.state.navigation).toEqual({
+    patchPanelState(store, "navigation", { activeTabUrl: "https://example.com/next" });
+    expect(store.navigation).toEqual({
       activeTabId: 42,
       activeTabUrl: "https://example.com/next",
       lastAgentNavigation: null,
@@ -30,24 +35,21 @@ describe("sidepanel panel state store", () => {
   });
 
   it("owns navigation policy markers without losing active tab identity", () => {
-    const store = createPanelStateStore();
-    store.dispatch({ type: "active-tab", tabId: 42, url: "https://example.com" });
-    store.dispatch({
-      type: "navigation-policy-update",
-      value: {
-        lastAgentNavigation: {
-          url: "https://example.com/next",
-          tabId: 43,
-          at: 100,
-        },
-        pendingPreserveChatForUrl: {
-          url: "https://example.com/next",
-          at: 101,
-        },
+    const store = createInitialPanelState();
+    patchPanelState(store, "navigation", { activeTabId: 42, activeTabUrl: "https://example.com" });
+    patchPanelState(store, "navigation", {
+      lastAgentNavigation: {
+        url: "https://example.com/next",
+        tabId: 43,
+        at: 100,
+      },
+      pendingPreserveChatForUrl: {
+        url: "https://example.com/next",
+        at: 101,
       },
     });
 
-    expect(store.state.navigation).toEqual({
+    expect(store.navigation).toEqual({
       activeTabId: 42,
       activeTabUrl: "https://example.com",
       lastAgentNavigation: {
@@ -61,14 +63,16 @@ describe("sidepanel panel state store", () => {
       },
     });
 
-    store.dispatch({ type: "active-tab", tabId: 44, url: "https://example.com/final" });
-    expect(store.state.navigation.lastAgentNavigation?.tabId).toBe(43);
+    patchPanelState(store, "navigation", {
+      activeTabId: 44,
+      activeTabUrl: "https://example.com/final",
+    });
+    expect(store.navigation.lastAgentNavigation?.tabId).toBe(43);
   });
 
   it("attaches runs as one transition", () => {
-    const store = createPanelStateStore();
-    store.dispatch({
-      type: "attach-run",
+    const store = createInitialPanelState();
+    attachPanelRun(store, {
       tabId: 42,
       runId: "run-1",
       slidesRunId: "run-1",
@@ -77,7 +81,7 @@ describe("sidepanel panel state store", () => {
       meta: { inputSummary: null, model: "auto", modelLabel: "auto" },
     });
 
-    expect(store.state).toMatchObject({
+    expect(store).toMatchObject({
       runId: "run-1",
       activeRun: { tabId: 42 },
       slidesRunId: "run-1",
@@ -88,7 +92,7 @@ describe("sidepanel panel state store", () => {
   });
 
   it("queues and consumes deferred runs by normalized URL key", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const urlKey = "https://example.com/video";
     const run = {
       id: "run-1",
@@ -98,31 +102,23 @@ describe("sidepanel panel state store", () => {
       reason: "tab-activated",
     } as const;
 
-    store.dispatch({
-      type: "pending-summary-run",
-      urlKey,
-      value: { type: "run", run },
-    });
-    store.dispatch({
-      type: "pending-slides-run",
-      urlKey,
-      value: { runId: "slides-1", url: urlKey, local: true },
-    });
+    setPendingSummaryRun(store, urlKey, { type: "run", run });
+    setPendingSlidesRun(store, urlKey, { runId: "slides-1", url: urlKey, local: true });
 
-    expect(store.state.pendingRuns).toEqual({
+    expect(store.pendingRuns).toEqual({
       summaryByUrl: { [urlKey]: { type: "run", run } },
       slidesByUrl: {
         [urlKey]: { runId: "slides-1", url: urlKey, local: true },
       },
     });
 
-    store.dispatch({ type: "pending-summary-run", urlKey, value: null });
-    store.dispatch({ type: "pending-slides-run", urlKey, value: null });
-    expect(store.state.pendingRuns).toEqual({ summaryByUrl: {}, slidesByUrl: {} });
+    setPendingSummaryRun(store, urlKey, null);
+    setPendingSlidesRun(store, urlKey, null);
+    expect(store.pendingRuns).toEqual({ summaryByUrl: {}, slidesByUrl: {} });
   });
 
   it("owns active and planned slides lifecycle state", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const plannedRun = {
       id: "run-1",
       url: "https://example.com/video",
@@ -131,37 +127,25 @@ describe("sidepanel panel state store", () => {
       reason: "tab-activated",
     } as const;
 
-    store.dispatch({
-      type: "active-slides-run",
-      value: { runId: "slides-1", url: plannedRun.url, local: true },
+    patchPanelState(store, "slidesLifecycle", {
+      activeRun: { runId: "slides-1", url: plannedRun.url, local: true },
     });
-    store.dispatch({ type: "planned-slides-run", value: plannedRun });
+    patchPanelState(store, "slidesLifecycle", { plannedRun: plannedRun });
 
-    expect(store.state.slidesLifecycle).toEqual({
+    expect(store.slidesLifecycle).toEqual({
       activeRun: { runId: "slides-1", url: plannedRun.url, local: true },
       plannedRun,
     });
 
-    store.dispatch({ type: "active-slides-run", value: null });
-    store.dispatch({ type: "planned-slides-run", value: null });
-    expect(store.state.slidesLifecycle).toEqual({ activeRun: null, plannedRun: null });
+    patchPanelState(store, "slidesLifecycle", { activeRun: null });
+    patchPanelState(store, "slidesLifecycle", { plannedRun: null });
+    expect(store.slidesLifecycle).toEqual({ activeRun: null, plannedRun: null });
   });
 
   it("owns slides summary lifecycle state", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
 
-    store.dispatch({
-      type: "slides-summary-update",
-      value: {
-        runId: "slides-1",
-        url: "https://example.com/video",
-        markdown: "Summary",
-        complete: true,
-        model: "test-model",
-      },
-    });
-
-    expect(store.state.slidesSummary).toMatchObject({
+    patchPanelState(store, "slidesSummary", {
       runId: "slides-1",
       url: "https://example.com/video",
       markdown: "Summary",
@@ -169,8 +153,16 @@ describe("sidepanel panel state store", () => {
       model: "test-model",
     });
 
-    store.dispatch({ type: "slides-summary-reset" });
-    expect(store.state.slidesSummary).toEqual({
+    expect(store.slidesSummary).toMatchObject({
+      runId: "slides-1",
+      url: "https://example.com/video",
+      markdown: "Summary",
+      complete: true,
+      model: "test-model",
+    });
+
+    store.slidesSummary = createInitialSlidesSummaryState();
+    expect(store.slidesSummary).toEqual({
       runId: null,
       url: null,
       markdown: "",
@@ -182,16 +174,17 @@ describe("sidepanel panel state store", () => {
   });
 
   it("updates slides session state and advances request identity", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
 
-    store.dispatch({
-      type: "slides-session-update",
-      value: { inputMode: "video", slidesBusy: true },
+    patchPanelState(store, "slidesSession", { inputMode: "video", slidesBusy: true });
+    patchPanelState(store, "slidesSession", {
+      slidesContextRequestId: store.slidesSession.slidesContextRequestId + 1,
     });
-    store.dispatch({ type: "slides-context-request-next" });
-    store.dispatch({ type: "slides-context-request-next" });
+    patchPanelState(store, "slidesSession", {
+      slidesContextRequestId: store.slidesSession.slidesContextRequestId + 1,
+    });
 
-    expect(store.state.slidesSession).toMatchObject({
+    expect(store.slidesSession).toMatchObject({
       inputMode: "video",
       slidesBusy: true,
       slidesContextRequestId: 2,
@@ -199,24 +192,21 @@ describe("sidepanel panel state store", () => {
   });
 
   it("owns serializable slides text state", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
 
-    store.dispatch({
-      type: "slides-text-update",
-      value: {
-        mode: "ocr",
-        toggleVisible: true,
-        transcriptTimedText: "[00:00] Intro",
-        transcriptAvailable: true,
-        ocrAvailable: true,
-        descriptionsByIndex: { 1: "Description" },
-        summariesByIndex: { 1: "Summary" },
-        titlesByIndex: { 1: "Title" },
-        summarySource: "slides",
-      },
+    patchPanelState(store, "slidesText", {
+      mode: "ocr",
+      toggleVisible: true,
+      transcriptTimedText: "[00:00] Intro",
+      transcriptAvailable: true,
+      ocrAvailable: true,
+      descriptionsByIndex: { 1: "Description" },
+      summariesByIndex: { 1: "Summary" },
+      titlesByIndex: { 1: "Title" },
+      summarySource: "slides",
     });
 
-    expect(store.state.slidesText).toMatchObject({
+    expect(store.slidesText).toMatchObject({
       mode: "ocr",
       toggleVisible: true,
       descriptionsByIndex: { 1: "Description" },
@@ -224,8 +214,8 @@ describe("sidepanel panel state store", () => {
       summarySource: "slides",
     });
 
-    store.dispatch({ type: "slides-text-reset" });
-    expect(store.state.slidesText).toEqual({
+    store.slidesText = createInitialSlidesTextState();
+    expect(store.slidesText).toEqual({
       mode: "transcript",
       toggleVisible: false,
       transcriptTimedText: null,
@@ -239,18 +229,15 @@ describe("sidepanel panel state store", () => {
   });
 
   it("owns local panel session state", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
 
-    store.dispatch({
-      type: "panel-session-update",
-      value: {
-        autoSummarize: true,
-        settingsHydrated: true,
-        lastAction: "summarize",
-      },
+    patchPanelState(store, "panelSession", {
+      autoSummarize: true,
+      settingsHydrated: true,
+      lastAction: "summarize",
     });
 
-    expect(store.state.panelSession).toMatchObject({
+    expect(store.panelSession).toMatchObject({
       autoSummarize: true,
       settingsHydrated: true,
       lastAction: "summarize",
@@ -259,7 +246,7 @@ describe("sidepanel panel state store", () => {
   });
 
   it("owns chat messages and streaming state", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const userMessage = {
       id: "user-1",
       role: "user" as const,
@@ -273,60 +260,57 @@ describe("sidepanel panel state store", () => {
       timestamp: 2,
     };
 
-    store.dispatch({ type: "chat-message-add", message: userMessage });
-    store.dispatch({ type: "chat-message-add", message: assistantMessage });
-    store.dispatch({ type: "chat-streaming", value: true });
-    store.dispatch({
-      type: "chat-message-replace",
-      message: { ...assistantMessage, content: "Updated" },
+    patchPanelState(store, "chat", { messages: [...store.chat.messages, userMessage] });
+    patchPanelState(store, "chat", { messages: [...store.chat.messages, assistantMessage] });
+    patchPanelState(store, "chat", { streaming: true });
+    replacePanelChatMessage(store, { ...assistantMessage, content: "Updated" });
+    patchPanelState(store, "chat", {
+      messages: store.chat.messages.filter((message) => message.id !== userMessage.id),
     });
-    store.dispatch({ type: "chat-message-remove", id: userMessage.id });
 
-    expect(store.state.chat).toEqual({
+    expect(store.chat).toEqual({
       messages: [{ ...assistantMessage, content: "Updated" }],
       streaming: true,
       queue: [],
     });
 
-    store.dispatch({ type: "chat-messages", messages: [userMessage] });
-    expect(store.state.chat.messages).toEqual([userMessage]);
+    patchPanelState(store, "chat", { messages: [userMessage] });
+    expect(store.chat.messages).toEqual([userMessage]);
 
-    store.dispatch({ type: "chat-reset" });
-    expect(store.state.chat).toEqual({ messages: [], streaming: false, queue: [] });
+    store.chat = { messages: [], streaming: false, queue: [] };
+    expect(store.chat).toEqual({ messages: [], streaming: false, queue: [] });
   });
 
   it("owns queued chat messages", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const first = { id: "queue-1", text: "First", createdAt: 1 };
     const second = { id: "queue-2", text: "Second", createdAt: 2 };
 
-    store.dispatch({ type: "chat-queue-add", item: first });
-    store.dispatch({ type: "chat-queue-add", item: second });
-    expect(store.state.chat.queue).toEqual([first, second]);
+    patchPanelState(store, "chat", { queue: [...store.chat.queue, first] });
+    patchPanelState(store, "chat", { queue: [...store.chat.queue, second] });
+    expect(store.chat.queue).toEqual([first, second]);
 
-    store.dispatch({ type: "chat-queue-remove", id: first.id });
-    expect(store.state.chat.queue).toEqual([second]);
+    patchPanelState(store, "chat", {
+      queue: store.chat.queue.filter((item) => item.id !== first.id),
+    });
+    expect(store.chat.queue).toEqual([second]);
 
-    store.dispatch({ type: "chat-queue-clear" });
-    expect(store.state.chat.queue).toEqual([]);
+    patchPanelState(store, "chat", { queue: [] });
+    expect(store.chat.queue).toEqual([]);
   });
 
   it("restores cached sessions without replacing omitted slides", () => {
-    const store = createPanelStateStore();
-    store.dispatch({
-      type: "slides",
-      slides: {
-        sourceUrl: "https://example.com",
-        sourceId: "slides-1",
-        sourceKind: "youtube",
-        ocrAvailable: false,
-        slides: [],
-      },
-    });
-    const existingSlides = store.state.slides;
+    const store = createInitialPanelState();
+    store.slides = {
+      sourceUrl: "https://example.com",
+      sourceId: "slides-1",
+      sourceKind: "youtube",
+      ocrAvailable: false,
+      slides: [],
+    };
+    const existingSlides = store.slides;
 
-    store.dispatch({
-      type: "restore-session",
+    restorePanelSession(store, {
       tabId: 42,
       runId: "run-1",
       slidesRunId: null,
@@ -335,27 +319,38 @@ describe("sidepanel panel state store", () => {
       summaryFromCache: true,
     });
 
-    expect(store.state.summaryFromCache).toBe(true);
-    expect(store.state.activeRun.tabId).toBe(42);
-    expect(store.state.slides).toBe(existingSlides);
+    expect(store.summaryFromCache).toBe(true);
+    expect(store.activeRun.tabId).toBe(42);
+    expect(store.slides).toBe(existingSlides);
   });
 
   it("keeps phase and error invariants together", () => {
-    const failed = reducePanelState(createPanelStateStore().state, {
-      type: "phase",
-      phase: "error",
-      error: "failed",
-    });
-    expect(failed).toMatchObject({ phase: "error", error: "failed" });
+    const state = createInitialPanelState();
+    setPanelPhase(state, "error", "failed");
+    expect(state).toMatchObject({ phase: "error", error: "failed" });
+    setPanelPhase(state, "error");
+    expect(state.error).toBe("failed");
+    setPanelPhase(state, "idle");
+    expect(state).toMatchObject({ phase: "idle", error: null });
+  });
 
-    const recovered = reducePanelState(failed, { type: "phase", phase: "idle" });
-    expect(recovered).toMatchObject({ phase: "idle", error: null });
+  it("keeps the root identity and replaces nested slices without mutating snapshots", () => {
+    const state = createInitialPanelState();
+    const original = state;
+    const navigation = state.navigation;
+    const chat = state.chat;
+    patchPanelState(state, "navigation", { activeTabId: 42 });
+    patchPanelState(state, "chat", { streaming: true });
+    expect(state).toBe(original);
+    expect(state.navigation).not.toBe(navigation);
+    expect(navigation.activeTabId).toBeNull();
+    expect(state.chat).not.toBe(chat);
+    expect(chat.streaming).toBe(false);
   });
 
   it("resets summary and run-owned slides together", () => {
-    const store = createPanelStateStore();
-    store.dispatch({
-      type: "attach-run",
+    const store = createInitialPanelState();
+    attachPanelRun(store, {
       tabId: 42,
       runId: "run-1",
       slidesRunId: "run-1",
@@ -363,15 +358,12 @@ describe("sidepanel panel state store", () => {
       source: { url: "https://example.com", title: null },
       meta: { inputSummary: null, model: null, modelLabel: null },
     });
-    store.dispatch({ type: "summary", markdown: "Summary" });
-    store.dispatch({ type: "summary-cache", value: true });
-    store.dispatch({
-      type: "retained-slide-summary",
-      value: { markdown: "Retained", url: "https://example.com" },
-    });
-    store.dispatch({ type: "reset-summary", clearRunId: true, clearSlides: true });
+    store.summaryMarkdown = "Summary";
+    store.summaryFromCache = true;
+    store.retainedSlideSummary = { markdown: "Retained", url: "https://example.com" };
+    resetPanelSummary(store, { clearRunId: true, clearSlides: true });
 
-    expect(store.state).toMatchObject({
+    expect(store).toMatchObject({
       runId: null,
       activeRun: { tabId: null },
       slidesRunId: null,
@@ -379,12 +371,12 @@ describe("sidepanel panel state store", () => {
       summaryFromCache: null,
       slides: null,
     });
-    expect(store.state.retainedSlideSummary).toEqual({
+    expect(store.retainedSlideSummary).toEqual({
       markdown: "Retained",
       url: "https://example.com",
     });
 
-    store.dispatch({ type: "retained-slide-summary", value: null });
-    expect(store.state.retainedSlideSummary).toBeNull();
+    store.retainedSlideSummary = null;
+    expect(store.retainedSlideSummary).toBeNull();
   });
 });

--- a/tests/sidepanel.planned-slides-runtime.test.ts
+++ b/tests/sidepanel.planned-slides-runtime.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  applyPanelStateAction,
-  createInitialPanelState,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createPlannedSlidesRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/planned-slides-runtime";
 import type {
   PanelState,
@@ -35,9 +32,7 @@ function createHarness(
   const schedulePanelCacheSync = vi.fn();
   const runtime = createPlannedSlidesRuntime({
     panelState,
-    dispatchPanelState: options.dispatch
-      ? (action) => applyPanelStateAction(panelState, action)
-      : undefined,
+
     getActiveTabUrl: () => options.activeTabUrl ?? null,
     getLengthValue: () => options.length ?? "medium",
     updateSlidesTextState,

--- a/tests/sidepanel.presentation-runtime.test.ts
+++ b/tests/sidepanel.presentation-runtime.test.ts
@@ -1,10 +1,9 @@
-// @vitest-environment happy-dom
-
 import { readFileSync } from "node:fs";
+// @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSidepanelDom } from "../apps/chrome-extension/src/entrypoints/sidepanel/dom";
 import { createMetricsController } from "../apps/chrome-extension/src/entrypoints/sidepanel/metrics-controller";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSidepanelPresentationRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime";
 
 vi.mock("../apps/chrome-extension/src/entrypoints/sidepanel/pickers", () => ({
@@ -36,12 +35,12 @@ describe("sidepanel presentation runtime", () => {
 
   it("composes controls, summary dispatch, and deferred feedback actions", async () => {
     const dom = createSidepanelDom();
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const send = vi.fn(async () => {});
     const runtime = createSidepanelPresentationRuntime({
       dom,
-      panelState: store.state,
-      dispatchPanelState: store.dispatch,
+      panelState: store,
+
       appearanceControls: {
         getLengthValue: () => "medium",
       },
@@ -59,7 +58,7 @@ describe("sidepanel presentation runtime", () => {
     dom.summarizeControlRoot.querySelector("button")?.click();
     await Promise.resolve();
 
-    expect(store.state.panelSession.lastAction).toBe("summarize");
+    expect(store.panelSession.lastAction).toBe("summarize");
     expect(send).toHaveBeenCalledWith({
       type: "panel:summarize",
       refresh: false,

--- a/tests/sidepanel.retained-slide-summary.test.ts
+++ b/tests/sidepanel.retained-slide-summary.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import {
   retainRenderedSlideSummary,
   selectRetainedSlideSummaryMarkdown,
@@ -10,34 +7,34 @@ import {
 
 describe("retained slide summary", () => {
   it("retains non-empty rendered markdown for the current source only", () => {
-    const store = createPanelStateStore(createInitialPanelState());
-    store.state.currentSource = {
+    const store = createInitialPanelState();
+    store.currentSource = {
       url: "https://example.com/watch?v=1#chapter",
       title: "Example",
     };
 
-    expect(selectRetainedSlideSummaryMarkdown(store.state)).toBeNull();
-    retainRenderedSlideSummary(store.state, store.dispatch, "  ");
-    expect(store.state.retainedSlideSummary).toBeNull();
+    expect(selectRetainedSlideSummaryMarkdown(store)).toBeNull();
+    retainRenderedSlideSummary(store, "  ");
+    expect(store.retainedSlideSummary).toBeNull();
 
-    retainRenderedSlideSummary(store.state, store.dispatch, "# Summary");
-    expect(selectRetainedSlideSummaryMarkdown(store.state)).toBe("# Summary");
+    retainRenderedSlideSummary(store, "# Summary");
+    expect(selectRetainedSlideSummaryMarkdown(store)).toBe("# Summary");
 
-    store.state.currentSource = { url: "https://example.com/other", title: "Other" };
-    expect(selectRetainedSlideSummaryMarkdown(store.state)).toBeNull();
+    store.currentSource = { url: "https://example.com/other", title: "Other" };
+    expect(selectRetainedSlideSummaryMarkdown(store)).toBeNull();
   });
 
   it("uses the active tab as the retained-summary scope fallback", () => {
-    const store = createPanelStateStore(createInitialPanelState());
-    store.state.navigation.activeTabUrl = "https://example.com/watch?v=1";
+    const store = createInitialPanelState();
+    store.navigation.activeTabUrl = "https://example.com/watch?v=1";
 
-    retainRenderedSlideSummary(store.state, store.dispatch, "Summary");
+    retainRenderedSlideSummary(store, "Summary");
 
-    expect(store.state.retainedSlideSummary).toEqual({
+    expect(store.retainedSlideSummary).toEqual({
       markdown: "Summary",
       url: "https://example.com/watch?v=1",
     });
-    store.state.navigation.activeTabUrl = null;
-    expect(selectRetainedSlideSummaryMarkdown(store.state)).toBe("Summary");
+    store.navigation.activeTabUrl = null;
+    expect(selectRetainedSlideSummaryMarkdown(store)).toBe("Summary");
   });
 });

--- a/tests/sidepanel.run-runtime.test.ts
+++ b/tests/sidepanel.run-runtime.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  applyPanelStateAction,
-  createInitialPanelState,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSidepanelRunRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/run-runtime";
 import type { RunStart } from "../apps/chrome-extension/src/entrypoints/sidepanel/types";
 
@@ -46,7 +43,7 @@ describe("sidepanel run runtime", () => {
 
     const runtime = createSidepanelRunRuntime({
       panelState,
-      dispatchPanelState: (action) => applyPanelStateAction(panelState, action),
+
       getActiveTabId: () => panelState.navigation.activeTabId,
       getActiveTabUrl: () => panelState.navigation.activeTabUrl,
       appearanceControls: {

--- a/tests/sidepanel.session-runtime.test.ts
+++ b/tests/sidepanel.session-runtime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SidepanelDom } from "../apps/chrome-extension/src/entrypoints/sidepanel/dom";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { createSidepanelPresentationRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime";
 import { createSidepanelSessionRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/session-runtime";
 
@@ -25,8 +25,8 @@ afterEach(() => {
 
 describe("sidepanel session runtime", () => {
   it("owns tab sync and coordinated view clearing", async () => {
-    const store = createPanelStateStore();
-    store.state.chat.streaming = true;
+    const store = createInitialPanelState();
+    store.chat.streaming = true;
     const abortSummaryStream = vi.fn();
     const stopSlidesStream = vi.fn();
     const resetSummaryView = vi.fn();
@@ -68,8 +68,8 @@ describe("sidepanel session runtime", () => {
 
     const runtime = createSidepanelSessionRuntime({
       dom: {} as SidepanelDom,
-      panelState: store.state,
-      dispatchPanelState: store.dispatch,
+      panelState: store,
+
       metricsController: {
         clearForMode: vi.fn(),
         setActiveMode: vi.fn(),

--- a/tests/sidepanel.settings-storage-binding.test.ts
+++ b/tests/sidepanel.settings-storage-binding.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { bindSettingsStorage } from "../apps/chrome-extension/src/entrypoints/sidepanel/bindings";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 
 describe("sidepanel settings storage binding", () => {
   let onChanged: (changes: Record<string, chrome.storage.StorageChange>, areaName: string) => void;
@@ -23,13 +20,13 @@ describe("sidepanel settings storage binding", () => {
   it("merges pre-hydration settings while applying live controls", () => {
     const initialState = createInitialPanelState();
     initialState.panelSession.pendingSettingsSnapshot = { autoSummarize: true };
-    const panelStateStore = createPanelStateStore(initialState);
+    const panelStateStore = initialState;
     const applyChatEnabled = vi.fn();
     const hideAutomationNotice = vi.fn();
 
     bindSettingsStorage({
-      panelState: panelStateStore.state,
-      dispatchPanelState: panelStateStore.dispatch,
+      panelState: panelStateStore,
+
       applyChatEnabled,
       hideAutomationNotice,
     });
@@ -46,7 +43,7 @@ describe("sidepanel settings storage binding", () => {
       "local",
     );
 
-    expect(panelStateStore.state.panelSession).toMatchObject({
+    expect(panelStateStore.panelSession).toMatchObject({
       chatEnabled: false,
       automationEnabled: false,
       pendingSettingsSnapshot: {
@@ -62,11 +59,11 @@ describe("sidepanel settings storage binding", () => {
   it("does not queue settings after hydration", () => {
     const initialState = createInitialPanelState();
     initialState.panelSession.settingsHydrated = true;
-    const panelStateStore = createPanelStateStore(initialState);
+    const panelStateStore = initialState;
 
     bindSettingsStorage({
-      panelState: panelStateStore.state,
-      dispatchPanelState: panelStateStore.dispatch,
+      panelState: panelStateStore,
+
       applyChatEnabled: vi.fn(),
       hideAutomationNotice: vi.fn(),
     });
@@ -80,7 +77,7 @@ describe("sidepanel settings storage binding", () => {
       "local",
     );
 
-    expect(panelStateStore.state.panelSession.pendingSettingsSnapshot).toBeNull();
-    expect(panelStateStore.state.panelSession.chatEnabled).toBe(true);
+    expect(panelStateStore.panelSession.pendingSettingsSnapshot).toBeNull();
+    expect(panelStateStore.panelSession.chatEnabled).toBe(true);
   });
 });

--- a/tests/sidepanel.slides-run-runtime.test.ts
+++ b/tests/sidepanel.slides-run-runtime.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  applyPanelStateAction,
-  createInitialPanelState,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSlidesRunRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/slides-run-runtime";
 import type {
   PanelState,
@@ -53,9 +50,7 @@ function createHarness(
   };
   const runtime = createSlidesRunRuntime({
     panelState,
-    dispatchPanelState: options.dispatch
-      ? (action) => applyPanelStateAction(panelState, action)
-      : undefined,
+
     refreshSummarizeControl: calls.refreshSummarizeControl,
     hideSlideNotice: calls.hideSlideNotice,
     setSlidesBusy: calls.setSlidesBusy,

--- a/tests/sidepanel.slides-text-controller.test.ts
+++ b/tests/sidepanel.slides-text-controller.test.ts
@@ -1,18 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store.js";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSlidesTextController } from "../apps/chrome-extension/src/entrypoints/sidepanel/slides-text-controller.js";
 
-type ControllerOptions = Omit<
-  Parameters<typeof createSlidesTextController>[0],
-  "panelState" | "dispatchPanelState"
->;
+type ControllerOptions = Omit<Parameters<typeof createSlidesTextController>[0], "panelState">;
 
 function createController(options: ControllerOptions) {
-  const store = createPanelStateStore();
+  const store = createInitialPanelState();
   return createSlidesTextController({
     ...options,
-    panelState: store.state,
-    dispatchPanelState: store.dispatch,
+    panelState: store,
   });
 }
 

--- a/tests/sidepanel.slides-view-runtime.test.ts
+++ b/tests/sidepanel.slides-view-runtime.test.ts
@@ -1,9 +1,6 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createInitialPanelState,
-  createPanelStateStore,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSlidesViewRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime";
 import type { PanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/types";
 
@@ -60,7 +57,7 @@ function createHarness(
   const panelState = options.panelState ?? createInitialPanelState();
   panelState.currentSource ??= { url: "https://example.com/video", title: "Video" };
   panelState.slides ??= createSlidePayload();
-  const store = createPanelStateStore(panelState);
+  const store = panelState;
   const send = vi.fn(async () => {});
   const refreshSummarizeControl = vi.fn();
   const headerSetProgressOverride = vi.fn();
@@ -95,7 +92,7 @@ function createHarness(
     refreshSummarizeControl,
     hideSlideNotice,
     panelState,
-    dispatchPanelState: options.dispatch ? store.dispatch : undefined,
+
     getFallbackSummaryMarkdown: () => options.fallbackSummary ?? null,
   });
   return {

--- a/tests/sidepanel.state-effects-runtime.test.ts
+++ b/tests/sidepanel.state-effects-runtime.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { createSidepanelBgMessageRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime";
 import type { SidepanelDom } from "../apps/chrome-extension/src/entrypoints/sidepanel/dom";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { createSidepanelPresentationRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime";
 import type { createSidepanelRunRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/run-runtime";
 import type { createSidepanelSessionRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/session-runtime";
@@ -35,7 +35,7 @@ afterEach(() => {
 
 describe("sidepanel state effects runtime", () => {
   it("wires UI state and background messages through subsystem ports", () => {
-    const store = createPanelStateStore();
+    const store = createInitialPanelState();
     const send = vi.fn(async () => {});
     const renderInlineSlides = vi.fn();
     const startSlidesSummaryStreamForRunId = vi.fn();
@@ -48,8 +48,8 @@ describe("sidepanel state effects runtime", () => {
         modelRefreshBtn: { disabled: false },
         renderMarkdownHostEl,
       } as SidepanelDom,
-      panelState: store.state,
-      dispatchPanelState: store.dispatch,
+      panelState: store,
+
       appearanceControls: {} as Parameters<
         typeof createSidepanelStateEffectsRuntime
       >[0]["appearanceControls"],
@@ -168,7 +168,7 @@ describe("sidepanel state effects runtime", () => {
     expect(handleBgMessage).toHaveBeenCalledWith(message);
     expect(send).toHaveBeenCalledWith({ type: "panel:slides-capture" });
     expect(setSlidesLayout).toHaveBeenCalledWith("gallery");
-    expect(store.state.slidesSession.slidesContextPending).toBe(true);
+    expect(store.slidesSession.slidesContextPending).toBe(true);
     expect(applyPanelCache).toHaveBeenCalledWith({}, { preserveChat: true });
     expect(renderInlineSlides).toHaveBeenCalledWith(renderMarkdownHostEl, { fallback: true });
     expect(startSlidesSummaryStreamForRunId).toHaveBeenCalledWith("run-1", null);

--- a/tests/sidepanel.summarize-control-runtime.test.ts
+++ b/tests/sidepanel.summarize-control-runtime.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createInitialPanelState,
-  createPanelStateStore,
+  patchPanelState,
 } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { SlideTextMode } from "../apps/chrome-extension/src/entrypoints/sidepanel/slides-state";
 import { createSummarizeControlRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime";
@@ -93,7 +93,7 @@ function buildRuntime(
   initialPanelState.currentSource = state.currentSourceUrl
     ? { url: state.currentSourceUrl, title: null }
     : null;
-  const panelStateStore = createPanelStateStore(initialPanelState);
+  const panelStateStore = initialPanelState;
   const calls = {
     patchSettings: vi.fn(async (_patch: Partial<Settings>) => {}),
     loadSettings: vi.fn(
@@ -102,10 +102,7 @@ function buildRuntime(
     showSlideNotice: vi.fn(),
     hideSlideNotice: vi.fn(),
     setSlidesBusy: vi.fn((value: boolean) => {
-      panelStateStore.dispatch({
-        type: "slides-session-update",
-        value: { slidesBusy: value },
-      });
+      patchPanelState(panelStateStore, "slidesSession", { slidesBusy: value });
     }),
     stopSlidesStream: vi.fn(),
     maybeApplyPendingSlidesSummary: vi.fn(),
@@ -133,7 +130,7 @@ function buildRuntime(
 
   const view = createSummarizeControlView({
     root: {} as HTMLElement,
-    panelState: panelStateStore.state,
+    panelState: panelStateStore,
     slidesTextController,
   });
   const runtime = createSummarizeControlRuntime({
@@ -141,8 +138,8 @@ function buildRuntime(
     renderSlidesHostEl,
     slidesLayoutEl,
     slidesTextController,
-    panelState: panelStateStore.state,
-    dispatchPanelState: panelStateStore.dispatch,
+    panelState: panelStateStore,
+
     patchSettings: calls.patchSettings,
     loadSettings: calls.loadSettings,
     showSlideNotice: calls.showSlideNotice,
@@ -169,7 +166,7 @@ function buildRuntime(
   });
 
   return {
-    state: panelStateStore.state,
+    state: panelStateStore,
     calls,
     runtime,
     view,

--- a/tests/sidepanel.summary-run-runtime.test.ts
+++ b/tests/sidepanel.summary-run-runtime.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  applyPanelStateAction,
-  createInitialPanelState,
-} from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import { createSummaryRunRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/summary-run-runtime";
 import type {
   PanelState,
@@ -58,9 +55,7 @@ function createHarness(
   };
   const runtime = createSummaryRunRuntime({
     panelState,
-    dispatchPanelState: options.dispatch
-      ? (action) => applyPanelStateAction(panelState, action)
-      : undefined,
+
     getActiveTabId: () => panelState.navigation.activeTabId,
     cancelAutoSummarize: calls.cancelAutoSummarize,
     summaryStream: {

--- a/tests/sidepanel.test-hooks-runtime.test.ts
+++ b/tests/sidepanel.test-hooks-runtime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SidepanelDom } from "../apps/chrome-extension/src/entrypoints/sidepanel/dom";
-import { createPanelStateStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
+import { createInitialPanelState } from "../apps/chrome-extension/src/entrypoints/sidepanel/panel-state-store";
 import type { createSidepanelPresentationRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime";
 import type { createSidepanelRunRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/run-runtime";
 import type { createSidepanelStateEffectsRuntime } from "../apps/chrome-extension/src/entrypoints/sidepanel/state-effects-runtime";
@@ -22,14 +22,14 @@ describe("sidepanel test hooks runtime", () => {
       }
     ).__summarizeTestHooks = hooks;
 
-    const store = createPanelStateStore();
-    store.state.runId = "run-1";
-    store.state.summaryMarkdown = "summary";
-    store.state.lastMeta.model = "openai/gpt-5.4";
-    store.state.slidesSession.mediaAvailable = true;
-    store.state.slidesSummary.markdown = "slide summary";
-    store.state.slidesSummary.complete = true;
-    store.state.slidesSummary.model = "openai/gpt-5.4";
+    const store = createInitialPanelState();
+    store.runId = "run-1";
+    store.summaryMarkdown = "summary";
+    store.lastMeta.model = "openai/gpt-5.4";
+    store.slidesSession.mediaAvailable = true;
+    store.slidesSummary.markdown = "slide summary";
+    store.slidesSummary.complete = true;
+    store.slidesSummary.model = "openai/gpt-5.4";
 
     const setSlidesTranscriptTimedText = vi.fn();
     const updateSlidesTextState = vi.fn();
@@ -99,8 +99,8 @@ describe("sidepanel test hooks runtime", () => {
           textContent: "Failure",
         },
       } as unknown as SidepanelDom,
-      panelState: store.state,
-      dispatchPanelState: store.dispatch,
+      panelState: store,
+
       presentationRuntime,
       runRuntime,
       stateEffectsRuntime,
@@ -135,7 +135,7 @@ describe("sidepanel test hooks runtime", () => {
     expect(updateSlidesTextState).toHaveBeenCalledOnce();
     expect(handleSummarizeControlChange).toHaveBeenCalledWith({ mode: "video", slides: true });
     expect(refreshSummarizeControl).toHaveBeenCalledOnce();
-    expect(store.state.ui).toEqual({ panelOpen: true });
+    expect(store.ui).toEqual({ panelOpen: true });
     expect(applyUiState).toHaveBeenCalledWith({ panelOpen: true });
     expect(handleBgMessage).toHaveBeenCalledWith({ type: "ui:status", status: "Ready" });
     expect(renderMarkdown).toHaveBeenCalledWith("next summary");
@@ -144,7 +144,7 @@ describe("sidepanel test hooks runtime", () => {
       source: "slides-partial",
     });
     expect(setPhase).toHaveBeenCalledTimes(2);
-    expect(store.state.slidesSession).toMatchObject({
+    expect(store.slidesSession).toMatchObject({
       slidesEnabled: true,
       inputMode: "video",
       inputModeOverride: "video",

--- a/tests/youtube.timestamps.live.test.ts
+++ b/tests/youtube.timestamps.live.test.ts
@@ -1,20 +1,9 @@
-import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { runCli } from "../src/run.js";
+import { captureStream as collectStream } from "./helpers/streams.js";
 
 const LIVE = process.env.SUMMARIZE_LIVE_TESTS === "1" && Boolean(process.env.OPENAI_API_KEY);
 const URL = "https://www.youtube.com/watch?v=9pUWFJgBc5Q";
-
-function collectStream() {
-  let text = "";
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      text += chunk.toString();
-      callback();
-    },
-  });
-  return { stream, getText: () => text };
-}
 
 function parseKeyMomentSeconds(summary: string): number[] {
   const lines = summary.split("\n");


### PR DESCRIPTION
## What changed

Replace 65 copied Writable stream factories across 60 CLI/daemon test files with two shared helpers. Move the ordinary browser-extension harness lifetime into a lazy, test-scoped Playwright fixture for 84 tests; each requesting test still gets a fresh profile, runtime-error checks, and guaranteed cleanup.

Live prerequisites, custom/native launchers, and multi-resource cleanup remain explicit. No production code or behavioral assertions were removed. An AST check confirms all 87 scenario names and direct expectation counts in the 14 migrated browser files are unchanged. Three focused tests cover stream capture, isolation, and discard behavior.

Net reduction: 1,450 lines. Most of the displayed browser diff is indentation from removing repeated try/finally blocks.

## Proof

- Full project gate passes: formatting, lint, core/CLI type checks, and 3,073 tests (43 skipped); coverage remains above all thresholds.
- Supported Chromium command: all three native/local-browser scenarios pass; the HTTP run passes 108 scenarios with seven explicit skips and four sidepanel-startup timeouts. Both affected slide suites then pass unchanged: all 12 scenarios, including all four failures. No timeout or assertion was relaxed.
- Independent Codex review: no actionable P0–P2 findings across the complete diff.

This is test infrastructure only; the packaged UI is unchanged. Stacked on #411; land only after its parent and this PR's hosted CI are green.
