### PR TITLE
refactor(core): consolidate content parsing and cache source ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Transcript cache: preserve embedded-caption and native YouTube media source metadata across cache hits instead of losing it to duplicated source lists.
 - Browser media: support MP4 files carrying Annex B AVC/HEVC and clarify missing WebCodecs errors in insecure contexts with MediaBunny 1.55.2.
 - FAL transcription: clear settled deadlines and stop local queue polling and retries after timeout (#392, thanks @vincent-peng).
 - Content extraction: decode HTML entities once so deliberately escaped markup remains literal text (#394, thanks @devYRPauli).
@@ -15,6 +16,7 @@
 
 ### Dependencies and maintenance
 
+- Return DOM documents directly instead of exposing no-op cleanup lifecycles, and share YouTube player-response parsing across captions, metadata, and page extraction.
 - Centralize test output streams and browser-extension lifecycles while preserving isolated profiles, runtime-error checks, and scenario coverage.
 - Remove the sidepanel's redundant action/reducer/dispatch layer; use one state object with explicit lifecycle transitions while preserving navigation, chat, and slide restoration.
 - Make provider metadata the shared source for configuration and model parsing; remove duplicated provider inventories, native model constructors, client defaults, and request-option parsing.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -96,6 +96,7 @@ Media cache eviction:
 
 ## Notes
 
+- Core owns the transcript-source inventory used by both extraction and SQLite reads, including embedded captions and native YouTube media. Cache hits retain their original source diagnostics.
 - No extension cache (daemon uses CLI cache).
 - No third-party SQLite deps.
 - Transcript namespace currently includes the YouTube mode (e.g. `yt:auto`, `yt:web`).

--- a/packages/core/src/content/html-document.ts
+++ b/packages/core/src/content/html-document.ts
@@ -1,10 +1,5 @@
 import { parseHTML } from "linkedom";
 
-export type ParsedHtmlDocument = {
-  document: Document;
-  close: () => void;
-};
-
 const HEAD_CONTENT_TAGS = new Set([
   "base",
   "basefont",
@@ -18,7 +13,7 @@ const HEAD_CONTENT_TAGS = new Set([
   "title",
 ]);
 
-export function parseHtmlDocument(html: string, url?: string): ParsedHtmlDocument {
+export function parseHtmlDocument(html: string, url?: string): Document {
   // LinkeDOM treats fragments as the document element; Readability requires normal body ancestry.
   const prolog = inspectProlog(html);
   const source = /^<html(?:\s|>)/i.test(html.slice(prolog.contentOffset))
@@ -50,10 +45,7 @@ export function parseHtmlDocument(html: string, url?: string): ParsedHtmlDocumen
   document.createElement = ((tagName: string, options?: ElementCreationOptions) =>
     createElement(tagName.toLowerCase(), options)) as typeof document.createElement;
 
-  return {
-    document,
-    close: () => undefined,
-  };
+  return document;
 }
 
 function normalizeHtmlAttributeNames(document: Document): void {

--- a/packages/core/src/content/index.ts
+++ b/packages/core/src/content/index.ts
@@ -62,6 +62,7 @@ export type {
 export { ProgressKind } from "./link-preview/deps.js";
 export {
   CACHE_MODES,
+  TRANSCRIPT_SOURCES,
   type CacheMode,
   type CacheStatus,
   type TranscriptSegment,

--- a/packages/core/src/content/link-preview/content/article.ts
+++ b/packages/core/src/content/link-preview/content/article.ts
@@ -107,39 +107,33 @@ export function collectSegmentsFromHtml(
     },
   });
 
-  const parsed = parseHtmlDocument(sanitized);
-  try {
-    const segments: string[] = [];
+  const document = parseHtmlDocument(sanitized);
+  const segments: string[] = [];
 
-    for (const element of parsed.document.querySelectorAll(
-      "h1,h2,h3,h4,h5,h6,li,p,blockquote,pre",
-    )) {
-      const tag = element.tagName.toLowerCase();
-      const text = normalizeWhitespace(element.textContent ?? "").replaceAll(/\n+/g, " ");
-      if (!text) continue;
+  for (const element of document.querySelectorAll("h1,h2,h3,h4,h5,h6,li,p,blockquote,pre")) {
+    const tag = element.tagName.toLowerCase();
+    const text = normalizeWhitespace(element.textContent ?? "").replaceAll(/\n+/g, " ");
+    if (!text) continue;
 
-      if (tag.startsWith("h")) {
-        if (text.length >= 10) segments.push(text);
-        continue;
-      }
-
-      if (tag === "li") {
-        if (text.length >= Math.min(20, minimumSegmentLength)) segments.push(`• ${text}`);
-        continue;
-      }
-
-      if (text.length >= minimumSegmentLength) segments.push(text);
+    if (tag.startsWith("h")) {
+      if (text.length >= 10) segments.push(text);
+      continue;
     }
 
-    if (segments.length === 0) {
-      const fallback = normalizeWhitespace(parsed.document.body?.textContent || sanitized);
-      return fallback ? [fallback] : [];
+    if (tag === "li") {
+      if (text.length >= Math.min(20, minimumSegmentLength)) segments.push(`• ${text}`);
+      continue;
     }
 
-    return mergeConsecutiveSegments(segments);
-  } finally {
-    parsed.close();
+    if (text.length >= minimumSegmentLength) segments.push(text);
   }
+
+  if (segments.length === 0) {
+    const fallback = normalizeWhitespace(document.body?.textContent || sanitized);
+    return fallback ? [fallback] : [];
+  }
+
+  return mergeConsecutiveSegments(segments);
 }
 
 export function extractPlainText(html: string): string {

--- a/packages/core/src/content/link-preview/content/jsonld.ts
+++ b/packages/core/src/content/link-preview/content/jsonld.ts
@@ -8,9 +8,9 @@ export type JsonLdContent = {
 };
 
 export function extractJsonLdContent(html: string): JsonLdContent | null {
-  const parsed = parseHtmlDocument(html);
+  const document = parseHtmlDocument(html);
   try {
-    const scripts = parsed.document.querySelectorAll('script[type="application/ld+json"]');
+    const scripts = document.querySelectorAll('script[type="application/ld+json"]');
     const candidates: JsonLdContent[] = [];
 
     for (const script of scripts) {
@@ -38,8 +38,6 @@ export function extractJsonLdContent(html: string): JsonLdContent | null {
     return sorted[0] ?? null;
   } catch {
     return null;
-  } finally {
-    parsed.close();
   }
 }
 

--- a/packages/core/src/content/link-preview/content/parsers.ts
+++ b/packages/core/src/content/link-preview/content/parsers.ts
@@ -16,39 +16,34 @@ export interface ParsedMetadata {
 }
 
 export function extractMetadataFromHtml(html: string, url: string): ParsedMetadata {
-  const parsed = parseHtmlDocument(html);
-  const { document } = parsed;
+  const document = parseHtmlDocument(html);
 
-  try {
-    const title = pickFirstText([
-      pickMetaContent(document, [
-        { attribute: "property", value: "og:title" },
-        { attribute: "name", value: "og:title" },
-        { attribute: "name", value: "twitter:title" },
-      ]),
-      extractTagText(document, "title"),
-    ]);
+  const title = pickFirstText([
+    pickMetaContent(document, [
+      { attribute: "property", value: "og:title" },
+      { attribute: "name", value: "og:title" },
+      { attribute: "name", value: "twitter:title" },
+    ]),
+    extractTagText(document, "title"),
+  ]);
 
-    const description = pickFirstText([
-      pickMetaContent(document, [
-        { attribute: "property", value: "og:description" },
-        { attribute: "name", value: "description" },
-        { attribute: "name", value: "twitter:description" },
-      ]),
-    ]);
+  const description = pickFirstText([
+    pickMetaContent(document, [
+      { attribute: "property", value: "og:description" },
+      { attribute: "name", value: "description" },
+      { attribute: "name", value: "twitter:description" },
+    ]),
+  ]);
 
-    const siteName = pickFirstText([
-      pickMetaContent(document, [
-        { attribute: "property", value: "og:site_name" },
-        { attribute: "name", value: "application-name" },
-      ]),
-      safeHostname(url),
-    ]);
+  const siteName = pickFirstText([
+    pickMetaContent(document, [
+      { attribute: "property", value: "og:site_name" },
+      { attribute: "name", value: "application-name" },
+    ]),
+    safeHostname(url),
+  ]);
 
-    return { title, description, siteName };
-  } finally {
-    parsed.close();
-  }
+  return { title, description, siteName };
 }
 
 export function extractMetadataFromFirecrawl(

--- a/packages/core/src/content/link-preview/content/readability.ts
+++ b/packages/core/src/content/link-preview/content/readability.ts
@@ -15,21 +15,17 @@ export async function extractReadabilityFromHtml(
   try {
     const cleanedHtml = stripCssFromHtml(stripHiddenHtml(html));
     const { Readability } = await import("@mozilla/readability");
-    const parsed = parseHtmlDocument(cleanedHtml, url);
-    try {
-      const article = new Readability(parsed.document).parse();
-      if (!article) return null;
+    const document = parseHtmlDocument(cleanedHtml, url);
+    const article = new Readability(document).parse();
+    if (!article) return null;
 
-      const text = (article.textContent ?? "").replace(/\s+/g, " ").trim();
-      return {
-        text,
-        html: article.content ?? null,
-        title: article.title ?? null,
-        excerpt: article.excerpt ?? null,
-      };
-    } finally {
-      parsed.close();
-    }
+    const text = (article.textContent ?? "").replace(/\s+/g, " ").trim();
+    return {
+      text,
+      html: article.content ?? null,
+      title: article.title ?? null,
+      excerpt: article.excerpt ?? null,
+    };
   } catch {
     return null;
   }

--- a/packages/core/src/content/link-preview/content/reddit.ts
+++ b/packages/core/src/content/link-preview/content/reddit.ts
@@ -41,25 +41,21 @@ export function isBlockedRedditThreadHtml(inputUrl: string, html: string): boole
   const redditUrl = parseRedditThreadUrl(inputUrl);
   if (!redditUrl) return false;
 
-  const parsed = parseHtmlDocument(html, redditUrl.href);
-  try {
-    const threadId = redditThreadId(redditUrl);
-    if (
-      parsed.document.querySelector(
-        `#thing_t3_${threadId}.thing[data-type="link"], .thing[data-fullname="t3_${threadId}"][data-type="link"], shreddit-post, [data-testid="post-container"]`,
-      )
-    ) {
-      return false;
-    }
-
-    const title = normalizeCandidate(parsed.document.querySelector("title")?.textContent) ?? "";
-    if (REDDIT_VERIFICATION_PATTERN.test(title)) return true;
-
-    const body = normalizeCandidate(parsed.document.body?.textContent) ?? "";
-    return body.length <= 1_000 && REDDIT_VERIFICATION_PATTERN.test(body);
-  } finally {
-    parsed.close();
+  const document = parseHtmlDocument(html, redditUrl.href);
+  const threadId = redditThreadId(redditUrl);
+  if (
+    document.querySelector(
+      `#thing_t3_${threadId}.thing[data-type="link"], .thing[data-fullname="t3_${threadId}"][data-type="link"], shreddit-post, [data-testid="post-container"]`,
+    )
+  ) {
+    return false;
   }
+
+  const title = normalizeCandidate(document.querySelector("title")?.textContent) ?? "";
+  if (REDDIT_VERIFICATION_PATTERN.test(title)) return true;
+
+  const body = normalizeCandidate(document.body?.textContent) ?? "";
+  return body.length <= 1_000 && REDDIT_VERIFICATION_PATTERN.test(body);
 }
 
 function directChildWithClass(element: Element, className: string): Element | null {
@@ -117,63 +113,57 @@ export function normalizeOldRedditThreadHtml(
   const redditUrl = parseRedditThreadUrl(inputUrl);
   if (!redditUrl) return null;
 
-  const parsed = parseHtmlDocument(html, redditUrl.href);
-  try {
-    const threadId = redditThreadId(redditUrl);
-    if (!threadId) return null;
-    const post = parsed.document.querySelector(
-      `#thing_t3_${threadId}.thing[data-type="link"], .thing[data-fullname="t3_${threadId}"][data-type="link"]`,
+  const document = parseHtmlDocument(html, redditUrl.href);
+  const threadId = redditThreadId(redditUrl);
+  if (!threadId) return null;
+  const post = document.querySelector(
+    `#thing_t3_${threadId}.thing[data-type="link"], .thing[data-fullname="t3_${threadId}"][data-type="link"]`,
+  );
+  if (!post || post.classList.contains("promoted")) return null;
+
+  const postEntry = thingEntry(post);
+  const titleLink = postEntry?.querySelector("a.title") ?? null;
+  const title = normalizeCandidate(titleLink?.textContent) ?? null;
+  if (!title) return null;
+  const isSelfPost =
+    post.classList.contains("self") ||
+    (post.getAttribute("data-domain") ?? "").toLowerCase().startsWith("self.");
+  const titleUrl = resolveHttpUrl(
+    isSelfPost && options?.canonicalUrl ? options.canonicalUrl : titleLink?.getAttribute("href"),
+    redditUrl,
+  );
+
+  const postAuthor = normalizeCandidate(postEntry?.querySelector(".tagline .author")?.textContent);
+  const subreddit = normalizeCandidate(post.getAttribute("data-subreddit"));
+  const postBody = safeBodyHtml(entryBody(postEntry));
+  const postByline = [postAuthor ? `u/${postAuthor}` : null, subreddit ? `r/${subreddit}` : null]
+    .filter(Boolean)
+    .join(" in ");
+
+  const commentSections: string[] = [];
+  for (const comment of document.querySelectorAll(".thing.comment")) {
+    const entry = thingEntry(comment);
+    const body = entryBody(entry);
+    const bodyText = normalizeCandidate(body?.textContent);
+    if (!bodyText) continue;
+
+    const author = normalizeCandidate(entry?.querySelector(".tagline .author")?.textContent);
+    const headingLevel = Math.min(6, 3 + commentDepth(comment));
+    const heading = author ? `Comment by u/${author}` : "Comment";
+    commentSections.push(
+      `<section><h${headingLevel}>${escapeHtml(heading)}</h${headingLevel}>${safeBodyHtml(body)}</section>`,
     );
-    if (!post || post.classList.contains("promoted")) return null;
-
-    const postEntry = thingEntry(post);
-    const titleLink = postEntry?.querySelector("a.title") ?? null;
-    const title = normalizeCandidate(titleLink?.textContent) ?? null;
-    if (!title) return null;
-    const isSelfPost =
-      post.classList.contains("self") ||
-      (post.getAttribute("data-domain") ?? "").toLowerCase().startsWith("self.");
-    const titleUrl = resolveHttpUrl(
-      isSelfPost && options?.canonicalUrl ? options.canonicalUrl : titleLink?.getAttribute("href"),
-      redditUrl,
-    );
-
-    const postAuthor = normalizeCandidate(
-      postEntry?.querySelector(".tagline .author")?.textContent,
-    );
-    const subreddit = normalizeCandidate(post.getAttribute("data-subreddit"));
-    const postBody = safeBodyHtml(entryBody(postEntry));
-    const postByline = [postAuthor ? `u/${postAuthor}` : null, subreddit ? `r/${subreddit}` : null]
-      .filter(Boolean)
-      .join(" in ");
-
-    const commentSections: string[] = [];
-    for (const comment of parsed.document.querySelectorAll(".thing.comment")) {
-      const entry = thingEntry(comment);
-      const body = entryBody(entry);
-      const bodyText = normalizeCandidate(body?.textContent);
-      if (!bodyText) continue;
-
-      const author = normalizeCandidate(entry?.querySelector(".tagline .author")?.textContent);
-      const headingLevel = Math.min(6, 3 + commentDepth(comment));
-      const heading = author ? `Comment by u/${author}` : "Comment";
-      commentSections.push(
-        `<section><h${headingLevel}>${escapeHtml(heading)}</h${headingLevel}>${safeBodyHtml(body)}</section>`,
-      );
-    }
-
-    const bylineHtml = postByline ? `<p>Posted by ${escapeHtml(postByline)}</p>` : "";
-    const commentsHtml =
-      commentSections.length > 0 ? `<h2>Comments</h2>${commentSections.join("")}` : "";
-    const titleHtml = titleUrl
-      ? `<a href="${escapeHtml(titleUrl)}">${escapeHtml(title)}</a>`
-      : escapeHtml(title);
-    const outboundLinkHtml =
-      titleUrl && !isSelfPost
-        ? `<p>Link: <a href="${escapeHtml(titleUrl)}">${escapeHtml(titleUrl)}</a></p>`
-        : "";
-    return `<!doctype html><html><head><title>${escapeHtml(title)}</title><meta property="og:site_name" content="Reddit"></head><body><article><h1>${titleHtml}</h1>${bylineHtml}${outboundLinkHtml}${postBody}${commentsHtml}</article></body></html>`;
-  } finally {
-    parsed.close();
   }
+
+  const bylineHtml = postByline ? `<p>Posted by ${escapeHtml(postByline)}</p>` : "";
+  const commentsHtml =
+    commentSections.length > 0 ? `<h2>Comments</h2>${commentSections.join("")}` : "";
+  const titleHtml = titleUrl
+    ? `<a href="${escapeHtml(titleUrl)}">${escapeHtml(title)}</a>`
+    : escapeHtml(title);
+  const outboundLinkHtml =
+    titleUrl && !isSelfPost
+      ? `<p>Link: <a href="${escapeHtml(titleUrl)}">${escapeHtml(titleUrl)}</a></p>`
+      : "";
+  return `<!doctype html><html><head><title>${escapeHtml(title)}</title><meta property="og:site_name" content="Reddit"></head><body><article><h1>${titleHtml}</h1>${bylineHtml}${outboundLinkHtml}${postBody}${commentsHtml}</article></body></html>`;
 }

--- a/packages/core/src/content/link-preview/content/video.ts
+++ b/packages/core/src/content/link-preview/content/video.ts
@@ -85,94 +85,89 @@ export function detectPrimaryVideoDetailsFromHtml(
   url: string,
 ): PrimaryVideoDetection | null {
   if (isLoomVideoUrl(url)) return null;
-  const parsed = parseHtmlDocument(html);
-  const { document } = parsed;
+  const document = parseHtmlDocument(html);
 
-  try {
-    const ogVideo = metaContent(document, [
-      { attribute: "property", value: "og:video" },
-      { attribute: "property", value: "og:video:url" },
-      { attribute: "property", value: "og:video:secure_url" },
-      { attribute: "name", value: "og:video" },
-      { attribute: "name", value: "og:video:url" },
-      { attribute: "name", value: "og:video:secure_url" },
-    ]);
-    const ogYoutubeVideo = ogVideo ? toYoutubeVideo(ogVideo, url) : null;
-    const iframeCandidates = Array.from(
-      document.querySelectorAll(
-        'iframe[src*="youtube.com/embed/"], iframe[src*="youtube-nocookie.com/embed/"], iframe[src*="youtu.be/"]',
-      ),
-    )
-      .map((element) => {
-        const src = element.getAttribute("src");
-        const video = src ? toYoutubeVideo(src, url) : null;
-        return video ? { element, video } : null;
-      })
-      .filter(
-        (
-          candidate,
-        ): candidate is {
-          element: Element;
-          video: DetectedVideo;
-        } => candidate !== null,
-      );
-    if (iframeCandidates.length > 0) {
-      const uniqueUrls = new Set(iframeCandidates.map((candidate) => candidate.video.url));
-      if (uniqueUrls.size === 1) {
-        if (ogYoutubeVideo && !uniqueUrls.has(ogYoutubeVideo.url)) {
-          return { video: iframeCandidates[0]!.video, source: "iframe", confidence: "medium" };
-        }
-        return { video: iframeCandidates[0]!.video, source: "iframe", confidence: "high" };
+  const ogVideo = metaContent(document, [
+    { attribute: "property", value: "og:video" },
+    { attribute: "property", value: "og:video:url" },
+    { attribute: "property", value: "og:video:secure_url" },
+    { attribute: "name", value: "og:video" },
+    { attribute: "name", value: "og:video:url" },
+    { attribute: "name", value: "og:video:secure_url" },
+  ]);
+  const ogYoutubeVideo = ogVideo ? toYoutubeVideo(ogVideo, url) : null;
+  const iframeCandidates = Array.from(
+    document.querySelectorAll(
+      'iframe[src*="youtube.com/embed/"], iframe[src*="youtube-nocookie.com/embed/"], iframe[src*="youtu.be/"]',
+    ),
+  )
+    .map((element) => {
+      const src = element.getAttribute("src");
+      const video = src ? toYoutubeVideo(src, url) : null;
+      return video ? { element, video } : null;
+    })
+    .filter(
+      (
+        candidate,
+      ): candidate is {
+        element: Element;
+        video: DetectedVideo;
+      } => candidate !== null,
+    );
+  if (iframeCandidates.length > 0) {
+    const uniqueUrls = new Set(iframeCandidates.map((candidate) => candidate.video.url));
+    if (uniqueUrls.size === 1) {
+      if (ogYoutubeVideo && !uniqueUrls.has(ogYoutubeVideo.url)) {
+        return { video: iframeCandidates[0]!.video, source: "iframe", confidence: "medium" };
       }
-      if (
-        ogYoutubeVideo &&
-        iframeCandidates.some((candidate) => candidate.video.url === ogYoutubeVideo.url)
-      ) {
-        return { video: ogYoutubeVideo, source: "open-graph", confidence: "high" };
-      }
-      const mainCandidates = iframeCandidates.filter((candidate) =>
-        candidate.element.closest("article, main, [role=main]"),
-      );
-      const uniqueMainUrls = new Set(mainCandidates.map((candidate) => candidate.video.url));
-      if (uniqueMainUrls.size === 1 && mainCandidates[0]) {
-        return { video: mainCandidates[0].video, source: "iframe", confidence: "high" };
-      }
-      return { video: iframeCandidates[0]!.video, source: "iframe", confidence: "medium" };
+      return { video: iframeCandidates[0]!.video, source: "iframe", confidence: "high" };
     }
-
-    if (ogVideo) {
-      const resolved = resolveAbsoluteUrl(ogVideo, url);
-      if (resolved && isDirectVideoUrl(resolved)) {
-        return {
-          video: { kind: "direct", url: resolved },
-          source: "open-graph",
-          confidence: "high",
-        };
-      }
-      if (ogYoutubeVideo) {
-        return { video: ogYoutubeVideo, source: "open-graph", confidence: "high" };
-      }
+    if (
+      ogYoutubeVideo &&
+      iframeCandidates.some((candidate) => candidate.video.url === ogYoutubeVideo.url)
+    ) {
+      return { video: ogYoutubeVideo, source: "open-graph", confidence: "high" };
     }
-
-    const videoSrc =
-      document.querySelector("video[src]")?.getAttribute("src") ??
-      document.querySelector("video source[src]")?.getAttribute("src") ??
-      null;
-    if (videoSrc) {
-      const resolved = resolveAbsoluteUrl(videoSrc, url);
-      if (resolved && isDirectVideoUrl(resolved)) {
-        return {
-          video: { kind: "direct", url: resolved },
-          source: "video-tag",
-          confidence: "high",
-        };
-      }
+    const mainCandidates = iframeCandidates.filter((candidate) =>
+      candidate.element.closest("article, main, [role=main]"),
+    );
+    const uniqueMainUrls = new Set(mainCandidates.map((candidate) => candidate.video.url));
+    if (uniqueMainUrls.size === 1 && mainCandidates[0]) {
+      return { video: mainCandidates[0].video, source: "iframe", confidence: "high" };
     }
-
-    return null;
-  } finally {
-    parsed.close();
+    return { video: iframeCandidates[0]!.video, source: "iframe", confidence: "medium" };
   }
+
+  if (ogVideo) {
+    const resolved = resolveAbsoluteUrl(ogVideo, url);
+    if (resolved && isDirectVideoUrl(resolved)) {
+      return {
+        video: { kind: "direct", url: resolved },
+        source: "open-graph",
+        confidence: "high",
+      };
+    }
+    if (ogYoutubeVideo) {
+      return { video: ogYoutubeVideo, source: "open-graph", confidence: "high" };
+    }
+  }
+
+  const videoSrc =
+    document.querySelector("video[src]")?.getAttribute("src") ??
+    document.querySelector("video source[src]")?.getAttribute("src") ??
+    null;
+  if (videoSrc) {
+    const resolved = resolveAbsoluteUrl(videoSrc, url);
+    if (resolved && isDirectVideoUrl(resolved)) {
+      return {
+        video: { kind: "direct", url: resolved },
+        source: "video-tag",
+        confidence: "high",
+      };
+    }
+  }
+
+  return null;
 }
 
 export function detectPrimaryVideoFromHtml(html: string, url: string): DetectedVideo | null {

--- a/packages/core/src/content/link-preview/content/visibility.ts
+++ b/packages/core/src/content/link-preview/content/visibility.ts
@@ -110,22 +110,18 @@ function shouldStripElement(
 export function stripHiddenHtml(html: string): string {
   if (!html) return html;
   const withoutComments = html.replace(COMMENT_PATTERN, "");
-  const parsed = parseHtmlDocument(withoutComments);
+  const document = parseHtmlDocument(withoutComments);
 
-  try {
-    for (const element of parsed.document.querySelectorAll("*")) {
-      const tagName = element.tagName.toLowerCase();
-      const attributes: AttributeMap = {};
-      for (const attribute of element.attributes) {
-        attributes[attribute.name.toLowerCase()] = attribute.value.toLowerCase();
-      }
-      if (shouldStripElement(tagName, attributes.style, attributes)) {
-        element.remove();
-      }
+  for (const element of document.querySelectorAll("*")) {
+    const tagName = element.tagName.toLowerCase();
+    const attributes: AttributeMap = {};
+    for (const attribute of element.attributes) {
+      attributes[attribute.name.toLowerCase()] = attribute.value.toLowerCase();
     }
-
-    return serializeHtmlDocument(parsed.document);
-  } finally {
-    parsed.close();
+    if (shouldStripElement(tagName, attributes.style, attributes)) {
+      element.remove();
+    }
   }
+
+  return serializeHtmlDocument(document);
 }

--- a/packages/core/src/content/link-preview/content/youtube.ts
+++ b/packages/core/src/content/link-preview/content/youtube.ts
@@ -1,90 +1,10 @@
+import { extractInitialPlayerResponse } from "../../transcript/utils.js";
 import { normalizeWhitespace } from "./cleaner.js";
 
-function extractBalancedJsonObject(source: string, startAt: number): string | null {
-  const start = source.indexOf("{", startAt);
-  if (start < 0) {
-    return null;
-  }
-
-  let depth = 0;
-  let inString = false;
-  let quote: '"' | "'" | null = null;
-  let escaping = false;
-
-  for (let i = start; i < source.length; i += 1) {
-    const ch = source[i];
-    if (!ch) {
-      continue;
-    }
-
-    if (inString) {
-      if (escaping) {
-        escaping = false;
-        continue;
-      }
-      if (ch === "\\") {
-        escaping = true;
-        continue;
-      }
-      if (quote && ch === quote) {
-        inString = false;
-        quote = null;
-      }
-      continue;
-    }
-
-    if (ch === '"' || ch === "'") {
-      inString = true;
-      quote = ch;
-      continue;
-    }
-
-    if (ch === "{") {
-      depth += 1;
-      continue;
-    }
-    if (ch === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return source.slice(start, i + 1);
-      }
-    }
-  }
-
-  return null;
-}
-
 export function extractYouTubeShortDescription(html: string): string | null {
-  const tokenIndex = html.indexOf("ytInitialPlayerResponse");
-  if (tokenIndex < 0) {
-    return null;
-  }
-  const assignmentIndex = html.indexOf("=", tokenIndex);
-  if (assignmentIndex < 0) {
-    return null;
-  }
-  const objectText = extractBalancedJsonObject(html, assignmentIndex);
-  if (!objectText) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(objectText) as unknown;
-    if (!parsed || typeof parsed !== "object") {
-      return null;
-    }
-    const videoDetails = (parsed as Record<string, unknown>).videoDetails;
-    if (!videoDetails || typeof videoDetails !== "object") {
-      return null;
-    }
-    const description = (videoDetails as Record<string, unknown>).shortDescription;
-    if (typeof description !== "string") {
-      return null;
-    }
-
-    const normalized = normalizeWhitespace(description);
-    return normalized && normalized.length > 0 ? normalized : null;
-  } catch {
-    return null;
-  }
+  const videoDetails = extractInitialPlayerResponse(html)?.videoDetails;
+  if (!videoDetails || typeof videoDetails !== "object") return null;
+  const description = (videoDetails as Record<string, unknown>).shortDescription;
+  if (typeof description !== "string") return null;
+  return normalizeWhitespace(description) || null;
 }

--- a/packages/core/src/content/link-preview/types.ts
+++ b/packages/core/src/content/link-preview/types.ts
@@ -1,15 +1,17 @@
-export type TranscriptSource =
-  | "youtubei"
-  | "captionTracks"
-  | "embedded"
-  | "yt-dlp"
-  | "youtube-media"
-  | "podcastTranscript"
-  | "whisper"
-  | "apify"
-  | "html"
-  | "unavailable"
-  | "unknown";
+export const TRANSCRIPT_SOURCES = [
+  "youtubei",
+  "captionTracks",
+  "embedded",
+  "yt-dlp",
+  "youtube-media",
+  "podcastTranscript",
+  "whisper",
+  "apify",
+  "html",
+  "unavailable",
+  "unknown",
+] as const;
+export type TranscriptSource = (typeof TRANSCRIPT_SOURCES)[number];
 
 export type TranscriptSegment = {
   startMs: number;

--- a/packages/core/src/content/transcript/cache.ts
+++ b/packages/core/src/content/transcript/cache.ts
@@ -1,10 +1,11 @@
 import type { DiarizationPreference } from "../../transcription/whisper/types.js";
 import type { TranscriptCache } from "../cache/types.js";
-import type {
-  CacheMode,
-  TranscriptDiagnostics,
-  TranscriptResolution,
-  TranscriptSource,
+import {
+  TRANSCRIPT_SOURCES,
+  type CacheMode,
+  type TranscriptDiagnostics,
+  type TranscriptResolution,
+  type TranscriptSource,
 } from "../link-preview/types.js";
 
 export const DEFAULT_TTL_MS = 1000 * 60 * 60 * 24 * 7;
@@ -144,20 +145,7 @@ const appendNote = (existing: string | null | undefined, next: string): string =
 
 export const mapCachedSource = (source: string | null): TranscriptSource | null => {
   if (source === null) return null;
-  if (
-    source === "youtubei" ||
-    source === "captionTracks" ||
-    source === "embedded" ||
-    source === "yt-dlp" ||
-    source === "podcastTranscript" ||
-    source === "whisper" ||
-    source === "apify" ||
-    source === "html" ||
-    source === "unavailable"
-  ) {
-    return source;
-  }
-  return "unknown";
+  return TRANSCRIPT_SOURCES.find((candidate) => candidate === source) ?? "unknown";
 };
 
 export const writeTranscriptCache = async ({

--- a/packages/core/src/content/transcript/providers/generic-embedded.ts
+++ b/packages/core/src/content/transcript/providers/generic-embedded.ts
@@ -22,46 +22,41 @@ export type EmbeddedMedia = {
 };
 
 export function detectEmbeddedMedia(html: string, baseUrl: string): EmbeddedMedia | null {
-  const parsed = parseHtmlDocument(html);
-  const { document } = parsed;
+  const document = parseHtmlDocument(html);
 
-  try {
-    const trackCandidates: EmbeddedTrack[] = [];
-    for (const element of document.querySelectorAll(
-      'track[kind="captions"], track[kind="subtitles"]',
-    )) {
-      const src = element.getAttribute("src")?.trim();
-      if (!src) continue;
-      const url = resolveAbsoluteUrl(src, baseUrl);
-      if (!url) continue;
-      const type = element.getAttribute("type")?.trim() ?? null;
-      const language =
-        element.getAttribute("srclang")?.trim() ?? element.getAttribute("lang")?.trim() ?? null;
-      trackCandidates.push({ url, type, language });
-    }
-
-    const track = selectPreferredTrack(trackCandidates);
-    const videoUrl = resolveFirstMediaUrl(document, baseUrl, "video");
-    const audioUrl = resolveFirstMediaUrl(document, baseUrl, "audio");
-    const ogVideo = resolveOgMediaUrl(document, baseUrl, "video");
-    const ogAudio = resolveOgMediaUrl(document, baseUrl, "audio");
-
-    if (videoUrl || ogVideo) {
-      return { kind: "video", mediaUrl: pickMediaUrl([videoUrl, ogVideo]), track };
-    }
-    if (audioUrl || ogAudio) {
-      return { kind: "audio", mediaUrl: pickMediaUrl([audioUrl, ogAudio]), track };
-    }
-
-    const hasVideoTag = document.querySelector("video") !== null;
-    const hasAudioTag = !hasVideoTag && document.querySelector("audio") !== null;
-    if (track || hasVideoTag || hasAudioTag) {
-      return { kind: hasAudioTag ? "audio" : "video", mediaUrl: null, track };
-    }
-    return null;
-  } finally {
-    parsed.close();
+  const trackCandidates: EmbeddedTrack[] = [];
+  for (const element of document.querySelectorAll(
+    'track[kind="captions"], track[kind="subtitles"]',
+  )) {
+    const src = element.getAttribute("src")?.trim();
+    if (!src) continue;
+    const url = resolveAbsoluteUrl(src, baseUrl);
+    if (!url) continue;
+    const type = element.getAttribute("type")?.trim() ?? null;
+    const language =
+      element.getAttribute("srclang")?.trim() ?? element.getAttribute("lang")?.trim() ?? null;
+    trackCandidates.push({ url, type, language });
   }
+
+  const track = selectPreferredTrack(trackCandidates);
+  const videoUrl = resolveFirstMediaUrl(document, baseUrl, "video");
+  const audioUrl = resolveFirstMediaUrl(document, baseUrl, "audio");
+  const ogVideo = resolveOgMediaUrl(document, baseUrl, "video");
+  const ogAudio = resolveOgMediaUrl(document, baseUrl, "audio");
+
+  if (videoUrl || ogVideo) {
+    return { kind: "video", mediaUrl: pickMediaUrl([videoUrl, ogVideo]), track };
+  }
+  if (audioUrl || ogAudio) {
+    return { kind: "audio", mediaUrl: pickMediaUrl([audioUrl, ogAudio]), track };
+  }
+
+  const hasVideoTag = document.querySelector("video") !== null;
+  const hasAudioTag = !hasVideoTag && document.querySelector("audio") !== null;
+  if (track || hasVideoTag || hasAudioTag) {
+    return { kind: hasAudioTag ? "audio" : "video", mediaUrl: null, track };
+  }
+  return null;
 }
 
 export async function fetchCaptionTrack(

--- a/packages/core/src/content/transcript/providers/podcast/xiaoyuzhou.ts
+++ b/packages/core/src/content/transcript/providers/podcast/xiaoyuzhou.ts
@@ -86,9 +86,9 @@ export async function fetchXiaoyuzhouTranscript(
 }
 
 export function extractXiaoyuzhouOgAudioUrl(html: string): string | null {
-  const parsed = parseHtmlDocument(html);
+  const document = parseHtmlDocument(html);
   try {
-    const meta = parsed.document.querySelector('meta[property="og:audio"]');
+    const meta = document.querySelector('meta[property="og:audio"]');
     const candidate = (meta?.getAttribute("content") ?? "").trim();
     if (!candidate) return null;
     const url = new URL(candidate);
@@ -104,8 +104,6 @@ export function extractXiaoyuzhouOgAudioUrl(html: string): string | null {
     return url.href;
   } catch {
     return null;
-  } finally {
-    parsed.close();
   }
 }
 

--- a/packages/core/src/content/transcript/providers/youtube/captions-player.ts
+++ b/packages/core/src/content/transcript/providers/youtube/captions-player.ts
@@ -1,86 +1,8 @@
 import { withBunCompressionHeaders } from "../../../bun.js";
 import { fetchWithTimeout } from "../../../link-preview/fetch-with-timeout.js";
+import { extractInitialPlayerResponse } from "../../utils.js";
 import { extractYoutubeiBootstrap } from "./api.js";
-import {
-  INNERTUBE_API_KEY_REGEX,
-  REQUEST_HEADERS,
-  YT_INITIAL_PLAYER_RESPONSE_TOKEN,
-  isObjectLike,
-} from "./captions-shared.js";
-
-function extractBalancedJsonObject(source: string, startAt: number): string | null {
-  const start = source.indexOf("{", startAt);
-  if (start < 0) {
-    return null;
-  }
-
-  let depth = 0;
-  let inString = false;
-  let quote: '"' | "'" | null = null;
-  let escaping = false;
-
-  for (let i = start; i < source.length; i += 1) {
-    const ch = source[i];
-    if (!ch) continue;
-
-    if (inString) {
-      if (escaping) {
-        escaping = false;
-        continue;
-      }
-      if (ch === "\\") {
-        escaping = true;
-        continue;
-      }
-      if (quote && ch === quote) {
-        inString = false;
-        quote = null;
-      }
-      continue;
-    }
-
-    if (ch === '"' || ch === "'") {
-      inString = true;
-      quote = ch;
-      continue;
-    }
-
-    if (ch === "{") {
-      depth += 1;
-      continue;
-    }
-    if (ch === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return source.slice(start, i + 1);
-      }
-    }
-  }
-
-  return null;
-}
-
-export function extractInitialPlayerResponse(html: string): Record<string, unknown> | null {
-  const tokenIndex = html.indexOf(YT_INITIAL_PLAYER_RESPONSE_TOKEN);
-  if (tokenIndex < 0) {
-    return null;
-  }
-  const assignmentIndex = html.indexOf("=", tokenIndex);
-  if (assignmentIndex < 0) {
-    return null;
-  }
-  const objectText = extractBalancedJsonObject(html, assignmentIndex);
-  if (!objectText) {
-    return null;
-  }
-
-  try {
-    const parsed: unknown = JSON.parse(objectText);
-    return isObjectLike(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
+import { INNERTUBE_API_KEY_REGEX, REQUEST_HEADERS, isObjectLike } from "./captions-shared.js";
 
 function coerceDurationSeconds(value: unknown): number | null {
   const asNumber =

--- a/packages/core/src/content/transcript/providers/youtube/captions-shared.ts
+++ b/packages/core/src/content/transcript/providers/youtube/captions-shared.ts
@@ -17,7 +17,6 @@ export const REQUEST_HEADERS: Record<string, string> = {
   "Accept-Language": "en-US,en;q=0.9",
 };
 
-export const YT_INITIAL_PLAYER_RESPONSE_TOKEN = "ytInitialPlayerResponse";
 export const INNERTUBE_API_KEY_REGEX =
   /"INNERTUBE_API_KEY":"([^"]+)"|INNERTUBE_API_KEY\\":\\"([^\\"]+)\\"/;
 

--- a/packages/core/src/content/transcript/providers/youtube/captions-transcript.ts
+++ b/packages/core/src/content/transcript/providers/youtube/captions-transcript.ts
@@ -6,8 +6,9 @@ import {
   type YoutubeCaptionTrack,
 } from "../../../youtube-captions.js";
 import { sanitizeYoutubeJsonResponse } from "../../utils.js";
+import { extractInitialPlayerResponse } from "../../utils.js";
 import { extractYoutubeiBootstrap } from "./api.js";
-import { extractInitialPlayerResponse, extractInnertubeApiKey } from "./captions-player.js";
+import { extractInnertubeApiKey } from "./captions-player.js";
 import {
   REQUEST_HEADERS,
   isObjectLike,

--- a/packages/core/src/content/transcript/utils.ts
+++ b/packages/core/src/content/transcript/utils.ts
@@ -27,9 +27,9 @@ export function decodeHtmlEntities(input: string): string {
 }
 
 export function extractYoutubeBootstrapConfig(html: string): Record<string, unknown> | null {
-  const parsed = parseHtmlDocument(html);
+  const document = parseHtmlDocument(html);
   try {
-    const scripts = parsed.document.querySelectorAll("script");
+    const scripts = document.querySelectorAll("script");
 
     for (const script of scripts) {
       const source = script.textContent;
@@ -44,11 +44,31 @@ export function extractYoutubeBootstrapConfig(html: string): Record<string, unkn
     }
   } catch {
     // fall through to legacy regex
-  } finally {
-    parsed.close();
   }
 
   return parseBootstrapFromScript(html);
+}
+
+export function extractInitialPlayerResponse(html: string): Record<string, unknown> | null {
+  const tokenIndex = html.indexOf("ytInitialPlayerResponse");
+  if (tokenIndex < 0) {
+    return null;
+  }
+  const assignmentIndex = html.indexOf("=", tokenIndex);
+  if (assignmentIndex < 0) {
+    return null;
+  }
+  const objectText = extractBalancedJsonObject(html, assignmentIndex);
+  if (!objectText) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(objectText);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 const YTCFG_SET_TOKEN = "ytcfg.set";

--- a/packages/core/src/content/youtube.ts
+++ b/packages/core/src/content/youtube.ts
@@ -1,4 +1,4 @@
-import { extractInitialPlayerResponse } from "./transcript/providers/youtube/captions-player.js";
+import { extractInitialPlayerResponse } from "./transcript/utils.js";
 
 const ANDROID_VR_CLIENT_NAME = "ANDROID_VR";
 const ANDROID_VR_CLIENT_ID = "28";

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -50,7 +50,11 @@ export {
   type CacheStats,
 } from "@steipete/summarize-core/runtime";
 import { cleanupSlidesPayload, collectSlidesPayloadArtifactPaths } from "./cache-slides-cleanup.js";
-import type { TranscriptCache, TranscriptSource } from "./content/index.js";
+import {
+  TRANSCRIPT_SOURCES,
+  type TranscriptCache,
+  type TranscriptSource,
+} from "./content/index.js";
 
 export type CacheConfig = {
   enabled?: boolean;
@@ -78,23 +82,8 @@ type CacheRow = {
   created_at: number;
 };
 
-const TRANSCRIPT_SOURCES: readonly TranscriptSource[] = [
-  "youtubei",
-  "captionTracks",
-  "yt-dlp",
-  "podcastTranscript",
-  "whisper",
-  "apify",
-  "html",
-  "unavailable",
-  "unknown",
-];
-
 function normalizeTranscriptSource(value: unknown): TranscriptSource | null {
-  if (typeof value !== "string") return null;
-  return TRANSCRIPT_SOURCES.includes(value as TranscriptSource)
-    ? (value as TranscriptSource)
-    : null;
+  return TRANSCRIPT_SOURCES.find((candidate) => candidate === value) ?? null;
 }
 
 export type CacheStore = {

--- a/tests/cache.store.test.ts
+++ b/tests/cache.store.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { readTranscriptCache } from "../packages/core/src/content/transcript/cache.js";
 import { buildTranscriptCacheKey, createCacheStore } from "../src/cache.js";
 
 describe("cache store", () => {
@@ -261,6 +262,43 @@ describe("cache store", () => {
 
     store.close();
   });
+
+  it.each(["embedded", "youtube-media"] as const)(
+    "preserves %s transcript sources through SQLite and core cache reads",
+    async (source) => {
+      const root = mkdtempSync(join(tmpdir(), "summarize-cache-"));
+      const store = await createCacheStore({
+        path: join(root, "cache.sqlite"),
+        maxBytes: 1024 * 1024,
+      });
+      const url = "https://example.com/video";
+      try {
+        await store.transcriptCache.set({
+          url,
+          service: "generic",
+          resourceKey: null,
+          ttlMs: 60_000,
+          content: "Cached transcript",
+          source,
+          metadata: null,
+        });
+        expect((await store.transcriptCache.get({ url }))?.source).toBe(source);
+        const result = await readTranscriptCache({
+          url,
+          cacheMode: "default",
+          transcriptCache: store.transcriptCache,
+        });
+        expect(result.resolution).toMatchObject({ text: "Cached transcript", source });
+        expect(result.diagnostics).toMatchObject({
+          cacheStatus: "hit",
+          provider: source,
+          attemptedProviders: [source],
+        });
+      } finally {
+        store.close();
+      }
+    },
+  );
 
   it("transcript cache normalizes unknown sources and handles bad payloads", async () => {
     const root = mkdtempSync(join(tmpdir(), "summarize-cache-"));

--- a/tests/html-document.test.ts
+++ b/tests/html-document.test.ts
@@ -7,17 +7,13 @@ import { extractReadabilityFromHtml } from "../packages/core/src/content/link-pr
 
 describe("HTML document adapter", () => {
   it("wraps fragments and keeps the doctype outside the body", () => {
-    const parsed = parseHtmlDocument('<!doctype html><p id="content">Hello</p>');
-    try {
-      expect(parsed.document.documentElement?.tagName.toLowerCase()).toBe("html");
-      expect(parsed.document.head).not.toBeNull();
-      expect(parsed.document.body?.querySelector("#content")?.textContent).toBe("Hello");
-      const serialized = serializeHtmlDocument(parsed.document);
-      expect(serialized.match(/<!doctype/gi)).toHaveLength(1);
-      expect(parsed.document.body?.innerHTML).not.toContain("doctype");
-    } finally {
-      parsed.close();
-    }
+    const document = parseHtmlDocument('<!doctype html><p id="content">Hello</p>');
+    expect(document.documentElement?.tagName.toLowerCase()).toBe("html");
+    expect(document.head).not.toBeNull();
+    expect(document.body?.querySelector("#content")?.textContent).toBe("Hello");
+    const serialized = serializeHtmlDocument(document);
+    expect(serialized.match(/<!doctype/gi)).toHaveLength(1);
+    expect(document.body?.innerHTML).not.toContain("doctype");
   });
 
   it("moves malformed document children into the body for Readability", async () => {
@@ -32,83 +28,57 @@ describe("HTML document adapter", () => {
   });
 
   it("does not mistake raw html text for the document element", () => {
-    const parsed = parseHtmlDocument(
+    const document = parseHtmlDocument(
       '<textarea><html></textarea><article id="content">Still present</article>',
     );
-    try {
-      expect(parsed.document.body?.querySelector("#content")?.textContent).toBe("Still present");
-      expect(parsed.document.body?.querySelector("textarea")?.textContent).toBe("<html>");
-    } finally {
-      parsed.close();
-    }
+    expect(document.body?.querySelector("#content")?.textContent).toBe("Still present");
+    expect(document.body?.querySelector("textarea")?.textContent).toBe("<html>");
   });
 
   it("normalizes documents with optional html tags", () => {
-    const parsed = parseHtmlDocument(
+    const document = parseHtmlDocument(
       "<!doctype html><head><title>Optional tags</title></head><body><p>Body</p></body>",
     );
-    try {
-      expect(parsed.document.head?.querySelector("title")?.textContent).toBe("Optional tags");
-      expect(parsed.document.body?.textContent).toBe("Body");
-      expect(parsed.document.body?.querySelector("head, body")).toBeNull();
-    } finally {
-      parsed.close();
-    }
+    expect(document.head?.querySelector("title")?.textContent).toBe("Optional tags");
+    expect(document.body?.textContent).toBe("Body");
+    expect(document.body?.querySelector("head, body")).toBeNull();
   });
 
   it("places leading document metadata in a synthesized head", () => {
-    const parsed = parseHtmlDocument(
+    const document = parseHtmlDocument(
       '<title>Fragment title</title><meta name="description" content="Details"><article>Body</article>',
     );
-    try {
-      expect(parsed.document.title).toBe("Fragment title");
-      expect(parsed.document.head?.querySelector('meta[name="description"]')).not.toBeNull();
-      expect(parsed.document.body?.textContent).toBe("Body");
-    } finally {
-      parsed.close();
-    }
+    expect(document.title).toBe("Fragment title");
+    expect(document.head?.querySelector('meta[name="description"]')).not.toBeNull();
+    expect(document.body?.textContent).toBe("Body");
   });
 
   it("normalizes HTML attribute names without changing foreign content", () => {
-    const parsed = parseHtmlDocument(
+    const document = parseHtmlDocument(
       '<META PROPERTY="og:title" CONTENT="Uppercase title"><video SRC="first.mp4" src="second.mp4"></video><svg viewBox="0 0 1 1"></svg><math><csymbol definitionURL="urn:example"></csymbol></math>',
     );
-    try {
-      expect(
-        parsed.document.head?.querySelector('meta[property="og:title"]')?.getAttribute("content"),
-      ).toBe("Uppercase title");
-      expect(parsed.document.body?.querySelector("video")?.getAttribute("src")).toBe("first.mp4");
-      expect(parsed.document.body?.querySelector("svg")?.hasAttribute("viewBox")).toBe(true);
-      expect(parsed.document.body?.querySelector("csymbol")?.hasAttribute("definitionURL")).toBe(
-        true,
-      );
-    } finally {
-      parsed.close();
-    }
+    expect(document.head?.querySelector('meta[property="og:title"]')?.getAttribute("content")).toBe(
+      "Uppercase title",
+    );
+    expect(document.body?.querySelector("video")?.getAttribute("src")).toBe("first.mp4");
+    expect(document.body?.querySelector("svg")?.hasAttribute("viewBox")).toBe(true);
+    expect(document.body?.querySelector("csymbol")?.hasAttribute("definitionURL")).toBe(true);
   });
 
   it("recognizes full documents after an XML declaration", () => {
-    const parsed = parseHtmlDocument(
+    const document = parseHtmlDocument(
       '<?xml version="1.0"?><!doctype html><html><head><title>XHTML</title></head><body><p>Body</p></body></html>',
     );
-    try {
-      expect(parsed.document.title).toBe("XHTML");
-      expect(parsed.document.body?.textContent).toBe("Body");
-    } finally {
-      parsed.close();
-    }
+    expect(document.title).toBe("XHTML");
+    expect(document.body?.textContent).toBe("Body");
   });
 
   it("preserves body content order around malformed head and body tags", () => {
-    const parsed = parseHtmlDocument(
+    const document = parseHtmlDocument(
       "<html><div>Before</div><head><title>Title</title></head><body><p>Main</p></body><div>After</div></html>",
     );
-    try {
-      expect(parsed.document.body?.textContent).toBe("BeforeMainAfter");
-      expect(parsed.document.head?.querySelector("title")?.textContent).toBe("Title");
-    } finally {
-      parsed.close();
-    }
+    expect(document.body?.textContent).toBe("BeforeMainAfter");
+    expect(document.head?.querySelector("title")?.textContent).toBe("Title");
   });
 
   it("resolves relative links against the page URL for Readability", async () => {
@@ -124,12 +94,11 @@ describe("HTML document adapter", () => {
   it("does not execute scripts while parsing", () => {
     const marker = "__summarizeLinkedomExecutionMarker";
     delete (globalThis as Record<string, unknown>)[marker];
-    const parsed = parseHtmlDocument(`<script>globalThis.${marker} = true</script><p>Safe</p>`);
+    const document = parseHtmlDocument(`<script>globalThis.${marker} = true</script><p>Safe</p>`);
     try {
       expect((globalThis as Record<string, unknown>)[marker]).toBeUndefined();
-      expect(parsed.document.body?.textContent).toContain("Safe");
+      expect(document.body?.textContent).toContain("Safe");
     } finally {
-      parsed.close();
       delete (globalThis as Record<string, unknown>)[marker];
     }
   });

--- a/tests/transcript.cache.more-branches.test.ts
+++ b/tests/transcript.cache.more-branches.test.ts
@@ -119,6 +119,8 @@ describe("transcript cache - more branches", () => {
   it("maps cached sources, including unknown values", () => {
     expect(mapCachedSource(null)).toBeNull();
     expect(mapCachedSource("yt-dlp")).toBe("yt-dlp");
+    expect(mapCachedSource("youtube-media")).toBe("youtube-media");
+    expect(mapCachedSource("embedded")).toBe("embedded");
     expect(mapCachedSource("weird")).toBe("unknown");
   });
 

--- a/tests/youtube.bootstrap.test.ts
+++ b/tests/youtube.bootstrap.test.ts
@@ -1,7 +1,68 @@
 import { describe, expect, it } from "vitest";
-import { extractYoutubeBootstrapConfig } from "../packages/core/src/content/transcript/utils.js";
+import { extractYouTubeShortDescription } from "../packages/core/src/content/link-preview/content/youtube.js";
+import {
+  extractInitialPlayerResponse,
+  extractYoutubeBootstrapConfig,
+} from "../packages/core/src/content/transcript/utils.js";
 
 describe("YouTube bootstrap parsing", () => {
+  it("shares balanced parsing for nested objects, quoted braces, and escapes", () => {
+    const description = String.raw`Quoted "}" and '{' with a backslash \\ stay literal.`;
+    const payload = {
+      videoDetails: { shortDescription: description },
+      nested: { values: [{ key: "value" }] },
+    };
+    const json = JSON.stringify(payload);
+    const html = `<script>var ytInitialPlayerResponse = ${json}; ignored({});</script>`;
+
+    expect(extractInitialPlayerResponse(html)).toEqual(payload);
+    expect(extractYoutubeBootstrapConfig(`<script>ytcfg.set(${json});</script>`)).toEqual(payload);
+    expect(extractYouTubeShortDescription(html)).toBe(description);
+  });
+
+  it.each([
+    "no player response",
+    'ytInitialPlayerResponse {"videoDetails":{}}',
+    "ytInitialPlayerResponse = null;",
+    "ytInitialPlayerResponse = {broken};",
+    "ytInitialPlayerResponse = {'single': '}'};",
+    'ytInitialPlayerResponse = {"videoDetails":{"shortDescription":"unterminated}',
+  ])("rejects missing or malformed player data: %s", (html) => {
+    expect(extractInitialPlayerResponse(html)).toBeNull();
+    expect(extractYouTubeShortDescription(html)).toBeNull();
+  });
+
+  it("keeps the first player assignment authoritative", () => {
+    expect(
+      extractInitialPlayerResponse(
+        'ytInitialPlayerResponse = {bad}; ytInitialPlayerResponse = {"ok":true};',
+      ),
+    ).toBeNull();
+  });
+
+  it("continues to later bootstrap calls after malformed JSON", () => {
+    expect(extractYoutubeBootstrapConfig('ytcfg.set({bad}); ytcfg.set({"ok":true});')).toEqual({
+      ok: true,
+    });
+  });
+
+  it.each([{}, { videoDetails: null }, { videoDetails: { shortDescription: 12 } }])(
+    "ignores absent or non-text short descriptions",
+    (payload) => {
+      expect(
+        extractYouTubeShortDescription(`ytInitialPlayerResponse = ${JSON.stringify(payload)};`),
+      ).toBeNull();
+    },
+  );
+
+  it("normalizes description whitespace", () => {
+    expect(
+      extractYouTubeShortDescription(
+        'ytInitialPlayerResponse = {"videoDetails":{"shortDescription":"  First\\n\\n second  "}};',
+      ),
+    ).toBe("First\nsecond");
+  });
+
   it("parses nested ytcfg.set objects (balanced braces)", () => {
     const html = `
       <html><head>


### PR DESCRIPTION
## What changed

Remove the DOM adapter's fictional lifetime: parseHtmlDocument now returns its Document directly, and callers no longer wrap extraction in finally blocks that invoke a no-op close. Real error handling, document normalization, and test marker cleanup remain intact.

Consolidate three balanced-JSON scanners and two initial-player parsers into one implementation shared by YouTube captions, metadata, and page descriptions. Public YouTube parsing no longer imports a caption HTTP module merely to read JSON.

Make the transcript source tuple own both the source type and cache validation. This fixes a real drift bug: SQLite discarded embedded and youtube-media sources, and core cache reads downgraded youtube-media to unknown. Unknown persisted values retain their prior handling.

Net reduction: 209 production lines and 136 lines overall, with new parser edge cases and SQLite-to-core cache round-trip regression coverage. No compatibility wrappers remain.

## Proof

- Build and full project gate pass: formatting, lint, core/CLI type checks, 3,088 tests (43 skipped), 94.27% line and 85.17% branch coverage.
- Focused HTML, Reddit, YouTube, and cache suites: 61 tests pass.
- New tests cover nested/quoted/escaped braces, malformed and first-assignment handling, retained newlines, and both formerly lost cache sources.
- Independent Codex review of the final diff: no actionable P0–P2 findings.

A new whitespace test initially expected a space; validation correctly showed the existing normalizer preserves one newline. The expectation was corrected without changing production behavior, and the full gate and review were rerun.

Stacked on #412. No dependency or public CLI behavior changes beyond preserving cache-source diagnostics.
