### PR TITLE
refactor(core): share page media resolution and composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Dependencies and maintenance
 
+- Share page-media resolution and embedded transcript composition across HTML and Firecrawl extraction, keeping source-specific metadata, Markdown, and timeout policies separate.
 - Delete the unreachable daemon chat pipeline and unused browser media adapters; keep chat on the agent endpoint and audio on the bounded chunked decoder.
 - Use one slide-download/cache/progress workflow with source-specific download and stream-fallback policies instead of three copied pipelines.
 - Return DOM documents directly instead of exposing no-op cleanup lifecycles, and share YouTube player-response parsing across captions, metadata, and page extraction.

--- a/docs/transcript-provider-flow.md
+++ b/docs/transcript-provider-flow.md
@@ -35,6 +35,8 @@ Goal: keep provider entrypoints thin; keep provider policy explicit.
 
 ## Shared policy
 
+- `content/link-preview/content/page-media.ts`
+  HTML and Firecrawl share media detection, transcript resolution, source-metric refresh, and embedded article/transcript composition. Each page builder retains its metadata and Markdown policy; metric deadlines still start at builder entry.
 - `transcription-capability.ts`
   One place for:
   - `resolveTranscriptProviderCapabilities`

--- a/packages/core/src/content/link-preview/content/firecrawl.ts
+++ b/packages/core/src/content/link-preview/content/firecrawl.ts
@@ -1,6 +1,4 @@
-import { resolveTranscriptForLink } from "../../transcript/index.js";
-import type { FirecrawlScrapeResult, LinkPreviewDeps } from "../deps.js";
-import type { FirecrawlDiagnostics } from "../types.js";
+import type { FirecrawlScrapeResult } from "../deps.js";
 import { extractArticleContent, extractPlainText } from "./article.js";
 import { normalizeForPrompt } from "./cleaner.js";
 import {
@@ -11,20 +9,17 @@ import {
   READABILITY_RELATIVE_THRESHOLD,
 } from "./constants.js";
 import { extractJsonLdContent } from "./jsonld.js";
+import { composePageContent, resolvePageMedia, type PageExtractionContext } from "./page-media.js";
 import { extractMetadataFromFirecrawl, extractMetadataFromHtml } from "./parsers.js";
 import { isPodcastHost, isPodcastLikeJsonLdType } from "./podcast-utils.js";
-import type { ExtractedLinkContent, FetchLinkContentOptions } from "./types.js";
+import type { ExtractedLinkContent } from "./types.js";
 import {
   appendNote,
   ensureTranscriptDiagnostics,
   finalizeExtractedLinkContent,
   pickFirstText,
   safeHostname,
-  selectBaseContent,
-  selectEmbeddedVideoContent,
 } from "./utils.js";
-import { detectPrimaryVideoDetailsFromHtml, resolveEmbeddedYoutubeDecision } from "./video.js";
-import { refreshYoutubeSourceMetrics } from "./youtube-source-metrics.js";
 
 export function shouldFallbackToFirecrawl(html: string): boolean {
   const plainText = normalizeForPrompt(extractPlainText(html));
@@ -40,37 +35,13 @@ export function shouldFallbackToFirecrawl(html: string): boolean {
   return html.length >= MIN_HTML_DOCUMENT_CHARACTERS_FOR_FALLBACK;
 }
 
-export async function buildResultFromFirecrawl({
-  url,
-  payload,
-  cacheMode,
-  maxCharacters,
-  youtubeTranscriptMode,
-  mediaTranscriptMode,
-  embeddedVideoMode,
-  transcriptTimestamps,
-  transcriptDiarization,
-  transcriptVideoDownload,
-  firecrawlDiagnostics,
-  markdownRequested,
-  timeoutMs,
-  deps,
-}: {
-  url: string;
-  payload: FirecrawlScrapeResult;
-  cacheMode: FetchLinkContentOptions["cacheMode"];
-  maxCharacters: number | null;
-  youtubeTranscriptMode: FetchLinkContentOptions["youtubeTranscript"];
-  mediaTranscriptMode: FetchLinkContentOptions["mediaTranscript"];
-  embeddedVideoMode: FetchLinkContentOptions["embeddedVideo"];
-  transcriptTimestamps?: FetchLinkContentOptions["transcriptTimestamps"];
-  transcriptDiarization?: FetchLinkContentOptions["transcriptDiarization"];
-  transcriptVideoDownload?: FetchLinkContentOptions["transcriptVideoDownload"];
-  firecrawlDiagnostics: FirecrawlDiagnostics;
-  markdownRequested: boolean;
-  timeoutMs: number;
-  deps: LinkPreviewDeps;
-}): Promise<ExtractedLinkContent | null> {
+export async function buildResultFromFirecrawl(
+  options: PageExtractionContext & {
+    payload: FirecrawlScrapeResult;
+  },
+): Promise<ExtractedLinkContent | null> {
+  const { url, payload, cacheMode, maxCharacters, firecrawlDiagnostics, markdownRequested } =
+    options;
   const extractionStartedAt = Date.now();
   const normalizedMarkdown = normalizeForPrompt(payload.markdown ?? "");
   if (normalizedMarkdown.length === 0) {
@@ -84,37 +55,13 @@ export async function buildResultFromFirecrawl({
   const jsonLd = payload.html ? extractJsonLdContent(payload.html) : null;
   const isPodcastJsonLd = isPodcastLikeJsonLdType(jsonLd?.type);
 
-  const videoDetection = payload.html ? detectPrimaryVideoDetailsFromHtml(payload.html, url) : null;
-  const video = videoDetection?.video ?? null;
-  const resolvedEmbeddedVideoMode = embeddedVideoMode ?? "auto";
-  const embeddedYoutube = resolveEmbeddedYoutubeDecision({
-    pageUrl: url,
-    detection: videoDetection,
-    mode: resolvedEmbeddedVideoMode,
-    youtubeTranscriptMode: youtubeTranscriptMode ?? "auto",
-    mediaTranscriptMode: mediaTranscriptMode ?? "auto",
-  });
-  const transcriptResolution = await resolveTranscriptForLink(url, payload.html ?? null, deps, {
-    timeoutMs,
-    youtubeTranscriptMode: embeddedYoutube.youtubeTranscriptMode,
-    mediaTranscriptMode: embeddedYoutube.mediaTranscriptMode,
-    transcriptTimestamps,
-    transcriptDiarization,
-    transcriptVideoDownload,
-    cacheMode,
-    embeddedMediaUrl: embeddedYoutube.shouldUse ? embeddedYoutube.detection?.video.url : null,
-  });
-  if (payload.html) {
-    await refreshYoutubeSourceMetrics({
-      url,
-      html: payload.html,
-      detectedVideo: video,
-      transcriptResolution,
-      deps,
-      timeoutMs,
-      startedAtMs: extractionStartedAt,
-    });
-  }
+  const media = await resolvePageMedia(
+    options,
+    payload.html ?? null,
+    extractionStartedAt,
+    Boolean(payload.html),
+  );
+  const { video, transcriptResolution } = media;
   const htmlMetadata = payload.html
     ? extractMetadataFromHtml(payload.html, url)
     : { title: null, description: null, siteName: null };
@@ -136,19 +83,7 @@ export async function buildResultFromFirecrawl({
       normalizedMarkdown.length < MIN_HTML_CONTENT_CHARACTERS ||
       descriptionCandidate.length >= normalizedMarkdown.length * READABILITY_RELATIVE_THRESHOLD);
   const baseCandidate = preferDescription ? descriptionCandidate : normalizedMarkdown;
-  const embeddedSelection =
-    embeddedYoutube.shouldUse && embeddedYoutube.detection
-      ? selectEmbeddedVideoContent({
-          articleContent: baseCandidate,
-          transcriptText: transcriptResolution.text,
-          transcriptSegments: transcriptResolution.segments,
-          mode: resolvedEmbeddedVideoMode,
-          videoUrl: embeddedYoutube.detection.video.url,
-        })
-      : null;
-  const baseContent =
-    embeddedSelection?.baseContent ??
-    selectBaseContent(baseCandidate, transcriptResolution.text, transcriptResolution.segments);
+  const { baseContent, contentSections, embeddedVideo } = composePageContent(baseCandidate, media);
   if (baseContent.length === 0) {
     firecrawlDiagnostics.notes = appendNote(
       firecrawlDiagnostics.notes,
@@ -172,7 +107,7 @@ export async function buildResultFromFirecrawl({
   return finalizeExtractedLinkContent({
     url,
     baseContent,
-    contentSections: embeddedSelection?.contentSections ?? null,
+    contentSections,
     maxCharacters,
     title,
     description,
@@ -189,16 +124,7 @@ export async function buildResultFromFirecrawl({
         provider: "firecrawl",
       },
       transcript: transcriptDiagnostics,
-      embeddedVideo: {
-        mode: resolvedEmbeddedVideoMode,
-        detected: embeddedYoutube.detection !== null,
-        used: Boolean(embeddedYoutube.shouldUse && transcriptResolution.text),
-        url: embeddedYoutube.detection?.video.url ?? null,
-        source: embeddedYoutube.detection?.source ?? null,
-        confidence: embeddedYoutube.detection?.confidence ?? null,
-        composition: embeddedSelection?.composition ?? "article",
-        notes: embeddedYoutube.notes,
-      },
+      embeddedVideo,
     },
   });
 }

--- a/packages/core/src/content/link-preview/content/html.ts
+++ b/packages/core/src/content/link-preview/content/html.ts
@@ -1,7 +1,5 @@
-import { resolveTranscriptForLink } from "../../transcript/index.js";
 import { extractYouTubeVideoId, isYouTubeUrl, isYouTubeVideoUrl } from "../../url.js";
-import type { LinkPreviewDeps } from "../deps.js";
-import type { FirecrawlDiagnostics, MarkdownDiagnostics } from "../types.js";
+import type { MarkdownDiagnostics } from "../types.js";
 import { extractArticleContent, sanitizeHtmlForMarkdownConversion } from "./article.js";
 import { normalizeForPrompt } from "./cleaner.js";
 import {
@@ -11,19 +9,16 @@ import {
   READABILITY_RELATIVE_THRESHOLD,
 } from "./constants.js";
 import { extractJsonLdContent } from "./jsonld.js";
+import { composePageContent, resolvePageMedia, type PageExtractionContext } from "./page-media.js";
 import { extractMetadataFromHtml } from "./parsers.js";
 import { isPodcastHost, isPodcastLikeJsonLdType } from "./podcast-utils.js";
 import { extractReadabilityFromHtml, toReadabilityHtml } from "./readability.js";
-import type { ExtractedLinkContent, FetchLinkContentOptions, MarkdownMode } from "./types.js";
+import type { ExtractedLinkContent, MarkdownMode } from "./types.js";
 import {
   ensureTranscriptDiagnostics,
   finalizeExtractedLinkContent,
   pickFirstText,
-  selectBaseContent,
-  selectEmbeddedVideoContent,
 } from "./utils.js";
-import { detectPrimaryVideoDetailsFromHtml, resolveEmbeddedYoutubeDecision } from "./video.js";
-import { refreshYoutubeSourceMetrics } from "./youtube-source-metrics.js";
 import { extractYouTubeShortDescription } from "./youtube.js";
 
 const LEADING_CONTROL_PATTERN = /^[\s\p{Cc}]+/u;
@@ -48,45 +43,29 @@ function stripLeadingTitle(content: string, title: string | null | undefined): s
   return remainder;
 }
 
-export async function buildResultFromHtmlDocument({
-  url,
-  html,
-  cacheMode,
-  maxCharacters,
-  youtubeTranscriptMode,
-  mediaTranscriptMode,
-  embeddedVideoMode,
-  transcriptTimestamps,
-  transcriptDiarization,
-  transcriptVideoDownload,
-  firecrawlDiagnostics,
-  markdownRequested,
-  markdownMode,
-  timeoutMs,
-  deps,
-  readabilityCandidate,
-  isNormalizedRedditThread = false,
-  mediaHtml = html,
-}: {
-  url: string;
-  html: string;
-  cacheMode: FetchLinkContentOptions["cacheMode"];
-  maxCharacters: number | null;
-  youtubeTranscriptMode: FetchLinkContentOptions["youtubeTranscript"];
-  mediaTranscriptMode: FetchLinkContentOptions["mediaTranscript"];
-  embeddedVideoMode: FetchLinkContentOptions["embeddedVideo"];
-  transcriptTimestamps?: FetchLinkContentOptions["transcriptTimestamps"];
-  transcriptDiarization?: FetchLinkContentOptions["transcriptDiarization"];
-  transcriptVideoDownload?: FetchLinkContentOptions["transcriptVideoDownload"];
-  firecrawlDiagnostics: FirecrawlDiagnostics;
-  markdownRequested: boolean;
-  markdownMode: MarkdownMode;
-  timeoutMs: number;
-  deps: LinkPreviewDeps;
-  readabilityCandidate: Awaited<ReturnType<typeof extractReadabilityFromHtml>> | null;
-  isNormalizedRedditThread?: boolean;
-  mediaHtml?: string;
-}): Promise<ExtractedLinkContent> {
+export async function buildResultFromHtmlDocument(
+  options: PageExtractionContext & {
+    html: string;
+    markdownMode: MarkdownMode;
+    readabilityCandidate: Awaited<ReturnType<typeof extractReadabilityFromHtml>> | null;
+    isNormalizedRedditThread?: boolean;
+    mediaHtml?: string;
+  },
+): Promise<ExtractedLinkContent> {
+  const {
+    url,
+    html,
+    cacheMode,
+    maxCharacters,
+    firecrawlDiagnostics,
+    markdownRequested,
+    markdownMode,
+    timeoutMs,
+    deps,
+    readabilityCandidate,
+    isNormalizedRedditThread = false,
+    mediaHtml = html,
+  } = options;
   const extractionStartedAt = Date.now();
   if (isYouTubeVideoUrl(url) && !extractYouTubeVideoId(url)) {
     throw new Error("Invalid YouTube video id in URL");
@@ -137,35 +116,8 @@ export async function buildResultFromHtmlDocument({
   const effectiveNormalizedWithDescription = preferDescription
     ? descriptionCandidate
     : effectiveNormalized;
-  const videoDetection = detectPrimaryVideoDetailsFromHtml(mediaHtml, url);
-  const detectedVideo = videoDetection?.video ?? null;
-  const resolvedEmbeddedVideoMode = embeddedVideoMode ?? "auto";
-  const embeddedYoutube = resolveEmbeddedYoutubeDecision({
-    pageUrl: url,
-    detection: videoDetection,
-    mode: resolvedEmbeddedVideoMode,
-    youtubeTranscriptMode: youtubeTranscriptMode ?? "auto",
-    mediaTranscriptMode: mediaTranscriptMode ?? "auto",
-  });
-  const transcriptResolution = await resolveTranscriptForLink(url, mediaHtml, deps, {
-    timeoutMs,
-    youtubeTranscriptMode: embeddedYoutube.youtubeTranscriptMode,
-    mediaTranscriptMode: embeddedYoutube.mediaTranscriptMode,
-    transcriptTimestamps,
-    transcriptDiarization,
-    transcriptVideoDownload,
-    cacheMode,
-    embeddedMediaUrl: embeddedYoutube.shouldUse ? embeddedYoutube.detection?.video.url : null,
-  });
-  await refreshYoutubeSourceMetrics({
-    url,
-    html: mediaHtml,
-    detectedVideo,
-    transcriptResolution,
-    deps,
-    timeoutMs,
-    startedAtMs: extractionStartedAt,
-  });
+  const media = await resolvePageMedia(options, mediaHtml, extractionStartedAt);
+  const { video, transcriptResolution } = media;
 
   const youtubeDescription =
     transcriptResolution.text === null ? extractYouTubeShortDescription(mediaHtml) : null;
@@ -248,21 +200,7 @@ export async function buildResultFromHtmlDocument({
     }
   })();
 
-  const embeddedSelection =
-    embeddedYoutube.shouldUse && embeddedYoutube.detection
-      ? selectEmbeddedVideoContent({
-          articleContent,
-          transcriptText: transcriptResolution.text,
-          transcriptSegments: transcriptResolution.segments,
-          mode: resolvedEmbeddedVideoMode,
-          videoUrl: embeddedYoutube.detection.video.url,
-        })
-      : null;
-  const baseContent =
-    embeddedSelection?.baseContent ??
-    selectBaseContent(articleContent, transcriptResolution.text, transcriptResolution.segments);
-  const contentSections = embeddedSelection?.contentSections ?? null;
-  const video = detectedVideo;
+  const { baseContent, contentSections, embeddedVideo } = composePageContent(articleContent, media);
   const isVideoOnly =
     !transcriptResolution.text &&
     articleContent.length < MIN_HTML_CONTENT_CHARACTERS &&
@@ -284,16 +222,7 @@ export async function buildResultFromHtmlDocument({
       firecrawl: firecrawlDiagnostics,
       markdown: markdownDiagnostics,
       transcript: transcriptDiagnostics,
-      embeddedVideo: {
-        mode: resolvedEmbeddedVideoMode,
-        detected: embeddedYoutube.detection !== null,
-        used: Boolean(embeddedYoutube.shouldUse && transcriptResolution.text),
-        url: embeddedYoutube.detection?.video.url ?? null,
-        source: embeddedYoutube.detection?.source ?? null,
-        confidence: embeddedYoutube.detection?.confidence ?? null,
-        composition: embeddedSelection?.composition ?? "article",
-        notes: embeddedYoutube.notes,
-      },
+      embeddedVideo,
     },
   });
 }

--- a/packages/core/src/content/link-preview/content/index.ts
+++ b/packages/core/src/content/link-preview/content/index.ts
@@ -8,6 +8,7 @@ import { MIN_READABILITY_CONTENT_CHARACTERS } from "./constants.js";
 import { fetchHtmlDocument, fetchWithFirecrawl, isAssetLikeHtmlFetchError } from "./fetcher.js";
 import { buildResultFromFirecrawl, shouldFallbackToFirecrawl } from "./firecrawl.js";
 import { buildResultFromHtmlDocument } from "./html.js";
+import type { PageExtractionContext } from "./page-media.js";
 import { extractReadabilityFromHtml } from "./readability.js";
 import {
   isBlockedRedditThreadHtml,
@@ -109,6 +110,22 @@ export async function fetchLinkContent(
     notes: null,
   };
 
+  const pageContext: PageExtractionContext = {
+    url,
+    deps,
+    timeoutMs,
+    cacheMode,
+    maxCharacters,
+    youtubeTranscriptMode,
+    mediaTranscriptMode,
+    embeddedVideoMode,
+    transcriptTimestamps,
+    transcriptDiarization,
+    transcriptVideoDownload,
+    firecrawlDiagnostics,
+    markdownRequested,
+  };
+
   const twitterStatus = isTwitterStatusUrl(url);
   const nitterUrls = twitterStatus ? toNitterUrls(url) : [];
   let birdError: unknown = null;
@@ -142,20 +159,8 @@ export async function fetchLinkContent(
     }
 
     const firecrawlResult = await buildResultFromFirecrawl({
-      url,
+      ...pageContext,
       payload: firecrawlPayload,
-      cacheMode,
-      maxCharacters,
-      youtubeTranscriptMode,
-      mediaTranscriptMode,
-      embeddedVideoMode,
-      transcriptTimestamps,
-      transcriptDiarization,
-      transcriptVideoDownload,
-      firecrawlDiagnostics,
-      markdownRequested,
-      timeoutMs,
-      deps,
     });
     if (firecrawlResult) {
       return firecrawlResult;
@@ -313,21 +318,9 @@ export async function fetchLinkContent(
   const nitterHtml = await attemptNitter();
   if (nitterHtml) {
     const nitterResult = await buildResultFromHtmlDocument({
-      url,
+      ...pageContext,
       html: nitterHtml,
-      cacheMode,
-      maxCharacters,
-      youtubeTranscriptMode,
-      mediaTranscriptMode,
-      embeddedVideoMode,
-      transcriptTimestamps,
-      transcriptDiarization,
-      transcriptVideoDownload,
-      firecrawlDiagnostics,
-      markdownRequested,
       markdownMode,
-      timeoutMs,
-      deps,
       readabilityCandidate: null,
     });
     if (!isBlockedTwitterContent(nitterResult.content)) {
@@ -453,21 +446,10 @@ export async function fetchLinkContent(
   }
 
   const htmlExtracted = await buildResultFromHtmlDocument({
+    ...pageContext,
     url: effectiveUrl,
     html,
-    cacheMode,
-    maxCharacters,
-    youtubeTranscriptMode,
-    mediaTranscriptMode,
-    embeddedVideoMode,
-    transcriptTimestamps,
-    transcriptDiarization,
-    transcriptVideoDownload,
-    firecrawlDiagnostics,
-    markdownRequested,
     markdownMode,
-    timeoutMs,
-    deps,
     readabilityCandidate,
     isNormalizedRedditThread,
     mediaHtml,

--- a/packages/core/src/content/link-preview/content/page-media.ts
+++ b/packages/core/src/content/link-preview/content/page-media.ts
@@ -1,0 +1,96 @@
+import { resolveTranscriptForLink } from "../../transcript/index.js";
+import type { LinkPreviewDeps } from "../deps.js";
+import type { FirecrawlDiagnostics } from "../types.js";
+import type { FetchLinkContentOptions } from "./types.js";
+import { selectBaseContent, selectEmbeddedVideoContent } from "./utils.js";
+import { detectPrimaryVideoDetailsFromHtml, resolveEmbeddedYoutubeDecision } from "./video.js";
+import { refreshYoutubeSourceMetrics } from "./youtube-source-metrics.js";
+
+export type PageExtractionContext = {
+  url: string;
+  deps: LinkPreviewDeps;
+  timeoutMs: number;
+  maxCharacters: number | null;
+  cacheMode: FetchLinkContentOptions["cacheMode"];
+  youtubeTranscriptMode: FetchLinkContentOptions["youtubeTranscript"];
+  mediaTranscriptMode: FetchLinkContentOptions["mediaTranscript"];
+  embeddedVideoMode?: FetchLinkContentOptions["embeddedVideo"];
+  transcriptTimestamps?: FetchLinkContentOptions["transcriptTimestamps"];
+  transcriptDiarization?: FetchLinkContentOptions["transcriptDiarization"];
+  transcriptVideoDownload?: FetchLinkContentOptions["transcriptVideoDownload"];
+  firecrawlDiagnostics: FirecrawlDiagnostics;
+  markdownRequested: boolean;
+};
+
+export async function resolvePageMedia(
+  context: PageExtractionContext,
+  html: string | null,
+  startedAtMs: number,
+  refreshMetrics = html !== null,
+) {
+  const { url, deps, timeoutMs } = context;
+  const detection = html ? detectPrimaryVideoDetailsFromHtml(html, url) : null;
+  const video = detection?.video ?? null;
+  const mode = context.embeddedVideoMode ?? "auto";
+  const embeddedYoutube = resolveEmbeddedYoutubeDecision({
+    pageUrl: url,
+    detection,
+    mode,
+    youtubeTranscriptMode: context.youtubeTranscriptMode ?? "auto",
+    mediaTranscriptMode: context.mediaTranscriptMode ?? "auto",
+  });
+  const transcriptResolution = await resolveTranscriptForLink(url, html, deps, {
+    timeoutMs,
+    youtubeTranscriptMode: embeddedYoutube.youtubeTranscriptMode,
+    mediaTranscriptMode: embeddedYoutube.mediaTranscriptMode,
+    transcriptTimestamps: context.transcriptTimestamps,
+    transcriptDiarization: context.transcriptDiarization,
+    transcriptVideoDownload: context.transcriptVideoDownload,
+    cacheMode: context.cacheMode,
+    embeddedMediaUrl: embeddedYoutube.shouldUse ? embeddedYoutube.detection?.video.url : null,
+  });
+  if (refreshMetrics && html !== null) {
+    await refreshYoutubeSourceMetrics({
+      url,
+      html,
+      detectedVideo: video,
+      transcriptResolution,
+      deps,
+      timeoutMs,
+      startedAtMs,
+    });
+  }
+  return { video, mode, embeddedYoutube, transcriptResolution };
+}
+
+export function composePageContent(
+  articleContent: string,
+  { mode, embeddedYoutube, transcriptResolution }: Awaited<ReturnType<typeof resolvePageMedia>>,
+) {
+  const selection =
+    embeddedYoutube.shouldUse && embeddedYoutube.detection
+      ? selectEmbeddedVideoContent({
+          articleContent,
+          transcriptText: transcriptResolution.text,
+          transcriptSegments: transcriptResolution.segments,
+          mode,
+          videoUrl: embeddedYoutube.detection.video.url,
+        })
+      : null;
+  return {
+    baseContent:
+      selection?.baseContent ??
+      selectBaseContent(articleContent, transcriptResolution.text, transcriptResolution.segments),
+    contentSections: selection?.contentSections ?? null,
+    embeddedVideo: {
+      mode,
+      detected: embeddedYoutube.detection !== null,
+      used: Boolean(embeddedYoutube.shouldUse && transcriptResolution.text),
+      url: embeddedYoutube.detection?.video.url ?? null,
+      source: embeddedYoutube.detection?.source ?? null,
+      confidence: embeddedYoutube.detection?.confidence ?? null,
+      composition: selection?.composition ?? "article",
+      notes: embeddedYoutube.notes,
+    },
+  };
+}

--- a/tests/link-preview.page-media.test.ts
+++ b/tests/link-preview.page-media.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { resolveTranscriptForLink, refreshYoutubeSourceMetrics } = vi.hoisted(() => ({
+  resolveTranscriptForLink: vi.fn(),
+  refreshYoutubeSourceMetrics: vi.fn(),
+}));
+
+vi.mock("../packages/core/src/content/transcript/index.js", () => ({ resolveTranscriptForLink }));
+vi.mock("../packages/core/src/content/link-preview/content/youtube-source-metrics.js", () => ({
+  refreshYoutubeSourceMetrics,
+}));
+
+import { buildResultFromFirecrawl } from "../packages/core/src/content/link-preview/content/firecrawl.js";
+import { buildResultFromHtmlDocument } from "../packages/core/src/content/link-preview/content/html.js";
+import type { PageExtractionContext } from "../packages/core/src/content/link-preview/content/page-media.js";
+
+const videoUrl = "https://www.youtube.com/watch?v=abcdefghijk";
+const article = "Useful article prose. ".repeat(200);
+const html = `<article><p>${article}</p><iframe src="https://www.youtube.com/embed/abcdefghijk"></iframe></article>`;
+
+function context(): PageExtractionContext {
+  return {
+    url: "https://example.com/article",
+    deps: { fetch: vi.fn() } as never,
+    timeoutMs: 2_000,
+    cacheMode: "bypass",
+    maxCharacters: null,
+    youtubeTranscriptMode: "auto",
+    mediaTranscriptMode: "prefer",
+    embeddedVideoMode: "both",
+    transcriptTimestamps: true,
+    transcriptDiarization: "auto",
+    transcriptVideoDownload: true,
+    firecrawlDiagnostics: {
+      attempted: true,
+      used: false,
+      cacheMode: "bypass",
+      cacheStatus: "bypassed",
+    },
+    markdownRequested: false,
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  resolveTranscriptForLink.mockResolvedValue({
+    text: "Video transcript",
+    source: "captionTracks",
+    segments: null,
+  });
+});
+
+describe.each(["html", "firecrawl"] as const)("%s page media", (strategy) => {
+  async function build(options: PageExtractionContext) {
+    return strategy === "html"
+      ? buildResultFromHtmlDocument({
+          ...options,
+          html,
+          markdownMode: "off",
+          readabilityCandidate: null,
+        })
+      : buildResultFromFirecrawl({ ...options, payload: { html, markdown: article } });
+  }
+
+  it("preserves transcript policy, source metadata, and both content sections", async () => {
+    const options = context();
+    const result = await build(options);
+    expect(resolveTranscriptForLink).toHaveBeenCalledExactlyOnceWith(
+      options.url,
+      html,
+      options.deps,
+      {
+        timeoutMs: 2_000,
+        cacheMode: "bypass",
+        youtubeTranscriptMode: "auto",
+        mediaTranscriptMode: "prefer",
+        embeddedMediaUrl: videoUrl,
+        transcriptTimestamps: true,
+        transcriptDiarization: "auto",
+        transcriptVideoDownload: true,
+      },
+    );
+    expect(refreshYoutubeSourceMetrics).toHaveBeenCalledOnce();
+    expect(result?.content).toContain("Article:\nUseful article prose.");
+    expect(result?.content).toContain(`Embedded video transcript (${videoUrl}):\nVideo transcript`);
+    expect(result?.diagnostics).toMatchObject({
+      strategy,
+      transcript: { cacheMode: "bypass", provider: "captionTracks" },
+      embeddedVideo: { mode: "both", used: true, confidence: "high", composition: "both" },
+    });
+  });
+
+  it("does not force incidental video transcription when embedding is disabled", async () => {
+    resolveTranscriptForLink.mockResolvedValue({ text: null, source: null });
+    const result = await build({ ...context(), embeddedVideoMode: "off" });
+    expect(resolveTranscriptForLink).toHaveBeenCalledWith(
+      expect.any(String),
+      html,
+      expect.any(Object),
+      expect.objectContaining({ embeddedMediaUrl: null, mediaTranscriptMode: "auto" }),
+    );
+    expect(result?.diagnostics.embeddedVideo).toMatchObject({
+      used: false,
+      composition: "article",
+    });
+  });
+});
+
+it("converts HTML Markdown only after transcript and source metric resolution", async () => {
+  const calls: string[] = [];
+  resolveTranscriptForLink.mockImplementation(async () => {
+    calls.push("transcript");
+    return { text: "Video transcript", source: "captionTracks" };
+  });
+  refreshYoutubeSourceMetrics.mockImplementation(async () => {
+    calls.push("metrics");
+  });
+  const options = context();
+  const result = await buildResultFromHtmlDocument({
+    ...options,
+    html,
+    deps: {
+      ...options.deps,
+      convertHtmlToMarkdown: async () => {
+        calls.push("markdown");
+        return "Converted article. ".repeat(200);
+      },
+    },
+    readabilityCandidate: null,
+    markdownRequested: true,
+    markdownMode: "llm",
+  });
+  expect(calls).toEqual(["transcript", "metrics", "markdown"]);
+  expect(result.content).toContain("Converted article.");
+  expect(result.content).toContain("Video transcript");
+});
+
+it("keeps Firecrawl's empty Markdown short circuit ahead of media resolution", async () => {
+  const options = context();
+  expect(
+    await buildResultFromFirecrawl({ ...options, payload: { html, markdown: "  " } }),
+  ).toBeNull();
+  expect(resolveTranscriptForLink).not.toHaveBeenCalled();
+  expect(options.firecrawlDiagnostics.used).toBe(false);
+});
+
+it("preserves empty Firecrawl HTML without attempting a source metric refresh", async () => {
+  await buildResultFromFirecrawl({ ...context(), payload: { html: "", markdown: article } });
+  expect(resolveTranscriptForLink.mock.calls[0]?.[1]).toBe("");
+  expect(refreshYoutubeSourceMetrics).not.toHaveBeenCalled();
+});
+
+it("still refreshes source metrics for an empty raw HTML document", async () => {
+  await buildResultFromHtmlDocument({
+    ...context(),
+    html: "",
+    readabilityCandidate: null,
+    markdownMode: "off",
+  });
+  expect(refreshYoutubeSourceMetrics).toHaveBeenCalledWith(expect.objectContaining({ html: "" }));
+});


### PR DESCRIPTION
## Shared page-media ownership

HTML and Firecrawl extraction previously repeated media detection, embedded-video policy, transcript resolution, source-metric refresh, content composition, and diagnostic shaping. A shared page-media module now owns those operations and their typed context; the fetch coordinator builds common options once.

The page builders retain their distinct Readability/Reddit, metadata, Markdown, empty-result, and video-only policies. Metrics still use the deadline captured at builder entry. Empty Firecrawl HTML is passed through unchanged without a metric refresh; raw HTML keeps its existing refresh behavior. Markdown conversion remains after transcript resolution.

Production code is 64 lines smaller. Eight new contract tests add coverage rather than trading away behavior for line count.

## Proof

- All 126 link-preview tests pass, including the new HTML/Firecrawl policy matrix, empty-input distinctions, and transcript/metrics/Markdown ordering.
- Build and full project gate pass: 3,087 tests (43 skipped), 94.29% line and 85.21% branch coverage.
- Independent Codex review: no actionable P0–P2 findings.

No dependency or public API changes. The new functions and context are private implementation boundaries.

Hosted CI also passes on the exact PR head: [Node 24 gate, Chromium E2E, and Firefox smoke](https://github.com/steipete/summarize/actions/runs/33943300810), with security checks green.
