### PR TITLE
refactor(extension): unify Options wiring and settings normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Dependencies and maintenance
 
+- Make Options use one element collection and declarative checkbox bindings; share settings normalization between load and save without mixing legacy migrations or managed policy into persistence.
 - Share page-media resolution and embedded transcript composition across HTML and Firecrawl extraction, keeping source-specific metadata, Markdown, and timeout policies separate.
 - Delete the unreachable daemon chat pipeline and unused browser media adapters; keep chat on the agent endpoint and audio on the bounded chunked decoder.
 - Use one slide-download/cache/progress workflow with source-specific download and stream-fallback policies instead of three copied pipelines.

--- a/apps/chrome-extension/src/entrypoints/options/boolean-settings.ts
+++ b/apps/chrome-extension/src/entrypoints/options/boolean-settings.ts
@@ -1,7 +1,7 @@
 import type { defaultSettings, SlideRuntime, SummaryRuntime } from "../../lib/settings";
 import { createBooleanToggleController } from "./toggles";
 
-type BooleanSettingsState = {
+export type BooleanSettingsState = {
   autoSummarize: boolean;
   chatEnabled: boolean;
   automationEnabled: boolean;
@@ -14,6 +14,63 @@ type BooleanSettingsState = {
   extendedLogging: boolean;
   autoCliFallback: boolean;
 };
+
+const booleanControls = [
+  {
+    key: "autoSummarize",
+    root: "autoToggleRoot",
+    id: "options-auto",
+    label: "Auto-summarize when panel is open",
+  },
+  {
+    key: "chatEnabled",
+    root: "chatToggleRoot",
+    id: "options-chat",
+    label: "Enable Chat mode in the side panel",
+  },
+  {
+    key: "automationEnabled",
+    root: "automationToggleRoot",
+    id: "options-automation",
+    label: "Enable website automation",
+  },
+  {
+    key: "hoverSummaries",
+    root: "hoverSummariesToggleRoot",
+    id: "options-hover-summaries",
+    label: "Hover summaries (experimental)",
+  },
+  {
+    key: "summaryTimestamps",
+    root: "summaryTimestampsToggleRoot",
+    id: "options-summary-timestamps",
+    label: "Summary timestamps (media only)",
+  },
+  {
+    key: "slidesParallel",
+    root: "slidesParallelToggleRoot",
+    id: "options-slides-parallel",
+    label: "Show summary first (parallel slides)",
+  },
+  {
+    key: "slidesOcrEnabled",
+    root: "slidesOcrToggleRoot",
+    id: "options-slides-ocr",
+    label: "Enable OCR slide text",
+  },
+  {
+    key: "extendedLogging",
+    root: "extendedLoggingToggleRoot",
+    id: "options-extended-logging",
+    label: "Extended logging",
+  },
+  {
+    key: "autoCliFallback",
+    root: "autoCliFallbackToggleRoot",
+    id: "options-auto-cli-fallback",
+    label: "Auto CLI fallback",
+  },
+] as const;
 
 type ToggleController = {
   render: () => void;
@@ -103,67 +160,19 @@ export function createBooleanSettingsRuntime(options: {
   };
 
   const toggles: ToggleController[] = [
-    createBooleanToggleController({
-      root: options.roots.autoToggleRoot,
-      id: "options-auto",
-      label: "Auto-summarize when panel is open",
-      getValue: () => state.autoSummarize,
-      setValue: (checked) => {
-        state.autoSummarize = checked;
-      },
-      scheduleAutoSave: options.scheduleAutoSave,
-    }),
-    createBooleanToggleController({
-      root: options.roots.chatToggleRoot,
-      id: "options-chat",
-      label: "Enable Chat mode in the side panel",
-      getValue: () => state.chatEnabled,
-      setValue: (checked) => {
-        state.chatEnabled = checked;
-      },
-      scheduleAutoSave: options.scheduleAutoSave,
-    }),
-    createBooleanToggleController({
-      root: options.roots.automationToggleRoot,
-      id: "options-automation",
-      label: "Enable website automation",
-      getValue: () => state.automationEnabled,
-      setValue: (checked) => {
-        state.automationEnabled = checked;
-      },
-      scheduleAutoSave: options.scheduleAutoSave,
-      afterChange: options.onAutomationChanged,
-    }),
-    createBooleanToggleController({
-      root: options.roots.hoverSummariesToggleRoot,
-      id: "options-hover-summaries",
-      label: "Hover summaries (experimental)",
-      getValue: () => state.hoverSummaries,
-      setValue: (checked) => {
-        state.hoverSummaries = checked;
-      },
-      scheduleAutoSave: options.scheduleAutoSave,
-    }),
-    createBooleanToggleController({
-      root: options.roots.summaryTimestampsToggleRoot,
-      id: "options-summary-timestamps",
-      label: "Summary timestamps (media only)",
-      getValue: () => state.summaryTimestamps,
-      setValue: (checked) => {
-        state.summaryTimestamps = checked;
-      },
-      scheduleAutoSave: options.scheduleAutoSave,
-    }),
-    createBooleanToggleController({
-      root: options.roots.slidesParallelToggleRoot,
-      id: "options-slides-parallel",
-      label: "Show summary first (parallel slides)",
-      getValue: () => state.slidesParallel,
-      setValue: (checked) => {
-        state.slidesParallel = checked;
-      },
-      scheduleAutoSave: options.scheduleAutoSave,
-    }),
+    ...booleanControls.map(({ key, root, id, label }) =>
+      createBooleanToggleController({
+        root: options.roots[root],
+        id,
+        label,
+        getValue: () => state[key],
+        setValue: (checked) => {
+          state[key] = checked;
+        },
+        scheduleAutoSave: options.scheduleAutoSave,
+        afterChange: key === "automationEnabled" ? options.onAutomationChanged : undefined,
+      }),
+    ),
     createRuntimeController({
       root: options.roots.summaryRuntimeModeRoot,
       name: "summaryRuntimeMode",
@@ -189,36 +198,6 @@ export function createBooleanSettingsRuntime(options: {
       beforeChange: (value) =>
         value !== "daemon" || !options.ensureDaemonEnabled ? true : options.ensureDaemonEnabled(),
       afterChange: options.onRuntimeChanged,
-    }),
-    createBooleanToggleController({
-      root: options.roots.slidesOcrToggleRoot,
-      id: "options-slides-ocr",
-      label: "Enable OCR slide text",
-      getValue: () => state.slidesOcrEnabled,
-      setValue: (checked) => {
-        state.slidesOcrEnabled = checked;
-      },
-      scheduleAutoSave: options.scheduleAutoSave,
-    }),
-    createBooleanToggleController({
-      root: options.roots.extendedLoggingToggleRoot,
-      id: "options-extended-logging",
-      label: "Extended logging",
-      getValue: () => state.extendedLogging,
-      setValue: (checked) => {
-        state.extendedLogging = checked;
-      },
-      scheduleAutoSave: options.scheduleAutoSave,
-    }),
-    createBooleanToggleController({
-      root: options.roots.autoCliFallbackToggleRoot,
-      id: "options-auto-cli-fallback",
-      label: "Auto CLI fallback",
-      getValue: () => state.autoCliFallback,
-      setValue: (checked) => {
-        state.autoCliFallback = checked;
-      },
-      scheduleAutoSave: options.scheduleAutoSave,
     }),
   ];
 

--- a/apps/chrome-extension/src/entrypoints/options/form-state.ts
+++ b/apps/chrome-extension/src/entrypoints/options/form-state.ts
@@ -1,6 +1,7 @@
 import { readPresetOrCustomValue, resolvePresetOrCustom } from "../../lib/combo";
-import type { DirectProvider, Settings, SlideRuntime, SummaryRuntime } from "../../lib/settings";
+import type { DirectProvider, Settings } from "../../lib/settings";
 import type { ColorMode, ColorScheme } from "../../lib/theme";
+import type { BooleanSettingsState } from "./boolean-settings";
 import type { createModelPresetsController } from "./model-presets";
 
 type FormElements = {
@@ -28,20 +29,6 @@ type FormElements = {
   fontSizeEl: HTMLInputElement;
 };
 
-type BooleanFormState = {
-  autoSummarize: boolean;
-  hoverSummaries: boolean;
-  chatEnabled: boolean;
-  automationEnabled: boolean;
-  slidesParallel: boolean;
-  slideRuntime: SlideRuntime;
-  summaryRuntime: SummaryRuntime;
-  slidesOcrEnabled: boolean;
-  summaryTimestamps: boolean;
-  extendedLogging: boolean;
-  autoCliFallback: boolean;
-};
-
 export function buildSavedOptionsSettings({
   current,
   defaults,
@@ -55,7 +42,7 @@ export function buildSavedOptionsSettings({
   defaults: Settings;
   elements: FormElements;
   modelPresets: ReturnType<typeof createModelPresetsController>;
-  booleans: BooleanFormState;
+  booleans: BooleanSettingsState;
   currentScheme: ColorScheme;
   currentMode: ColorMode;
 }): Settings {

--- a/apps/chrome-extension/src/entrypoints/options/main.ts
+++ b/apps/chrome-extension/src/entrypoints/options/main.ts
@@ -25,92 +25,12 @@ import { createOptionsTabs, resolveActiveOptionsTab } from "./tab-controller";
 declare const __SUMMARIZE_GIT_HASH__: string;
 declare const __SUMMARIZE_VERSION__: string;
 
-const {
-  formEl,
-  statusEl,
-  tokenEl,
-  daemonPortEl,
-  daemonCapabilityStatusEl,
-  daemonPermissionEnableBtn,
-  daemonFieldsEl,
-  tokenCopyBtn,
-  summaryRuntimeModeRoot,
-  providerEl,
-  providerApiKeyEl,
-  providerBaseUrlEl,
-  modelPresetEl,
-  modelCustomEl,
-  languagePresetEl,
-  languageCustomEl,
-  promptOverrideEl,
-  autoToggleRoot,
-  maxCharsEl,
-  hoverPromptEl,
-  hoverPromptResetBtn,
-  chatToggleRoot,
-  automationToggleRoot,
-  automationPermissionsBtn,
-  userScriptsNoticeEl,
-  skillsExportBtn,
-  skillsImportBtn,
-  skillsSearchEl,
-  skillsListEl,
-  skillsEmptyEl,
-  skillsConflictsEl,
-  hoverSummariesToggleRoot,
-  summaryTimestampsToggleRoot,
-  slidesParallelToggleRoot,
-  slideRuntimeModeRoot,
-  slidesOcrToggleRoot,
-  extendedLoggingToggleRoot,
-  autoCliFallbackToggleRoot,
-  autoCliOrderEl,
-  requestModeEl,
-  firecrawlModeEl,
-  markdownModeEl,
-  preprocessModeEl,
-  youtubeModeEl,
-  transcriberEl,
-  timeoutEl,
-  retriesEl,
-  maxOutputTokensEl,
-  pickersRoot,
-  fontFamilyEl,
-  fontSizeEl,
-  buildInfoEl,
-  daemonStatusEl,
-  browserCacheStatusEl,
-  browserCacheClearBtn,
-  logsSourceEl,
-  logsTailEl,
-  logsRefreshBtn,
-  logsAutoEl,
-  logsOutputEl,
-  logsRawEl,
-  logsTableEl,
-  logsParsedEl,
-  logsMetaEl,
-  processesRefreshBtn,
-  processesAutoEl,
-  processesShowCompletedEl,
-  processesLimitEl,
-  processesStreamEl,
-  processesTailEl,
-  processesMetaEl,
-  processesTableEl,
-  processesLogsTitleEl,
-  processesLogsCopyBtn,
-  processesLogsOutputEl,
-  tabsRoot,
-  tabButtons,
-  tabPanels,
-  logsLevelInputs,
-} = getOptionsElements();
+const elements = getOptionsElements();
 
-const resolveActiveTab = () => resolveActiveOptionsTab(tabButtons);
+const resolveActiveTab = () => resolveActiveOptionsTab(elements.tabButtons);
 
 let isInitializing = true;
-const { setStatus, flashStatus } = createStatusController(statusEl);
+const { setStatus, flashStatus } = createStatusController(elements.statusEl);
 type SkillsController = ReturnType<typeof createSkillsController>;
 let skillsController: SkillsController | null = null;
 let skillsControllerPromise: Promise<SkillsController> | null = null;
@@ -123,12 +43,12 @@ const getSkillsController = async () => {
       .then(({ createSkillsController }) => {
         const controller = createSkillsController({
           elements: {
-            searchEl: skillsSearchEl,
-            listEl: skillsListEl,
-            emptyEl: skillsEmptyEl,
-            conflictsEl: skillsConflictsEl,
-            exportBtn: skillsExportBtn,
-            importBtn: skillsImportBtn,
+            searchEl: elements.skillsSearchEl,
+            listEl: elements.skillsListEl,
+            emptyEl: elements.skillsEmptyEl,
+            conflictsEl: elements.skillsConflictsEl,
+            exportBtn: elements.skillsExportBtn,
+            importBtn: elements.skillsImportBtn,
           },
           setStatus,
           flashStatus,
@@ -164,45 +84,45 @@ const loadSkillsTab = () => {
 
 const logsViewer = createLogsViewer({
   elements: {
-    sourceEl: logsSourceEl,
-    tailEl: logsTailEl,
-    refreshBtn: logsRefreshBtn,
-    autoEl: logsAutoEl,
-    outputEl: logsOutputEl,
-    rawEl: logsRawEl,
-    tableEl: logsTableEl,
-    parsedEl: logsParsedEl,
-    metaEl: logsMetaEl,
-    levelInputs: logsLevelInputs,
+    sourceEl: elements.logsSourceEl,
+    tailEl: elements.logsTailEl,
+    refreshBtn: elements.logsRefreshBtn,
+    autoEl: elements.logsAutoEl,
+    outputEl: elements.logsOutputEl,
+    rawEl: elements.logsRawEl,
+    tableEl: elements.logsTableEl,
+    parsedEl: elements.logsParsedEl,
+    metaEl: elements.logsMetaEl,
+    levelInputs: elements.logsLevelInputs,
   },
-  getToken: () => tokenEl.value.trim(),
+  getToken: () => elements.tokenEl.value.trim(),
   isActive: () => resolveActiveTab() === "logs",
 });
 
 const processesViewer = createProcessesViewer({
   elements: {
-    refreshBtn: processesRefreshBtn,
-    autoEl: processesAutoEl,
-    showCompletedEl: processesShowCompletedEl,
-    limitEl: processesLimitEl,
-    streamEl: processesStreamEl,
-    tailEl: processesTailEl,
-    metaEl: processesMetaEl,
-    tableEl: processesTableEl,
-    logsTitleEl: processesLogsTitleEl,
-    logsCopyBtn: processesLogsCopyBtn,
-    logsOutputEl: processesLogsOutputEl,
+    refreshBtn: elements.processesRefreshBtn,
+    autoEl: elements.processesAutoEl,
+    showCompletedEl: elements.processesShowCompletedEl,
+    limitEl: elements.processesLimitEl,
+    streamEl: elements.processesStreamEl,
+    tailEl: elements.processesTailEl,
+    metaEl: elements.processesMetaEl,
+    tableEl: elements.processesTableEl,
+    logsTitleEl: elements.processesLogsTitleEl,
+    logsCopyBtn: elements.processesLogsCopyBtn,
+    logsOutputEl: elements.processesLogsOutputEl,
   },
-  getToken: () => tokenEl.value.trim(),
+  getToken: () => elements.tokenEl.value.trim(),
   isActive: () => resolveActiveTab() === "processes",
 });
 
 let refreshBrowserCacheStatus = () => {};
 
 createOptionsTabs({
-  root: tabsRoot,
-  buttons: tabButtons,
-  panels: tabPanels,
+  root: elements.tabsRoot,
+  buttons: elements.tabButtons,
+  panels: elements.tabPanels,
   storageKey: optionsTabStorageKey,
   onTabActivated: (tabId) => {
     if (tabId === "skills") loadSkillsTab();
@@ -226,31 +146,7 @@ createOptionsTabs({
 
 let booleanSettings: ReturnType<typeof createBooleanSettingsRuntime> | null = null;
 let daemonCapability: ReturnType<typeof createDaemonCapabilityController> | null = null;
-let refreshRuntimeStatus = (_token = tokenEl.value) => {};
-const settingsElements = {
-  tokenEl,
-  daemonPortEl,
-  providerEl,
-  providerApiKeyEl,
-  providerBaseUrlEl,
-  languagePresetEl,
-  languageCustomEl,
-  promptOverrideEl,
-  hoverPromptEl,
-  autoCliOrderEl,
-  maxCharsEl,
-  requestModeEl,
-  firecrawlModeEl,
-  markdownModeEl,
-  preprocessModeEl,
-  youtubeModeEl,
-  transcriberEl,
-  timeoutEl,
-  retriesEl,
-  maxOutputTokensEl,
-  fontFamilyEl,
-  fontSizeEl,
-};
+let refreshRuntimeStatus = (_token = elements.tokenEl.value) => {};
 
 const { saveNow, scheduleAutoSave } = createOptionsSaveRuntime({
   isInitializing: () => isInitializing,
@@ -262,21 +158,9 @@ const { saveNow, scheduleAutoSave } = createOptionsSaveRuntime({
       buildSavedOptionsSettings({
         current,
         defaults: defaultSettings,
-        elements: settingsElements,
+        elements,
         modelPresets,
-        booleans: booleanSettings?.getState() ?? {
-          autoSummarize: defaultSettings.autoSummarize,
-          chatEnabled: defaultSettings.chatEnabled,
-          automationEnabled: defaultSettings.automationEnabled,
-          hoverSummaries: defaultSettings.hoverSummaries,
-          summaryTimestamps: defaultSettings.summaryTimestamps,
-          slidesParallel: defaultSettings.slidesParallel,
-          slideRuntime: defaultSettings.slideRuntime,
-          summaryRuntime: defaultSettings.summaryRuntime,
-          slidesOcrEnabled: defaultSettings.slidesOcrEnabled,
-          extendedLogging: defaultSettings.extendedLogging,
-          autoCliFallback: defaultSettings.autoCliFallback,
-        },
+        booleans: booleanSettings?.getState() ?? defaultSettings,
         currentScheme,
         currentMode,
       }),
@@ -286,19 +170,7 @@ const { saveNow, scheduleAutoSave } = createOptionsSaveRuntime({
 
 booleanSettings = createBooleanSettingsRuntime({
   defaults: defaultSettings,
-  roots: {
-    autoToggleRoot,
-    chatToggleRoot,
-    automationToggleRoot,
-    hoverSummariesToggleRoot,
-    summaryTimestampsToggleRoot,
-    slidesParallelToggleRoot,
-    slideRuntimeModeRoot,
-    summaryRuntimeModeRoot,
-    slidesOcrToggleRoot,
-    extendedLoggingToggleRoot,
-    autoCliFallbackToggleRoot,
-  },
+  roots: elements,
   scheduleAutoSave,
   onAutomationChanged: () => {
     void automationPermissions.updateUi();
@@ -316,7 +188,7 @@ const resolveExtensionVersion = () => {
 };
 
 const { checkDaemonStatus, setDaemonStatus } = createDaemonStatusChecker({
-  statusEl: daemonStatusEl,
+  statusEl: elements.daemonStatusEl,
   getExtensionVersion: resolveExtensionVersion,
   isDaemonMode: () => {
     const state = booleanSettings?.getState();
@@ -325,15 +197,15 @@ const { checkDaemonStatus, setDaemonStatus } = createDaemonStatusChecker({
 });
 
 daemonCapability = createDaemonCapabilityController({
-  statusEl: daemonCapabilityStatusEl,
-  enableBtn: daemonPermissionEnableBtn,
-  daemonFieldsEl,
-  summaryRuntimeRoot: summaryRuntimeModeRoot,
-  slideRuntimeRoot: slideRuntimeModeRoot,
+  statusEl: elements.daemonCapabilityStatusEl,
+  enableBtn: elements.daemonPermissionEnableBtn,
+  daemonFieldsEl: elements.daemonFieldsEl,
+  summaryRuntimeRoot: elements.summaryRuntimeModeRoot,
+  slideRuntimeRoot: elements.slideRuntimeModeRoot,
   onStateChanged: () => refreshRuntimeStatus(),
 });
 
-refreshRuntimeStatus = (token = tokenEl.value) => {
+refreshRuntimeStatus = (token = elements.tokenEl.value) => {
   const capability = daemonCapability?.getState();
   if (capability && !capability.policy.daemonAllowed) {
     setDaemonStatus("Disabled by administrator", "warn");
@@ -368,29 +240,29 @@ async function sendBrowserCacheMessage(type: "browser-cache:stats" | "browser-ca
 
 function renderBrowserCacheStatus(stats: CacheStats | null | undefined) {
   if (!stats) {
-    browserCacheStatusEl.textContent = "Unavailable";
+    elements.browserCacheStatusEl.textContent = "Unavailable";
     return;
   }
   const entryLabel = stats.totalEntries === 1 ? "entry" : "entries";
-  browserCacheStatusEl.textContent = `${stats.totalEntries} ${entryLabel} · ${formatBytes(
+  elements.browserCacheStatusEl.textContent = `${stats.totalEntries} ${entryLabel} · ${formatBytes(
     stats.sizeBytes,
   )} · expires after 30 days`;
 }
 
 refreshBrowserCacheStatus = () => {
-  browserCacheStatusEl.textContent = "Loading...";
+  elements.browserCacheStatusEl.textContent = "Loading...";
   void sendBrowserCacheMessage("browser-cache:stats")
     .then((response) => {
       renderBrowserCacheStatus(response.ok ? response.stats : null);
     })
     .catch(() => {
-      browserCacheStatusEl.textContent = "Unavailable";
+      elements.browserCacheStatusEl.textContent = "Unavailable";
     });
 };
 
-browserCacheClearBtn.addEventListener("click", () => {
-  browserCacheClearBtn.disabled = true;
-  browserCacheStatusEl.textContent = "Clearing...";
+elements.browserCacheClearBtn.addEventListener("click", () => {
+  elements.browserCacheClearBtn.disabled = true;
+  elements.browserCacheStatusEl.textContent = "Clearing...";
   void sendBrowserCacheMessage("browser-cache:clear")
     .then((response) => {
       if (!response.ok) {
@@ -402,17 +274,17 @@ browserCacheClearBtn.addEventListener("click", () => {
       flashStatus("Browser cache cleared");
     })
     .catch(() => {
-      browserCacheStatusEl.textContent = "Clear failed";
+      elements.browserCacheStatusEl.textContent = "Clear failed";
       setStatus("Failed to clear browser cache");
     })
     .finally(() => {
-      browserCacheClearBtn.disabled = false;
+      elements.browserCacheClearBtn.disabled = false;
     });
 });
 
 const modelPresets = createModelPresetsController({
-  presetEl: modelPresetEl,
-  customEl: modelCustomEl,
+  presetEl: elements.modelPresetEl,
+  customEl: elements.modelCustomEl,
   defaultValue: defaultSettings.model,
 });
 
@@ -433,20 +305,20 @@ const pickerHandlers = {
   },
 };
 
-const pickers = mountOptionsPickers(pickersRoot, {
+const pickers = mountOptionsPickers(elements.pickersRoot, {
   scheme: currentScheme,
   mode: currentMode,
   ...pickerHandlers,
 });
 
 const automationPermissions = createAutomationPermissionsController({
-  automationPermissionsBtn,
-  userScriptsNoticeEl,
+  automationPermissionsBtn: elements.automationPermissionsBtn,
+  userScriptsNoticeEl: elements.userScriptsNoticeEl,
   getAutomationEnabled: () => booleanSettings.getState().automationEnabled,
   flashStatus,
 });
 
-automationPermissionsBtn.addEventListener("click", () => {
+elements.automationPermissionsBtn.addEventListener("click", () => {
   void automationPermissions.requestPermissions();
 });
 
@@ -459,7 +331,7 @@ async function load() {
     settings: s,
     defaults: defaultSettings,
     languagePresets,
-    elements: settingsElements,
+    elements,
   });
   booleanSettings.setState(loadedState.booleans);
   booleanSettings.render();
@@ -484,70 +356,40 @@ chrome.storage.onChanged.addListener((_changes, areaName) => {
   if (areaName === "managed") void load();
 });
 
-providerEl.addEventListener("change", () => {
+elements.providerEl.addEventListener("change", () => {
   void (async () => {
     const stored = await loadSettings();
     await saveSettings({
       ...stored,
       providerApiKeys: {
         ...stored.providerApiKeys,
-        [activeProvider]: providerApiKeyEl.value.trim(),
+        [activeProvider]: elements.providerApiKeyEl.value.trim(),
       },
       providerBaseUrls: {
         ...stored.providerBaseUrls,
-        [activeProvider]: providerBaseUrlEl.value.trim(),
+        [activeProvider]: elements.providerBaseUrlEl.value.trim(),
       },
     });
-    const nextProvider = providerEl.value as typeof activeProvider;
+    const nextProvider = elements.providerEl.value as typeof activeProvider;
     activeProvider = nextProvider;
     const refreshed = await loadSettings();
-    providerApiKeyEl.value = refreshed.providerApiKeys[nextProvider] ?? "";
-    providerBaseUrlEl.value = refreshed.providerBaseUrls[nextProvider] ?? "";
+    elements.providerApiKeyEl.value = refreshed.providerApiKeys[nextProvider] ?? "";
+    elements.providerBaseUrlEl.value = refreshed.providerBaseUrls[nextProvider] ?? "";
     scheduleAutoSave(0);
   })();
 });
 
-providerApiKeyEl.addEventListener("input", () => scheduleAutoSave(400));
-providerBaseUrlEl.addEventListener("input", () => scheduleAutoSave(400));
+elements.providerApiKeyEl.addEventListener("input", () => scheduleAutoSave(400));
+elements.providerBaseUrlEl.addEventListener("input", () => scheduleAutoSave(400));
 
-const copyToken = () => copyTokenToClipboard({ tokenEl, flashStatus });
+const copyToken = () => copyTokenToClipboard({ tokenEl: elements.tokenEl, flashStatus });
 
 const refreshModelsIfStale = () => {
-  modelPresets.refreshIfStale(tokenEl.value);
+  modelPresets.refreshIfStale(elements.tokenEl.value);
 };
 
 bindOptionsInputs({
-  elements: {
-    formEl,
-    tokenEl,
-    daemonPortEl,
-    tokenCopyBtn,
-    modelPresetEl,
-    modelCustomEl,
-    languagePresetEl,
-    languageCustomEl,
-    promptOverrideEl,
-    hoverPromptEl,
-    hoverPromptResetBtn,
-    maxCharsEl,
-    requestModeEl,
-    firecrawlModeEl,
-    markdownModeEl,
-    preprocessModeEl,
-    youtubeModeEl,
-    transcriberEl,
-    timeoutEl,
-    retriesEl,
-    maxOutputTokensEl,
-    autoCliOrderEl,
-    fontFamilyEl,
-    fontSizeEl,
-    logsSourceEl,
-    logsTailEl,
-    logsParsedEl,
-    logsAutoEl,
-    logsLevelInputs,
-  },
+  elements,
   scheduleAutoSave,
   saveNow,
   checkDaemonStatus: refreshRuntimeStatus,
@@ -559,7 +401,7 @@ bindOptionsInputs({
   defaultHoverPrompt: defaultSettings.hoverPrompt,
 });
 
-applyBuildInfo(buildInfoEl, {
+applyBuildInfo(elements.buildInfoEl, {
   injectedVersion:
     typeof __SUMMARIZE_VERSION__ === "string" && __SUMMARIZE_VERSION__ ? __SUMMARIZE_VERSION__ : "",
   manifestVersion: chrome?.runtime?.getManifest?.().version ?? "",

--- a/apps/chrome-extension/src/lib/settings.ts
+++ b/apps/chrome-extension/src/lib/settings.ts
@@ -185,22 +185,6 @@ function normalizeAutoCliOrder(value: unknown): string {
   return out.length > 0 ? out.join(",") : defaultSettings.autoCliOrder;
 }
 
-function normalizeTranscriber(value: unknown): TranscriberSetting {
-  if (typeof value !== "string") return defaultSettings.transcriber;
-  const trimmed = value.trim().toLowerCase();
-  if (!trimmed) return defaultSettings.transcriber;
-  if (trimmed === "whisper" || trimmed === "parakeet" || trimmed === "canary") return trimmed;
-  return defaultSettings.transcriber;
-}
-
-function normalizeRequestMode(value: unknown): RequestModeSetting {
-  if (typeof value !== "string") return defaultSettings.requestMode;
-  const trimmed = value.trim().toLowerCase();
-  if (!trimmed) return defaultSettings.requestMode;
-  if (trimmed === "page" || trimmed === "url") return trimmed;
-  return defaultSettings.requestMode;
-}
-
 function normalizeSlidesLayout(value: unknown): SlidesLayout {
   if (typeof value !== "string") return defaultSettings.slidesLayout;
   const trimmed = value.trim().toLowerCase();
@@ -257,48 +241,6 @@ function normalizeProviderMap(value: unknown): Partial<Record<DirectProvider, st
     if (typeof entry === "string") out[provider] = entry.trim();
   }
   return out;
-}
-
-function normalizeFirecrawlMode(value: unknown): FirecrawlModeSetting {
-  if (typeof value !== "string") return defaultSettings.firecrawlMode;
-  const trimmed = value.trim().toLowerCase();
-  if (!trimmed) return defaultSettings.firecrawlMode;
-  if (trimmed === "off" || trimmed === "auto" || trimmed === "always") return trimmed;
-  return defaultSettings.firecrawlMode;
-}
-
-function normalizeMarkdownMode(value: unknown): MarkdownModeSetting {
-  if (typeof value !== "string") return defaultSettings.markdownMode;
-  const trimmed = value.trim().toLowerCase();
-  if (!trimmed) return defaultSettings.markdownMode;
-  if (trimmed === "off" || trimmed === "auto" || trimmed === "llm" || trimmed === "readability") {
-    return trimmed;
-  }
-  return defaultSettings.markdownMode;
-}
-
-function normalizePreprocessMode(value: unknown): PreprocessModeSetting {
-  if (typeof value !== "string") return defaultSettings.preprocessMode;
-  const trimmed = value.trim().toLowerCase();
-  if (!trimmed) return defaultSettings.preprocessMode;
-  if (trimmed === "off" || trimmed === "auto" || trimmed === "always") return trimmed;
-  return defaultSettings.preprocessMode;
-}
-
-function normalizeYoutubeMode(value: unknown): YoutubeModeSetting {
-  if (typeof value !== "string") return defaultSettings.youtubeMode;
-  const trimmed = value.trim().toLowerCase();
-  if (!trimmed) return defaultSettings.youtubeMode;
-  if (
-    trimmed === "auto" ||
-    trimmed === "web" ||
-    trimmed === "apify" ||
-    trimmed === "yt-dlp" ||
-    trimmed === "no-auto"
-  ) {
-    return trimmed;
-  }
-  return defaultSettings.youtubeMode;
 }
 
 function normalizeTimeout(value: unknown): string {
@@ -426,25 +368,84 @@ export const defaultSettings: Settings = {
   colorMode: defaultColorMode,
 };
 
+function normalizeChoice<Value extends string>(
+  value: unknown,
+  choices: readonly Value[],
+  fallback: Value,
+): Value {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return choices.find((choice) => choice === normalized) ?? fallback;
+}
+
+function normalizeSettings(settings: Settings): Settings {
+  return {
+    ...settings,
+    daemonPort: normalizeDaemonPort(settings.daemonPort),
+    summaryRuntime: normalizeSummaryRuntime(settings.summaryRuntime),
+    provider: normalizeProvider(settings.provider),
+    providerApiKeys: normalizeProviderMap(settings.providerApiKeys),
+    providerBaseUrls: normalizeProviderMap(settings.providerBaseUrls),
+    model: normalizeModel(settings.model),
+    length: normalizeLength(settings.length),
+    language: normalizeLanguage(settings.language),
+    promptOverride: normalizePromptOverride(settings.promptOverride),
+    hoverPrompt: normalizeHoverPrompt(settings.hoverPrompt),
+    autoCliOrder: normalizeAutoCliOrder(settings.autoCliOrder),
+    requestMode: normalizeChoice(
+      settings.requestMode,
+      ["page", "url"],
+      defaultSettings.requestMode,
+    ),
+    slidesLayout: normalizeSlidesLayout(settings.slidesLayout),
+    firecrawlMode: normalizeChoice(
+      settings.firecrawlMode,
+      ["off", "auto", "always"],
+      defaultSettings.firecrawlMode,
+    ),
+    markdownMode: normalizeChoice(
+      settings.markdownMode,
+      ["off", "auto", "llm", "readability"],
+      defaultSettings.markdownMode,
+    ),
+    preprocessMode: normalizeChoice(
+      settings.preprocessMode,
+      ["off", "auto", "always"],
+      defaultSettings.preprocessMode,
+    ),
+    youtubeMode: normalizeChoice(
+      settings.youtubeMode,
+      ["auto", "web", "apify", "yt-dlp", "no-auto"],
+      defaultSettings.youtubeMode,
+    ),
+    timeout: normalizeTimeout(settings.timeout),
+    retries: normalizeRetries(settings.retries),
+    maxOutputTokens: normalizeMaxOutputTokens(settings.maxOutputTokens),
+    transcriber: normalizeChoice(
+      settings.transcriber,
+      ["whisper", "parakeet", "canary"],
+      defaultSettings.transcriber,
+    ),
+    fontFamily: normalizeFontFamily(settings.fontFamily),
+    maxChars: normalizeMaxChars(settings.maxChars),
+    fontSize: normalizeFontSize(settings.fontSize),
+    lineHeight: normalizeLineHeight(settings.lineHeight),
+    colorScheme: normalizeColorScheme(settings.colorScheme),
+    colorMode: normalizeColorMode(settings.colorMode),
+  };
+}
+
 export async function loadSettings(): Promise<EffectiveSettings> {
   const raw = (await readStoredSettings()) as Partial<Settings> & Record<string, unknown>;
-  const normalized: Settings = {
+  const normalized = normalizeSettings({
     ...defaultSettings,
     ...raw,
     token: typeof raw.token === "string" ? raw.token : defaultSettings.token,
-    daemonPort: normalizeDaemonPort(raw.daemonPort),
     summaryRuntime: normalizeSummaryRuntime(raw.summaryRuntime, raw),
-    provider: normalizeProvider(raw.provider),
-    providerApiKeys: normalizeProviderMap(raw.providerApiKeys),
-    providerBaseUrls: normalizeProviderMap(raw.providerBaseUrls),
     daemonHintDismissed:
       typeof raw.daemonHintDismissed === "boolean"
         ? raw.daemonHintDismissed
         : defaultSettings.daemonHintDismissed,
     model: normalizeModel(raw.model, raw),
-    length: normalizeLength(raw.length),
-    language: normalizeLanguage(raw.language),
-    promptOverride: normalizePromptOverride(raw.promptOverride),
     autoSummarize:
       typeof raw.autoSummarize === "boolean" ? raw.autoSummarize : defaultSettings.autoSummarize,
     hoverSummaries:
@@ -464,7 +465,6 @@ export async function loadSettings(): Promise<EffectiveSettings> {
       typeof raw.slidesOcrEnabled === "boolean"
         ? raw.slidesOcrEnabled
         : defaultSettings.slidesOcrEnabled,
-    slidesLayout: normalizeSlidesLayout(raw.slidesLayout),
     summaryTimestamps:
       typeof raw.summaryTimestamps === "boolean"
         ? raw.summaryTimestamps
@@ -484,23 +484,7 @@ export async function loadSettings(): Promise<EffectiveSettings> {
         ? raw.autoCliOrder
         : (raw as Record<string, unknown>).magicCliOrder,
     ),
-    hoverPrompt: normalizeHoverPrompt(raw.hoverPrompt),
-    transcriber: normalizeTranscriber(raw.transcriber),
-    maxChars: normalizeMaxChars(raw.maxChars),
-    requestMode: normalizeRequestMode(raw.requestMode),
-    firecrawlMode: normalizeFirecrawlMode(raw.firecrawlMode),
-    markdownMode: normalizeMarkdownMode(raw.markdownMode),
-    preprocessMode: normalizePreprocessMode(raw.preprocessMode),
-    youtubeMode: normalizeYoutubeMode(raw.youtubeMode),
-    timeout: normalizeTimeout(raw.timeout),
-    retries: normalizeRetries(raw.retries),
-    maxOutputTokens: normalizeMaxOutputTokens(raw.maxOutputTokens),
-    fontFamily: normalizeFontFamily(raw.fontFamily),
-    fontSize: normalizeFontSize(raw.fontSize),
-    lineHeight: normalizeLineHeight(raw.lineHeight),
-    colorScheme: normalizeColorScheme(raw.colorScheme),
-    colorMode: normalizeColorMode(raw.colorMode),
-  };
+  });
   const policy = await readDaemonPolicy();
   return {
     ...enforceDaemonPolicy(normalized, policy),
@@ -515,37 +499,8 @@ export async function saveSettings(settings: Settings): Promise<void> {
     daemonManaged: _daemonManaged,
     ...storedSettings
   } = settings as EffectiveSettings;
-  const normalized = {
-    ...storedSettings,
-    daemonPort: normalizeDaemonPort(storedSettings.daemonPort),
-    summaryRuntime: normalizeSummaryRuntime(storedSettings.summaryRuntime),
-    provider: normalizeProvider(storedSettings.provider),
-    providerApiKeys: normalizeProviderMap(storedSettings.providerApiKeys),
-    providerBaseUrls: normalizeProviderMap(storedSettings.providerBaseUrls),
-    model: normalizeModel(storedSettings.model),
-    length: normalizeLength(storedSettings.length),
-    language: normalizeLanguage(storedSettings.language),
-    promptOverride: normalizePromptOverride(storedSettings.promptOverride),
-    hoverPrompt: normalizeHoverPrompt(storedSettings.hoverPrompt),
-    autoCliOrder: normalizeAutoCliOrder(storedSettings.autoCliOrder),
-    requestMode: normalizeRequestMode(storedSettings.requestMode),
-    slidesLayout: normalizeSlidesLayout(storedSettings.slidesLayout),
-    firecrawlMode: normalizeFirecrawlMode(storedSettings.firecrawlMode),
-    markdownMode: normalizeMarkdownMode(storedSettings.markdownMode),
-    preprocessMode: normalizePreprocessMode(storedSettings.preprocessMode),
-    youtubeMode: normalizeYoutubeMode(storedSettings.youtubeMode),
-    timeout: normalizeTimeout(storedSettings.timeout),
-    retries: normalizeRetries(storedSettings.retries),
-    maxOutputTokens: normalizeMaxOutputTokens(storedSettings.maxOutputTokens),
-    transcriber: normalizeTranscriber(storedSettings.transcriber),
-    fontFamily: normalizeFontFamily(storedSettings.fontFamily),
-    maxChars: normalizeMaxChars(storedSettings.maxChars),
-    fontSize: normalizeFontSize(storedSettings.fontSize),
-    lineHeight: normalizeLineHeight(storedSettings.lineHeight),
-    colorScheme: normalizeColorScheme(storedSettings.colorScheme),
-    colorMode: normalizeColorMode(storedSettings.colorMode),
-  };
-  await writeStoredSettings(normalized);
+
+  await writeStoredSettings(normalizeSettings(storedSettings));
 }
 
 export function getProviderSettings(settings: Settings): ProviderSettings {

--- a/apps/chrome-extension/tests/options.spec.ts
+++ b/apps/chrome-extension/tests/options.spec.ts
@@ -9,6 +9,42 @@ import {
   trackErrors,
 } from "./helpers/extension-harness";
 
+test("options checkbox controllers persist only their own setting", async ({ harness }) => {
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await expect(page.locator("html")).toHaveAttribute("data-settings-ready", "true");
+  const toggles = [
+    ["autoSummarize", "options-auto"],
+    ["chatEnabled", "options-chat"],
+    ["automationEnabled", "options-automation"],
+    ["hoverSummaries", "options-hover-summaries"],
+    ["summaryTimestamps", "options-summary-timestamps"],
+    ["slidesParallel", "options-slides-parallel"],
+    ["slidesOcrEnabled", "options-slides-ocr"],
+    ["extendedLogging", "options-extended-logging"],
+    ["autoCliFallback", "options-auto-cli-fallback"],
+  ] as const;
+  const expected = Object.fromEntries(
+    await Promise.all(
+      toggles.map(async ([key, id]) => [key, await page.locator(`#${id}`).isChecked()]),
+    ),
+  );
+  for (const [key, id] of toggles) {
+    const input = page.locator(`#${id}`);
+    const tab = await input.evaluate((element) =>
+      element.closest("[data-tab-panel]")?.getAttribute("data-tab-panel"),
+    );
+    await page.click(`#tab-${tab}`);
+    expected[key] = !(await input.isChecked());
+    await input.setChecked(expected[key], { force: true });
+    await expect
+      .poll(async () => {
+        const saved = await getSettings(harness);
+        return Object.fromEntries(toggles.map(([setting]) => [setting, saved[setting]]));
+      })
+      .toEqual(expected);
+  }
+});
+
 test("options pickers apply overlay selection", async ({ harness }) => {
   const page = await openExtensionPage(harness, "options.html", "#tabs");
   await page.click("#tab-ui");

--- a/tests/chrome.settings.test.ts
+++ b/tests/chrome.settings.test.ts
@@ -25,6 +25,31 @@ describe("chrome/settings", () => {
     expect(s.length).toBe("long");
   });
 
+  it("keeps migrations on load and preserves unknown fields without persisting policy", async () => {
+    storage.settings = {
+      summaryRuntime: "browser",
+      daemonlessSlides: false,
+      magicCliAuto: false,
+      magicCliOrder: " PI,claude ",
+      futureOption: { enabled: true },
+    };
+    const loaded = await loadSettings();
+    expect(loaded).toMatchObject({
+      model: "browser/gemini-nano",
+      summaryRuntime: "direct",
+      slideRuntime: "daemon",
+      autoCliFallback: false,
+      autoCliOrder: "pi,claude",
+      futureOption: { enabled: true },
+    });
+    await saveSettings(loaded);
+    const stored = storage.settings as Record<string, unknown>;
+    expect(stored.futureOption).toEqual({ enabled: true });
+    expect(stored).not.toHaveProperty("daemonAllowed");
+    expect(stored).not.toHaveProperty("daemonManaged");
+    expect(await loadSettings()).toEqual(loaded);
+  });
+
   it("normalizes model/length/language on save", async () => {
     await saveSettings({
       ...defaultSettings,


### PR DESCRIPTION
## One owner for Options wiring and settings normalization

Options previously unpacked its DOM collection and reconstructed large overlapping projections, then maintained nine copies of checkbox-controller wiring. It now passes the existing collection to narrow consumers and declares checkbox IDs, labels, and state keys once. Viewer-specific mappings and runtime-radio permission gates remain explicit.

Settings load and save share normalization without sharing the wrong responsibilities: legacy migrations remain load-only, managed policy is applied only to effective settings, unknown stored fields survive, and policy metadata is never persisted. The form and checkbox runtime use the same state type.

This removes 237 production lines and adds regression coverage, for a net reduction of 175 lines. There are no public API, dependency, or intended behavior changes.

## Proof

- Full project gate: 3,088 tests pass (43 skipped), 94.30% line coverage and 85.22% branch coverage.
- All 49 focused Options/settings unit tests pass, including migration/policy/unknown-field round trips.
- Supported Chromium suite: 3 native-transport checks and 113 HTTP-build checks pass (7 expected skips). The new browser test toggles every checkbox and verifies no other preference changes.
- Extension builds and independent Codex review pass; no actionable P0–P2 findings.
- The new checkbox test initially compared raw storage with effective defaults. Its baseline now comes from the rendered controls; the completed suite passes without production workarounds.

## Before and after

Synthetic General-tab captures are byte-identical. The same inspected image therefore represents both before and after; only the build label was fixed to synthetic text for comparison.

![Options before and after (identical)](https://github.com/user-attachments/assets/39109a6e-d288-4d35-a978-fc7db7a7ae97)

Hosted CI passes on the exact PR head: [Node 24 gate, Chromium E2E, and Firefox smoke](https://github.com/steipete/summarize/actions/runs/33944379958), with security checks green.
