### PR TITLE
refactor(application): build model resources in one owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Dependencies and maintenance
 
+- Build model resources once from resolved run intent; remove intermediate factories while keeping selection separate from provider, metrics, and stream state.
 - Make Options use one element collection and declarative checkbox bindings; share settings normalization between load and save without mixing legacy migrations or managed policy into persistence.
 - Share page-media resolution and embedded transcript composition across HTML and Firecrawl extraction, keeping source-specific metadata, Markdown, and timeout policies separate.
 - Delete the unreachable daemon chat pipeline and unused browser media adapters; keep chat on the agent endpoint and audio on the bounded chunked decoder.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -74,6 +74,8 @@ The user-facing error text remains descriptive, but it is not a control-flow con
 
 ## Adapter ownership
 
+Model selection resolves intent without creating process resources. `src/application/model-runtime.ts` then builds metrics, provider bindings, and the executable model in one factory; URL and asset flows share those same instances. Execution resources compose the flow contexts rather than rebuilding model options through intermediate factories.
+
 `src/application/flow-contexts.ts` composes asset and URL contexts from the same IO, flags, model, and runtime hooks. Asset execution receives its flat context directly; `assetFormat` is the explicit asset-only override. Fetch tracking, shared caches, and summary-cache notifications stay wired at this application boundary.
 
 Adapters own:

--- a/src/application/execution-resources.ts
+++ b/src/application/execution-resources.ts
@@ -1,8 +1,5 @@
 import type { CacheState } from "../cache.js";
 import type { MediaCache } from "../content/index.js";
-import type { SummaryStreamHandler } from "../engine/events.js";
-import type { ModelExecutorDeps } from "../engine/model-executor.js";
-import type { ExecFileFn } from "../markitdown.js";
 import { executeAssetSummary } from "../run/flows/asset/summary.js";
 import type { AssetSummaryContext } from "../run/flows/asset/types.js";
 import type {
@@ -14,22 +11,9 @@ import type {
 import type { PerfTrace } from "../run/perf-trace.js";
 import { scopeTranscriptCacheForDiarization } from "../shared/transcript-diarization-cache-scope.js";
 import { createRunFlowContexts } from "./flow-contexts.js";
-import {
-  createExecutableRunModel,
-  createRunModelRuntime,
-  type ExecutableRunModel,
-  type ModelExecutorRequestOptions,
-  type RunModelRuntime,
-} from "./model-runtime.js";
-import type { ResolvedSummarizeRun, ResolvedSummarizeSpec } from "./run-spec.js";
+import { createSummarizeModelResources, type SummarizeModelResources } from "./model-runtime.js";
+import type { ResolvedSummarizeSpec } from "./run-spec.js";
 import type { SummarizeEventSink } from "./summarize-contracts.js";
-
-export type SummarizeModelResources = {
-  context: ResolvedSummarizeRun["bindings"]["context"];
-  envForRun: Record<string, string | undefined>;
-  runtime: RunModelRuntime;
-  model: ExecutableRunModel;
-};
 
 type SummarizeFlowAdapterHooks = Pick<
   UrlFlowRuntimeHooks,
@@ -193,92 +177,25 @@ export function createSummarizeFlowFlags(
   };
 }
 
-export function createSummarizeModelResources(options: {
-  resolvedRun: ResolvedSummarizeRun;
-  env: Record<string, string | undefined>;
-  metricsEnv?: Record<string, string | undefined>;
-  fetchImpl: typeof fetch;
-  execFileImpl: ExecFileFn;
-  streamingEnabled: boolean;
-  summaryStream: SummaryStreamHandler | null;
-  requestOptions?: ModelExecutorRequestOptions;
-  log?: ModelExecutorDeps["log"];
-  trace?: ModelExecutorDeps["trace"];
-}): SummarizeModelResources {
-  const {
-    resolvedRun,
-    env,
-    metricsEnv = env,
-    fetchImpl,
-    execFileImpl,
-    streamingEnabled,
-    summaryStream,
-    requestOptions,
-    log,
-    trace,
-  } = options;
-  const { context, envForRun } = resolvedRun.bindings;
-  const runtime = createRunModelRuntime({
-    context,
-    env,
-    envForRun,
-    metricsEnv,
-    fetchImpl,
-    execFileImpl,
-    maxOutputTokensArg: resolvedRun.spec.maxOutputTokensArg,
-    timeoutMs: resolvedRun.spec.timeoutMs,
-    retries: resolvedRun.spec.retries,
-    streamingEnabled,
-    requestOptions,
-    log,
-    trace,
-  });
-  const model = createExecutableRunModel({
-    spec: resolvedRun.bindings.model,
-    runtime,
-    context,
-    allowAutoCliFallback: resolvedRun.spec.allowAutoCliFallback,
-    summaryStream,
-    requestOptions,
-  });
-
-  return { context, envForRun, runtime, model };
-}
-
-export function createSummarizeExecutionResources(options: {
-  resolvedRun: ResolvedSummarizeRun;
-  env: Record<string, string | undefined>;
-  metricsEnv?: Record<string, string | undefined>;
-  fetchImpl: typeof fetch;
-  execFileImpl: ExecFileFn;
-  cacheState: CacheState;
-  mediaCache: MediaCache | null;
-  stdout: NodeJS.WritableStream;
-  stderr: NodeJS.WritableStream;
-  urlFetch?: typeof fetch | null;
-  summaryStream: SummaryStreamHandler | null;
-  requestOptions?: ModelExecutorRequestOptions;
-  log?: ModelExecutorDeps["log"];
-  trace?: ModelExecutorDeps["trace"];
-  flow: SummarizeFlowOptions;
-  adapterHooks: SummarizeFlowAdapterHooks;
-  eventHooks?: Partial<UrlFlowEventHooks>;
-  assetFormat?: Parameters<typeof createRunFlowContexts>[0]["assetFormat"];
-  perfTrace?: PerfTrace | null;
-}): SummarizeExecutionResources {
+export function createSummarizeExecutionResources(
+  options: Omit<Parameters<typeof createSummarizeModelResources>[0], "streamingEnabled"> & {
+    cacheState: CacheState;
+    mediaCache: MediaCache | null;
+    stdout: NodeJS.WritableStream;
+    stderr: NodeJS.WritableStream;
+    urlFetch?: typeof fetch | null;
+    flow: SummarizeFlowOptions;
+    adapterHooks: SummarizeFlowAdapterHooks;
+    eventHooks?: Partial<UrlFlowEventHooks>;
+    assetFormat?: Parameters<typeof createRunFlowContexts>[0]["assetFormat"];
+    perfTrace?: PerfTrace | null;
+  },
+): SummarizeExecutionResources {
   const { resolvedRun, flow } = options;
   const { spec } = resolvedRun;
   const modelResources = createSummarizeModelResources({
-    resolvedRun,
-    env: options.env,
-    metricsEnv: options.metricsEnv,
-    fetchImpl: options.fetchImpl,
-    execFileImpl: options.execFileImpl,
+    ...options,
     streamingEnabled: flow.streamingEnabled,
-    summaryStream: options.summaryStream,
-    requestOptions: options.requestOptions,
-    log: options.log,
-    trace: options.trace,
   });
   const { metrics } = modelResources.runtime;
   const cacheState = scopeTranscriptCacheForDiarization(

--- a/src/application/model-runtime.ts
+++ b/src/application/model-runtime.ts
@@ -1,28 +1,29 @@
-import type { SummarizeConfig } from "../config.js";
 import type { SummaryStreamHandler } from "../engine/events.js";
 import { createModelExecutor, type ModelExecutorDeps } from "../engine/model-executor.js";
-import type { LengthArg } from "../flags.js";
+import type { ExecFileFn } from "../markitdown.js";
 import { resolveRunApiStatus } from "./api-status.js";
 import type { RunContextState } from "./context.js";
 import { createRunMetrics } from "./metrics.js";
-import { resolveModelSelection, type ModelSelection } from "./model-selection.js";
-import { resolveDesiredOutputTokens } from "./output-policy.js";
+import type { RunModelSpec } from "./model-selection.js";
 import { resolveProviderRuntimeBindings } from "./provider-runtime.js";
+import type { ResolvedSummarizeRun } from "./run-spec.js";
 
 export type ModelExecutorRequestOptions = Pick<
   ModelExecutorDeps,
   "openaiRequestOptions" | "openaiRequestOptionsOverride" | "cliReasoningEffortOverride"
 >;
 
-export type RunModelSpec = ModelSelection & {
-  fixedModelSpec: Extract<ModelSelection["requestedModel"], { kind: "fixed" }> | null;
-  desiredOutputTokens: number | null;
-};
-
-export type RunModelRuntime = {
+type RunModelRuntime = {
   metrics: ReturnType<typeof createRunMetrics>;
   apiStatus: ReturnType<typeof resolveRunApiStatus>;
   summaryEngine: ReturnType<typeof createModelExecutor>;
+};
+
+export type SummarizeModelResources = {
+  context: RunContextState;
+  envForRun: Record<string, string | undefined>;
+  runtime: RunModelRuntime;
+  model: ExecutableRunModel;
 };
 
 export type ExecutableRunModel = RunModelSpec &
@@ -39,67 +40,31 @@ export type ExecutableRunModel = RunModelSpec &
     llmCalls: RunModelRuntime["metrics"]["llmCalls"];
   };
 
-export function resolveRunModelSpec({
-  context,
-  envForRun,
-  explicitModelArg,
-  configForSelection,
-  lengthArg,
-  maxOutputTokensArg,
-}: {
-  context: RunContextState;
-  envForRun: Record<string, string | undefined>;
-  explicitModelArg: string | null;
-  configForSelection: SummarizeConfig | null;
-  lengthArg: LengthArg;
-  maxOutputTokensArg: number | null;
-}): RunModelSpec {
-  const selection = resolveModelSelection({
-    config: context.config,
-    configForCli: configForSelection,
-    configPath: context.configPath,
-    envForRun,
-    explicitModelArg,
-  });
-  return {
-    ...selection,
-    fixedModelSpec: selection.requestedModel.kind === "fixed" ? selection.requestedModel : null,
-    desiredOutputTokens: resolveDesiredOutputTokens({
-      lengthArg,
-      maxOutputTokensArg,
-    }),
-  };
-}
-
-export function createRunModelRuntime({
-  context,
+export function createSummarizeModelResources({
+  resolvedRun,
   env,
-  envForRun,
-  metricsEnv,
+  metricsEnv = env,
   fetchImpl,
   execFileImpl,
-  maxOutputTokensArg,
-  timeoutMs,
-  retries,
   streamingEnabled,
+  summaryStream,
   requestOptions = {},
   log,
   trace,
 }: {
-  context: RunContextState;
+  resolvedRun: ResolvedSummarizeRun;
   env: Record<string, string | undefined>;
-  envForRun: Record<string, string | undefined>;
-  metricsEnv: Record<string, string | undefined>;
+  metricsEnv?: Record<string, string | undefined>;
   fetchImpl: typeof fetch;
-  execFileImpl: ModelExecutorDeps["execFileImpl"];
-  maxOutputTokensArg: number | null;
-  timeoutMs: number;
-  retries: number;
+  execFileImpl: ExecFileFn;
   streamingEnabled: boolean;
+  summaryStream: SummaryStreamHandler | null;
   requestOptions?: ModelExecutorRequestOptions;
   log?: ModelExecutorDeps["log"];
   trace?: ModelExecutorDeps["trace"];
-}): RunModelRuntime {
+}): SummarizeModelResources {
+  const { context, envForRun } = resolvedRun.bindings;
+  const { maxOutputTokensArg, timeoutMs, retries, allowAutoCliFallback } = resolvedRun.spec;
   const metrics = createRunMetrics({
     env: metricsEnv,
     fetchImpl,
@@ -131,40 +96,20 @@ export function createRunModelRuntime({
     openrouterApiKey: apiStatus.openrouterApiKey,
   });
 
-  return {
-    metrics,
-    apiStatus,
-    summaryEngine,
-  };
-}
-
-export function createExecutableRunModel({
-  spec,
-  runtime,
-  context,
-  allowAutoCliFallback,
-  summaryStream,
-  requestOptions = {},
-}: {
-  spec: RunModelSpec;
-  runtime: RunModelRuntime;
-  context: RunContextState;
-  allowAutoCliFallback: boolean;
-  summaryStream: SummaryStreamHandler | null;
-  requestOptions?: ModelExecutorRequestOptions;
-}): ExecutableRunModel {
-  return {
-    ...spec,
+  const model: ExecutableRunModel = {
+    ...resolvedRun.bindings.model,
     allowAutoCliFallback,
     envForAuto: context.envForAuto,
     cliAvailability: context.cliAvailability,
     openaiUseChatCompletions: context.openaiUseChatCompletions,
     openaiWhisperUsdPerMinute: context.openaiWhisperUsdPerMinute,
     ...requestOptions,
-    apiStatus: runtime.apiStatus,
-    summaryEngine: runtime.summaryEngine,
+    apiStatus,
+    summaryEngine,
     summaryStream,
-    getLiteLlmCatalog: runtime.metrics.getLiteLlmCatalog,
-    llmCalls: runtime.metrics.llmCalls,
+    getLiteLlmCatalog: metrics.getLiteLlmCatalog,
+    llmCalls: metrics.llmCalls,
   };
+
+  return { context, envForRun, runtime: { metrics, apiStatus, summaryEngine }, model };
 }

--- a/src/application/model-selection.ts
+++ b/src/application/model-selection.ts
@@ -1,8 +1,11 @@
 import type { CliProvider, ModelConfig, SummarizeConfig } from "../config.js";
+import type { LengthArg } from "../flags.js";
 import { mergeModelRequestOptions } from "../llm/model-options.js";
 import type { RequestedModel } from "../model-spec.js";
 import { parseRequestedModelId } from "../model-spec.js";
+import type { RunContextState } from "./context.js";
 import { BUILTIN_MODELS } from "./model-catalog.js";
+import { resolveDesiredOutputTokens } from "./output-policy.js";
 
 function resolveConfiguredCliModel(
   provider: CliProvider,
@@ -66,6 +69,43 @@ export type ModelSelection = {
   configForModelSelection: SummarizeConfig | null;
   isFallbackModel: boolean;
 };
+
+export type RunModelSpec = ModelSelection & {
+  fixedModelSpec: Extract<ModelSelection["requestedModel"], { kind: "fixed" }> | null;
+  desiredOutputTokens: number | null;
+};
+
+export function resolveRunModelSpec({
+  context,
+  envForRun,
+  explicitModelArg,
+  configForSelection,
+  lengthArg,
+  maxOutputTokensArg,
+}: {
+  context: RunContextState;
+  envForRun: Record<string, string | undefined>;
+  explicitModelArg: string | null;
+  configForSelection: SummarizeConfig | null;
+  lengthArg: LengthArg;
+  maxOutputTokensArg: number | null;
+}): RunModelSpec {
+  const selection = resolveModelSelection({
+    config: context.config,
+    configForCli: configForSelection,
+    configPath: context.configPath,
+    envForRun,
+    explicitModelArg,
+  });
+  return {
+    ...selection,
+    fixedModelSpec: selection.requestedModel.kind === "fixed" ? selection.requestedModel : null,
+    desiredOutputTokens: resolveDesiredOutputTokens({
+      lengthArg,
+      maxOutputTokensArg,
+    }),
+  };
+}
 
 export function resolveModelSelection({
   config,

--- a/src/application/run-spec.ts
+++ b/src/application/run-spec.ts
@@ -19,7 +19,7 @@ import {
 } from "../run/run-settings.js";
 import { createRunConfigInput, type RunConfigInput } from "./config-state.js";
 import { resolveRunContextState, type RunContextState } from "./context.js";
-import { resolveRunModelSpec, type RunModelSpec } from "./model-runtime.js";
+import { resolveRunModelSpec, type RunModelSpec } from "./model-selection.js";
 import type { SummarizeRequest } from "./summarize-contracts.js";
 
 export type SummarizeRunInput = SummarizeRequest["input"];

--- a/tests/application.model-runtime.test.ts
+++ b/tests/application.model-runtime.test.ts
@@ -1,63 +1,102 @@
-import { describe, expect, it, vi } from "vitest";
-import { createRunConfigInput } from "../src/application/config-state.js";
-import { resolveRunContextState } from "../src/application/context.js";
-import {
-  createExecutableRunModel,
-  createRunModelRuntime,
-  resolveRunModelSpec,
-} from "../src/application/model-runtime.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as metricsModule from "../src/application/metrics.js";
+import { createSummarizeModelResources } from "../src/application/model-runtime.js";
+import { resolveSummarizeRun } from "../src/application/run-spec.js";
+import * as executorModule from "../src/engine/model-executor.js";
+import { createEmptyRunOverrides } from "../src/run/run-settings.js";
+
+afterEach(() => vi.restoreAllMocks());
 
 describe("application model runtime", () => {
-  it("resolves model intent separately from process resources", () => {
-    const env = { OPENAI_API_KEY: "openai-key" };
-    const context = resolveRunContextState({
-      env,
-      envForRun: env,
-      configInput: createRunConfigInput(),
-    });
-
-    const spec = resolveRunModelSpec({
-      context,
-      envForRun: env,
-      explicitModelArg: "openai/gpt-5.4",
-      configForSelection: context.configForCli,
-      lengthArg: { kind: "preset", preset: "medium" },
-      maxOutputTokensArg: null,
-    });
-    const runtime = createRunModelRuntime({
-      context,
-      env,
-      envForRun: env,
-      metricsEnv: env,
-      fetchImpl: vi.fn() as unknown as typeof fetch,
-      execFileImpl: vi.fn(),
-      maxOutputTokensArg: null,
-      timeoutMs: 1_000,
-      retries: 1,
-      streamingEnabled: false,
-    });
-
-    expect(spec.requestedModel).toMatchObject({
-      kind: "fixed",
-      userModelId: "openai/gpt-5.4",
-    });
-    expect(spec.fixedModelSpec).toBe(spec.requestedModel);
-    expect(spec.desiredOutputTokens).toBeGreaterThan(0);
-    expect(runtime.apiStatus.apiKey).toBe("openai-key");
-    expect(runtime.summaryEngine.envHasKeyFor("OPENAI_API_KEY")).toBe(true);
-    expect(runtime.metrics.llmCalls).toEqual([]);
-
-    const executable = createExecutableRunModel({
-      spec,
-      runtime,
-      context,
-      allowAutoCliFallback: true,
-      summaryStream: null,
-    });
-    expect(executable.requestedModel).toBe(spec.requestedModel);
-    expect(executable.allowAutoCliFallback).toBe(true);
-    expect(executable.apiStatus).toBe(runtime.apiStatus);
-    expect(executable.summaryEngine).toBe(runtime.summaryEngine);
-    expect(executable.llmCalls).toBe(runtime.metrics.llmCalls);
-  });
+  it.each([false, true])(
+    "shares resources with explicit metrics environment: %s",
+    (explicitMetrics) => {
+      const env = { OPENAI_API_KEY: "openai-key" };
+      const metricsEnv = explicitMetrics ? { SUMMARIZE_DISABLE_PRICING: "1" } : undefined;
+      const createMetrics = vi.spyOn(metricsModule, "createRunMetrics");
+      const createExecutor = vi.spyOn(executorModule, "createModelExecutor");
+      const resolvedRun = resolveSummarizeRun({
+        env,
+        request: {
+          input: {
+            kind: "visible-page",
+            url: "https://example.com",
+            title: null,
+            text: "",
+            truncated: false,
+          },
+          modelOverride: "openai/gpt-5.4",
+          promptOverride: null,
+          lengthRaw: "medium",
+          languageRaw: null,
+          format: "text",
+          extractOnly: false,
+          slides: null,
+          overrides: {
+            ...createEmptyRunOverrides(),
+            timeoutMs: 1_000,
+            retries: 2,
+            maxOutputTokensArg: 512,
+            autoCliFallbackEnabled: true,
+            transcriber: "parakeet",
+          },
+        },
+      });
+      expect(createMetrics).not.toHaveBeenCalled();
+      expect(createExecutor).not.toHaveBeenCalled();
+      const fetchImpl = vi.fn() as unknown as typeof fetch;
+      const execFileImpl = vi.fn();
+      const summaryStream = { onChunk: vi.fn(), onReset: vi.fn() };
+      const requestOptions = {
+        openaiRequestOptions: { serviceTier: "fast" as const },
+        cliReasoningEffortOverride: "high" as const,
+      };
+      const resources = createSummarizeModelResources({
+        resolvedRun,
+        env,
+        metricsEnv,
+        fetchImpl,
+        execFileImpl,
+        streamingEnabled: true,
+        summaryStream,
+        requestOptions,
+      });
+      const { model, runtime } = resources;
+      expect(resources.context).toBe(resolvedRun.bindings.context);
+      expect(resources.envForRun).toBe(resolvedRun.bindings.envForRun);
+      expect(resources.envForRun.SUMMARIZE_TRANSCRIBER).toBe("parakeet");
+      expect(createMetrics).toHaveBeenCalledExactlyOnceWith({
+        env: metricsEnv ?? env,
+        fetchImpl,
+        maxOutputTokensArg: 512,
+      });
+      expect(createExecutor).toHaveBeenCalledTimes(1);
+      expect(createExecutor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env,
+          envForRun: resources.envForRun,
+          execFileImpl,
+          timeoutMs: 1_000,
+          retries: 2,
+          streamingEnabled: true,
+          ...requestOptions,
+          trackedFetch: runtime.metrics.trackedFetch,
+          llmCalls: runtime.metrics.llmCalls,
+        }),
+      );
+      expect(model.requestedModel).toMatchObject({ kind: "fixed", userModelId: "openai/gpt-5.4" });
+      expect(model.requestedModel).toBe(resolvedRun.bindings.model.requestedModel);
+      expect(model.fixedModelSpec).toBe(model.requestedModel);
+      expect(model.desiredOutputTokens).toBe(512);
+      expect(model).toMatchObject({ ...requestOptions, allowAutoCliFallback: true });
+      expect(model.summaryStream).toBe(summaryStream);
+      expect(model.apiStatus).toBe(runtime.apiStatus);
+      expect(model.apiStatus.apiKey).toBe("openai-key");
+      expect(model.summaryEngine).toBe(runtime.summaryEngine);
+      expect(model.summaryEngine.envHasKeyFor("OPENAI_API_KEY")).toBe(true);
+      expect(model.getLiteLlmCatalog).toBe(runtime.metrics.getLiteLlmCatalog);
+      expect(model.llmCalls).toBe(runtime.metrics.llmCalls);
+      expect(model.llmCalls).toEqual([]);
+    },
+  );
 });


### PR DESCRIPTION
## One owner for model resources

The application previously constructed one model runtime through three factories, repeatedly declaring and forwarding the same environment, request options, and resolved run policy. Model selection now owns intent resolution; one model-runtime factory creates the metrics, provider bindings, executor, and executable model. Execution resources only compose the URL and asset flows.

The original environment, per-run environment, optional metrics environment, execution budgets, request-option precedence, CLI fallback policy, and stream/log/trace hooks retain their meaning. Both flows still share the same metric collectors and executor references. The old private constructor paths are deleted rather than kept as compatibility aliases.

This removes 98 production lines; expanded contract tests and documentation leave the complete change 56 lines smaller. Public exports and dependencies are unchanged.

## Proof

- Build and full project gate pass: 3,089 tests (43 skipped), 94.30% line coverage and 85.21% branch coverage.
- All 40 application/architecture tests pass, including cycle detection and workspace/engine boundaries.
- Expanded model-resource tests verify that selection allocates no runtime resources, construction happens once, reference identity is shared, overrides propagate, and explicit/default metrics environments stay distinct.
- The built CLI preserves synthetic short-file output byte-for-byte in an isolated home with no inherited credentials.
- Independent Codex review is clean for actionable P0–P2 findings.

The first build caught an overly permissive subprocess dependency type inherited from the lower-level executor. The final factory retains the original required subprocess function contract, and the complete build/gate/review were rerun successfully.

Hosted CI passes on the exact PR head: [Node 24 gate, Chromium E2E, and Firefox smoke](https://github.com/steipete/summarize/actions/runs/33945170690), with security checks green.
