### PR TITLE
refactor(slides): share subprocess lifecycle and drain ignored output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Slides: drain ignored subprocess output so a verbose media tool cannot stall on a full stdout pipe.
 - Transcript cache: preserve embedded-caption and native YouTube media source metadata across cache hits instead of losing it to duplicated source lists.
 - Browser media: support MP4 files carrying Annex B AVC/HEVC and clarify missing WebCodecs errors in insecure contexts with MediaBunny 1.55.2.
 - FAL transcription: clear settled deadlines and stop local queue polling and retries after timeout (#392, thanks @vincent-peng).
@@ -16,6 +17,7 @@
 
 ### Dependencies and maintenance
 
+- Share one media subprocess lifecycle across line streaming, text/binary capture, and OCR while preserving output tracking and timeout/error behavior.
 - Build model resources once from resolved run intent; remove intermediate factories while keeping selection separate from provider, metrics, and stream state.
 - Make Options use one element collection and declarative checkbox bindings; share settings normalization between load and save without mixing legacy migrations or managed policy into persistence.
 - Share page-media resolution and embedded transcript composition across HTML and Firecrawl extraction, keeping source-specific metadata, Markdown, and timeout policies separate.

--- a/docs/slides-rendering-flow.md
+++ b/docs/slides-rendering-flow.md
@@ -28,6 +28,8 @@ Two main paths.
 
 Rule: keep terminal I/O in render helpers; keep state mutations in the state store.
 
+`src/slides/process.ts` owns media-tool spawning, deadlines, exit errors, and output collection. Line callbacks, text capture, and binary capture share that lifecycle; OCR uses binary capture to avoid logging recognized text. Ignored stdout is drained so child processes cannot block on a full pipe.
+
 ## Chrome extension
 
 - `apps/chrome-extension/src/entrypoints/sidepanel/stream-controller.ts`

--- a/src/slides/ocr.ts
+++ b/src/slides/ocr.ts
@@ -1,5 +1,4 @@
-import { spawnTracked } from "../processes.js";
-import { runWithConcurrency } from "./process.js";
+import { runProcessCaptureBuffer, runWithConcurrency } from "./process.js";
 import type { SlideImage } from "./types.js";
 
 const TESSERACT_TIMEOUT_MS = 120_000;
@@ -23,62 +22,13 @@ export function estimateOcrConfidence(text: string): number {
 }
 
 export async function runTesseract(tesseractPath: string, imagePath: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const { proc, handle } = spawnTracked(
-      tesseractPath,
-      [imagePath, "stdout", "--oem", "3", "--psm", "6"],
-      {
-        stdio: ["ignore", "pipe", "pipe"],
-        label: "tesseract",
-        kind: "tesseract",
-        captureOutput: false,
-      },
-    );
-    let stdout = "";
-    let stderr = "";
-    let stderrBuffer = "";
-
-    const timeout = setTimeout(() => {
-      proc.kill("SIGKILL");
-      reject(new Error("tesseract timed out"));
-    }, TESSERACT_TIMEOUT_MS);
-
-    if (proc.stdout) {
-      proc.stdout.setEncoding("utf8");
-      proc.stdout.on("data", (chunk: string) => {
-        stdout += chunk;
-      });
-    }
-
-    if (proc.stderr) {
-      proc.stderr.setEncoding("utf8");
-      proc.stderr.on("data", (chunk: string) => {
-        if (stderr.length < 8192) stderr += chunk;
-        stderrBuffer += chunk;
-        const lines = stderrBuffer.split(/\r?\n/);
-        stderrBuffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (line) handle?.appendOutput("stderr", line);
-        }
-      });
-    }
-
-    proc.on("error", (error) => {
-      clearTimeout(timeout);
-      reject(error);
-    });
-
-    proc.on("close", (code) => {
-      clearTimeout(timeout);
-      if (stderrBuffer.trim()) handle?.appendOutput("stderr", stderrBuffer.trim());
-      if (code === 0) {
-        resolve(stdout);
-        return;
-      }
-      const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
-      reject(new Error(`tesseract exited with code ${code}${suffix}`));
-    });
+  const output = await runProcessCaptureBuffer({
+    command: tesseractPath,
+    args: [imagePath, "stdout", "--oem", "3", "--psm", "6"],
+    timeoutMs: TESSERACT_TIMEOUT_MS,
+    errorLabel: "tesseract",
   });
+  return output.toString("utf8");
 }
 
 export async function runOcrOnSlides(

--- a/src/slides/process.ts
+++ b/src/slides/process.ts
@@ -17,110 +17,48 @@ function resolveProcessCommand(command: ProcessCommand, args: string[]) {
   };
 }
 
-export async function runProcess({
-  command,
-  args,
-  timeoutMs,
-  errorLabel,
-  onStderrLine,
-  onStdoutLine,
-}: {
+type ProcessOptions = {
   command: ProcessCommand;
   args: string[];
   timeoutMs: number;
   errorLabel: string;
-  onStderrLine?: (line: string, handle: ProcessHandle | null) => void;
-  onStdoutLine?: (line: string, handle: ProcessHandle | null) => void;
-}): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const resolved = resolveProcessCommand(command, args);
-    const { proc, handle } = spawnTracked(resolved.command, resolved.args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      label: errorLabel,
-      kind: errorLabel,
-      captureOutput: false,
-    });
-    let stderr = "";
-    let stderrBuffer = "";
-    let stdoutBuffer = "";
+};
 
-    const flushLine = (line: string) => {
-      onStderrLine?.(line, handle);
-      handle?.appendOutput("stderr", line);
-      if (stderr.length < 8192) {
-        stderr += line;
-        if (!line.endsWith("\n")) stderr += "\n";
-      }
-    };
+type ProcessLineHandler = (line: string, handle: ProcessHandle | null) => void;
+type ProcessLineOptions = ProcessOptions & {
+  onStderrLine?: ProcessLineHandler;
+  onStdoutLine?: ProcessLineHandler;
+};
 
-    if (proc.stderr) {
-      proc.stderr.setEncoding("utf8");
-      proc.stderr.on("data", (chunk: string) => {
-        stderrBuffer += chunk;
-        const lines = stderrBuffer.split(/\r?\n/);
-        stderrBuffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (line) flushLine(line);
-        }
-      });
+function readProcessLines(
+  stream: NodeJS.ReadableStream | null,
+  onLine: (line: string) => void,
+  onChunk?: (chunk: string) => void,
+): () => void {
+  let buffer = "";
+  stream?.setEncoding("utf8");
+  stream?.on("data", (chunk: string) => {
+    onChunk?.(chunk);
+    buffer += chunk;
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line) onLine(line);
     }
-
-    if (proc.stdout) {
-      const handleStdoutLine = onStdoutLine ?? onStderrLine;
-      if (handleStdoutLine) {
-        proc.stdout.setEncoding("utf8");
-        proc.stdout.on("data", (chunk: string) => {
-          stdoutBuffer += chunk;
-          const lines = stdoutBuffer.split(/\r?\n/);
-          stdoutBuffer = lines.pop() ?? "";
-          for (const line of lines) {
-            if (!line) continue;
-            handleStdoutLine(line, handle);
-            handle?.appendOutput("stdout", line);
-          }
-        });
-      }
-    }
-
-    const timeout = setTimeout(() => {
-      proc.kill("SIGKILL");
-      reject(new Error(`${errorLabel} timed out`));
-    }, timeoutMs);
-
-    proc.on("error", (error) => {
-      clearTimeout(timeout);
-      reject(error);
-    });
-
-    proc.on("close", (code) => {
-      clearTimeout(timeout);
-      if (stderrBuffer.trim().length > 0) flushLine(stderrBuffer.trim());
-      if (stdoutBuffer.trim().length > 0) {
-        const handleStdoutLine = onStdoutLine ?? onStderrLine;
-        if (handleStdoutLine) handleStdoutLine(stdoutBuffer.trim(), handle);
-        handle?.appendOutput("stdout", stdoutBuffer.trim());
-      }
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
-      reject(new Error(`${errorLabel} exited with code ${code}${suffix}`));
-    });
   });
+  return () => {
+    if (buffer.trim()) onLine(buffer.trim());
+  };
 }
 
-export async function runProcessCapture({
-  command,
-  args,
-  timeoutMs,
-  errorLabel,
-}: {
-  command: ProcessCommand;
-  args: string[];
-  timeoutMs: number;
-  errorLabel: string;
-}): Promise<string> {
+function runProcessWithOutput(options: ProcessLineOptions, mode: "lines"): Promise<void>;
+function runProcessWithOutput(options: ProcessOptions, mode: "text"): Promise<string>;
+function runProcessWithOutput(options: ProcessOptions, mode: "buffer"): Promise<Buffer>;
+function runProcessWithOutput(
+  options: ProcessLineOptions,
+  mode: "lines" | "text" | "buffer",
+): Promise<void | string | Buffer> {
+  const { command, args, timeoutMs, errorLabel, onStderrLine, onStdoutLine } = options;
   return new Promise((resolve, reject) => {
     const resolved = resolveProcessCommand(command, args);
     const { proc, handle } = spawnTracked(resolved.command, resolved.args, {
@@ -129,124 +67,76 @@ export async function runProcessCapture({
       kind: errorLabel,
       captureOutput: false,
     });
+    let stderr = "";
     let stdout = "";
-    let stderr = "";
-    let stdoutBuffer = "";
-    let stderrBuffer = "";
+    const chunks: Buffer[] = [];
+    const appendError = (text: string) => {
+      if (stderr.length < 8192) stderr += text;
+    };
+    const flushStderr = readProcessLines(
+      proc.stderr,
+      (line) => {
+        if (mode === "lines") onStderrLine?.(line, handle);
+        handle?.appendOutput("stderr", line);
+        if (mode === "lines") appendError(`${line}\n`);
+      },
+      mode === "lines" ? undefined : appendError,
+    );
+
+    const stdoutHandler = onStdoutLine ?? onStderrLine;
+    let flushStdout: (() => void) | undefined;
+    if (mode === "buffer") {
+      proc.stdout?.on("data", (chunk: Buffer) => chunks.push(chunk));
+    } else if (mode === "text" || stdoutHandler) {
+      flushStdout = readProcessLines(
+        proc.stdout,
+        (line) => {
+          if (mode === "lines") stdoutHandler?.(line, handle);
+          handle?.appendOutput("stdout", line);
+        },
+        mode === "text"
+          ? (chunk) => {
+              stdout += chunk;
+            }
+          : undefined,
+      );
+    } else {
+      proc.stdout?.resume();
+    }
 
     const timeout = setTimeout(() => {
       proc.kill("SIGKILL");
       reject(new Error(`${errorLabel} timed out`));
     }, timeoutMs);
-
-    if (proc.stdout) {
-      proc.stdout.setEncoding("utf8");
-      proc.stdout.on("data", (chunk: string) => {
-        stdout += chunk;
-        stdoutBuffer += chunk;
-        const lines = stdoutBuffer.split(/\r?\n/);
-        stdoutBuffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (line) handle?.appendOutput("stdout", line);
-        }
-      });
-    }
-
-    if (proc.stderr) {
-      proc.stderr.setEncoding("utf8");
-      proc.stderr.on("data", (chunk: string) => {
-        if (stderr.length < 8192) stderr += chunk;
-        stderrBuffer += chunk;
-        const lines = stderrBuffer.split(/\r?\n/);
-        stderrBuffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (line) handle?.appendOutput("stderr", line);
-        }
-      });
-    }
-
     proc.on("error", (error) => {
       clearTimeout(timeout);
       reject(error);
     });
-
     proc.on("close", (code) => {
       clearTimeout(timeout);
-      if (stdoutBuffer.trim()) handle?.appendOutput("stdout", stdoutBuffer.trim());
-      if (stderrBuffer.trim()) handle?.appendOutput("stderr", stderrBuffer.trim());
+      if (mode === "lines") flushStderr();
+      flushStdout?.();
+      if (mode !== "lines") flushStderr();
       if (code === 0) {
-        resolve(stdout);
-        return;
+        resolve(mode === "buffer" ? Buffer.concat(chunks) : mode === "text" ? stdout : undefined);
+      } else {
+        const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
+        reject(new Error(`${errorLabel} exited with code ${code}${suffix}`));
       }
-      const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
-      reject(new Error(`${errorLabel} exited with code ${code}${suffix}`));
     });
   });
 }
 
-export async function runProcessCaptureBuffer({
-  command,
-  args,
-  timeoutMs,
-  errorLabel,
-}: {
-  command: ProcessCommand;
-  args: string[];
-  timeoutMs: number;
-  errorLabel: string;
-}): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    const resolved = resolveProcessCommand(command, args);
-    const { proc, handle } = spawnTracked(resolved.command, resolved.args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      label: errorLabel,
-      kind: errorLabel,
-      captureOutput: false,
-    });
-    const chunks: Buffer[] = [];
-    let stderr = "";
-    let stderrBuffer = "";
+export async function runProcess(options: ProcessLineOptions): Promise<void> {
+  await runProcessWithOutput(options, "lines");
+}
 
-    const timeout = setTimeout(() => {
-      proc.kill("SIGKILL");
-      reject(new Error(`${errorLabel} timed out`));
-    }, timeoutMs);
+export async function runProcessCapture(options: ProcessOptions): Promise<string> {
+  return runProcessWithOutput(options, "text");
+}
 
-    if (proc.stdout) {
-      proc.stdout.on("data", (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
-    }
-
-    if (proc.stderr) {
-      proc.stderr.setEncoding("utf8");
-      proc.stderr.on("data", (chunk: string) => {
-        if (stderr.length < 8192) stderr += chunk;
-        stderrBuffer += chunk;
-        const lines = stderrBuffer.split(/\r?\n/);
-        stderrBuffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (line) handle?.appendOutput("stderr", line);
-        }
-      });
-    }
-
-    proc.on("error", (error) => {
-      clearTimeout(timeout);
-      reject(error);
-    });
-
-    proc.on("close", (code) => {
-      clearTimeout(timeout);
-      if (stderrBuffer.trim()) handle?.appendOutput("stderr", stderrBuffer.trim());
-      if (code === 0) {
-        resolve(Buffer.concat(chunks));
-        return;
-      }
-      const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
-      reject(new Error(`${errorLabel} exited with code ${code}${suffix}`));
-    });
-  });
+export async function runProcessCaptureBuffer(options: ProcessOptions): Promise<Buffer> {
+  return runProcessWithOutput(options, "buffer");
 }
 
 export async function runWithConcurrency<T>(

--- a/tests/slides.ocr.test.ts
+++ b/tests/slides.ocr.test.ts
@@ -1,7 +1,22 @@
-import { describe, expect, it } from "vitest";
-import { cleanOcrText, estimateOcrConfidence } from "../src/slides/ocr.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanOcrText, estimateOcrConfidence, runTesseract } from "../src/slides/ocr.js";
+import * as processHelpers from "../src/slides/process.js";
+
+afterEach(() => vi.restoreAllMocks());
 
 describe("slides ocr helpers", () => {
+  it("runs OCR through binary capture without logging recognized text", async () => {
+    const capture = vi
+      .spyOn(processHelpers, "runProcessCaptureBuffer")
+      .mockResolvedValue(Buffer.from("Résumé\n"));
+    await expect(runTesseract("custom-tesseract", "/tmp/frame.png")).resolves.toBe("Résumé\n");
+    expect(capture).toHaveBeenCalledExactlyOnceWith({
+      command: "custom-tesseract",
+      args: ["/tmp/frame.png", "stdout", "--oem", "3", "--psm", "6"],
+      timeoutMs: 120_000,
+      errorLabel: "tesseract",
+    });
+  });
   it("cleans noisy lines and keeps readable content", () => {
     expect(
       cleanOcrText(

--- a/tests/slides.process.test.ts
+++ b/tests/slides.process.test.ts
@@ -1,5 +1,118 @@
-import { describe, expect, it, vi } from "vitest";
-import { runWithConcurrency } from "../src/slides/process.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  setProcessObserver,
+  terminateTrackedProcesses,
+  type ProcessHandle,
+} from "../src/processes.js";
+import {
+  runProcess,
+  runProcessCapture,
+  runProcessCaptureBuffer,
+  runWithConcurrency,
+} from "../src/slides/process.js";
+
+afterEach(() => {
+  terminateTrackedProcesses("SIGKILL");
+  setProcessObserver(null);
+});
+
+function processOptions(source: string) {
+  return {
+    command: { command: process.execPath, argsPrefix: ["-e", source], source: "wasm" as const },
+    args: [],
+    timeoutMs: 5_000,
+    errorLabel: "test tool",
+  };
+}
+
+function observeOutput() {
+  const handle: ProcessHandle = {
+    id: "test-process",
+    setPid: vi.fn(),
+    appendOutput: vi.fn(),
+    setProgress: vi.fn(),
+    setStatus: vi.fn(),
+    finish: vi.fn(),
+  };
+  setProcessObserver({ register: () => handle });
+  return handle;
+}
+
+describe("media subprocess lifecycle", () => {
+  it.each([false, true])(
+    "preserves line callbacks and stdout fallback: %s",
+    async (separateStdout) => {
+      const handle = observeOutput();
+      const stderr = vi.fn();
+      const stdout = vi.fn();
+      await runProcess({
+        ...processOptions(
+          'process.stdout.write("first\\r\\n\\n  tail  "); process.stderr.write("warning\\n\\n  last  ");',
+        ),
+        onStderrLine: stderr,
+        onStdoutLine: separateStdout ? stdout : undefined,
+      });
+      const stdoutCallback = separateStdout ? stdout : stderr;
+      expect(stdoutCallback).toHaveBeenCalledWith("first", handle);
+      expect(stdoutCallback).toHaveBeenCalledWith("tail", handle);
+      expect(stderr).toHaveBeenCalledWith("warning", handle);
+      expect(stderr).toHaveBeenCalledWith("last", handle);
+      expect(stderr).toHaveBeenCalledTimes(separateStdout ? 2 : 4);
+      expect(handle.appendOutput).toHaveBeenCalledTimes(4);
+    },
+  );
+
+  it("captures UTF-8 across chunks and tracks complete and final partial lines", async () => {
+    const handle = observeOutput();
+    const output = await runProcessCapture(
+      processOptions(
+        "process.stdout.write(Buffer.from([0xe2])); setTimeout(() => process.stdout.write(Buffer.from([0x82, 0xac, 10, 32, 120, 32])), 20);",
+      ),
+    );
+    expect(output).toBe("€\n x ");
+    expect(handle.appendOutput).toHaveBeenCalledWith("stdout", "€");
+    expect(handle.appendOutput).toHaveBeenCalledWith("stdout", "x");
+  });
+
+  it("preserves arbitrary bytes without logging binary stdout", async () => {
+    const handle = observeOutput();
+    const output = await runProcessCaptureBuffer(
+      processOptions(
+        'process.stdout.write(Buffer.from([0, 255, 13, 10, 128])); process.stderr.write("  warning  ");',
+      ),
+    );
+    expect(output).toEqual(Buffer.from([0, 255, 13, 10, 128]));
+    expect(handle.appendOutput).toHaveBeenCalledExactlyOnceWith("stderr", "warning");
+  });
+
+  it("drains ignored stdout rather than blocking the child on a full pipe", async () => {
+    await expect(
+      runProcess(
+        processOptions(
+          "process.stdout.write(Buffer.alloc(4 * 1024 * 1024), () => process.exit(0));",
+        ),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  describe.each([runProcess, runProcessCapture, runProcessCaptureBuffer])("%s", (run) => {
+    it("reports nonzero exits with the final stderr line", async () => {
+      await expect(
+        run(processOptions('process.stderr.write("  failed  "); process.exitCode = 7;')),
+      ).rejects.toThrow("test tool exited with code 7: failed");
+    });
+    it("rejects launch failures", async () => {
+      await expect(
+        run({ ...processOptions(""), command: "summarize-missing-test-command" }),
+      ).rejects.toThrow(/ENOENT/);
+    });
+    it("kills a timed-out child", async () => {
+      await expect(
+        run({ ...processOptions("setInterval(() => {}, 1000)"), timeoutMs: 25 }),
+      ).rejects.toThrow("test tool timed out");
+    });
+  });
+});
 
 describe("slides process helpers", () => {
   it("returns early for empty task lists", async () => {


### PR DESCRIPTION
## One media subprocess lifecycle

Line streaming, text capture, binary capture, and OCR repeated the same subprocess startup, stderr buffering, timer, and exit handling. They now share one lifecycle with explicit output policies. OCR still avoids logging recognized text; byte capture stays binary, line callbacks keep their stdout fallback, and error/timeout messages and argument prefixes are unchanged.

The consolidation exposed a real hang: line-mode calls without a stdout callback left the pipe unread. Ignored stdout is now drained. Running the same 4 MiB-output child against old and new implementations proves the old path times out and the new one completes.

Production is 160 lines smaller. Real-process regression tests expand the previously untested lifecycle; the overall change is 28 lines smaller.

## Proof

- All 103 focused slide/process tests pass: callbacks, UTF-8 chunk boundaries, binary identity, observer exclusions, ignored stdout, launch errors, nonzero exits, and timeout kills.
- Build and full gate pass: 3,104 tests (43 skipped), 94.31% line coverage and 85.21% branch coverage.
- Independent Codex review: no actionable P0–P2 findings.

No dependency or public API changes. Existing output policy differences remain explicit rather than being homogenized.

Hosted CI passes on the exact PR head: [Node 24 gate, Chromium E2E, and Firefox smoke](https://github.com/steipete/summarize/actions/runs/33962688288), with security checks green.
