### PR TITLE
refactor(core): share file prompt and timestamp policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Dependencies and maintenance
 
+- Consolidate file-summary prompt policy and timed-transcript parsing/formatting while preserving prompt text and source-specific length limits.
 - Share one media subprocess lifecycle across line streaming, text/binary capture, and OCR while preserving output tracking and timeout/error behavior.
 - Build model resources once from resolved run intent; remove intermediate factories while keeping selection separate from provider, metrics, and stream state.
 - Make Options use one element collection and declarative checkbox bindings; share settings normalization between load and save without mixing legacy migrations or managed policy into persistence.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -42,6 +42,8 @@ Engine modules may depend on portable domain/config modules, provider clients, c
 
 ## Streaming
 
+Core owns file-summary instruction construction and timed-transcript parsing/formatting. Attached-file and extracted-text entry points retain their distinct length/context policies; CLI slide output and engine prompt/timestamp validation consume the same timestamp primitives.
+
 The engine never writes summary text to stdout.
 
 Each provider attempt resolves one request shared by streaming, direct completion, and fallback completion. Stream consumption owns output-handler lifecycle and marks visible or handler failures as interrupted; only an uncommitted provider failure can fall back to completion. Usage collection happens after successful stream consumption and does not trigger another model call.

--- a/packages/core/src/prompts/file.ts
+++ b/packages/core/src/prompts/file.ts
@@ -4,63 +4,71 @@ import { buildInstructions, buildTaggedPrompt, type PromptOverrides } from "./fo
 import { pickSummaryLengthForCharacters, type SummaryLengthTarget } from "./link-summary.js";
 import { formatPresetLengthGuidance, resolveSummaryLengthSpec } from "./summary-lengths.js";
 
-export function buildFileSummaryPrompt({
-  filename,
-  mediaType,
-  outputLanguage,
-  summaryLength,
-  contentLength,
-  promptOverride,
-  lengthInstruction,
-  languageInstruction,
-}: {
+type FilePromptOptions = Pick<
+  PromptOverrides,
+  "promptOverride" | "lengthInstruction" | "languageInstruction"
+> & {
   filename: string | null;
-  mediaType: string | null;
   summaryLength: SummaryLengthTarget;
-  contentLength?: number | null;
   outputLanguage?: OutputLanguage | null;
-  promptOverride?: string | null;
-  lengthInstruction?: string | null;
-  languageInstruction?: string | null;
-}): string {
+};
+
+type AttachedFileOptions = FilePromptOptions & {
+  mediaType: string | null;
+  contentLength?: number | null;
+};
+
+type FileTextOptions = FilePromptOptions & {
+  originalMediaType: string | null;
+  contentMediaType: string;
+  contentLength: number;
+  content?: string | null;
+};
+
+function buildFilePrompt(
+  input: (AttachedFileOptions & { kind: "attached" }) | (FileTextOptions & { kind: "text" }),
+): string {
+  const {
+    filename,
+    summaryLength,
+    outputLanguage,
+    promptOverride,
+    lengthInstruction,
+    languageInstruction,
+  } = input;
+  const isText = input.kind === "text";
+  const mediaType = isText ? input.originalMediaType : input.mediaType;
   const shouldIgnoreSponsors = Boolean(
     mediaType?.startsWith("audio/") || mediaType?.startsWith("video/"),
   );
-  const contentCharacters = typeof contentLength === "number" ? contentLength : null;
+  const contentCharacters = typeof input.contentLength === "number" ? input.contentLength : null;
   const effectiveSummaryLength =
-    typeof summaryLength === "string"
-      ? summaryLength
-      : contentCharacters &&
-          contentCharacters > 0 &&
-          summaryLength.maxCharacters > contentCharacters
-        ? { maxCharacters: contentCharacters }
-        : summaryLength;
+    typeof summaryLength !== "string" &&
+    contentCharacters !== null &&
+    (isText || contentCharacters > 0) &&
+    summaryLength.maxCharacters > contentCharacters
+      ? { maxCharacters: contentCharacters }
+      : summaryLength;
   const preset =
     typeof effectiveSummaryLength === "string"
       ? effectiveSummaryLength
       : pickSummaryLengthForCharacters(effectiveSummaryLength.maxCharacters);
   const directive = resolveSummaryLengthSpec(preset);
-  const presetLengthLine =
-    typeof effectiveSummaryLength === "string" ? formatPresetLengthGuidance(preset) : "";
-  const maxCharactersLine =
-    typeof effectiveSummaryLength === "string"
-      ? ""
-      : `Target length: up to ${effectiveSummaryLength.maxCharacters.toLocaleString()} characters total (including Markdown and whitespace). Hard limit: do not exceed it.`;
   const contentLengthLine =
-    contentCharacters && contentCharacters > 0
+    contentCharacters !== null && (isText || contentCharacters > 0)
       ? `Extracted content length: ${contentCharacters.toLocaleString()} characters. Hard limit: never exceed this length. If the requested length is larger, do not pad—finish early rather than adding filler.`
       : "";
-
   const headerLines = [
     filename ? `Filename: ${filename}` : null,
-    mediaType ? `Media type: ${mediaType}` : null,
+    mediaType ? `${isText ? "Original media type" : "Media type"}: ${mediaType}` : null,
+    ...(isText ? [`Provided as: ${input.contentMediaType}`, contentLengthLine] : []),
   ].filter(Boolean);
 
   const baseInstructions = [
     "Hard rules: never mention sponsor/ads; never output quotation marks of any kind (straight or curly), even for titles.",
     "Never include quotation marks in the output. Apostrophes in contractions are OK. If a title or excerpt would normally use quotes, remove them and optionally italicize the text instead.",
     "You summarize files for curious users.",
-    "Summarize the attached file.",
+    isText ? "Summarize the file content below." : "Summarize the attached file.",
     "Be factual and do not invent details.",
     shouldIgnoreSponsors
       ? "Omit sponsor messages, ads, promos, and calls-to-action (including podcast ad reads), even if they appear in the transcript. Do not mention or acknowledge them, and do not say you skipped or ignored anything. Avoid sponsor/ad/promo language, brand names like Squarespace, or CTA phrases like discount code."
@@ -71,9 +79,11 @@ export function buildFileSummaryPrompt({
     "Use short paragraphs; use bullet lists only when they improve scanability; avoid rigid templates.",
     "If a standout line is present, include 1-2 short exact excerpts (max 25 words each) formatted as Markdown italics using single asterisks only. Do not use quotation marks of any kind (straight or curly). Remove any quotation marks from excerpts. If you cannot format an italic excerpt, omit it. Never include ad/sponsor/boilerplate excerpts and do not mention them.",
     "Do not use emojis.",
-    presetLengthLine,
-    maxCharactersLine,
-    contentLengthLine,
+    typeof effectiveSummaryLength === "string" ? formatPresetLengthGuidance(preset) : "",
+    typeof effectiveSummaryLength === "string"
+      ? ""
+      : `Target length: up to ${effectiveSummaryLength.maxCharacters.toLocaleString()} characters total (including Markdown and whitespace). Hard limit: do not exceed it.`,
+    isText ? "" : contentLengthLine,
     formatOutputLanguageInstruction(outputLanguage ?? { kind: "auto" }),
     "Final check: remove any sponsor/ad references or mentions of skipping/ignoring content. Remove any quotation marks. Ensure standout excerpts are italicized; otherwise omit them.",
     "Return only the summary.",
@@ -81,104 +91,20 @@ export function buildFileSummaryPrompt({
     .filter((line) => typeof line === "string" && line.trim().length > 0)
     .join("\n");
 
-  const instructions = buildInstructions({
-    base: baseInstructions,
-    overrides: { promptOverride, lengthInstruction, languageInstruction } satisfies PromptOverrides,
-  });
-  const context = headerLines.join("\n");
-
   return buildTaggedPrompt({
-    instructions,
-    context,
-    content: "",
+    instructions: buildInstructions({
+      base: baseInstructions,
+      overrides: { promptOverride, lengthInstruction, languageInstruction },
+    }),
+    context: headerLines.join("\n"),
+    content: isText && typeof input.content === "string" ? input.content : "",
   });
 }
 
-export function buildFileTextSummaryPrompt({
-  filename,
-  originalMediaType,
-  contentMediaType,
-  outputLanguage,
-  summaryLength,
-  contentLength,
-  content,
-  promptOverride,
-  lengthInstruction,
-  languageInstruction,
-}: {
-  filename: string | null;
-  originalMediaType: string | null;
-  contentMediaType: string;
-  summaryLength: SummaryLengthTarget;
-  contentLength: number;
-  outputLanguage?: OutputLanguage | null;
-  content?: string | null;
-  promptOverride?: string | null;
-  lengthInstruction?: string | null;
-  languageInstruction?: string | null;
-}): string {
-  const shouldIgnoreSponsors = Boolean(
-    originalMediaType?.startsWith("audio/") || originalMediaType?.startsWith("video/"),
-  );
-  const effectiveSummaryLength =
-    typeof summaryLength === "string"
-      ? summaryLength
-      : summaryLength.maxCharacters > contentLength
-        ? { maxCharacters: contentLength }
-        : summaryLength;
-  const preset =
-    typeof effectiveSummaryLength === "string"
-      ? effectiveSummaryLength
-      : pickSummaryLengthForCharacters(effectiveSummaryLength.maxCharacters);
-  const directive = resolveSummaryLengthSpec(preset);
-  const presetLengthLine =
-    typeof effectiveSummaryLength === "string" ? formatPresetLengthGuidance(preset) : "";
-  const maxCharactersLine =
-    typeof effectiveSummaryLength === "string"
-      ? ""
-      : `Target length: up to ${effectiveSummaryLength.maxCharacters.toLocaleString()} characters total (including Markdown and whitespace). Hard limit: do not exceed it.`;
+export function buildFileSummaryPrompt(options: AttachedFileOptions): string {
+  return buildFilePrompt({ ...options, kind: "attached" });
+}
 
-  const headerLines = [
-    filename ? `Filename: ${filename}` : null,
-    originalMediaType ? `Original media type: ${originalMediaType}` : null,
-    `Provided as: ${contentMediaType}`,
-    `Extracted content length: ${contentLength.toLocaleString()} characters. Hard limit: never exceed this length. If the requested length is larger, do not pad—finish early rather than adding filler.`,
-  ].filter(Boolean);
-
-  const baseInstructions = [
-    "Hard rules: never mention sponsor/ads; never output quotation marks of any kind (straight or curly), even for titles.",
-    "Never include quotation marks in the output. Apostrophes in contractions are OK. If a title or excerpt would normally use quotes, remove them and optionally italicize the text instead.",
-    "You summarize files for curious users.",
-    "Summarize the file content below.",
-    "Be factual and do not invent details.",
-    shouldIgnoreSponsors
-      ? "Omit sponsor messages, ads, promos, and calls-to-action (including podcast ad reads), even if they appear in the transcript. Do not mention or acknowledge them, and do not say you skipped or ignored anything. Avoid sponsor/ad/promo language, brand names like Squarespace, or CTA phrases like discount code."
-      : "",
-    directive.guidance,
-    directive.formatting,
-    "Format the answer in Markdown.",
-    "Use short paragraphs; use bullet lists only when they improve scanability; avoid rigid templates.",
-    "If a standout line is present, include 1-2 short exact excerpts (max 25 words each) formatted as Markdown italics using single asterisks only. Do not use quotation marks of any kind (straight or curly). Remove any quotation marks from excerpts. If you cannot format an italic excerpt, omit it. Never include ad/sponsor/boilerplate excerpts and do not mention them.",
-    "Do not use emojis.",
-    presetLengthLine,
-    maxCharactersLine,
-    formatOutputLanguageInstruction(outputLanguage ?? { kind: "auto" }),
-    "Final check: remove any sponsor/ad references or mentions of skipping/ignoring content. Remove any quotation marks. Ensure standout excerpts are italicized; otherwise omit them.",
-    "Return only the summary.",
-  ]
-    .filter((line) => typeof line === "string" && line.trim().length > 0)
-    .join("\n");
-
-  const instructions = buildInstructions({
-    base: baseInstructions,
-    overrides: { promptOverride, lengthInstruction, languageInstruction } satisfies PromptOverrides,
-  });
-  const context = headerLines.join("\n");
-  const contentText = typeof content === "string" ? content : "";
-
-  return buildTaggedPrompt({
-    instructions,
-    context,
-    content: contentText,
-  });
+export function buildFileTextSummaryPrompt(options: FileTextOptions): string {
+  return buildFilePrompt({ ...options, kind: "text" });
 }

--- a/packages/core/src/slides/text-transcript.ts
+++ b/packages/core/src/slides/text-transcript.ts
@@ -27,7 +27,7 @@ const SLIDE_WINDOW_SECONDS_MAX = 180;
 const clampNumber = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
 
-function parseTimestampSeconds(value: string): number | null {
+export function parseTimestampSeconds(value: string): number | null {
   const rawParts = value.split(":").map((item) => item.trim());
   if (rawParts.length !== 2 && rawParts.length !== 3) return null;
   if (rawParts.some((item) => !/^\d+$/.test(item))) return null;

--- a/packages/core/src/slides/text.ts
+++ b/packages/core/src/slides/text.ts
@@ -19,6 +19,7 @@ export {
   getTranscriptTextForSlide,
   interleaveSlidesIntoTranscript,
   parseTranscriptTimedText,
+  parseTimestampSeconds,
   resolveSlideTextBudget,
   resolveSlideWindowSeconds,
 } from "./text-transcript.js";

--- a/src/engine/summary-timestamps.ts
+++ b/src/engine/summary-timestamps.ts
@@ -1,3 +1,4 @@
+import { formatTimestamp, parseTimestampSeconds } from "@steipete/summarize-core/slides";
 import type { ExtractedLinkContent } from "../content/index.js";
 
 const TIMED_TRANSCRIPT_LINE_RE = /^\[(\d{1,2}:\d{2}(?::\d{2})?)\]\s+/;
@@ -7,37 +8,6 @@ const KEY_MOMENT_LINE_RE =
   /^\s*(?:[-*+]\s+)?(?:\[(\d{1,2}:\d{2}(?::\d{2})?)\]|(\d{1,2}:\d{2}(?::\d{2})?))(?=\s|[-:–—])/;
 const SMALL_OVERSHOOT_TOLERANCE_SECONDS = 5;
 const FALLBACK_KEY_MOMENT_COUNT = 3;
-
-function parseTimestampSeconds(value: string): number | null {
-  const rawParts = value.split(":").map((item) => item.trim());
-  if (rawParts.length !== 2 && rawParts.length !== 3) return null;
-  if (rawParts.some((item) => !/^\d+$/.test(item))) return null;
-  const parts = rawParts.map((item) => Number(item));
-  if (parts.some((item) => !Number.isFinite(item))) return null;
-  if (parts.length === 2) {
-    const [minutes, seconds] = parts;
-    if (seconds >= 60) return null;
-    return minutes * 60 + seconds;
-  }
-  if (parts.length === 3) {
-    const [hours, minutes, seconds] = parts;
-    if (minutes >= 60 || seconds >= 60) return null;
-    return hours * 3600 + minutes * 60 + seconds;
-  }
-  return null;
-}
-
-function formatTimestamp(seconds: number): string {
-  const clamped = Math.max(0, Math.floor(seconds));
-  const hours = Math.floor(clamped / 3600);
-  const minutes = Math.floor((clamped % 3600) / 60);
-  const secs = clamped % 60;
-  const mm = String(minutes).padStart(2, "0");
-  const ss = String(secs).padStart(2, "0");
-  if (hours <= 0) return `${minutes}:${ss}`;
-  const hh = String(hours).padStart(2, "0");
-  return `${hh}:${mm}:${ss}`;
-}
 
 function readTranscriptMaxSeconds(
   extracted: Pick<ExtractedLinkContent, "transcriptSegments" | "transcriptTimedText">,

--- a/src/engine/web-prompt.ts
+++ b/src/engine/web-prompt.ts
@@ -1,3 +1,4 @@
+import { formatTimestamp, parseTranscriptTimedText } from "@steipete/summarize-core/slides";
 import type { ExtractedLinkContent } from "../content/index.js";
 import type { OutputLanguage } from "../language.js";
 import { buildLinkSummaryPrompt, SUMMARY_LENGTH_TARGET_CHARACTERS } from "../prompts/index.js";
@@ -5,8 +6,6 @@ import { resolveTargetCharacters, type SummaryLengthArg } from "../shared/summar
 import { buildSummaryTimestampLimitInstruction } from "./summary-timestamps.js";
 
 type SlidesResult = Awaited<ReturnType<typeof import("../slides/index.js").extractSlidesForSource>>;
-
-type TranscriptSegment = { startSeconds: number; text: string };
 
 const MAX_SLIDE_TRANSCRIPT_CHARS_BY_PRESET = {
   short: 2500,
@@ -18,51 +17,6 @@ const MAX_SLIDE_TRANSCRIPT_CHARS_BY_PRESET = {
 
 const SLIDE_TRANSCRIPT_DEFAULT_EDGE_SECONDS = 30;
 const SLIDE_TRANSCRIPT_LEEWAY_SECONDS = 10;
-
-function parseTimestampSeconds(value: string): number | null {
-  const rawParts = value.split(":").map((item) => item.trim());
-  if (rawParts.length !== 2 && rawParts.length !== 3) return null;
-  if (rawParts.some((item) => !/^\d+$/.test(item))) return null;
-  const parts = rawParts.map((item) => Number(item));
-  if (parts.some((item) => !Number.isFinite(item))) return null;
-  if (parts.length === 2) {
-    if (parts[1] >= 60) return null;
-    return parts[0] * 60 + parts[1];
-  }
-  if (parts.length === 3) {
-    if (parts[1] >= 60 || parts[2] >= 60) return null;
-    return parts[0] * 3600 + parts[1] * 60 + parts[2];
-  }
-  return null;
-}
-
-function parseTranscriptTimedText(input: string | null | undefined): TranscriptSegment[] {
-  if (!input) return [];
-  const segments: TranscriptSegment[] = [];
-  for (const line of input.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed.startsWith("[")) continue;
-    const match = trimmed.match(/^\[(\d{1,2}:\d{2}(?::\d{2})?)\]\s*(.*)$/);
-    if (!match) continue;
-    const seconds = parseTimestampSeconds(match[1]);
-    if (seconds == null) continue;
-    const text = (match[2] ?? "").trim();
-    if (!text) continue;
-    segments.push({ startSeconds: seconds, text });
-  }
-  return segments.sort((a, b) => a.startSeconds - b.startSeconds);
-}
-
-function formatTimestamp(seconds: number): string {
-  const clamped = Math.max(0, Math.floor(seconds));
-  const hours = Math.floor(clamped / 3600);
-  const minutes = Math.floor((clamped % 3600) / 60);
-  const secs = clamped % 60;
-  if (hours <= 0) return `${minutes}:${String(secs).padStart(2, "0")}`;
-  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(
-    secs,
-  ).padStart(2, "0")}`;
-}
 
 function truncateTranscript(value: string, limit: number): string {
   if (value.length <= limit) return value;

--- a/src/run/slides-cli.ts
+++ b/src/run/slides-cli.ts
@@ -1,3 +1,4 @@
+import { formatTimestamp } from "@steipete/summarize-core/slides";
 import { CommanderError } from "commander";
 import { resolveEnvState } from "../application/environment-state.js";
 import { loadSummarizeConfig } from "../config.js";
@@ -30,18 +31,6 @@ type SlidesCliContext = {
   stdout: NodeJS.WritableStream;
   stderr: NodeJS.WritableStream;
 };
-
-function formatTimestamp(seconds: number): string {
-  const clamped = Math.max(0, Math.floor(seconds));
-  const hours = Math.floor(clamped / 3600);
-  const minutes = Math.floor((clamped % 3600) / 60);
-  const secs = clamped % 60;
-  const mm = String(minutes).padStart(2, "0");
-  const ss = String(secs).padStart(2, "0");
-  if (hours <= 0) return `${minutes}:${ss}`;
-  const hh = String(hours).padStart(2, "0");
-  return `${hh}:${mm}:${ss}`;
-}
 
 function parseRenderMode(raw: unknown): SlidesRenderMode {
   const value = typeof raw === "string" ? raw.trim().toLowerCase() : "";

--- a/tests/prompts.file.test.ts
+++ b/tests/prompts.file.test.ts
@@ -66,6 +66,22 @@ describe("buildFileSummaryPrompt", () => {
 });
 
 describe("buildFileTextSummaryPrompt", () => {
+  it("keeps attached-file and extracted-text zero-length policies distinct", () => {
+    const options = { filename: null, summaryLength: { maxCharacters: 100 }, contentLength: 0 };
+    const attached = buildFileSummaryPrompt({ ...options, mediaType: "audio/mpeg" });
+    const extracted = buildFileTextSummaryPrompt({
+      ...options,
+      originalMediaType: "audio/mpeg",
+      contentMediaType: "text/plain",
+    });
+    expect(attached).toContain("Target length: up to 100 characters");
+    expect(attached).not.toContain("Extracted content length:");
+    expect(extracted).toContain("Target length: up to 0 characters");
+    expect(extracted).toContain("Extracted content length: 0 characters");
+    expect(attached).toContain("Omit sponsor messages");
+    expect(extracted).toContain("Omit sponsor messages");
+  });
+
   it("clamps length to extracted content", () => {
     const prompt = buildFileTextSummaryPrompt({
       filename: "notes.txt",

--- a/tests/slides-text.utils.test.ts
+++ b/tests/slides-text.utils.test.ts
@@ -11,6 +11,7 @@ import {
   interleaveSlidesIntoTranscript,
   parseSlideSummariesFromMarkdown,
   parseTranscriptTimedText,
+  parseTimestampSeconds,
   resolveSlideTextBudget,
   resolveSlideWindowSeconds,
   splitSlideTitleFromText,
@@ -18,6 +19,21 @@ import {
 } from "../packages/core/src/slides/text.js";
 
 describe("slides text helpers", () => {
+  it.each([
+    ["0:00", 0],
+    ["99:59", 5999],
+    ["01:02:03", 3723],
+    [" 1 : 02 ", 62],
+    ["1:60", null],
+    ["1:60:00", null],
+    ["-1:00", null],
+    ["Infinity:00", null],
+    ["1", null],
+    ["1:2:3:4", null],
+  ])("parses shared timestamp %s as %s", (value, expected) => {
+    expect(parseTimestampSeconds(value as string)).toBe(expected);
+  });
+
   it("finds the earliest slides marker", () => {
     const markdown = ["# Title", "", "[slide:2] Second", "", "### Slides", "[slide:1] First"].join(
       "\n",


### PR DESCRIPTION
## Shared prompt and timestamp policy

Attached-file and extracted-text prompts now share one source-aware instruction builder rather than copying the same policy. The public entry points retain their input shapes, different metadata layouts, and distinct zero/negative/unknown content-length limits. Prompt overrides and escaping remain unchanged.

Core's timed-transcript parser and formatter now also serve engine prompt construction, timestamp validation, and CLI slide output. Browser minute-only rendering remains separate because it has a different output contract.

This removes 160 production lines and 125 lines overall without changing generated prompts.

## Proof

- 896 before/after prompt outputs are byte-identical across media types, missing metadata, preset/character lengths, zero/negative/unknown content lengths, and overrides.
- Build and full gate pass: 3,115 tests (43 skipped), 94.32% line coverage and 85.32% branch coverage.
- Focused prompt, timestamp, slide, and import-boundary tests pass; additional tests lock down zero-length distinctions and shared timestamp validation.
- Independent Codex review: no actionable P0–P2 findings.

Existing public entry points remain intact; the existing timestamp parser is additionally available from core's slides entry point. No dependencies changed.

Hosted CI passes on the exact PR head: [Node 24 gate, Chromium E2E, and Firefox smoke](https://github.com/steipete/summarize/actions/runs/33963254080), with security checks green.
