### PR TITLE
refactor(extension): share content message retry policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Dependencies and maintenance
 
+- Share content-script message retries across extraction, seeking, and slide preparation while retaining operation-specific timeouts and reinjection policies.
 - Consolidate file-summary prompt policy and timed-transcript parsing/formatting while preserving prompt text and source-specific length limits.
 - Share one media subprocess lifecycle across line streaming, text/binary capture, and OCR while preserving output tracking and timeout/error behavior.
 - Build model resources once from resolved run intent; remove intermediate factories while keeping selection separate from provider, metrics, and stream state.

--- a/apps/chrome-extension/src/entrypoints/background/content-script-bridge.ts
+++ b/apps/chrome-extension/src/entrypoints/background/content-script-bridge.ts
@@ -93,6 +93,53 @@ export function canSummarizeUrl(url: string | undefined): url is string {
   return true;
 }
 
+function hasNoContentReceiver(message: string): boolean {
+  return (
+    message.includes("Receiving end does not exist") ||
+    message.includes("Could not establish connection")
+  );
+}
+
+async function retryContentMessage<Result extends { ok: true } | { ok: false; error: string }>(
+  tabId: number,
+  send: () => Promise<Result>,
+  extraction?: {
+    timeoutMs: number;
+    log?: (event: string, detail?: Record<string, unknown>) => void;
+  },
+): Promise<Result | { ok: false; error: string }> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      extraction?.log?.("extract:attempt", {
+        attempt: attempt + 1,
+        timeoutMs: extraction.timeoutMs,
+      });
+      const result = await send();
+      if (!result.ok) return { ok: false, error: result.error };
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const didTimeout = Boolean(extraction && message.includes("extract timed out"));
+      if (hasNoContentReceiver(message) || didTimeout) {
+        const injected = await injectExtractScript(tabId, extraction);
+        if (!injected.ok) return injected;
+        if (didTimeout && attempt === 2) {
+          return {
+            ok: false,
+            error:
+              "Page extraction timed out. Reload the tab (or “Summarize → Refresh”), then retry.",
+          };
+        }
+        await new Promise((resolve) => setTimeout(resolve, 120));
+      } else {
+        if (attempt === 2) return { ok: false, error: message };
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      }
+    }
+  }
+  return { ok: false, error: "Content script not ready" };
+}
+
 export async function extractFromTab(
   tabId: number,
   maxChars: number,
@@ -135,45 +182,8 @@ export async function extractFromTab(
     }
   };
 
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    try {
-      opts?.log?.("extract:attempt", { attempt: attempt + 1, timeoutMs });
-      const res = await sendMessageWithTimeout();
-      if (!res.ok) return { ok: false, error: res.error };
-      return { ok: true, data: res };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const noReceiver =
-        message.includes("Receiving end does not exist") ||
-        message.includes("Could not establish connection");
-      const didTimeout = message.includes("extract timed out");
-      if (noReceiver || didTimeout) {
-        const injected = await injectExtractScript(tabId, opts);
-        if (!injected.ok) return injected;
-        if (didTimeout && attempt === 2) {
-          return {
-            ok: false,
-            error:
-              "Page extraction timed out. Reload the tab (or “Summarize → Refresh”), then retry.",
-          };
-        }
-        await new Promise((resolve) => setTimeout(resolve, 120));
-        continue;
-      }
-
-      if (attempt === 2) {
-        return {
-          ok: false,
-          error: noReceiver
-            ? "Content script not ready. Check extension “Site access” → “On all sites”, then reload the tab."
-            : message,
-        };
-      }
-      await new Promise((resolve) => setTimeout(resolve, 350));
-    }
-  }
-
-  return { ok: false, error: "Content script not ready" };
+  const result = await retryContentMessage(tabId, sendMessageWithTimeout, { ...opts, timeoutMs });
+  return result.ok ? { ok: true, data: result } : result;
 }
 
 export async function seekInTab(
@@ -182,36 +192,11 @@ export async function seekInTab(
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const req = { type: "seek", seconds } satisfies SeekRequest;
 
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    try {
-      const res = (await chrome.tabs.sendMessage(tabId, req)) as SeekResponse;
-      if (!res.ok) return { ok: false, error: res.error };
-      return { ok: true };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const noReceiver =
-        message.includes("Receiving end does not exist") ||
-        message.includes("Could not establish connection");
-      if (noReceiver) {
-        const injected = await injectExtractScript(tabId);
-        if (!injected.ok) return injected;
-        await new Promise((resolve) => setTimeout(resolve, 120));
-        continue;
-      }
-
-      if (attempt === 2) {
-        return {
-          ok: false,
-          error: noReceiver
-            ? "Content script not ready. Check extension “Site access” → “On all sites”, then reload the tab."
-            : message,
-        };
-      }
-      await new Promise((resolve) => setTimeout(resolve, 350));
-    }
-  }
-
-  return { ok: false, error: "Content script not ready" };
+  const result = await retryContentMessage(
+    tabId,
+    () => chrome.tabs.sendMessage(tabId, req) as Promise<SeekResponse>,
+  );
+  return result.ok ? { ok: true } : result;
 }
 
 export async function prepareSlideFrameInTab(
@@ -220,36 +205,11 @@ export async function prepareSlideFrameInTab(
 ): Promise<{ ok: true; data: SlideFrameResponse & { ok: true } } | { ok: false; error: string }> {
   const req = { type: "prepare-slide-frame", seconds } satisfies PrepareSlideFrameRequest;
 
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    try {
-      const res = (await chrome.tabs.sendMessage(tabId, req)) as SlideFrameResponse;
-      if (!res.ok) return { ok: false, error: res.error };
-      return { ok: true, data: res };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const noReceiver =
-        message.includes("Receiving end does not exist") ||
-        message.includes("Could not establish connection");
-      if (noReceiver) {
-        const injected = await injectExtractScript(tabId);
-        if (!injected.ok) return injected;
-        await new Promise((resolve) => setTimeout(resolve, 120));
-        continue;
-      }
-
-      if (attempt === 2) {
-        return {
-          ok: false,
-          error: noReceiver
-            ? "Content script not ready. Check extension “Site access” → “On all sites”, then reload the tab."
-            : message,
-        };
-      }
-      await new Promise((resolve) => setTimeout(resolve, 350));
-    }
-  }
-
-  return { ok: false, error: "Content script not ready" };
+  const result = await retryContentMessage(
+    tabId,
+    () => chrome.tabs.sendMessage(tabId, req) as Promise<SlideFrameResponse>,
+  );
+  return result.ok ? { ok: true, data: result } : result;
 }
 
 export async function prepareCurrentSlideFrameInTab(
@@ -257,36 +217,11 @@ export async function prepareCurrentSlideFrameInTab(
 ): Promise<{ ok: true; data: SlideFrameResponse & { ok: true } } | { ok: false; error: string }> {
   const req = { type: "prepare-current-slide-frame" } satisfies PrepareCurrentSlideFrameRequest;
 
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    try {
-      const res = (await chrome.tabs.sendMessage(tabId, req)) as SlideFrameResponse;
-      if (!res.ok) return { ok: false, error: res.error };
-      return { ok: true, data: res };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const noReceiver =
-        message.includes("Receiving end does not exist") ||
-        message.includes("Could not establish connection");
-      if (noReceiver) {
-        const injected = await injectExtractScript(tabId);
-        if (!injected.ok) return injected;
-        await new Promise((resolve) => setTimeout(resolve, 120));
-        continue;
-      }
-
-      if (attempt === 2) {
-        return {
-          ok: false,
-          error: noReceiver
-            ? "Content script not ready. Check extension “Site access” → “On all sites”, then reload the tab."
-            : message,
-        };
-      }
-      await new Promise((resolve) => setTimeout(resolve, 350));
-    }
-  }
-
-  return { ok: false, error: "Content script not ready" };
+  const result = await retryContentMessage(
+    tabId,
+    () => chrome.tabs.sendMessage(tabId, req) as Promise<SlideFrameResponse>,
+  );
+  return result.ok ? { ok: true, data: result } : result;
 }
 
 export async function beginSlideFrameCaptureInTab(
@@ -336,10 +271,7 @@ export async function beginSlideFrameCaptureInTab(
     return { ok: true, state: req.state };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const noReceiver =
-      message.includes("Receiving end does not exist") ||
-      message.includes("Could not establish connection");
-    if (!noReceiver) return { ok: false, error: message };
+    if (!hasNoContentReceiver(message)) return { ok: false, error: message };
     const injected = await injectExtractScript(tabId);
     if (!injected.ok) return injected;
     await new Promise((resolve) => setTimeout(resolve, 120));

--- a/docs/slides-rendering-flow.md
+++ b/docs/slides-rendering-flow.md
@@ -32,6 +32,8 @@ Rule: keep terminal I/O in render helpers; keep state mutations in the state sto
 
 ## Chrome extension
 
+`background/content-script-bridge.ts` shares retry/reinjection handling across extraction, seeking, and frame preparation. Only extraction has a message deadline; capture startup and restoration keep their separate recovery policies and self-contained main-world scripts.
+
 - `apps/chrome-extension/src/entrypoints/sidepanel/stream-controller.ts`
   Transport lifecycle.
 - `stream-controller-policy.ts`

--- a/tests/chrome.content-script-bridge.test.ts
+++ b/tests/chrome.content-script-bridge.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  extractFromTab,
+  prepareCurrentSlideFrameInTab,
+  prepareSlideFrameInTab,
+  seekInTab,
+} from "../apps/chrome-extension/src/entrypoints/background/content-script-bridge.js";
+
+const sendMessage = vi.fn();
+const executeScript = vi.fn();
+const success = { ok: true, url: "https://example.com", text: "page" };
+const methods = [
+  {
+    name: "extract",
+    run: () => extractFromTab(7, 1000, { timeoutMs: 10 }),
+    request: { type: "extract", maxChars: 1000, inputMode: undefined },
+    result: { ok: true, data: success },
+  },
+  {
+    name: "seek",
+    run: () => seekInTab(7, 12),
+    request: { type: "seek", seconds: 12 },
+    result: { ok: true },
+  },
+  {
+    name: "frame",
+    run: () => prepareSlideFrameInTab(7, 12),
+    request: { type: "prepare-slide-frame", seconds: 12 },
+    result: { ok: true, data: success },
+  },
+  {
+    name: "current frame",
+    run: () => prepareCurrentSlideFrameInTab(7),
+    request: { type: "prepare-current-slide-frame" },
+    result: { ok: true, data: success },
+  },
+];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  sendMessage.mockReset().mockResolvedValue(success);
+  executeScript.mockReset().mockResolvedValue([]);
+  vi.stubGlobal("chrome", { tabs: { sendMessage }, scripting: { executeScript } });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+async function settle<Result>(pending: Promise<Result>): Promise<Result> {
+  await vi.runAllTimersAsync();
+  return pending;
+}
+
+describe.each(methods)("content bridge: $name", ({ run, request, result }) => {
+  it("keeps request and success envelopes unchanged", async () => {
+    expect(await settle(run())).toEqual(result);
+    expect(sendMessage).toHaveBeenCalledExactlyOnceWith(7, request);
+    expect(executeScript).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns application errors without retrying", async () => {
+    sendMessage.mockResolvedValue({ ok: false, error: "content error", ignored: true });
+    expect(await settle(run())).toEqual({ ok: false, error: "content error" });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(executeScript).not.toHaveBeenCalled();
+  });
+
+  it.each(["Receiving end does not exist", "Could not establish connection"])(
+    "reinjects after %s",
+    async (message) => {
+      sendMessage.mockRejectedValueOnce(new Error(message));
+      expect(await settle(run())).toEqual(result);
+      expect(executeScript).toHaveBeenCalledExactlyOnceWith({
+        target: { tabId: 7 },
+        files: ["content-scripts/extract.js"],
+      });
+      expect(sendMessage).toHaveBeenCalledTimes(2);
+      expect(Date.now()).toBe(120);
+    },
+  );
+
+  it("keeps the third missing-receiver injection and delay", async () => {
+    sendMessage.mockRejectedValue(new Error("Receiving end does not exist"));
+    expect(await settle(run())).toEqual({ ok: false, error: "Content script not ready" });
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(executeScript).toHaveBeenCalledTimes(3);
+    expect(Date.now()).toBe(360);
+  });
+
+  it("uses the generic backoff without injecting on unrelated errors", async () => {
+    sendMessage.mockRejectedValue(new Error("port closed"));
+    expect(await settle(run())).toEqual({ ok: false, error: "port closed" });
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(executeScript).not.toHaveBeenCalled();
+    expect(Date.now()).toBe(700);
+  });
+
+  it("stops immediately when injection is blocked", async () => {
+    sendMessage.mockRejectedValue(new Error("Receiving end does not exist"));
+    executeScript.mockRejectedValue(new Error("Cannot access this page"));
+    expect(await settle(run())).toEqual({
+      ok: false,
+      error: expect.stringContaining("Chrome blocked content access"),
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(Date.now()).toBe(0);
+  });
+});
+
+it("keeps extraction deadlines, terminal guidance, and attempt logs", async () => {
+  sendMessage.mockImplementation(() => new Promise(() => {}));
+  const log = vi.fn();
+  const result = await settle(extractFromTab(7, 1000, { timeoutMs: 10, log }));
+  expect(result).toEqual({
+    ok: false,
+    error: "Page extraction timed out. Reload the tab (or “Summarize → Refresh”), then retry.",
+  });
+  expect(log).toHaveBeenCalledWith("extract:attempt", { attempt: 3, timeoutMs: 10 });
+  expect(executeScript).toHaveBeenCalledTimes(3);
+  expect(Date.now()).toBe(270);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("does not apply extraction timeout policy to a seek error", async () => {
+  sendMessage.mockRejectedValue(new Error("extract timed out"));
+  expect(await settle(seekInTab(7, 12))).toEqual({ ok: false, error: "extract timed out" });
+  expect(executeScript).not.toHaveBeenCalled();
+  expect(Date.now()).toBe(700);
+});


### PR DESCRIPTION
## One content-message retry policy

Extraction, seek, and both frame-preparation operations copied the same transport retry and content-script injection loop. They now use one owner while preserving their request/response envelopes and operation-specific behavior.

The policy still makes three attempts, waits 120 ms after injection or 350 ms after unrelated errors, and retains the final missing-receiver injection/delay. Only extraction has deadlines and timeout guidance. Application errors do not retry. Capture startup/restoration keep their separate recovery policies and self-contained main-world scripts.

This removes 68 production lines. Thirty new fake-clock contract cases intentionally add coverage to a previously indirect-only boundary; this PR is 68 lines larger overall rather than hiding that test investment.

## Proof

- All 60 focused bridge/browser-slide/extraction tests pass.
- Full gate: 3,145 tests pass (43 skipped), 94.32% line and 85.31% branch coverage.
- Supported Chromium suite passes: 3 native-transport checks plus 113 HTTP-build checks (7 expected skips), including navigation, frame preparation, and slide restoration.
- Independent Codex review: no actionable P0–P2 findings.

No UI, dependency, or public contract changes.

Hosted CI passes on the exact PR head: [Node 24 gate, Chromium E2E, and Firefox smoke](https://github.com/steipete/summarize/actions/runs/33964014484), with security checks green.
