### PR TITLE
refactor(extension): enforce browser type contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Typecheck extension
+        run: pnpm -C apps/chrome-extension typecheck
+
       - name: macOS release contract
         run: scripts/test-macos-release.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Browser settings: retain a dismissed local-companion hint when saving other Options preferences.
+- Browser chat: normalize partial or malformed saved usage metadata and unknown stop reasons when restoring assistant history.
 - Slides: drain ignored subprocess output so a verbose media tool cannot stall on a full stdout pipe.
 - Transcript cache: preserve embedded-caption and native YouTube media source metadata across cache hits instead of losing it to duplicated source lists.
 - Browser media: support MP4 files carrying Annex B AVC/HEVC and clarify missing WebCodecs errors in insecure contexts with MediaBunny 1.55.2.
@@ -17,6 +19,7 @@
 
 ### Dependencies and maintenance
 
+- Type-check the entire extension in the local gate and CI using browser/bundler settings; remove stale copies of session, settings, API, and callback contracts.
 - Share model discovery, selection preservation, and refresh throttling between Options and the side panel while retaining their distinct presets and provider hints.
 - Build HTML and transcript LLM Markdown converters from one model configuration and generation path; preserve their separate prompts, input limits, and usage callbacks.
 - Share content-script message retries across extraction, seeking, and slide preparation while retaining operation-specific timeouts and reinjection policies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,12 +48,15 @@ pnpm -s format
 Extension:
 
 ```bash
+pnpm -C apps/chrome-extension typecheck
 pnpm -C apps/chrome-extension build
 pnpm -C apps/chrome-extension test:chrome
 pnpm -C apps/chrome-extension test:firefox
 ```
 
 The supported automated browser path is `test:chrome`. Firefox uses a temporary-install smoke test because Playwright cannot reliably drive `moz-extension://` pages.
+
+The root `check` gate also type-checks the extension with bundler module resolution and WXT's generated browser declarations. Keep callback, settings, and message types tied to their owning modules so changes are checked across runtime boundaries.
 
 Build and run the Node 24 CLI test container, including `ffmpeg` and `yt-dlp`:
 

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -15,6 +15,7 @@ Docs + setup: `https://summarize.sh`
 - Chrome dev: `pnpm -C apps/chrome-extension dev`
 - Firefox dev: `pnpm -C apps/chrome-extension dev:firefox`
 - Prod build (Chrome): `pnpm -C apps/chrome-extension build`
+- Type check browser code and runtime contracts: `pnpm -C apps/chrome-extension typecheck`
 - Debugger-enabled automation build (Chrome): `pnpm -C apps/chrome-extension build:automation`
 - Prod build (Firefox): `pnpm -C apps/chrome-extension build:firefox`
 - Build both: `pnpm -C apps/chrome-extension build:all`

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -17,7 +17,8 @@
     "test:e2e": "pnpm test:chrome",
     "test:firefox": "env -u NO_COLOR pnpm build:firefox && env -u NO_COLOR node scripts/firefox-smoke.mjs",
     "test:firefox:force": "env -u NO_COLOR ALLOW_FIREFOX_EXTENSION_TESTS=1 pnpm build:firefox && env -u NO_COLOR ALLOW_FIREFOX_EXTENSION_TESTS=1 playwright test -c playwright.config.ts --project=firefox",
-    "test:firefox:lint": "env -u NO_COLOR pnpm build:firefox && env -u NO_COLOR web-ext lint --source-dir .output/firefox-mv3 --self-hosted --boring"
+    "test:firefox:lint": "env -u NO_COLOR pnpm build:firefox && env -u NO_COLOR web-ext lint --source-dir .output/firefox-mv3 --self-hosted --boring",
+    "typecheck": "wxt prepare && tsc --noEmit"
   },
   "dependencies": {
     "@huggingface/transformers": "4.2.0",

--- a/apps/chrome-extension/src/automation/ask-user-which-element.ts
+++ b/apps/chrome-extension/src/automation/ask-user-which-element.ts
@@ -17,11 +17,12 @@ export async function executeAskUserWhichElementTool(
 ): Promise<ElementInfo> {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab?.id) throw new Error("No active tab");
+  const tabId = tab.id;
 
   const ensureInjected = async () => {
     try {
       await chrome.scripting.executeScript({
-        target: { tabId: tab.id },
+        target: { tabId },
         files: ["content-scripts/automation.js"],
       });
     } catch (err) {

--- a/apps/chrome-extension/src/automation/navigate.ts
+++ b/apps/chrome-extension/src/automation/navigate.ts
@@ -21,7 +21,7 @@ export type SkillInfo = {
 };
 
 export type NavigateResult = {
-  finalUrl?: string;
+  finalUrl?: string | null;
   title?: string | null;
   tabId?: number;
   tabs?: TabInfo[];
@@ -36,7 +36,7 @@ async function waitForTabComplete(tabId: number, timeoutMs = 15_000): Promise<ch
       reject(new Error("Navigation timed out"));
     }, timeoutMs);
 
-    const onUpdated = (updatedTabId: number, changeInfo: chrome.tabs.TabChangeInfo) => {
+    const onUpdated = (updatedTabId: number, changeInfo: chrome.tabs.OnUpdatedInfo) => {
       if (updatedTabId !== tabId) return;
       if (changeInfo.status !== "complete") return;
       void chrome.tabs.get(tabId).then(

--- a/apps/chrome-extension/src/automation/repl-browser-js.ts
+++ b/apps/chrome-extension/src/automation/repl-browser-js.ts
@@ -10,22 +10,6 @@ export type BrowserJsResult = {
   error?: string;
 };
 
-type UserScriptsApi = {
-  execute?: (options: {
-    target: { tabId: number; allFrames?: boolean };
-    world: "USER_SCRIPT";
-    worldId?: string;
-    injectImmediately?: boolean;
-    js: Array<{ code: string }>;
-    executionId?: string;
-  }) => Promise<Array<{ result?: unknown }>>;
-  configureWorld?: (options: {
-    worldId: string;
-    messaging?: boolean;
-    csp?: string;
-  }) => Promise<void>;
-};
-
 export async function ensureAutomationContentScript(tabId: number): Promise<void> {
   try {
     await chrome.scripting.executeScript({
@@ -49,12 +33,13 @@ export async function runBrowserJs(
   if (signal?.aborted) return { ok: false, error: "Execution aborted" };
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab?.id) throw new Error("No active tab");
+  const tabId = tab.id;
 
   await ensureAutomationContentScript(tab.id);
   const skills = await listSkills(tab.url ?? undefined);
   const libraries = skills.map((skill) => skill.library).filter(Boolean);
   const nativeInputEnabled = await hasDebuggerPermission();
-  const userScripts = chrome.userScripts as UserScriptsApi | undefined;
+  const userScripts = chrome.userScripts;
   const status = await getUserScriptsStatus();
   if (!userScripts?.execute || !status.apiAvailable || !status.permissionGranted) {
     throw new Error(buildUserScriptsGuidance(status));
@@ -102,17 +87,17 @@ export async function runBrowserJs(
   try {
     return await withArtifactsArmedTab({
       enabled: true,
-      tabId: tab.id,
+      tabId,
       sendMessage: (message) => chrome.runtime.sendMessage(message),
       run: async () =>
         withNativeInputArmedTab({
           enabled: nativeInputEnabled,
-          tabId: tab.id,
+          tabId,
           sendMessage: (message) => chrome.runtime.sendMessage(message),
           capability: nativeInputCapability,
           run: async () => {
             const results = await userScripts.execute!({
-              target: { tabId: tab.id },
+              target: { tabId },
               world: "USER_SCRIPT",
               worldId: "summarize-browserjs",
               injectImmediately: true,

--- a/apps/chrome-extension/src/automation/tools/debugger.ts
+++ b/apps/chrome-extension/src/automation/tools/debugger.ts
@@ -20,10 +20,10 @@ export async function executeDebuggerTool(args: { action?: string; code?: string
   }
 
   try {
-    const result = await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+    const result = (await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
       expression: args.code,
       returnByValue: true,
-    });
+    })) as { result?: { value?: unknown } } | undefined;
     const value = result?.result?.value ?? result?.result ?? null;
     const text =
       value == null ? "null" : typeof value === "string" ? value : JSON.stringify(value, null, 2);

--- a/apps/chrome-extension/src/entrypoints/background/browser-media.ts
+++ b/apps/chrome-extension/src/entrypoints/background/browser-media.ts
@@ -40,7 +40,7 @@ export type BrowserAudioChunk = {
 
 export type BrowserAudioProcessResult = {
   chunkCount: number;
-  codec: string;
+  codec: string | null;
   durationSeconds: number;
 };
 
@@ -327,7 +327,7 @@ async function processBrowserAudioInput({
 }
 
 export async function browserMediaCanvasToDataUrl({ canvas }: WrappedCanvas): Promise<string> {
-  if (!(typeof OffscreenCanvas !== "undefined" && canvas instanceof OffscreenCanvas)) {
+  if ("toDataURL" in canvas) {
     // Chrome throttles HTMLCanvasElement.toBlob() to roughly one callback per second in offscreen documents.
     return canvas.toDataURL(FRAME_IMAGE_TYPE, FRAME_IMAGE_QUALITY);
   }

--- a/apps/chrome-extension/src/entrypoints/background/content-script-bridge.ts
+++ b/apps/chrome-extension/src/entrypoints/background/content-script-bridge.ts
@@ -25,7 +25,7 @@ export type ExtractResponse =
       text: string;
       truncated: boolean;
       mediaDurationSeconds?: number | null;
-      media?: { hasVideo: boolean; hasAudio: boolean; hasCaptions: boolean };
+      media?: { hasVideo: boolean; hasAudio: boolean; hasCaptions: boolean } | null;
     }
   | { ok: false; error: string };
 
@@ -83,7 +83,7 @@ async function injectExtractScript(
   }
 }
 
-export function canSummarizeUrl(url: string | undefined): url is string {
+export function canSummarizeUrl(url: string | null | undefined): url is string {
   if (!url) return false;
   if (url.startsWith("chrome://")) return false;
   if (url.startsWith("chrome-extension://")) return false;

--- a/apps/chrome-extension/src/entrypoints/background/extract-cache.ts
+++ b/apps/chrome-extension/src/entrypoints/background/extract-cache.ts
@@ -7,8 +7,8 @@ import type { SlidesPayload } from "./panel-utils";
 
 export { createCachedExtract, type CachedExtract } from "./cached-extract";
 
-type CachedExtractStore = {
-  getCachedExtract(tabId: number, url: string): CachedExtract | null | undefined;
+export type CachedExtractStore = {
+  getCachedExtract(tabId: number, url?: string | null): CachedExtract | null;
   setCachedExtract(tabId: number, value: CachedExtract): void;
   getLastMediaProbe(tabId: number): string | null | undefined;
   rememberMediaProbe(tabId: number, url: string): void;
@@ -200,7 +200,7 @@ export async function ensureChatExtract({
   return next;
 }
 
-export async function primeMediaHint({
+export async function primeMediaHint<Session>({
   session,
   tabId,
   url,
@@ -210,14 +210,14 @@ export async function primeMediaHint({
   extractFromTab,
   emitState,
 }: {
-  session: unknown;
+  session: Session;
   tabId: number;
   url: string;
   title: string | null;
   panelSessionStore: CachedExtractStore;
   urlsMatch: (left: string, right: string) => boolean;
-  extractFromTab: (tabId: number, maxCharacters: number) => Promise<ExtractResponse>;
-  emitState: (session: unknown, status: string) => void;
+  extractFromTab: ExtractorContext["extractFromTab"];
+  emitState: (session: Session, status: string) => void;
 }): Promise<void> {
   const lastProbeUrl = panelSessionStore.getLastMediaProbe(tabId);
   if (lastProbeUrl && urlsMatch(lastProbeUrl, url)) return;

--- a/apps/chrome-extension/src/entrypoints/background/panel-cache-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-cache-runtime.ts
@@ -21,7 +21,7 @@ export function createPanelCacheRuntime<Session extends PanelCacheSession>(optio
   startBrowserSlides: (
     session: Session,
     options: { inputMode: "video"; reason: "cache-restore" },
-  ) => void;
+  ) => void | Promise<void>;
 }) {
   const { panelSessionStore, getActiveTab, urlsMatch, send, startBrowserSlides } = options;
 
@@ -60,7 +60,7 @@ export function createPanelCacheRuntime<Session extends PanelCacheSession>(optio
       cached.url &&
       isYouTubeVideoUrl(cached.url)
     ) {
-      startBrowserSlides(session, { inputMode: "video", reason: "cache-restore" });
+      void startBrowserSlides(session, { inputMode: "video", reason: "cache-restore" });
     }
   };
 

--- a/apps/chrome-extension/src/entrypoints/background/panel-chat.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-chat.ts
@@ -287,10 +287,11 @@ export async function handlePanelChatHistoryRequest({
       }),
     });
     const rawText = await res.text();
-    let json: { ok?: boolean; messages?: Message[]; error?: string } | null = null;
+    type HistoryResponse = { ok?: boolean; messages?: Message[]; error?: string };
+    let json: HistoryResponse | null = null;
     if (rawText) {
       try {
-        json = JSON.parse(rawText) as typeof json;
+        json = JSON.parse(rawText) as HistoryResponse;
       } catch {
         json = null;
       }

--- a/apps/chrome-extension/src/entrypoints/background/panel-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-runtime.ts
@@ -4,15 +4,14 @@ import { summarizeActiveTab as runPanelSummarize } from "./panel-summarize";
 
 export function createBackgroundPanelRuntime<
   Session extends {
-    windowId: number;
     port: chrome.runtime.Port;
-    activeSummaryRun: Parameters<typeof runPanelSummarize>[0]["session"]["activeSummaryRun"];
     daemonRecovery: { clearPending: () => void };
-  },
+  } & Parameters<typeof resolvePanelState>[0]["session"] &
+    Parameters<typeof runPanelSummarize>[0]["session"],
 >(options: {
   panelSessionStore: {
     isPanelOpen: (session: Session) => boolean;
-  } & Record<string, unknown>;
+  } & import("./extract-cache").CachedExtractStore;
   loadSettings: typeof import("../../lib/settings").loadSettings;
   getActiveTab: typeof import("./panel-utils").getActiveTab;
   daemonHealth: typeof import("./daemon-client").daemonHealth;
@@ -21,7 +20,7 @@ export function createBackgroundPanelRuntime<
   urlsMatch: typeof import("./panel-utils").urlsMatch;
   primeMediaHint: typeof import("./extract-cache").primeMediaHint;
   extractFromTab: typeof import("./content-script-bridge").extractFromTab;
-  buildSummarizeRequestBody: typeof import("../lib/daemon-payload").buildSummarizeRequestBody;
+  buildSummarizeRequestBody: typeof import("../../lib/daemon-payload").buildSummarizeRequestBody;
   friendlyFetchError: typeof import("./daemon-client").friendlyFetchError;
   isDaemonUnreachableError: typeof import("../../lib/daemon-recovery").isDaemonUnreachableError;
   fetchImpl: typeof fetch;

--- a/apps/chrome-extension/src/entrypoints/background/panel-slides-context.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-slides-context.ts
@@ -64,7 +64,8 @@ export async function handlePanelSlidesContextRequest<Recovery, Status>(options:
   }
 
   const canUseCache = Boolean(tab?.id && tabUrl && urlsMatch(tabUrl, targetUrl));
-  let cached = canUseCache ? panelSessionStore.getCachedExtract(tab.id, tabUrl ?? null) : null;
+  let cached =
+    canUseCache && tab?.id ? panelSessionStore.getCachedExtract(tab.id, tabUrl ?? null) : null;
   let transcriptTimedText = cached?.transcriptTimedText ?? null;
 
   if (!transcriptTimedText && settings.token.trim()) {

--- a/apps/chrome-extension/src/entrypoints/background/panel-state.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-state.ts
@@ -31,30 +31,7 @@ type SessionLike = {
   };
 };
 
-type SettingsLike = {
-  token: string;
-  autoSummarize: boolean;
-  hoverSummaries: boolean;
-  chatEnabled: boolean;
-  automationEnabled: boolean;
-  slidesEnabled: boolean;
-  slidesParallel: boolean;
-  slidesOcrEnabled: boolean;
-  slidesLayout: "strip" | "gallery";
-  slideRuntime: "browser" | "daemon";
-  summaryRuntime: "direct" | "daemon";
-  provider: string;
-  providerApiKeys: Record<string, string | undefined>;
-  daemonAllowed?: boolean;
-  daemonManaged?: boolean;
-  daemonHintDismissed: boolean;
-  fontSize: number;
-  lineHeight: number;
-  model: string;
-  length: string;
-};
-
-export async function resolvePanelState({
+export async function resolvePanelState<Session extends SessionLike>({
   session,
   status,
   checkRecovery,
@@ -66,15 +43,15 @@ export async function resolvePanelState({
   urlsMatch,
   canSummarizeUrl,
 }: {
-  session: SessionLike;
+  session: Session;
   status: string;
   checkRecovery?: boolean;
-  loadSettings: () => Promise<SettingsLike>;
+  loadSettings: typeof import("../../lib/settings").loadSettings;
   getActiveTab: (windowId: number) => Promise<chrome.tabs.Tab | null>;
   daemonHealth: () => Promise<{ ok: boolean; error?: string }>;
   daemonPing: (token: string) => Promise<{ ok: boolean; error?: string }>;
   panelSessionStore: {
-    isPanelOpen: (session: SessionLike) => boolean;
+    isPanelOpen: (session: Session) => boolean;
     getCachedExtract: (tabId: number, url?: string | null) => CachedExtractLike | null;
   };
   urlsMatch: (a: string, b: string) => boolean;

--- a/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
@@ -31,8 +31,8 @@ import {
 import type { BrowserYoutubeLocalTranscript } from "./youtube-local-transcript";
 import { extractYouTubeTranscriptInTab } from "./youtube-transcript";
 
-type StoreLike = {
-  isPanelOpen: (session: BackgroundSummarizeSession) => boolean;
+type StoreLike<Session extends BackgroundSummarizeSession> = {
+  isPanelOpen: (session: Session) => boolean;
   setCachedExtract: (tabId: number, value: CachedExtract) => void;
 };
 
@@ -61,7 +61,7 @@ function resolveBrowserAiLength(value: string): "short" | "medium" | "long" {
   return "long";
 }
 
-export async function summarizeActiveTab({
+export async function summarizeActiveTab<Session extends BackgroundSummarizeSession>({
   session,
   reason,
   opts,
@@ -91,14 +91,14 @@ export async function summarizeActiveTab({
   extractYouTubeTranscript = extractYouTubeTranscriptInTab,
   youtubeTranscriptTimeoutMs = 12_000,
 }: {
-  session: BackgroundSummarizeSession;
+  session: Session;
   reason: string;
   opts?: { refresh?: boolean; inputMode?: "page" | "video" };
   loadSettings: () => Promise<Settings>;
-  emitState: (session: BackgroundSummarizeSession, status: string) => Promise<void>;
+  emitState: (session: Session, status: string) => Promise<void>;
   getActiveTab: (windowId?: number) => Promise<chrome.tabs.Tab | null>;
   canSummarizeUrl: (url?: string | null) => boolean;
-  panelSessionStore: StoreLike;
+  panelSessionStore: StoreLike<Session>;
   sendStatus: (status: string) => void;
   send: SendFn;
   fetchImpl: typeof fetch;
@@ -155,6 +155,7 @@ export async function summarizeActiveTab({
 
   const tab = await getActiveTab(session.windowId);
   if (!tab?.id || !canSummarizeUrl(tab.url)) return;
+  const tabId = tab.id;
   const tabUrl = tab.url ?? "";
   const extractionPlan = planMediaExtraction({
     url: tabUrl,
@@ -225,7 +226,7 @@ export async function summarizeActiveTab({
   const ensureLocalBrowserTranscript = async () => {
     preparedContent = await ensurePreparedPanelTranscript({
       content: preparedContent,
-      tab: { id: tab.id, url: tabUrl, title: tab.title },
+      tab: { id: tabId, url: tabUrl, title: tab.title },
       tabUrl,
       settings,
       requestedInputMode,
@@ -308,7 +309,7 @@ export async function summarizeActiveTab({
 
   const cacheResolvedPayload = () => {
     panelSessionStore.setCachedExtract(
-      tab.id,
+      tabId,
       createCachedExtract({
         extracted: resolvedPayload,
         source: preparedContent.source,

--- a/apps/chrome-extension/src/entrypoints/background/runtime-actions.ts
+++ b/apps/chrome-extension/src/entrypoints/background/runtime-actions.ts
@@ -201,10 +201,10 @@ export function createRuntimeActionsHandler({
           senderTabId: tabId,
           capability: msg.capability,
         });
-        if (guardError) {
+        if (guardError || typeof tabId !== "number") {
           safeSendResponse(sendResponse, {
             ok: false,
-            error: guardError,
+            error: guardError ?? "Missing sender tab",
           } satisfies NativeInputResponse);
           return;
         }
@@ -223,8 +223,8 @@ export function createRuntimeActionsHandler({
         armedTabs: artifactsArmedTabs,
         senderTabId: tabId,
       });
-      if (guardError) {
-        safeSendResponse(sendResponse, { ok: false, error: guardError });
+      if (guardError || typeof tabId !== "number") {
+        safeSendResponse(sendResponse, { ok: false, error: guardError ?? "Missing sender tab" });
         return;
       }
 

--- a/apps/chrome-extension/src/entrypoints/background/youtube-transcript.ts
+++ b/apps/chrome-extension/src/entrypoints/background/youtube-transcript.ts
@@ -13,7 +13,10 @@ export async function hasYouTubeCaptionTracksInTab(tabId: number): Promise<boole
       world: "MAIN",
       func: readYouTubePageCaptionSource,
     });
-    return (result?.result.tracks.length ?? 0) > 0;
+    if (!result) return false;
+    const source = result?.result;
+    if (!source) return true;
+    return source.tracks.length > 0;
   } catch {
     return true;
   }

--- a/apps/chrome-extension/src/entrypoints/extract.content.ts
+++ b/apps/chrome-extension/src/entrypoints/extract.content.ts
@@ -242,7 +242,7 @@ function findBestVideo(): HTMLVideoElement | null {
 
 function waitForEventOrTimeout(target: EventTarget, eventName: string, timeoutMs: number) {
   return new Promise<void>((resolve) => {
-    let timer: ReturnType<typeof setTimeout> | null = null;
+    let timer: number | null = null;
     const cleanup = () => {
       if (timer) window.clearTimeout(timer);
       target.removeEventListener(eventName, onEvent);

--- a/apps/chrome-extension/src/entrypoints/hover.content.ts
+++ b/apps/chrome-extension/src/entrypoints/hover.content.ts
@@ -209,13 +209,13 @@ function hideTooltip() {
 function getAnchorFromEvent(event: Event): HTMLAnchorElement | null {
   const target = event.target as Element | null;
   if (target && typeof target.closest === "function") {
-    return target.closest("a[href]");
+    return target.closest<HTMLAnchorElement>("a[href]");
   }
   const composedPath = typeof event.composedPath === "function" ? event.composedPath() : [];
   for (const node of composedPath) {
     const element = node as Element;
     if (element && typeof element.closest === "function") {
-      const anchor = element.closest("a[href]");
+      const anchor = element.closest<HTMLAnchorElement>("a[href]");
       if (anchor) return anchor;
     }
   }

--- a/apps/chrome-extension/src/entrypoints/offscreen/media-transcription.ts
+++ b/apps/chrome-extension/src/entrypoints/offscreen/media-transcription.ts
@@ -13,7 +13,7 @@ import {
 export type BrowserMediaTranscriptionDiagnostics = {
   chunksProcessed: number;
   chunksTotal: number;
-  codec: string;
+  codec: BrowserAudioProcessResult["codec"];
   decoder: "mediabunny-webcodecs";
   durationSeconds: number;
   input: "buffer" | "url-range";

--- a/apps/chrome-extension/src/entrypoints/offscreen/whisper.ts
+++ b/apps/chrome-extension/src/entrypoints/offscreen/whisper.ts
@@ -2,7 +2,7 @@ import {
   env,
   pipeline,
   type AutomaticSpeechRecognitionOutput,
-  type AutomaticSpeechRecognitionPipelineType,
+  type AutomaticSpeechRecognitionPipeline,
 } from "@huggingface/transformers";
 
 const WHISPER_MODEL = "onnx-community/whisper-tiny";
@@ -13,11 +13,11 @@ type WhisperDevice = "webgpu" | "wasm";
 type WhisperPipelineFactory = (
   device: WhisperDevice,
   onStatus: (status: string) => void,
-) => Promise<AutomaticSpeechRecognitionPipelineType>;
+) => Promise<AutomaticSpeechRecognitionPipeline>;
 type WhisperRuntime = {
   device: WhisperDevice;
   loadMs: number;
-  transcriber: AutomaticSpeechRecognitionPipelineType;
+  transcriber: AutomaticSpeechRecognitionPipeline;
 };
 
 export type WhisperRuntimeDiagnostics = {
@@ -87,7 +87,7 @@ export async function transcribePcmChunkWithWhisper({
 
 async function getTranscriber(onStatus: (status: string) => void): Promise<{
   diagnostics: WhisperRuntimeDiagnostics;
-  transcriber: AutomaticSpeechRecognitionPipelineType;
+  transcriber: AutomaticSpeechRecognitionPipeline;
 }> {
   const reused = Boolean(transcriberPromise);
   if (!transcriberPromise) {
@@ -151,7 +151,7 @@ export async function loadWhisperTranscriber({
   webGpuTimeoutMs?: number;
   wasmTimeoutMs?: number;
   onDevice?: (device: WhisperDevice) => void;
-}): Promise<AutomaticSpeechRecognitionPipelineType> {
+}): Promise<AutomaticSpeechRecognitionPipeline> {
   let activeAttempt = 0;
   const load = async (device: WhisperDevice, timeoutMs: number, timeoutMessage: string) => {
     const attempt = ++activeAttempt;
@@ -190,7 +190,7 @@ export async function loadWhisperTranscriber({
 async function createWhisperPipeline(
   device: WhisperDevice,
   onStatus: (status: string) => void,
-): Promise<AutomaticSpeechRecognitionPipelineType> {
+): Promise<AutomaticSpeechRecognitionPipeline> {
   return await pipeline("automatic-speech-recognition", WHISPER_MODEL, {
     device,
     dtype:

--- a/apps/chrome-extension/src/entrypoints/options/form-state.ts
+++ b/apps/chrome-extension/src/entrypoints/options/form-state.ts
@@ -1,6 +1,6 @@
 import { readPresetOrCustomValue, resolvePresetOrCustom } from "../../lib/combo";
 import type { createModelPresetsController } from "../../lib/model-presets";
-import type { DirectProvider, Settings } from "../../lib/settings";
+import { normalizeSettingChoices, type DirectProvider, type Settings } from "../../lib/settings";
 import type { ColorMode, ColorScheme } from "../../lib/theme";
 import type { BooleanSettingsState } from "./boolean-settings";
 
@@ -49,6 +49,7 @@ export function buildSavedOptionsSettings({
   return {
     token: elements.tokenEl.value || defaults.token,
     daemonPort: elements.daemonPortEl.value || defaults.daemonPort,
+    daemonHintDismissed: current.daemonHintDismissed,
     summaryRuntime: booleans.summaryRuntime,
     provider: elements.providerEl.value as DirectProvider,
     providerApiKeys: {
@@ -82,12 +83,14 @@ export function buildSavedOptionsSettings({
     autoCliFallback: booleans.autoCliFallback,
     autoCliOrder: elements.autoCliOrderEl.value || defaults.autoCliOrder,
     maxChars: Number(elements.maxCharsEl.value) || defaults.maxChars,
-    requestMode: elements.requestModeEl.value || defaults.requestMode,
-    firecrawlMode: elements.firecrawlModeEl.value || defaults.firecrawlMode,
-    markdownMode: elements.markdownModeEl.value || defaults.markdownMode,
-    preprocessMode: elements.preprocessModeEl.value || defaults.preprocessMode,
-    youtubeMode: elements.youtubeModeEl.value || defaults.youtubeMode,
-    transcriber: elements.transcriberEl.value || defaults.transcriber,
+    ...normalizeSettingChoices({
+      requestMode: elements.requestModeEl.value || defaults.requestMode,
+      firecrawlMode: elements.firecrawlModeEl.value || defaults.firecrawlMode,
+      markdownMode: elements.markdownModeEl.value || defaults.markdownMode,
+      preprocessMode: elements.preprocessModeEl.value || defaults.preprocessMode,
+      youtubeMode: elements.youtubeModeEl.value || defaults.youtubeMode,
+      transcriber: elements.transcriberEl.value || defaults.transcriber,
+    }),
     timeout: elements.timeoutEl.value || defaults.timeout,
     retries: (() => {
       const raw = elements.retriesEl.value.trim();
@@ -112,7 +115,7 @@ export function applyLoadedOptionsSettings({
 }: {
   settings: Settings;
   defaults: Settings;
-  languagePresets: string[];
+  languagePresets: readonly string[];
   elements: FormElements;
 }) {
   elements.tokenEl.value = settings.token;

--- a/apps/chrome-extension/src/entrypoints/options/main.ts
+++ b/apps/chrome-extension/src/entrypoints/options/main.ts
@@ -144,7 +144,6 @@ createOptionsTabs({
   },
 });
 
-let booleanSettings: ReturnType<typeof createBooleanSettingsRuntime> | null = null;
 let daemonCapability: ReturnType<typeof createDaemonCapabilityController> | null = null;
 let refreshRuntimeStatus = (_token = elements.tokenEl.value) => {};
 
@@ -160,7 +159,7 @@ const { saveNow, scheduleAutoSave } = createOptionsSaveRuntime({
         defaults: defaultSettings,
         elements,
         modelPresets,
-        booleans: booleanSettings?.getState() ?? defaultSettings,
+        booleans: booleanSettings.getState(),
         currentScheme,
         currentMode,
       }),
@@ -168,7 +167,7 @@ const { saveNow, scheduleAutoSave } = createOptionsSaveRuntime({
   },
 });
 
-booleanSettings = createBooleanSettingsRuntime({
+const booleanSettings = createBooleanSettingsRuntime({
   defaults: defaultSettings,
   roots: elements,
   scheduleAutoSave,
@@ -191,8 +190,8 @@ const { checkDaemonStatus, setDaemonStatus } = createDaemonStatusChecker({
   statusEl: elements.daemonStatusEl,
   getExtensionVersion: resolveExtensionVersion,
   isDaemonMode: () => {
-    const state = booleanSettings?.getState();
-    return state?.summaryRuntime === "daemon" || state?.slideRuntime === "daemon";
+    const state = booleanSettings.getState();
+    return state.summaryRuntime === "daemon" || state.slideRuntime === "daemon";
   },
 });
 

--- a/apps/chrome-extension/src/entrypoints/options/persistence.ts
+++ b/apps/chrome-extension/src/entrypoints/options/persistence.ts
@@ -5,7 +5,7 @@ export function createOptionsSaveRuntime(options: {
   persist: () => Promise<void>;
 }) {
   const { isInitializing, setStatus, flashStatus, persist } = options;
-  let saveTimer = 0;
+  let saveTimer: ReturnType<typeof globalThis.setTimeout> | 0 = 0;
   let saveInFlight = false;
   let saveQueued = false;
   let saveSequence = 0;

--- a/apps/chrome-extension/src/entrypoints/options/pickers.tsx
+++ b/apps/chrome-extension/src/entrypoints/options/pickers.tsx
@@ -1,4 +1,4 @@
-import { render } from "preact";
+import { render, type JSX } from "preact";
 import { createPortal } from "preact/compat";
 import type { ColorMode, ColorScheme } from "../../lib/theme";
 import { getOverlayRoot } from "../../ui/portal";

--- a/apps/chrome-extension/src/entrypoints/sidepanel/appearance-controls.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/appearance-controls.ts
@@ -1,5 +1,5 @@
-import { defaultSettings } from "../../lib/settings";
-import { applyTheme } from "../../lib/theme";
+import { defaultSettings, type Settings } from "../../lib/settings";
+import { applyTheme, type ColorMode, type ColorScheme } from "../../lib/theme";
 import { mountCheckbox } from "../../ui/checkbox";
 import { mountSidepanelLengthPicker, mountSidepanelPickers } from "./pickers";
 
@@ -34,14 +34,14 @@ export function createAppearanceControls(options: {
   };
 
   const pickerHandlers = {
-    onSchemeChange: (value: string) => {
+    onSchemeChange: (value: ColorScheme) => {
       void (async () => {
         const next = await options.patchSettings({ colorScheme: value });
         pickerSettings = { ...pickerSettings, scheme: next.colorScheme, mode: next.colorMode };
         applyTheme({ scheme: next.colorScheme, mode: next.colorMode });
       })();
     },
-    onModeChange: (value: string) => {
+    onModeChange: (value: ColorMode) => {
       void (async () => {
         const next = await options.patchSettings({ colorMode: value });
         pickerSettings = { ...pickerSettings, scheme: next.colorScheme, mode: next.colorMode };
@@ -102,15 +102,18 @@ export function createAppearanceControls(options: {
       });
       return true;
     },
-    initializeFromSettings: (settings: {
-      autoSummarize: boolean;
-      colorScheme: string;
-      colorMode: string;
-      fontFamily: string;
-      length: string;
-      fontSize: number;
-      lineHeight: number;
-    }) => {
+    initializeFromSettings: (
+      settings: Pick<
+        Settings,
+        | "autoSummarize"
+        | "colorScheme"
+        | "colorMode"
+        | "fontFamily"
+        | "length"
+        | "fontSize"
+        | "lineHeight"
+      >,
+    ) => {
       autoValue = settings.autoSummarize;
       updateAutoToggle();
       pickerSettings = {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/bg-message-runtime.ts
@@ -118,12 +118,12 @@ export function createSidepanelBgMessageRuntime(options: {
   rememberPendingSummarySnapshot: (payload: SummarySnapshotPayload) => void;
   attachSummaryRun: (run: RunStart) => void;
   applySummarySnapshot: (payload: SummarySnapshotPayload) => void;
-  handleChatHistory: (msg: Extract<BgMessage, { type: "chat:history" }>) => void;
-  handleAgentChunk: (msg: Extract<BgMessage, { type: "agent:chunk" }>) => void;
-  handleAgentResponse: (msg: Extract<BgMessage, { type: "agent:response" }>) => void;
+  handleChatHistory: (msg: Extract<BgToPanel, { type: "chat:history" }>) => void;
+  handleAgentChunk: (msg: Extract<BgToPanel, { type: "agent:chunk" }>) => void;
+  handleAgentResponse: (msg: Extract<BgToPanel, { type: "agent:response" }>) => void;
 }) {
   return {
-    handle(msg: BgMessage) {
+    handle(msg: BgToPanel) {
       handleSidepanelBgMessage({
         msg,
         applyUiState: (state) => {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/bootstrap-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/bootstrap-runtime.ts
@@ -1,23 +1,12 @@
-import type { Settings } from "../../lib/settings";
+import type { loadSettings } from "../../lib/settings";
 import { bindSettingsStorage, bindSidepanelLifecycle } from "./bindings";
 import { patchPanelState } from "./panel-state-store";
 import type { PanelState } from "./types";
 
-type LoadedSettings = Pick<
-  Settings,
-  | "autoSummarize"
-  | "chatEnabled"
-  | "automationEnabled"
-  | "slidesLayout"
-  | "fontSize"
-  | "lineHeight"
-  | "fontFamily"
-  | "model"
-  | "token"
->;
+type LoadedSettings = Awaited<ReturnType<typeof loadSettings>>;
 
 export function bootstrapSidepanel(options: {
-  ensurePanelPort: () => Promise<void>;
+  ensurePanelPort: () => Promise<unknown>;
   loadSettings: () => Promise<LoadedSettings>;
   panelState: PanelState;
 

--- a/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime.ts
@@ -24,11 +24,12 @@ export function createBrowserAiSnapshotRuntime(options: {
       options.browserAi.cancel("summary");
       return;
     }
+    const browserAi = snapshot.browserAi;
     const runId = snapshot.run.id;
     const runUrl = snapshot.run.url;
     void options.browserAi
       .summarize({
-        input: snapshot.browserAi,
+        input: browserAi,
         context: snapshot.run.title
           ? `Summarize the page or media titled "${snapshot.run.title}".`
           : undefined,
@@ -63,7 +64,7 @@ export function createBrowserAiSnapshotRuntime(options: {
           buildBrowserAiSummaryMarkdown({
             title: snapshot.run.title,
             summary,
-            keyMoments: snapshot.browserAi.keyMoments,
+            keyMoments: browserAi.keyMoments,
           }),
         );
       });

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-controller.ts
@@ -16,7 +16,7 @@ export type ChatControllerOptions = {
   inputEl: HTMLTextAreaElement;
   sendBtn: HTMLButtonElement;
   contextEl: HTMLDivElement;
-  markdown: MarkdownIt;
+  markdown: InstanceType<typeof MarkdownIt>;
   limits: ChatHistoryLimits;
   panelState: PanelState;
 
@@ -29,7 +29,7 @@ export class ChatController {
   private readonly inputEl: HTMLTextAreaElement;
   private readonly sendBtn: HTMLButtonElement;
   private readonly contextEl: HTMLDivElement;
-  private readonly markdown: MarkdownIt;
+  private readonly markdown: InstanceType<typeof MarkdownIt>;
   private readonly limits: ChatHistoryLimits;
   private readonly panelState: PanelState;
 
@@ -139,7 +139,7 @@ export class ChatController {
         ...lastMsg,
         content: [{ type: "text", text: content }],
       });
-      const msgEl = this.messagesEl.querySelector(`[data-id="${lastMsg.id}"]`);
+      const msgEl = this.messagesEl.querySelector<HTMLElement>(`[data-id="${lastMsg.id}"]`);
       if (msgEl) {
         if (content.trim()) {
           msgEl.innerHTML = this.markdown.render(this.linkifyTimestamps(content));

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.ts
@@ -26,6 +26,30 @@ export function buildEmptyUsage() {
   };
 }
 
+function normalizeNumbers<Field extends string>(
+  defaults: Record<Field, number>,
+  raw: unknown,
+): Record<Field, number> {
+  const source = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  const normalized: Record<Field, number> = { ...source, ...defaults };
+  for (const field in defaults) {
+    const value = source[field];
+    if (typeof value === "number" && Number.isFinite(value)) normalized[field] = value;
+  }
+  return normalized;
+}
+
+function normalizeStoredUsage(raw: unknown) {
+  const { cost, ...counts } = buildEmptyUsage();
+  return {
+    ...normalizeNumbers(counts, raw),
+    cost: normalizeNumbers(
+      cost,
+      raw && typeof raw === "object" ? (raw as Record<string, unknown>).cost : null,
+    ),
+  };
+}
+
 export function normalizeStoredMessage(raw: Record<string, unknown>): ChatMessage | null {
   const role = raw.role;
   const timestamp = typeof raw.timestamp === "number" ? raw.timestamp : Date.now();
@@ -50,8 +74,11 @@ export function normalizeStoredMessage(raw: Record<string, unknown>): ChatMessag
       api: typeof raw.api === "string" ? raw.api : "openai-completions",
       provider: typeof raw.provider === "string" ? raw.provider : "openai",
       model: typeof raw.model === "string" ? raw.model : "unknown",
-      usage: typeof raw.usage === "object" && raw.usage ? raw.usage : buildEmptyUsage(),
-      stopReason: typeof raw.stopReason === "string" ? raw.stopReason : "stop",
+      usage: normalizeStoredUsage(raw.usage),
+      stopReason:
+        (["stop", "length", "toolUse", "error", "aborted"] as const).find(
+          (reason) => reason === raw.stopReason,
+        ) ?? "stop",
       timestamp,
       id,
     };

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime.ts
@@ -59,7 +59,7 @@ export function createSidepanelChatRuntime({
 }: {
   panelState: PanelState;
 
-  markdown: MarkdownIt;
+  markdown: InstanceType<typeof MarkdownIt>;
   mainEl: HTMLElement;
   renderEl: HTMLElement;
   chatContainerEl: HTMLElement;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-ui-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-ui-runtime.ts
@@ -26,12 +26,8 @@ type InputEl = {
   focus: () => void;
 };
 
-type DockEl = {
-  getBoundingClientRect: () => { height: number };
-};
-
 type ResizeObserverCtor = new (callback: ResizeObserverCallback) => {
-  observe: (target: Element | DockEl) => void;
+  observe: (target: Element) => void;
   disconnect: () => void;
 };
 
@@ -65,7 +61,7 @@ export function createChatUiRuntime({
     ) => void;
   };
   chatInputEl: InputEl;
-  chatDockEl: DockEl;
+  chatDockEl: Element;
   chatContainerEl: ToggleableEl;
   chatDockContainerEl: ToggleableEl;
   renderEl: ClassListEl;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/main.ts
@@ -244,7 +244,7 @@ const interactionRuntime = createSidepanelInteractionRuntime({
   typographyController,
   patchSettings,
   updateModelRowUI,
-  isCustomModelHidden: () => modelCustomEl.hidden,
+  isCustomModelHidden: () => Boolean(modelCustomEl.hidden),
   focusCustomModel: () => {
     modelCustomEl.focus();
   },

--- a/apps/chrome-extension/src/entrypoints/sidepanel/panel-cache.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/panel-cache.ts
@@ -65,7 +65,7 @@ export function createPanelCacheController(
 ): PanelCacheController {
   const { getSnapshot, sendCache, sendRequest } = options;
   const cacheByKey = new Map<string, PanelCachePayload>();
-  let syncTimer = 0;
+  let syncTimer: ReturnType<typeof globalThis.setTimeout> | 0 = 0;
   let requestCounter = 0;
   let pendingRequest: {
     requestId: string;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/pickers.tsx
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/pickers.tsx
@@ -1,6 +1,6 @@
 import type { SummaryLength } from "@steipete/summarize-core";
 import { SUMMARY_LENGTH_SPECS } from "@steipete/summarize-core/prompts";
-import { render } from "preact";
+import { render, type JSX } from "preact";
 import { createPortal } from "preact/compat";
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { readPresetOrCustomValue, resolvePresetOrCustom } from "../../lib/combo";
@@ -355,7 +355,7 @@ function LengthField({
                 placeholder="Custom (e.g. 20k)"
                 autocapitalize="off"
                 autocomplete="off"
-                spellcheck="false"
+                spellcheck={false}
                 value={customValue}
                 onInput={(event) => setCustomValue(event.currentTarget.value)}
                 onBlur={commitCustom}
@@ -607,7 +607,6 @@ function SummarizeControl(props: SummarizeControlProps) {
     <div className="summarizeControlGroup">
       <div className="picker summarizePicker" {...api.getRootProps()}>
         <button
-          type="button"
           className="ghost summarizeButton isDropdown"
           aria-label={`Summarize (${selectedLabel})`}
           data-busy={props.busy ? "true" : "false"}

--- a/apps/chrome-extension/src/entrypoints/sidepanel/setup-controls-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/setup-controls-runtime.ts
@@ -21,22 +21,22 @@ export function createSetupControlsRuntime({
   patchSettings,
   setupEl,
 }: {
-  advancedSettingsBodyEl: HTMLDivElement;
+  advancedSettingsBodyEl: HTMLElement;
   advancedSettingsEl: HTMLDetailsElement;
   defaultModel: string;
-  drawerEl: HTMLDivElement;
+  drawerEl: HTMLElement;
   drawerToggleBtn: HTMLButtonElement;
   friendlyFetchError: (error: unknown, fallback: string) => string;
   generateToken: () => string;
   getStatusResetText: () => string;
   headerSetStatus: (text: string) => void;
-  loadSettings: () => Promise<{ token: string }>;
+  loadSettings: typeof import("../../lib/settings").loadSettings;
   modelCustomEl: HTMLInputElement;
   modelPresetEl: HTMLSelectElement;
   modelRefreshBtn: HTMLButtonElement;
   modelRowEl: HTMLDivElement;
   modelStatusEl: HTMLSpanElement;
-  patchSettings: (patch: Record<string, unknown>) => Promise<unknown>;
+  patchSettings: typeof import("../../lib/settings").patchSettings;
   setupEl: HTMLDivElement;
 }) {
   const modelPresetsController = createModelPresetsController({

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-payload.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-payload.ts
@@ -131,6 +131,6 @@ export function resolveSlidesPayload(
     appliedSlidesRunId?: string | null;
   } = {},
 ): SlidesPayload {
-  if (shouldReplaceSlidesPayload(prev, next, opts)) return next;
+  if (!prev || shouldReplaceSlidesPayload(prev, next, opts)) return next;
   return mergeSlidesPayload(prev, next);
 }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-renderer.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-renderer.ts
@@ -255,8 +255,10 @@ export function createSlidesRenderer({
     const list = root.querySelector<HTMLDivElement>(".slideGallery__list");
     if (!list) return;
 
-    const existingItems = new Map<number, HTMLElement>();
-    for (const item of Array.from(list.querySelectorAll<HTMLElement>(".slideGallery__item"))) {
+    const existingItems = new Map<number, HTMLButtonElement>();
+    for (const item of Array.from(
+      list.querySelectorAll<HTMLButtonElement>(".slideGallery__item"),
+    )) {
       const idx = Number(item.dataset.slideIndex);
       if (Number.isFinite(idx)) existingItems.set(idx, item);
     }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-summary-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-summary-controller.ts
@@ -15,7 +15,7 @@ type SlidesSummaryControllerOptions = {
   getToken: () => Promise<string>;
 
   friendlyFetchError: (error: unknown, fallback: string) => string;
-  panelUrlsMatch: (left: string | null | undefined, right: string | null | undefined) => boolean;
+  panelUrlsMatch: (left: string, right: string) => boolean;
   getPanelState: () => PanelState;
   getUiState: () => UiState | null;
   getActiveTabUrl: () => string | null;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime.ts
@@ -12,6 +12,7 @@ import {
 import { createSlidesRenderer } from "./slides-renderer";
 import { resolveSlidesInputMode } from "./slides-session-state";
 import { formatSlideTimestamp } from "./slides-state";
+import type { createSlidesTextController } from "./slides-text-controller";
 import { renderSummaryMarkdownDisplay } from "./summary-renderer";
 import type { PanelState, SlideSummarySource } from "./types";
 
@@ -36,22 +37,20 @@ export function createSlidesViewRuntime({
   renderSlidesHostEl: HTMLElement;
   summaryCopyBtn: HTMLButtonElement;
   chatMessagesEl: HTMLElement;
-  md: MarkdownIt;
+  md: InstanceType<typeof MarkdownIt>;
   headerSetStatus: (text: string) => void;
   headerSetProgressOverride: (busy: boolean) => void;
-  slidesTextController: {
-    hasSummaryTitles: () => boolean;
-    updateSummaryFromMarkdown: (
-      markdown: string,
-      opts?: { preserveIfEmpty?: boolean; source?: "summary" | "slides" },
-    ) => boolean;
-    rebuildDescriptions: () => void;
-    syncTextState: () => void;
-    getDescriptions: () => Map<number, string>;
-    getTitles: () => Map<number, string>;
-    getDescriptionEntries: () => Array<[number, string]>;
-    getTranscriptTimedText: () => string | null;
-  };
+  slidesTextController: Pick<
+    ReturnType<typeof createSlidesTextController>,
+    | "hasSummaryTitles"
+    | "updateSummaryFromMarkdown"
+    | "rebuildDescriptions"
+    | "syncTextState"
+    | "getDescriptions"
+    | "getTitles"
+    | "getDescriptionEntries"
+    | "getTranscriptTimedText"
+  >;
   panelCacheController: { scheduleSync: () => void };
   send: (
     message:

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summarize-control-runtime.ts
@@ -17,7 +17,7 @@ type SummarizeControlRuntimeOptions = {
   slidesTextController: SlidesTextControllerLike;
   panelState: PanelState;
 
-  patchSettings: (patch: Partial<Settings>) => Promise<void>;
+  patchSettings: (patch: Partial<Settings>) => Promise<unknown>;
   loadSettings: () => Promise<Pick<Settings, "slideRuntime" | "token">>;
   showSlideNotice: (message: string) => void;
   hideSlideNotice: () => void;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summary-renderer.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summary-renderer.ts
@@ -1,6 +1,7 @@
 import { selectMarkdownForLayout } from "./slides-state";
 import { buildSummaryEmptyState } from "./summary-empty-state";
 import { linkifyTimestamps } from "./timestamp-links";
+import type { PanelPhase } from "./types";
 
 const scrollRestoreVersions = new WeakMap<HTMLElement, number>();
 
@@ -151,7 +152,7 @@ export function renderSummaryMarkdownDisplay({
   inputMode: "page" | "video";
   markdown: string;
   md: { render: (value: string) => string };
-  phase: string;
+  phase: PanelPhase;
   renderInlineSlides: (container: HTMLElement, opts?: { fallback?: boolean }) => void;
   slidesEnabled: boolean;
   slidesLayout: string;

--- a/apps/chrome-extension/src/lib/daemon-status.ts
+++ b/apps/chrome-extension/src/lib/daemon-status.ts
@@ -46,7 +46,7 @@ export function createDaemonStatusTracker(options: DaemonStatusTrackerOptions = 
         lastReadyState &&
         (opts.keepReady || now - lastReadyAt <= transientGraceMs);
 
-      if (shouldKeepReady) {
+      if (shouldKeepReady && lastReadyState) {
         return { ...lastReadyState };
       }
 

--- a/apps/chrome-extension/src/lib/extension-logs.ts
+++ b/apps/chrome-extension/src/lib/extension-logs.ts
@@ -13,7 +13,7 @@ const MAX_LOG_LINES = 4000;
 const FLUSH_DELAY_MS = 250;
 const FLUSH_BATCH = 50;
 
-let flushTimer = 0;
+let flushTimer: ReturnType<typeof globalThis.setTimeout> | 0 = 0;
 let flushInFlight = false;
 let pendingLines: string[] = [];
 

--- a/apps/chrome-extension/src/lib/settings-storage.ts
+++ b/apps/chrome-extension/src/lib/settings-storage.ts
@@ -32,7 +32,7 @@ export async function readStoredSettings(): Promise<Record<string, unknown>> {
 
   const result = await new Promise<Record<string, unknown>>((resolve, reject) => {
     let settled = false;
-    const maybePromise = storage.get(storageKey, (value) => {
+    const maybePromise: unknown = storage.get(storageKey, (value) => {
       settled = true;
       resolve(value as Record<string, unknown>);
     });

--- a/apps/chrome-extension/src/lib/settings.ts
+++ b/apps/chrome-extension/src/lib/settings.ts
@@ -377,26 +377,25 @@ function normalizeChoice<Value extends string>(
   return choices.find((choice) => choice === normalized) ?? fallback;
 }
 
-function normalizeSettings(settings: Settings): Settings {
+type ChoiceSettings = Pick<
+  Settings,
+  | "requestMode"
+  | "firecrawlMode"
+  | "markdownMode"
+  | "preprocessMode"
+  | "youtubeMode"
+  | "transcriber"
+>;
+
+export function normalizeSettingChoices(
+  settings: Record<keyof ChoiceSettings, unknown>,
+): ChoiceSettings {
   return {
-    ...settings,
-    daemonPort: normalizeDaemonPort(settings.daemonPort),
-    summaryRuntime: normalizeSummaryRuntime(settings.summaryRuntime),
-    provider: normalizeProvider(settings.provider),
-    providerApiKeys: normalizeProviderMap(settings.providerApiKeys),
-    providerBaseUrls: normalizeProviderMap(settings.providerBaseUrls),
-    model: normalizeModel(settings.model),
-    length: normalizeLength(settings.length),
-    language: normalizeLanguage(settings.language),
-    promptOverride: normalizePromptOverride(settings.promptOverride),
-    hoverPrompt: normalizeHoverPrompt(settings.hoverPrompt),
-    autoCliOrder: normalizeAutoCliOrder(settings.autoCliOrder),
     requestMode: normalizeChoice(
       settings.requestMode,
       ["page", "url"],
       defaultSettings.requestMode,
     ),
-    slidesLayout: normalizeSlidesLayout(settings.slidesLayout),
     firecrawlMode: normalizeChoice(
       settings.firecrawlMode,
       ["off", "auto", "always"],
@@ -417,14 +416,33 @@ function normalizeSettings(settings: Settings): Settings {
       ["auto", "web", "apify", "yt-dlp", "no-auto"],
       defaultSettings.youtubeMode,
     ),
-    timeout: normalizeTimeout(settings.timeout),
-    retries: normalizeRetries(settings.retries),
-    maxOutputTokens: normalizeMaxOutputTokens(settings.maxOutputTokens),
     transcriber: normalizeChoice(
       settings.transcriber,
       ["whisper", "parakeet", "canary"],
       defaultSettings.transcriber,
     ),
+  };
+}
+
+function normalizeSettings(settings: Settings): Settings {
+  return {
+    ...settings,
+    ...normalizeSettingChoices(settings),
+    daemonPort: normalizeDaemonPort(settings.daemonPort),
+    summaryRuntime: normalizeSummaryRuntime(settings.summaryRuntime),
+    provider: normalizeProvider(settings.provider),
+    providerApiKeys: normalizeProviderMap(settings.providerApiKeys),
+    providerBaseUrls: normalizeProviderMap(settings.providerBaseUrls),
+    model: normalizeModel(settings.model),
+    length: normalizeLength(settings.length),
+    language: normalizeLanguage(settings.language),
+    promptOverride: normalizePromptOverride(settings.promptOverride),
+    hoverPrompt: normalizeHoverPrompt(settings.hoverPrompt),
+    autoCliOrder: normalizeAutoCliOrder(settings.autoCliOrder),
+    slidesLayout: normalizeSlidesLayout(settings.slidesLayout),
+    timeout: normalizeTimeout(settings.timeout),
+    retries: normalizeRetries(settings.retries),
+    maxOutputTokens: normalizeMaxOutputTokens(settings.maxOutputTokens),
     fontFamily: normalizeFontFamily(settings.fontFamily),
     maxChars: normalizeMaxChars(settings.maxChars),
     fontSize: normalizeFontSize(settings.fontSize),

--- a/apps/chrome-extension/src/ui/select.tsx
+++ b/apps/chrome-extension/src/ui/select.tsx
@@ -241,7 +241,7 @@ export function useSelect({ id, items, value, onValueChange }: UseSelectArgs) {
     getTriggerProps: () => ({
       id: `${id}-trigger`,
       type: "button" as const,
-      role: "combobox",
+      role: "combobox" as const,
       "aria-controls": `${id}-listbox`,
       "aria-expanded": open,
       "aria-haspopup": "listbox" as const,
@@ -265,7 +265,7 @@ export function useSelect({ id, items, value, onValueChange }: UseSelectArgs) {
     }),
     getListProps: () => ({
       id: `${id}-listbox`,
-      role: "listbox",
+      role: "listbox" as const,
       "aria-labelledby": `${id}-trigger`,
     }),
     getItemProps: ({ item }: { item: SelectItem }) => {
@@ -274,7 +274,7 @@ export function useSelect({ id, items, value, onValueChange }: UseSelectArgs) {
       return {
         id: `${id}-option-${index}`,
         type: "button" as const,
-        role: "option",
+        role: "option" as const,
         "aria-selected": selected,
         disabled: item.disabled,
         tabIndex: highlightedIndex === index ? 0 : -1,

--- a/apps/chrome-extension/tests/options.spec.ts
+++ b/apps/chrome-extension/tests/options.spec.ts
@@ -45,6 +45,16 @@ test("options checkbox controllers persist only their own setting", async ({ har
   }
 });
 
+test("options saves preserve a dismissed companion hint", async ({ harness }) => {
+  await seedSettings(harness, { daemonHintDismissed: true, autoSummarize: true });
+  const page = await openExtensionPage(harness, "options.html", "#tabs");
+  await expect(page.locator("html")).toHaveAttribute("data-settings-ready", "true");
+  await page.locator("#options-auto").setChecked(false, { force: true });
+  await expect
+    .poll(async () => await getSettings(harness))
+    .toMatchObject({ autoSummarize: false, daemonHintDismissed: true });
+});
+
 test("options pickers apply overlay selection", async ({ harness }) => {
   const page = await openExtensionPage(harness, "options.html", "#tabs");
   await page.click("#tab-ui");

--- a/apps/chrome-extension/tsconfig.json
+++ b/apps/chrome-extension/tsconfig.json
@@ -2,9 +2,13 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "erasableSyntaxOnly": false,
     "types": ["chrome"],
     "jsx": "react-jsx",
     "jsxImportSource": "preact"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "wxt.config.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "wxt.config.ts", ".wxt/wxt.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:coverage": "vitest run --coverage",
     "test:coverage:build": "pnpm build && pnpm test:coverage",
     "test:extension-e2e": "pnpm -C apps/chrome-extension test:e2e",
-    "typecheck": "pnpm -C packages/core typecheck && tsc -p tsconfig.build.json --noEmit"
+    "typecheck": "pnpm -C packages/core typecheck && tsc -p tsconfig.build.json --noEmit && pnpm -C apps/chrome-extension typecheck"
   },
   "dependencies": {
     "@earendil-works/pi-ai": "^0.84.3",

--- a/tests/chrome.youtube-transcript.test.ts
+++ b/tests/chrome.youtube-transcript.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { extractYouTubeTranscriptInTab } from "../apps/chrome-extension/src/entrypoints/background/youtube-transcript";
+import {
+  extractYouTubeTranscriptInTab,
+  hasYouTubeCaptionTracksInTab,
+} from "../apps/chrome-extension/src/entrypoints/background/youtube-transcript";
 import { extractYouTubePageTranscript } from "../apps/chrome-extension/src/lib/youtube-page-transcript";
 
 type ExecuteScriptOptions = {
@@ -45,6 +48,19 @@ function installExecuteScriptStub() {
 }
 
 describe("chrome youtube transcript extraction", () => {
+  it.each([
+    { response: [], expected: false },
+    { response: [{}], expected: true },
+    { response: [{ result: { tracks: [] } }], expected: false },
+    { response: [{ result: { tracks: [{}] } }], expected: true },
+  ])("preserves caption availability for $response", async ({ response, expected }) => {
+    Object.defineProperty(globalThis, "chrome", {
+      configurable: true,
+      value: { scripting: { executeScript: async () => response } },
+    });
+    expect(await hasYouTubeCaptionTracksInTab(7)).toBe(expected);
+  });
+
   beforeEach(() => {
     installDocumentStub();
     installExecuteScriptStub();

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -69,9 +69,9 @@ describe("package scripts", () => {
     expect(pnpmLockfile).not.toMatch(/^\s{2}(?:esbuild|tsx)@/mu);
   });
 
-  it("typechecks both workspace layers from the root script", () => {
+  it("typechecks all workspace layers from the root script", () => {
     expect(rootPackage.scripts.typecheck).toBe(
-      "pnpm -C packages/core typecheck && tsc -p tsconfig.build.json --noEmit",
+      "pnpm -C packages/core typecheck && tsc -p tsconfig.build.json --noEmit && pnpm -C apps/chrome-extension typecheck",
     );
     expect(corePackage.scripts.typecheck).toBe("tsc -p tsconfig.build.json --noEmit");
   });

--- a/tests/sidepanel.chat-history-store.test.ts
+++ b/tests/sidepanel.chat-history-store.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createChatHistoryStore } from "../apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.js";
+import {
+  buildEmptyUsage,
+  createChatHistoryStore,
+  normalizeStoredMessage,
+} from "../apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.js";
 import type { ChatMessage } from "../apps/chrome-extension/src/entrypoints/sidepanel/types.js";
 
 function createMemoryStorage(): chrome.storage.StorageArea {
@@ -23,6 +27,48 @@ function createMemoryStorage(): chrome.storage.StorageArea {
 }
 
 describe("sidepanel chat history store", () => {
+  it("restores partial usage with numeric defaults and preserves unknown metadata", () => {
+    const message = normalizeStoredMessage({
+      role: "assistant",
+      content: "Saved reply",
+      stopReason: "unknown-reason",
+      usage: {
+        input: 12,
+        output: "invalid",
+        totalTokens: Number.NaN,
+        providerDetail: "retained",
+        cost: { total: 0.25, input: null, providerDetail: "retained" },
+      },
+    });
+    expect(message).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Saved reply" }],
+      stopReason: "stop",
+      usage: {
+        ...buildEmptyUsage(),
+        input: 12,
+        providerDetail: "retained",
+        cost: { ...buildEmptyUsage().cost, total: 0.25, providerDetail: "retained" },
+      },
+    });
+  });
+
+  it.each(["stop", "length", "toolUse", "error", "aborted"])(
+    "preserves valid saved usage and %s stop reason",
+    (stopReason) => {
+      const usage = {
+        ...buildEmptyUsage(),
+        input: 12,
+        output: 5,
+        totalTokens: 17,
+        cost: { ...buildEmptyUsage().cost, total: 0.2 },
+      };
+      expect(
+        normalizeStoredMessage({ role: "assistant", content: [], usage, stopReason }),
+      ).toMatchObject({ usage, stopReason });
+    },
+  );
+
   it("isolates cached history by tab and normalized URL", async () => {
     const storage = createMemoryStorage();
     const store = createChatHistoryStore({


### PR DESCRIPTION
The extension could bundle while its TypeScript contracts were broken because it inherited the CLI's Node module settings. It now uses browser/bundler resolution and WXT declarations, and its strict typecheck runs in both the root gate and CI. The corrected configuration exposed 113 errors; those are resolved across settings, messages, session generics, DOM properties, SDK types, and async callbacks.

The compiler also exposed a lost setting: saving Options omitted `daemonHintDismissed`, making a dismissed companion hint reappear. Saves now preserve it. Stored assistant history also receives valid numeric usage defaults and stop reasons, while retaining unknown metadata.

Builds and `pnpm check` pass: 3,165 tests (43 skipped), with 94.32% line and 85.32% branch coverage. The supported Chromium suite passes 3 native-transport tests and 114 HTTP-build tests (7 expected skips). Independent review found no actionable P0–P2 issues. Regressions cover saved settings, malformed history, and caption-inspection uncertainty; cache restoration retains its nonblocking slide startup.

### Saving another option after dismissing the hint

Before, the preference was discarded and the hint returned:

![Before: dismissed hint returns](https://github.com/user-attachments/assets/453bf1aa-1653-46c2-b0fb-68ca762ae9f1)

After, the preference survives and the hint remains hidden:

![After: dismissed hint stays hidden](https://github.com/user-attachments/assets/4ac001dd-498a-400c-a382-4fadecb9381b)

Both captures use an isolated browser profile with synthetic settings and an empty token.
Hosted [CI](https://github.com/steipete/summarize/actions/runs/33982546465) passes on this PR's head: Node 24, the new extension typecheck step, Chromium E2E, Firefox smoke, and security checks.
