### PR TITLE
refactor(core): consolidate podcast resolution and media lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Dependencies and maintenance
 
+- Share podcast feed transcript resolution, media download/progress completion, and Apple URL parsing; collapse Spotify's duplicated episode-search fallback while preserving provider order and failure metadata.
 - Type-check the entire extension in the local gate and CI using browser/bundler settings; remove stale copies of session, settings, API, and callback contracts.
 - Share model discovery, selection preservation, and refresh throttling between Options and the side panel while retaining their distinct presets and provider hints.
 - Build HTML and transcript LLM Markdown converters from one model configuration and generation path; preserve their separate prompts, input limits, and usage callbacks.

--- a/docs/transcript-provider-flow.md
+++ b/docs/transcript-provider-flow.md
@@ -35,6 +35,8 @@ Goal: keep provider entrypoints thin; keep provider policy explicit.
 
 ## Shared policy
 
+- `podcast/feed-flow.ts` owns RSS transcript lookup, timestamp selection, and result shaping for direct feeds, Apple, and Spotify. Each source retains feed fetching, fallback decisions, and failure metadata; Apple's iTunes path still records the feed attempt before fetching.
+- `podcast/media.ts` shares download progress, transcription options, and completion across in-memory and temporary-file sources. Size limits and duration probing remain source-specific; temporary files are removed after success or failure.
 - `content/link-preview/content/page-media.ts`
   HTML and Firecrawl share media detection, transcript resolution, source-metric refresh, and embedded article/transcript composition. Each page builder retains its metadata and Markdown policy; metric deadlines still start at builder entry.
 - `transcription-capability.ts`

--- a/packages/core/src/content/link-preview/content/podcast-utils.ts
+++ b/packages/core/src/content/link-preview/content/podcast-utils.ts
@@ -35,23 +35,6 @@ export function extractSpotifyEpisodeId(url: string): string | null {
   }
 }
 
-export function extractApplePodcastIds(
-  url: string,
-): { showId: string; episodeId: string | null } | null {
-  try {
-    const parsed = new URL(url);
-    const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
-    if (host !== "podcasts.apple.com") return null;
-    const showId = parsed.pathname.match(/\/id(\d+)(?:\/|$)/)?.[1] ?? null;
-    if (!showId) return null;
-    const episodeIdRaw = parsed.searchParams.get("i");
-    const episodeId = episodeIdRaw && /^\d+$/.test(episodeIdRaw) ? episodeIdRaw : null;
-    return { showId, episodeId };
-  } catch {
-    return null;
-  }
-}
-
 export function extractXiaoyuzhouEpisodeId(url: string): string | null {
   return url.match(/^https:\/\/www\.xiaoyuzhoufm\.com\/episode\/([a-f0-9]{24})$/)?.[1] ?? null;
 }

--- a/packages/core/src/content/link-preview/content/transcript-only-strategies.ts
+++ b/packages/core/src/content/link-preview/content/transcript-only-strategies.ts
@@ -1,14 +1,10 @@
 import { resolveTranscriptForLink } from "../../transcript/index.js";
 import { resolveTranscriptionAvailability } from "../../transcript/providers/transcription-start.js";
 import type { resolveTranscriptionConfig } from "../../transcript/transcription-config.js";
-import { isDirectMediaUrl, isLoomVideoUrl } from "../../url.js";
+import { extractApplePodcastIds, isDirectMediaUrl, isLoomVideoUrl } from "../../url.js";
 import type { LinkPreviewDeps } from "../deps.js";
 import type { CacheMode } from "../types.js";
-import {
-  extractApplePodcastIds,
-  extractSpotifyEpisodeId,
-  extractXiaoyuzhouEpisodeId,
-} from "./podcast-utils.js";
+import { extractSpotifyEpisodeId, extractXiaoyuzhouEpisodeId } from "./podcast-utils.js";
 import { isTwitterBroadcastUrl } from "./twitter-utils.js";
 import type { ExtractedLinkContent, MediaTranscriptMode, YoutubeTranscriptMode } from "./types.js";
 import {

--- a/packages/core/src/content/transcript/providers/podcast.ts
+++ b/packages/core/src/content/transcript/providers/podcast.ts
@@ -108,29 +108,19 @@ export const fetchTranscript = async (
     transcribe,
   };
 
-  const directResult = await tryPodcastTranscriptFromFeed(flow);
-  if (directResult) return directResult;
-
-  const xiaoyuzhouResult = await fetchXiaoyuzhouTranscript(flow);
-  if (xiaoyuzhouResult) return xiaoyuzhouResult;
-
-  const spotifyResult = await fetchSpotifyTranscript(flow);
-  if (spotifyResult) return spotifyResult;
-
-  const appleLookupResult = await fetchAppleTranscriptFromItunesLookup(flow);
-  if (appleLookupResult) return appleLookupResult;
-
-  const appleEmbeddedResult = await fetchAppleTranscriptFromEmbeddedHtml(flow);
-  if (appleEmbeddedResult) return appleEmbeddedResult;
-
-  const enclosureResult = await tryFeedEnclosureTranscript(flow);
-  if (enclosureResult) return enclosureResult;
-
-  const ogAudioResult = await tryOgAudioTranscript(flow);
-  if (ogAudioResult) return ogAudioResult;
-
-  const ytDlpResult = await tryPodcastYtDlpTranscript(flow);
-  if (ytDlpResult) return ytDlpResult;
+  for (const fetchFromSource of [
+    tryPodcastTranscriptFromFeed,
+    fetchXiaoyuzhouTranscript,
+    fetchSpotifyTranscript,
+    fetchAppleTranscriptFromItunesLookup,
+    fetchAppleTranscriptFromEmbeddedHtml,
+    tryFeedEnclosureTranscript,
+    tryOgAudioTranscript,
+    tryPodcastYtDlpTranscript,
+  ]) {
+    const result = await fetchFromSource(flow);
+    if (result) return result;
+  }
 
   return buildNoTranscriptResult(flow);
 };

--- a/packages/core/src/content/transcript/providers/podcast/apple-flow.ts
+++ b/packages/core/src/content/transcript/providers/podcast/apple-flow.ts
@@ -1,19 +1,13 @@
+import { extractApplePodcastIds } from "../../../url.js";
 import type { ProviderResult } from "../../types.js";
-import {
-  extractAppleEpisodeTitleFromHtml,
-  extractApplePodcastIds,
-  extractEmbeddedJsonUrl,
-} from "./apple.js";
+import { extractAppleEpisodeTitleFromHtml, extractEmbeddedJsonUrl } from "./apple.js";
 import { TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
+import { fetchFeedTranscript } from "./feed-flow.js";
 import type { PodcastFlowContext } from "./flow-context.js";
 import { resolveApplePodcastEpisodeFromItunesLookup } from "./itunes.js";
-import { buildWhisperResult, joinNotes } from "./results.js";
-import {
-  decodeXmlEntities,
-  extractEnclosureForEpisode,
-  extractEnclosureFromFeed,
-  tryFetchTranscriptFromFeedXml,
-} from "./rss.js";
+import type { TranscribeRequest } from "./media.js";
+import { buildWhisperResult } from "./results.js";
+import { decodeXmlEntities, extractEnclosureForEpisode, extractEnclosureFromFeed } from "./rss.js";
 
 export async function fetchAppleTranscriptFromItunesLookup(
   flow: PodcastFlowContext,
@@ -39,36 +33,20 @@ export async function fetchAppleTranscriptFromItunesLookup(
         signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
       });
       if (feedResponse.ok) {
-        const feedXml = await feedResponse.text();
-        let maybeTranscript: Awaited<ReturnType<typeof tryFetchTranscriptFromFeedXml>> = null;
-        if (/podcast:transcript/i.test(feedXml)) {
-          maybeTranscript = await tryFetchTranscriptFromFeedXml({
-            fetchImpl: flow.options.fetch,
-            feedXml,
+        const transcript = await fetchFeedTranscript(
+          flow,
+          await feedResponse.text(),
+          episode.episodeTitle,
+          {
+            kind: "apple_itunes_rss_transcript",
+            showId: appleIds.showId,
+            episodeId: appleIds.episodeId,
+            feedUrl: episode.feedUrl,
             episodeTitle: episode.episodeTitle,
-            notes: flow.notes,
-          });
-        }
-        if (maybeTranscript) {
-          flow.notes.push("Resolved Apple Podcasts episode via RSS <podcast:transcript>");
-          return {
-            text: maybeTranscript.text,
-            source: "podcastTranscript",
-            segments: flow.options.transcriptTimestamps ? (maybeTranscript.segments ?? null) : null,
-            attemptedProviders: flow.attemptedProviders,
-            notes: joinNotes(flow.notes),
-            metadata: {
-              provider: "podcast",
-              kind: "apple_itunes_rss_transcript",
-              showId: appleIds.showId,
-              episodeId: appleIds.episodeId,
-              feedUrl: episode.feedUrl,
-              episodeTitle: episode.episodeTitle,
-              transcriptUrl: maybeTranscript.transcriptUrl,
-              transcriptType: maybeTranscript.transcriptType,
-            },
-          };
-        }
+          },
+          "Resolved Apple Podcasts episode via RSS <podcast:transcript>",
+        );
+        if (transcript) return transcript;
       }
     }
 
@@ -128,33 +106,12 @@ export async function fetchAppleTranscriptFromEmbeddedHtml(
       }
       const xml = await feedResponse.text();
 
-      let maybeTranscript: Awaited<ReturnType<typeof tryFetchTranscriptFromFeedXml>> = null;
-      if (/podcast:transcript/i.test(xml)) {
-        flow.pushOnce("podcastTranscript");
-        maybeTranscript = await tryFetchTranscriptFromFeedXml({
-          fetchImpl: flow.options.fetch,
-          feedXml: xml,
-          episodeTitle: appleEpisodeTitle,
-          notes: flow.notes,
-        });
-      }
-      if (maybeTranscript) {
-        return {
-          text: maybeTranscript.text,
-          source: "podcastTranscript",
-          segments: flow.options.transcriptTimestamps ? (maybeTranscript.segments ?? null) : null,
-          attemptedProviders: flow.attemptedProviders,
-          notes: joinNotes(flow.notes),
-          metadata: {
-            provider: "podcast",
-            kind: "apple_feed_transcript",
-            feedUrl: appleFeedUrl,
-            episodeTitle: appleEpisodeTitle,
-            transcriptUrl: maybeTranscript.transcriptUrl,
-            transcriptType: maybeTranscript.transcriptType,
-          },
-        };
-      }
+      const transcript = await fetchFeedTranscript(flow, xml, appleEpisodeTitle, {
+        kind: "apple_feed_transcript",
+        feedUrl: appleFeedUrl,
+        episodeTitle: appleEpisodeTitle,
+      });
+      if (transcript) return transcript;
 
       const enclosure =
         appleEpisodeTitle != null
@@ -163,37 +120,14 @@ export async function fetchAppleTranscriptFromEmbeddedHtml(
       if (enclosure) {
         const resolvedUrl = decodeXmlEntities(enclosure.enclosureUrl);
         const durationSeconds = enclosure.durationSeconds;
-        const missing = flow.ensureTranscriptionProvider();
-        if (missing) return missing;
-        flow.pushOnce("whisper");
-        let result: Awaited<ReturnType<typeof flow.transcribe>>;
-        try {
-          result = await flow.transcribe({
+        return await transcribeAppleMedia(
+          flow,
+          {
             url: resolvedUrl,
             filenameHint: "episode.mp3",
             durationSecondsHint: durationSeconds,
-          });
-        } catch (error) {
-          return {
-            text: null,
-            source: null,
-            attemptedProviders: flow.attemptedProviders,
-            notes: error instanceof Error ? error.message : String(error),
-            metadata: {
-              provider: "podcast",
-              kind: "apple_feed_url",
-              feedUrl: appleFeedUrl,
-              episodeTitle: appleEpisodeTitle,
-              enclosureUrl: resolvedUrl,
-              durationSeconds,
-            },
-          };
-        }
-        return buildWhisperResult({
-          attemptedProviders: flow.attemptedProviders,
-          notes: flow.notes,
-          outcome: result,
-          metadata: {
+          },
+          {
             provider: "podcast",
             kind: "apple_feed_url",
             feedUrl: appleFeedUrl,
@@ -201,7 +135,7 @@ export async function fetchAppleTranscriptFromEmbeddedHtml(
             enclosureUrl: resolvedUrl,
             durationSeconds,
           },
-        });
+        );
       }
     } catch (error) {
       // Apple pages usually contain both `feedUrl` and `streamUrl`. If the feed is flaky/blocked,
@@ -213,33 +147,43 @@ export async function fetchAppleTranscriptFromEmbeddedHtml(
   }
 
   const appleStreamUrl = extractEmbeddedJsonUrl(flow.context.html, "streamUrl");
-  if (appleStreamUrl) {
-    const missing = flow.ensureTranscriptionProvider();
-    if (missing) return missing;
-    flow.pushOnce("whisper");
-    let result: Awaited<ReturnType<typeof flow.transcribe>>;
-    try {
-      result = await flow.transcribe({
-        url: appleStreamUrl,
-        filenameHint: "episode.mp3",
-        durationSecondsHint: null,
-      });
-    } catch (error) {
-      return {
-        text: null,
-        source: null,
-        attemptedProviders: flow.attemptedProviders,
-        notes: error instanceof Error ? error.message : String(error),
-        metadata: { provider: "podcast", kind: "apple_stream_url", streamUrl: appleStreamUrl },
-      };
-    }
-    return buildWhisperResult({
-      attemptedProviders: flow.attemptedProviders,
-      notes: flow.notes,
-      outcome: result,
-      metadata: { provider: "podcast", kind: "apple_stream_url", streamUrl: appleStreamUrl },
-    });
-  }
+  return appleStreamUrl
+    ? transcribeAppleMedia(
+        flow,
+        {
+          url: appleStreamUrl,
+          filenameHint: "episode.mp3",
+          durationSecondsHint: null,
+        },
+        { provider: "podcast", kind: "apple_stream_url", streamUrl: appleStreamUrl },
+      )
+    : null;
+}
 
-  return null;
+async function transcribeAppleMedia(
+  flow: PodcastFlowContext,
+  request: TranscribeRequest,
+  metadata: Record<string, unknown>,
+): Promise<ProviderResult> {
+  const missing = flow.ensureTranscriptionProvider();
+  if (missing) return missing;
+  flow.pushOnce("whisper");
+  let outcome: Awaited<ReturnType<typeof flow.transcribe>>;
+  try {
+    outcome = await flow.transcribe(request);
+  } catch (error) {
+    return {
+      text: null,
+      source: null,
+      attemptedProviders: flow.attemptedProviders,
+      notes: error instanceof Error ? error.message : String(error),
+      metadata,
+    };
+  }
+  return buildWhisperResult({
+    attemptedProviders: flow.attemptedProviders,
+    notes: flow.notes,
+    outcome,
+    metadata,
+  });
 }

--- a/packages/core/src/content/transcript/providers/podcast/apple.ts
+++ b/packages/core/src/content/transcript/providers/podcast/apple.ts
@@ -19,20 +19,3 @@ export function extractEmbeddedJsonUrl(html: string, field: string): string | nu
     return null;
   }
 }
-
-export function extractApplePodcastIds(
-  url: string,
-): { showId: string; episodeId: string | null } | null {
-  try {
-    const parsed = new URL(url);
-    const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
-    if (host !== "podcasts.apple.com") return null;
-    const showId = parsed.pathname.match(/\/id(\d+)(?:\/|$)/)?.[1] ?? null;
-    if (!showId) return null;
-    const episodeIdRaw = parsed.searchParams.get("i");
-    const episodeId = episodeIdRaw && /^\d+$/.test(episodeIdRaw) ? episodeIdRaw : null;
-    return { showId, episodeId };
-  } catch {
-    return null;
-  }
-}

--- a/packages/core/src/content/transcript/providers/podcast/feed-flow.ts
+++ b/packages/core/src/content/transcript/providers/podcast/feed-flow.ts
@@ -1,0 +1,36 @@
+import type { ProviderResult } from "../../types.js";
+import type { PodcastFlowContext } from "./flow-context.js";
+import { joinNotes } from "./results.js";
+import { tryFetchTranscriptFromFeedXml } from "./rss-transcript.js";
+
+export async function fetchFeedTranscript(
+  flow: PodcastFlowContext,
+  feedXml: string,
+  episodeTitle: string | null,
+  metadata: Record<string, unknown>,
+  successNote?: string,
+): Promise<ProviderResult | null> {
+  if (!/podcast:transcript/i.test(feedXml)) return null;
+  flow.pushOnce("podcastTranscript");
+  const transcript = await tryFetchTranscriptFromFeedXml({
+    fetchImpl: flow.options.fetch,
+    feedXml,
+    episodeTitle,
+    notes: flow.notes,
+  });
+  if (!transcript) return null;
+  if (successNote) flow.notes.push(successNote);
+  return {
+    text: transcript.text,
+    source: "podcastTranscript",
+    segments: flow.options.transcriptTimestamps ? (transcript.segments ?? null) : null,
+    attemptedProviders: flow.attemptedProviders,
+    notes: joinNotes(flow.notes),
+    metadata: {
+      provider: "podcast",
+      ...metadata,
+      transcriptUrl: transcript.transcriptUrl,
+      transcriptType: transcript.transcriptType,
+    },
+  };
+}

--- a/packages/core/src/content/transcript/providers/podcast/media.ts
+++ b/packages/core/src/content/transcript/providers/podcast/media.ts
@@ -131,86 +131,34 @@ export async function transcribeMediaUrl({
   const shouldTranscribeInMemory =
     !shouldUseDeepgramFileUpload &&
     (!canChunk || (head.contentLength !== null && head.contentLength <= MAX_OPENAI_UPLOAD_BYTES));
-  if (shouldTranscribeInMemory) {
-    const bytes = await downloadCappedMediaBytes(fetchImpl, url, remoteMediaMaxBytes, totalBytes, {
-      onProgress: (downloadedBytes) =>
-        progress?.onProgress?.({
-          kind: "transcript-media-download-progress",
-          url: progress.url,
-          service: progress.service,
-          downloadedBytes,
-          totalBytes,
-          mediaKind: "audio",
-        }),
-    });
+  const onDownloadProgress = (downloadedBytes: number) =>
     progress?.onProgress?.({
-      kind: "transcript-media-download-done",
+      kind: "transcript-media-download-progress",
       url: progress.url,
       service: progress.service,
-      downloadedBytes: bytes.byteLength,
+      downloadedBytes,
       totalBytes,
       mediaKind: "audio",
     });
-    progress?.onProgress?.({
-      kind: "transcript-whisper-start",
-      url: progress.url,
-      service: progress.service,
-      providerHint,
-      modelId,
-      totalDurationSeconds: durationSecondsHint,
-      parts: null,
-    });
-    if (!canChunk) {
-      notes.push(`Transcribed first ${formatBytes(bytes.byteLength)} only (ffmpeg not available)`);
-    }
-    const transcript = await transcribeMediaWithWhisper({
-      bytes,
-      mediaType,
-      filename,
-      groqApiKey: effectiveTranscription.groqApiKey,
-      assemblyaiApiKey: effectiveTranscription.assemblyaiApiKey,
-      geminiApiKey: effectiveTranscription.geminiApiKey,
-      openaiApiKey: effectiveTranscription.openaiApiKey,
-      falApiKey: effectiveTranscription.falApiKey,
-      deepgramApiKey: effectiveTranscription.deepgramApiKey,
-      totalDurationSeconds: durationSecondsHint,
-      env: effectiveEnv,
-      onProgress: (event) => {
-        progress?.onProgress?.({
-          kind: "transcript-whisper-progress",
-          url: progress.url,
-          service: progress.service,
-          processedDurationSeconds: event.processedDurationSeconds,
-          totalDurationSeconds: event.totalDurationSeconds,
-          partIndex: event.partIndex,
-          parts: event.parts,
-        });
-      },
-    });
-    if (transcript.notes.length > 0) notes.push(...transcript.notes);
-    return {
-      text: transcript.text,
-      provider: transcript.provider,
-      error: transcript.error,
-      segments: transcript.segments ?? null,
-    };
-  }
-
-  const tmpFile = join(tmpdir(), `summarize-podcast-${randomUUID()}.bin`);
+  const tmpFile = shouldTranscribeInMemory
+    ? null
+    : join(tmpdir(), `summarize-podcast-${randomUUID()}.bin`);
   try {
-    const downloadedBytes = await downloadToFile(fetchImpl, url, tmpFile, {
-      maxBytes: remoteMediaMaxBytes,
-      totalBytes,
-      onProgress: (nextDownloadedBytes) =>
-        progress?.onProgress?.({
-          kind: "transcript-media-download-progress",
-          url: progress.url,
-          service: progress.service,
-          downloadedBytes: nextDownloadedBytes,
-          totalBytes,
-          mediaKind: "audio",
-        }),
-    });
+    const source: { bytes: Uint8Array } | { filePath: string } = tmpFile
+      ? { filePath: tmpFile }
+      : {
+          bytes: await downloadCappedMediaBytes(fetchImpl, url, remoteMediaMaxBytes, totalBytes, {
+            onProgress: onDownloadProgress,
+          }),
+        };
+    const downloadedBytes =
+      "bytes" in source
+        ? source.bytes.byteLength
+        : await downloadToFile(fetchImpl, url, source.filePath, {
+            maxBytes: remoteMediaMaxBytes,
+            totalBytes,
+            onProgress: onDownloadProgress,
+          });
     progress?.onProgress?.({
       kind: "transcript-media-download-done",
       url: progress.url,
@@ -219,20 +167,25 @@ export async function transcribeMediaUrl({
       totalBytes,
       mediaKind: "audio",
     });
-
-    const probedDurationSeconds =
-      durationSecondsHint ?? (await probeMediaDurationSecondsWithFfprobe(tmpFile));
+    const totalDurationSeconds =
+      "bytes" in source
+        ? durationSecondsHint
+        : (durationSecondsHint ?? (await probeMediaDurationSecondsWithFfprobe(source.filePath)));
     progress?.onProgress?.({
       kind: "transcript-whisper-start",
       url: progress.url,
       service: progress.service,
       providerHint,
       modelId,
-      totalDurationSeconds: probedDurationSeconds,
+      totalDurationSeconds,
       parts: null,
     });
-    const transcript = await transcribeMediaFileWithWhisper({
-      filePath: tmpFile,
+    if ("bytes" in source && !canChunk) {
+      notes.push(
+        `Transcribed first ${formatBytes(source.bytes.byteLength)} only (ffmpeg not available)`,
+      );
+    }
+    const transcriptionOptions = {
       mediaType,
       filename,
       groqApiKey: effectiveTranscription.groqApiKey,
@@ -241,7 +194,7 @@ export async function transcribeMediaUrl({
       openaiApiKey: effectiveTranscription.openaiApiKey,
       falApiKey: effectiveTranscription.falApiKey,
       deepgramApiKey: effectiveTranscription.deepgramApiKey,
-      totalDurationSeconds: probedDurationSeconds,
+      totalDurationSeconds,
       env: effectiveEnv,
       onProgress: (event) => {
         progress?.onProgress?.({
@@ -254,7 +207,14 @@ export async function transcribeMediaUrl({
           parts: event.parts,
         });
       },
-    });
+    } satisfies Omit<Parameters<typeof transcribeMediaWithWhisper>[0], "bytes">;
+    const transcript =
+      "bytes" in source
+        ? await transcribeMediaWithWhisper({ ...transcriptionOptions, bytes: source.bytes })
+        : await transcribeMediaFileWithWhisper({
+            ...transcriptionOptions,
+            filePath: source.filePath,
+          });
     if (transcript.notes.length > 0) notes.push(...transcript.notes);
     return {
       text: transcript.text,
@@ -263,7 +223,7 @@ export async function transcribeMediaUrl({
       segments: transcript.segments ?? null,
     };
   } finally {
-    await fs.unlink(tmpFile).catch(() => {});
+    if (tmpFile) await fs.unlink(tmpFile).catch(() => {});
   }
 }
 

--- a/packages/core/src/content/transcript/providers/podcast/provider-flow.ts
+++ b/packages/core/src/content/transcript/providers/podcast/provider-flow.ts
@@ -1,41 +1,16 @@
-import type { TranscriptionConfig } from "../../transcription-config.js";
 import type { ProviderResult } from "../../types.js";
 import { fetchTranscriptWithYtDlp } from "../youtube/yt-dlp.js";
+import { fetchFeedTranscript } from "./feed-flow.js";
 import type { PodcastFlowContext } from "./flow-context.js";
 import { buildWhisperResult, joinNotes } from "./results.js";
-import {
-  decodeXmlEntities,
-  extractEnclosureFromFeed,
-  tryFetchTranscriptFromFeedXml,
-} from "./rss.js";
+import { decodeXmlEntities, extractEnclosureFromFeed } from "./rss.js";
 
 export async function tryPodcastTranscriptFromFeed(
   flow: PodcastFlowContext,
 ): Promise<ProviderResult | null> {
-  if (!flow.feedHtml || !/podcast:transcript/i.test(flow.feedHtml)) return null;
-
-  flow.pushOnce("podcastTranscript");
-  const direct = await tryFetchTranscriptFromFeedXml({
-    fetchImpl: flow.options.fetch,
-    feedXml: flow.feedHtml,
-    episodeTitle: null,
-    notes: flow.notes,
-  });
-  if (!direct) return null;
-
-  return {
-    text: direct.text,
-    source: "podcastTranscript",
-    segments: flow.options.transcriptTimestamps ? (direct.segments ?? null) : null,
-    attemptedProviders: flow.attemptedProviders,
-    notes: joinNotes(flow.notes),
-    metadata: {
-      provider: "podcast",
-      kind: "rss_podcast_transcript",
-      transcriptUrl: direct.transcriptUrl,
-      transcriptType: direct.transcriptType,
-    },
-  };
+  return flow.feedHtml
+    ? fetchFeedTranscript(flow, flow.feedHtml, null, { kind: "rss_podcast_transcript" })
+    : null;
 }
 
 export async function tryFeedEnclosureTranscript(
@@ -99,25 +74,13 @@ export async function tryOgAudioTranscript(
   });
   if (result.text) {
     flow.notes.push("Used og:audio media (may be a preview clip, not the full episode)");
-    return buildWhisperResult({
-      attemptedProviders: flow.attemptedProviders,
-      notes: flow.notes,
-      outcome: result,
-      metadata: {
-        provider: "podcast",
-        kind: "og_audio",
-        ogAudioUrl,
-      },
-    });
   }
-
-  return {
-    text: null,
-    source: null,
+  return buildWhisperResult({
     attemptedProviders: flow.attemptedProviders,
-    notes: result.error?.message ?? null,
+    notes: flow.notes,
+    outcome: result,
     metadata: { provider: "podcast", kind: "og_audio", ogAudioUrl },
-  };
+  });
 }
 
 export async function tryPodcastYtDlpTranscript(

--- a/packages/core/src/content/transcript/providers/podcast/spotify-flow.ts
+++ b/packages/core/src/content/transcript/providers/podcast/spotify-flow.ts
@@ -1,16 +1,13 @@
 import type { ProviderResult } from "../../types.js";
 import { TRANSCRIPTION_TIMEOUT_MS } from "./constants.js";
+import { fetchFeedTranscript } from "./feed-flow.js";
 import type { PodcastFlowContext } from "./flow-context.js";
 import {
   resolvePodcastEpisodeFromItunesSearch,
   resolvePodcastFeedUrlFromItunesSearch,
 } from "./itunes.js";
-import { buildWhisperResult, joinNotes } from "./results.js";
-import {
-  decodeXmlEntities,
-  extractEnclosureForEpisode,
-  tryFetchTranscriptFromFeedXml,
-} from "./rss.js";
+import { buildWhisperResult } from "./results.js";
+import { decodeXmlEntities, extractEnclosureForEpisode } from "./rss.js";
 import {
   extractSpotifyEmbedData,
   extractSpotifyEpisodeId,
@@ -109,148 +106,95 @@ export async function fetchSpotifyTranscript(
     }
 
     const feedUrl = await resolvePodcastFeedUrlFromItunesSearch(flow.options.fetch, showTitle);
-    if (!feedUrl) {
-      const episodeFromSearch = await resolvePodcastEpisodeFromItunesSearch(
-        flow.options.fetch,
-        showTitle,
-        episodeTitle,
-      );
-      if (episodeFromSearch) {
-        const missing = flow.ensureTranscriptionProvider();
-        if (missing) return missing;
-        flow.pushOnce("whisper");
-        const result = await flow.transcribe({
-          url: episodeFromSearch.episodeUrl,
-          filenameHint: "episode.mp3",
-          durationSecondsHint: episodeFromSearch.durationSeconds,
-        });
-        if (result.text) {
-          flow.notes.push("Resolved Spotify episode via iTunes episode search");
-          return buildWhisperResult({
-            attemptedProviders: flow.attemptedProviders,
-            notes: flow.notes,
-            outcome: result,
-            metadata: {
-              provider: "podcast",
-              kind: "spotify_itunes_search_episode",
-              episodeId: spotifyEpisodeId,
-              showTitle,
-              episodeTitle: episodeFromSearch.episodeTitle,
-              episodeUrl: episodeFromSearch.episodeUrl,
-              durationSeconds: episodeFromSearch.durationSeconds,
-            },
-          });
-        }
-      }
-      throw new Error(
-        `Spotify episode audio appears DRM-protected; could not resolve RSS feed via iTunes Search API for show "${showTitle}"`,
-      );
-    }
-
-    const feedResponse = await flow.options.fetch(feedUrl, {
-      signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
-    });
-    if (!feedResponse.ok) {
-      throw new Error(`Podcast feed fetch failed (${feedResponse.status})`);
-    }
-    const feedXml = await feedResponse.text();
-    let maybeTranscript: Awaited<ReturnType<typeof tryFetchTranscriptFromFeedXml>> = null;
-    if (/podcast:transcript/i.test(feedXml)) {
-      flow.pushOnce("podcastTranscript");
-      maybeTranscript = await tryFetchTranscriptFromFeedXml({
-        fetchImpl: flow.options.fetch,
-        feedXml,
-        episodeTitle,
-        notes: flow.notes,
+    if (feedUrl) {
+      const feedResponse = await flow.options.fetch(feedUrl, {
+        signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
       });
-    }
-    if (maybeTranscript) {
-      return {
-        text: maybeTranscript.text,
-        source: "podcastTranscript",
-        segments: flow.options.transcriptTimestamps ? (maybeTranscript.segments ?? null) : null,
-        attemptedProviders: flow.attemptedProviders,
-        notes: joinNotes(flow.notes),
-        metadata: {
-          provider: "podcast",
-          kind: "spotify_itunes_rss_transcript",
-          episodeId: spotifyEpisodeId,
-          showTitle,
-          episodeTitle,
-          feedUrl,
-          transcriptUrl: maybeTranscript.transcriptUrl,
-          transcriptType: maybeTranscript.transcriptType,
-        },
-      };
-    }
-    const match = extractEnclosureForEpisode(feedXml, episodeTitle);
-    if (!match) {
-      const episodeFromSearch = await resolvePodcastEpisodeFromItunesSearch(
-        flow.options.fetch,
-        showTitle,
-        episodeTitle,
-      );
-      if (episodeFromSearch) {
-        const missing = flow.ensureTranscriptionProvider();
-        if (missing) return missing;
-        flow.pushOnce("whisper");
-        const result = await flow.transcribe({
-          url: episodeFromSearch.episodeUrl,
-          filenameHint: "episode.mp3",
-          durationSecondsHint: episodeFromSearch.durationSeconds,
-        });
-        if (result.text) {
-          flow.notes.push("Resolved Spotify episode via iTunes episode search");
-          return buildWhisperResult({
-            attemptedProviders: flow.attemptedProviders,
-            notes: flow.notes,
-            outcome: result,
-            metadata: {
-              provider: "podcast",
-              kind: "spotify_itunes_search_episode",
-              episodeId: spotifyEpisodeId,
-              showTitle,
-              episodeTitle: episodeFromSearch.episodeTitle,
-              episodeUrl: episodeFromSearch.episodeUrl,
-              durationSeconds: episodeFromSearch.durationSeconds,
-            },
-          });
-        }
+      if (!feedResponse.ok) {
+        throw new Error(`Podcast feed fetch failed (${feedResponse.status})`);
       }
-      throw new Error(`Episode enclosure not found in RSS feed for "${episodeTitle}"`);
-    }
-    const enclosureUrl = decodeXmlEntities(match.enclosureUrl);
-    const durationSeconds = match.durationSeconds;
-
-    flow.notes.push(
-      via === "firecrawl"
-        ? "Resolved Spotify episode via Firecrawl embed + iTunes RSS"
-        : "Resolved Spotify episode via iTunes RSS",
-    );
-    const missing = flow.ensureTranscriptionProvider();
-    if (missing) return missing;
-    flow.pushOnce("whisper");
-    const result = await flow.transcribe({
-      url: enclosureUrl,
-      filenameHint: "episode.mp3",
-      durationSecondsHint: durationSeconds,
-    });
-    return buildWhisperResult({
-      attemptedProviders: flow.attemptedProviders,
-      notes: flow.notes,
-      outcome: result,
-      includeProviderOnFailure: true,
-      metadata: {
-        provider: "podcast",
-        kind: "spotify_itunes_rss_enclosure",
+      const feedXml = await feedResponse.text();
+      const transcript = await fetchFeedTranscript(flow, feedXml, episodeTitle, {
+        kind: "spotify_itunes_rss_transcript",
         episodeId: spotifyEpisodeId,
         showTitle,
         episodeTitle,
         feedUrl,
-        enclosureUrl,
-        durationSeconds,
-      },
-    });
+      });
+      if (transcript) return transcript;
+      const match = extractEnclosureForEpisode(feedXml, episodeTitle);
+      if (match) {
+        const enclosureUrl = decodeXmlEntities(match.enclosureUrl);
+        const durationSeconds = match.durationSeconds;
+
+        flow.notes.push(
+          via === "firecrawl"
+            ? "Resolved Spotify episode via Firecrawl embed + iTunes RSS"
+            : "Resolved Spotify episode via iTunes RSS",
+        );
+        const missing = flow.ensureTranscriptionProvider();
+        if (missing) return missing;
+        flow.pushOnce("whisper");
+        const result = await flow.transcribe({
+          url: enclosureUrl,
+          filenameHint: "episode.mp3",
+          durationSecondsHint: durationSeconds,
+        });
+        return buildWhisperResult({
+          attemptedProviders: flow.attemptedProviders,
+          notes: flow.notes,
+          outcome: result,
+          includeProviderOnFailure: true,
+          metadata: {
+            provider: "podcast",
+            kind: "spotify_itunes_rss_enclosure",
+            episodeId: spotifyEpisodeId,
+            showTitle,
+            episodeTitle,
+            feedUrl,
+            enclosureUrl,
+            durationSeconds,
+          },
+        });
+      }
+    }
+    const episodeFromSearch = await resolvePodcastEpisodeFromItunesSearch(
+      flow.options.fetch,
+      showTitle,
+      episodeTitle,
+    );
+    if (episodeFromSearch) {
+      const missing = flow.ensureTranscriptionProvider();
+      if (missing) return missing;
+      flow.pushOnce("whisper");
+      const result = await flow.transcribe({
+        url: episodeFromSearch.episodeUrl,
+        filenameHint: "episode.mp3",
+        durationSecondsHint: episodeFromSearch.durationSeconds,
+      });
+      if (result.text) {
+        flow.notes.push("Resolved Spotify episode via iTunes episode search");
+        return buildWhisperResult({
+          attemptedProviders: flow.attemptedProviders,
+          notes: flow.notes,
+          outcome: result,
+          metadata: {
+            provider: "podcast",
+            kind: "spotify_itunes_search_episode",
+            episodeId: spotifyEpisodeId,
+            showTitle,
+            episodeTitle: episodeFromSearch.episodeTitle,
+            episodeUrl: episodeFromSearch.episodeUrl,
+            durationSeconds: episodeFromSearch.durationSeconds,
+          },
+        });
+      }
+    }
+    throw new Error(
+      feedUrl
+        ? `Episode enclosure not found in RSS feed for "${episodeTitle}"`
+        : `Spotify episode audio appears DRM-protected; could not resolve RSS feed via iTunes Search API for show "${showTitle}"`,
+    );
   } catch (error) {
     return {
       text: null,

--- a/packages/core/src/content/url.ts
+++ b/packages/core/src/content/url.ts
@@ -131,3 +131,20 @@ export {
   isDirectMediaUrl,
   isDirectVideoInput,
 };
+
+export function extractApplePodcastIds(
+  url: string,
+): { showId: string; episodeId: string | null } | null {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+    if (host !== "podcasts.apple.com") return null;
+    const showId = parsed.pathname.match(/\/id(\d+)(?:\/|$)/)?.[1] ?? null;
+    if (!showId) return null;
+    const episodeIdRaw = parsed.searchParams.get("i");
+    const episodeId = episodeIdRaw && /^\d+$/.test(episodeIdRaw) ? episodeIdRaw : null;
+    return { showId, episodeId };
+  } catch {
+    return null;
+  }
+}

--- a/tests/content.podcast-utils.test.ts
+++ b/tests/content.podcast-utils.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
-  extractApplePodcastIds,
   extractSpotifyEpisodeId,
   extractXiaoyuzhouEpisodeId,
   isPodcastHost,
   isPodcastLikeJsonLdType,
 } from "../packages/core/src/content/link-preview/content/podcast-utils.js";
+import { extractApplePodcastIds } from "../packages/core/src/content/url.js";
 
 describe("podcast utils", () => {
   it("extracts spotify episode ids only from valid spotify urls", () => {

--- a/tests/transcript.podcast-provider.apple-itunes-lookup.test.ts
+++ b/tests/transcript.podcast-provider.apple-itunes-lookup.test.ts
@@ -37,76 +37,86 @@ const baseOptions = {
 };
 
 describe("podcast provider - Apple Podcasts iTunes lookup", () => {
-  it("resolves episodeUrl via iTunes lookup when HTML is missing", async () => {
-    const { fetchTranscript } = await importPodcastProvider();
+  it.each([false, true])(
+    "resolves iTunes audio when HTML is missing (RSS attempted: %s)",
+    async (hasTitle) => {
+      const { fetchTranscript } = await importPodcastProvider();
 
-    const showId = "1794526548";
-    const episodeId = "1000741457032";
-    const pageUrl = `https://podcasts.apple.com/us/podcast/test/id${showId}?i=${episodeId}`;
-    const lookupUrl = `https://itunes.apple.com/lookup?id=${showId}&entity=podcastEpisode&limit=200`;
-    const episodeUrl = "https://cdn.example/episode.mp3?source=feed";
+      const showId = "1794526548";
+      const episodeId = "1000741457032";
+      const pageUrl = `https://podcasts.apple.com/us/podcast/test/id${showId}?i=${episodeId}`;
+      const lookupUrl = `https://itunes.apple.com/lookup?id=${showId}&entity=podcastEpisode&limit=200`;
+      const episodeUrl = "https://cdn.example/episode.mp3?source=feed";
 
-    const lookupPayload = {
-      resultCount: 2,
-      results: [
-        { wrapperType: "track", kind: "podcast", feedUrl: "https://example.com/feed.xml" },
-        {
-          wrapperType: "podcastEpisode",
-          trackId: Number(episodeId),
-          episodeUrl,
-          episodeFileExtension: "mp3",
-          trackTimeMillis: 96_000,
-          releaseDate: "2025-12-01T00:00:00Z",
-        },
-      ],
-    };
+      const lookupPayload = {
+        resultCount: 2,
+        results: [
+          { wrapperType: "track", kind: "podcast", feedUrl: "https://example.com/feed.xml" },
+          {
+            wrapperType: "podcastEpisode",
+            trackId: Number(episodeId),
+            trackName: hasTitle ? "Episode title" : undefined,
+            episodeUrl,
+            episodeFileExtension: "mp3",
+            trackTimeMillis: 96_000,
+            releaseDate: "2025-12-01T00:00:00Z",
+          },
+        ],
+      };
 
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-      const method = (init?.method ?? "GET").toUpperCase();
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        const method = (init?.method ?? "GET").toUpperCase();
 
-      if (url === lookupUrl && method === "GET") {
-        return new Response(JSON.stringify(lookupPayload), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
-      }
+        if (url === "https://example.com/feed.xml") {
+          return new Response("<rss><channel/></rss>");
+        }
+        if (url === lookupUrl && method === "GET") {
+          return new Response(JSON.stringify(lookupPayload), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
 
-      if (url === episodeUrl && method === "HEAD") {
-        return new Response(null, {
-          status: 200,
-          headers: { "content-type": "audio/mpeg", "content-length": String(1234) },
-        });
-      }
+        if (url === episodeUrl && method === "HEAD") {
+          return new Response(null, {
+            status: 200,
+            headers: { "content-type": "audio/mpeg", "content-length": String(1234) },
+          });
+        }
 
-      if (url === episodeUrl && method === "GET") {
-        return new Response(new Uint8Array([1, 2, 3]), {
-          status: 200,
-          headers: { "content-type": "audio/mpeg" },
-        });
-      }
+        if (url === episodeUrl && method === "GET") {
+          return new Response(new Uint8Array([1, 2, 3]), {
+            status: 200,
+            headers: { "content-type": "audio/mpeg" },
+          });
+        }
 
-      throw new Error(`Unexpected fetch: ${method} ${url}`);
-    });
+        throw new Error(`Unexpected fetch: ${method} ${url}`);
+      });
 
-    const result = await fetchTranscript(
-      { url: pageUrl, html: null, resourceKey: null },
-      { ...baseOptions, fetch: fetchImpl as unknown as typeof fetch },
-    );
+      const result = await fetchTranscript(
+        { url: pageUrl, html: null, resourceKey: null },
+        { ...baseOptions, fetch: fetchImpl as unknown as typeof fetch },
+      );
 
-    expect(result.source).toBe("whisper");
-    expect(result.text).toContain("hello from apple");
-    expect(result.metadata?.kind).toBe("apple_itunes_episode");
-    const meta = result.metadata as unknown as {
-      showId?: string;
-      episodeId?: string;
-      episodeUrl?: string;
-      durationSeconds?: number;
-    };
-    expect(meta.showId).toBe(showId);
-    expect(meta.episodeId).toBe(episodeId);
-    expect(meta.episodeUrl).toBe(episodeUrl);
-    expect(meta.durationSeconds).toBe(96);
-  });
+      expect(result.source).toBe("whisper");
+      expect(result.attemptedProviders).toEqual(
+        hasTitle ? ["podcastTranscript", "whisper"] : ["whisper"],
+      );
+      expect(result.text).toContain("hello from apple");
+      expect(result.metadata?.kind).toBe("apple_itunes_episode");
+      const meta = result.metadata as unknown as {
+        showId?: string;
+        episodeId?: string;
+        episodeUrl?: string;
+        durationSeconds?: number;
+      };
+      expect(meta.showId).toBe(showId);
+      expect(meta.episodeId).toBe(episodeId);
+      expect(meta.episodeUrl).toBe(episodeUrl);
+      expect(meta.durationSeconds).toBe(96);
+    },
+  );
 });

--- a/tests/transcript.podcast-provider.spotify-itunes-selection.test.ts
+++ b/tests/transcript.podcast-provider.spotify-itunes-selection.test.ts
@@ -163,90 +163,96 @@ describe("podcast transcript provider - Spotify iTunes feed resolution", () => {
     }
   });
 
-  it("falls back to iTunes episode search when feed lacks enclosure", async () => {
-    const showTitle = "Show Name";
-    const episodeTitle = "Episode Missing in Feed";
-    const feedUrl = "https://example.com/feed.xml";
-    const episodeUrl = "https://example.com/episode.mp3";
+  it.each([false, true])(
+    "falls back to iTunes episode search (feed available: %s)",
+    async (hasFeed) => {
+      const showTitle = "Show Name";
+      const episodeTitle = "Episode Missing in Feed";
+      const feedUrl = "https://example.com/feed.xml";
+      const episodeUrl = "https://example.com/episode.mp3";
 
-    const embedHtml = `<script id="__NEXT_DATA__" type="application/json">${JSON.stringify({
-      props: {
-        pageProps: { state: { data: { entity: { title: episodeTitle, subtitle: showTitle } } } },
-      },
-    })}</script>`;
+      const embedHtml = `<script id="__NEXT_DATA__" type="application/json">${JSON.stringify({
+        props: {
+          pageProps: { state: { data: { entity: { title: episodeTitle, subtitle: showTitle } } } },
+        },
+      })}</script>`;
 
-    const feedXml = `<rss><channel><item><title>Other episode</title></item></channel></rss>`;
+      const feedXml = `<rss><channel><item><title>Other episode</title></item></channel></rss>`;
 
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-      const method = (init?.method ?? "GET").toUpperCase();
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        const method = (init?.method ?? "GET").toUpperCase();
 
-      if (url === "https://open.spotify.com/embed/episode/abc") {
-        return new Response(embedHtml, { status: 200, headers: { "content-type": "text/html" } });
-      }
-      if (url.startsWith("https://itunes.apple.com/search")) {
-        if (url.includes("entity=podcastEpisode")) {
+        if (url === "https://open.spotify.com/embed/episode/abc") {
+          return new Response(embedHtml, { status: 200, headers: { "content-type": "text/html" } });
+        }
+        if (url.startsWith("https://itunes.apple.com/search")) {
+          if (url.includes("entity=podcastEpisode")) {
+            return new Response(
+              JSON.stringify({
+                resultCount: 1,
+                results: [
+                  {
+                    trackName: episodeTitle,
+                    collectionName: showTitle,
+                    episodeUrl,
+                    trackTimeMillis: 90000,
+                  },
+                ],
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          }
           return new Response(
-            JSON.stringify({
-              resultCount: 1,
-              results: [
-                {
-                  trackName: episodeTitle,
-                  collectionName: showTitle,
-                  episodeUrl,
-                  trackTimeMillis: 90000,
-                },
-              ],
-            }),
+            JSON.stringify({ results: hasFeed ? [{ collectionName: showTitle, feedUrl }] : [] }),
             { status: 200, headers: { "content-type": "application/json" } },
           );
         }
-        return new Response(
-          JSON.stringify({ resultCount: 1, results: [{ collectionName: showTitle, feedUrl }] }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        );
-      }
-      if (url === feedUrl) {
-        return new Response(feedXml, {
-          status: 200,
-          headers: { "content-type": "application/xml" },
-        });
-      }
-      if (url === episodeUrl) {
-        if (method === "HEAD") {
-          return new Response(null, {
+        if (url === feedUrl) {
+          return new Response(feedXml, {
+            status: 200,
+            headers: { "content-type": "application/xml" },
+          });
+        }
+        if (url === episodeUrl) {
+          if (method === "HEAD") {
+            return new Response(null, {
+              status: 200,
+              headers: { "content-type": "audio/mpeg", "content-length": "4" },
+            });
+          }
+          return new Response(new Uint8Array([0, 1, 2, 3]), {
             status: 200,
             headers: { "content-type": "audio/mpeg", "content-length": "4" },
           });
         }
-        return new Response(new Uint8Array([0, 1, 2, 3]), {
-          status: 200,
-          headers: { "content-type": "audio/mpeg", "content-length": "4" },
-        });
-      }
-      throw new Error(`Unexpected fetch: ${method} ${url}`);
-    });
-
-    const openaiFetch = vi.fn(async () => {
-      return new Response(JSON.stringify({ text: "ok" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
+        throw new Error(`Unexpected fetch: ${method} ${url}`);
       });
-    });
 
-    try {
-      vi.stubGlobal("fetch", openaiFetch);
-      const result = await fetchTranscript(
-        { url: "https://open.spotify.com/episode/abc", html: "<html/>", resourceKey: null },
-        { ...baseOptions, fetch: fetchImpl as unknown as typeof fetch },
-      );
+      const openaiFetch = vi.fn(async () => {
+        return new Response(JSON.stringify({ text: "ok" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      });
 
-      expect(result.source).toBe("whisper");
-      expect(result.metadata?.kind).toBe("spotify_itunes_search_episode");
-      expect(result.metadata?.episodeUrl).toBe(episodeUrl);
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
+      try {
+        vi.stubGlobal("fetch", openaiFetch);
+        const result = await fetchTranscript(
+          { url: "https://open.spotify.com/episode/abc", html: "<html/>", resourceKey: null },
+          { ...baseOptions, fetch: fetchImpl as unknown as typeof fetch },
+        );
+
+        expect(result.source).toBe("whisper");
+        expect(result.metadata?.kind).toBe("spotify_itunes_search_episode");
+        expect(result.metadata?.episodeUrl).toBe(episodeUrl);
+        expect(
+          fetchImpl.mock.calls.filter(([input]) => String(input).includes("entity=podcastEpisode")),
+        ).toHaveLength(1);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Podcast extraction repeated the same RSS transcript assembly in four source paths, duplicated Spotify's episode-search fallback, and maintained separate byte/file progress and transcription completion paths. This moves RSS transcript ownership into one feed-flow module, makes source order an explicit sequential chain, and shares the media lifecycle without merging provider-specific fallback or error policies.

Apple URL parsing now has one owner. Apple feed failures can still fall back to embedded stream audio, while failed audio transcription remains terminal. Spotify's feed lookup and enclosure misses share one episode-search fallback; unsuccessful feed downloads still stop at their original error boundary. Timestamp selection, notes, attempt order, metadata, size caps, duration probing, and temporary-file cleanup remain unchanged.

Net reduction: 184 production lines and 165 lines overall across 15 files. No breaking API or dependency changes.

## Validation

- 87 focused podcast, URL, link-preview, and architecture tests passed before the additional parameterized regression cases.
- Root build, formatting, lint, and all three TypeScript layers passed.
- Independent Codex review: scoped-clean at P0–P2.
- CI is green at the exact PR head: Node 24 unit/coverage and type checks, Chromium extension E2E, Firefox smoke, and GitGuardian.
- The first local full-coverage run was interrupted after overlapping-build import failures and slow host transcription probes; CI's clean build and full suite passed. The expanded focused run also passes all podcast cases.
