### PR TITLE
refactor: simplify asset and agent request preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Dependencies and maintenance
 
+- Share asset text validation and Markdown conversion across extraction and summaries; simplify prompt construction and prepare daemon agent requests once for streaming and completion without changing retry boundaries.
 - Share podcast feed transcript resolution, media download/progress completion, and Apple URL parsing; collapse Spotify's duplicated episode-search fallback while preserving provider order and failure metadata.
 - Type-check the entire extension in the local gate and CI using browser/bundler settings; remove stale copies of session, settings, API, and callback contracts.
 - Share model discovery, selection preservation, and refresh throttling between Options and the side panel while retaining their distinct presets and provider hints.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -15,7 +15,7 @@ Scope:
 - **Off (default):** chat is Q&A only (no tools).
 - **On:** chat runs a tool-capable agent for web automation.
 
-Explicit exclusions (per product direction): **no update checker**, **no tutorial/welcome flow**, **no proxy config**, **no API key dialog**. All model calls go through the **local daemon**.
+This document describes **Daemon mode**, where model calls go through the local daemon. In **Direct mode**, a configured provider can also support chat and automation without a daemon; see [the extension guide](chrome-extension.md).
 
 ## Architecture (High Level)
 
@@ -25,6 +25,8 @@ Explicit exclusions (per product direction): **no update checker**, **no tutoria
 4. **Daemon** provides `/v1/agent` (SSE stream of chunks + final assistant message).
 
 Chat-only Q&A and automation use this same endpoint and implementation. The automation flag selects the prompt and available tools; there is no separate chat execution pipeline.
+
+The daemon prepares message history, tools, prompts, model selection, and CLI execution once for both SSE and JSON responses. Native completion and streaming retain separate retry policies: streaming may retry the compatibility model only before emitting text.
 
 ### Data Flow (Agent Loop)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -103,6 +103,8 @@ Missing or disabled providers are omitted.
 
 ## Attachments (images/files)
 
+Asset extraction and summary preparation share text-size validation and Markdown conversion in `src/run/flows/asset/content.ts`. Summary preparation retains provider-specific native attachment selection and returns either an attachment prompt or inline text; extraction applies its character budget after conversion.
+
 When a CLI attempt is used for an image or non-text file, Summarize switches to a
 path-based prompt and enables the required tool flags:
 

--- a/src/daemon/agent.ts
+++ b/src/daemon/agent.ts
@@ -297,19 +297,7 @@ const TOOL_DEFINITIONS: Record<string, Tool> = {
   },
 };
 
-export async function streamAgentResponse({
-  env,
-  pageUrl,
-  pageTitle,
-  pageContent,
-  messages,
-  modelOverride,
-  tools,
-  automationEnabled,
-  onChunk,
-  onAssistant,
-  signal,
-}: {
+type AgentRequest = {
   env: Record<string, string | undefined>;
   pageUrl: string;
   pageTitle: string | null;
@@ -318,10 +306,20 @@ export async function streamAgentResponse({
   modelOverride: string | null;
   tools: string[];
   automationEnabled: boolean;
-  onChunk: (text: string) => void;
-  onAssistant: (assistant: AssistantMessage) => void;
   signal?: AbortSignal;
-}): Promise<void> {
+};
+
+async function prepareAgentRequest({
+  env,
+  pageUrl,
+  pageTitle,
+  pageContent,
+  messages,
+  modelOverride,
+  tools,
+  automationEnabled,
+  signal,
+}: AgentRequest) {
   const normalizedMessages = normalizeMessages(messages);
   const toolList = resolveToolList(automationEnabled, tools, TOOL_DEFINITIONS);
 
@@ -352,9 +350,7 @@ export async function streamAgentResponse({
         signal,
       }),
     );
-    onChunk(result.text);
-    onAssistant({ role: "assistant", content: result.text } as unknown as AssistantMessage);
-    return;
+    return { transport: "cli" as const, text: result.text };
   }
 
   const { provider, model, maxOutputTokens, apiKeys } = resolved;
@@ -367,6 +363,23 @@ export async function streamAgentResponse({
     apiKey,
     signal,
   };
+  return { transport: "native" as const, provider, model, context, options };
+}
+
+export async function streamAgentResponse(
+  request: AgentRequest & {
+    onChunk: (text: string) => void;
+    onAssistant: (assistant: AssistantMessage) => void;
+  },
+): Promise<void> {
+  const { onChunk, onAssistant } = request;
+  const prepared = await prepareAgentRequest(request);
+  if (prepared.transport === "cli") {
+    onChunk(prepared.text);
+    onAssistant({ role: "assistant", content: prepared.text } as unknown as AssistantMessage);
+    return;
+  }
+  const { provider, model, context, options } = prepared;
   let activeModel = model;
   let usedCompatFallback = false;
 
@@ -407,70 +420,12 @@ export async function streamAgentResponse({
   }
 }
 
-export async function completeAgentResponse({
-  env,
-  pageUrl,
-  pageTitle,
-  pageContent,
-  messages,
-  modelOverride,
-  tools,
-  automationEnabled,
-  signal,
-}: {
-  env: Record<string, string | undefined>;
-  pageUrl: string;
-  pageTitle: string | null;
-  pageContent: string;
-  messages: unknown;
-  modelOverride: string | null;
-  tools: string[];
-  automationEnabled: boolean;
-  signal?: AbortSignal;
-}): Promise<AssistantMessage> {
-  const normalizedMessages = normalizeMessages(messages);
-  const toolList = resolveToolList(automationEnabled, tools, TOOL_DEFINITIONS);
-
-  const systemPrompt = buildSystemPrompt({
-    pageUrl,
-    pageTitle,
-    pageContent,
-    automationEnabled,
-  });
-
-  const resolved = await resolveAgentModel({
-    env,
-    pageContent,
-    modelOverride,
-  });
-
-  if ("transport" in resolved && resolved.transport === "cli") {
-    const prompt = flattenAgentForCli({ systemPrompt, messages: normalizedMessages });
-    const result = await import("../llm/cli.js").then(({ runCliModel }) =>
-      runCliModel({
-        provider: resolved.cliProvider,
-        prompt,
-        model: resolved.cliModel,
-        allowTools: false,
-        timeoutMs: 120_000,
-        env,
-        config: resolved.cliConfig,
-        signal,
-      }),
-    );
-    return { role: "assistant", content: result.text } as unknown as AssistantMessage;
+export async function completeAgentResponse(request: AgentRequest): Promise<AssistantMessage> {
+  const prepared = await prepareAgentRequest(request);
+  if (prepared.transport === "cli") {
+    return { role: "assistant", content: prepared.text } as unknown as AssistantMessage;
   }
-
-  const { provider, model, maxOutputTokens, apiKeys } = resolved;
-  const apiKey = resolveApiKeyForModel({ provider, apiKeys });
-
-  const context = { systemPrompt, messages: normalizedMessages, tools: toolList };
-  const options = {
-    maxTokens: maxOutputTokens,
-    ...resolveProviderPayloadOptions(provider),
-    apiKey,
-    signal,
-  };
+  const { provider, model, context, options } = prepared;
   const assistant = await completeSimple(model, context, options);
   if (assistant.stopReason !== "error" && assistant.stopReason !== "aborted") return assistant;
 

--- a/src/run/flows/asset/content.ts
+++ b/src/run/flows/asset/content.ts
@@ -1,0 +1,58 @@
+import { convertToMarkdownWithMarkitdown } from "../../../markitdown.js";
+import { formatBytes } from "../../../tty/format.js";
+import { type AssetAttachment, getTextContentFromAttachment } from "../../attachments.js";
+import { MAX_TEXT_BYTES_DEFAULT } from "../../constants.js";
+import { hasUvxCli } from "../../env.js";
+import { withUvxTip } from "../../tips.js";
+
+export type AssetConversionContext = {
+  env: Record<string, string | undefined>;
+  envForRun: Record<string, string | undefined>;
+  execFileImpl: Parameters<typeof convertToMarkdownWithMarkitdown>[0]["execFileImpl"];
+  timeoutMs: number;
+};
+
+export function readAssetText(attachment: AssetAttachment) {
+  const text = getTextContentFromAttachment(attachment);
+  if (text) assertTextSize(text.bytes, "Text file");
+  return text;
+}
+
+export async function convertAssetToMarkdown(
+  ctx: AssetConversionContext,
+  attachment: AssetAttachment,
+  bytes: Uint8Array,
+) {
+  if (!hasUvxCli(ctx.env)) {
+    throw withUvxTip(
+      new Error(`Missing uvx/markitdown for preprocessing ${attachment.mediaType}.`),
+      ctx.env,
+    );
+  }
+  let converted: Awaited<ReturnType<typeof convertToMarkdownWithMarkitdown>>;
+  try {
+    converted = await convertToMarkdownWithMarkitdown({
+      bytes,
+      filenameHint: attachment.filename,
+      mediaTypeHint: attachment.mediaType,
+      uvxCommand: ctx.envForRun.UVX_PATH,
+      timeoutMs: ctx.timeoutMs,
+      env: ctx.env,
+      execFileImpl: ctx.execFileImpl,
+      ocrFallback: true,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to preprocess ${attachment.mediaType} with markitdown: ${message}.`);
+  }
+  assertTextSize(Buffer.byteLength(converted.markdown, "utf8"), "Preprocessed Markdown");
+  return converted;
+}
+
+function assertTextSize(bytes: number, label: string) {
+  if (bytes > MAX_TEXT_BYTES_DEFAULT) {
+    throw new Error(
+      `${label} too large (${formatBytes(bytes)}). Limit is ${formatBytes(MAX_TEXT_BYTES_DEFAULT)}.`,
+    );
+  }
+}

--- a/src/run/flows/asset/extract.ts
+++ b/src/run/flows/asset/extract.ts
@@ -1,23 +1,13 @@
 import { applyContentBudget } from "@steipete/summarize-core/content";
-import type { ExecFileFn } from "../../../markitdown.js";
-import { convertToMarkdownWithMarkitdown } from "../../../markitdown.js";
-import { formatBytes } from "../../../tty/format.js";
 import {
   type AssetAttachment,
   getFileBytesFromAttachment,
-  getTextContentFromAttachment,
   shouldMarkitdownConvertMediaType,
 } from "../../attachments.js";
-import { MAX_TEXT_BYTES_DEFAULT } from "../../constants.js";
-import { hasUvxCli } from "../../env.js";
 import type { ExtractDiagnosticsForFinishLine } from "../../finish-line.js";
-import { withUvxTip } from "../../tips.js";
+import { type AssetConversionContext, convertAssetToMarkdown, readAssetText } from "./content.js";
 
-export type AssetExtractContext = {
-  env: Record<string, string | undefined>;
-  envForRun: Record<string, string | undefined>;
-  execFileImpl: ExecFileFn;
-  timeoutMs: number;
+export type AssetExtractContext = AssetConversionContext & {
   preprocessMode: "off" | "auto" | "always";
 };
 
@@ -42,13 +32,8 @@ export async function extractAssetContent({
   attachment: AssetAttachment;
   maxCharacters?: number | null;
 }): Promise<AssetExtractResult> {
-  const textContent = getTextContentFromAttachment(attachment);
+  const textContent = readAssetText(attachment);
   if (textContent) {
-    if (textContent.bytes > MAX_TEXT_BYTES_DEFAULT) {
-      throw new Error(
-        `Text file too large (${formatBytes(textContent.bytes)}). Limit is ${formatBytes(MAX_TEXT_BYTES_DEFAULT)}.`,
-      );
-    }
     return {
       content:
         typeof maxCharacters === "number"
@@ -80,36 +65,7 @@ export async function extractAssetContent({
         `This build can only extract text-like files. Convert this file to text first.`,
     );
   }
-  if (!hasUvxCli(ctx.env)) {
-    throw withUvxTip(
-      new Error(`Missing uvx/markitdown for preprocessing ${attachment.mediaType}.`),
-      ctx.env,
-    );
-  }
-
-  let markdown: string;
-  let usedOcr = false;
-  try {
-    ({ markdown, usedOcr } = await convertToMarkdownWithMarkitdown({
-      bytes: fileBytes,
-      filenameHint: attachment.filename,
-      mediaTypeHint: attachment.mediaType,
-      uvxCommand: ctx.envForRun.UVX_PATH,
-      timeoutMs: ctx.timeoutMs,
-      env: ctx.env,
-      execFileImpl: ctx.execFileImpl,
-      ocrFallback: true,
-    }));
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to preprocess ${attachment.mediaType} with markitdown: ${message}.`);
-  }
-
-  if (Buffer.byteLength(markdown, "utf8") > MAX_TEXT_BYTES_DEFAULT) {
-    throw new Error(
-      `Preprocessed Markdown too large (${formatBytes(Buffer.byteLength(markdown, "utf8"))}). Limit is ${formatBytes(MAX_TEXT_BYTES_DEFAULT)}.`,
-    );
-  }
+  const { markdown, usedOcr } = await convertAssetToMarkdown(ctx, attachment, fileBytes);
 
   return {
     content:

--- a/src/run/flows/asset/preprocess.ts
+++ b/src/run/flows/asset/preprocess.ts
@@ -2,27 +2,19 @@ import type { SummaryLength } from "@steipete/summarize-core";
 import type { OutputLanguage } from "../../../language.js";
 import type { Attachment } from "../../../llm/attachments.js";
 import { resolveOpenAiClientConfig } from "../../../llm/providers/openai.js";
-import { convertToMarkdownWithMarkitdown } from "../../../markitdown.js";
 import type { FixedModelSpec } from "../../../model-spec.js";
 import { buildFileSummaryPrompt, buildFileTextSummaryPrompt } from "../../../prompts/index.js";
 import { formatBytes } from "../../../tty/format.js";
 import {
   type AssetAttachment,
   getFileBytesFromAttachment,
-  getTextContentFromAttachment,
   MAX_DOCUMENT_BYTES_DEFAULT,
   shouldMarkitdownConvertMediaType,
   supportsNativeFileAttachment,
 } from "../../attachments.js";
-import { MAX_TEXT_BYTES_DEFAULT } from "../../constants.js";
-import { hasUvxCli } from "../../env.js";
-import { withUvxTip } from "../../tips.js";
+import { type AssetConversionContext, convertAssetToMarkdown, readAssetText } from "./content.js";
 
-export type AssetPreprocessContext = {
-  env: Record<string, string | undefined>;
-  envForRun: Record<string, string | undefined>;
-  execFileImpl: Parameters<typeof convertToMarkdownWithMarkitdown>[0]["execFileImpl"];
-  timeoutMs: number;
+export type AssetPreprocessContext = AssetConversionContext & {
   preprocessMode: "off" | "auto" | "always";
   format: "text" | "markdown";
   lengthArg: { kind: "preset"; preset: SummaryLength } | { kind: "chars"; maxCharacters: number };
@@ -145,185 +137,82 @@ export async function prepareAssetPrompt({
   ctx: AssetPreprocessContext;
   attachment: AssetAttachment;
 }): Promise<AssetPreprocessResult> {
-  const textContent = getTextContentFromAttachment(attachment);
-  if (textContent && textContent.bytes > MAX_TEXT_BYTES_DEFAULT) {
-    throw new Error(
-      `Text file too large (${formatBytes(textContent.bytes)}). Limit is ${formatBytes(MAX_TEXT_BYTES_DEFAULT)}.`,
-    );
-  }
-
+  const textContent = readAssetText(attachment);
   const fileBytes = getFileBytesFromAttachment(attachment);
+  const promptOptions = {
+    filename: attachment.filename,
+    summaryLength:
+      ctx.lengthArg.kind === "preset"
+        ? ctx.lengthArg.preset
+        : { maxCharacters: ctx.lengthArg.maxCharacters },
+    outputLanguage: ctx.outputLanguage,
+    promptOverride: ctx.promptOverride ?? null,
+    lengthInstruction: ctx.lengthInstruction ?? null,
+    languageInstruction: ctx.languageInstruction ?? null,
+  };
+  const documentHandling = resolveDocumentHandling({
+    attachment,
+    textContent,
+    fileBytes,
+    preprocessMode: ctx.preprocessMode,
+    fixedModelSpec: ctx.fixedModelSpec,
+    openaiApiKey: ctx.openaiApiKey ?? (ctx.envForRun.OPENAI_API_KEY?.trim() || null),
+    openrouterApiKey: ctx.openrouterApiKey ?? (ctx.envForRun.OPENROUTER_API_KEY?.trim() || null),
+    openaiBaseUrl: ctx.openaiBaseUrl ?? (ctx.envForRun.OPENAI_BASE_URL?.trim() || null),
+  });
+  if (documentHandling.mode === "error") throw documentHandling.error;
 
-  const summaryLengthTarget =
-    ctx.lengthArg.kind === "preset"
-      ? ctx.lengthArg.preset
-      : { maxCharacters: ctx.lengthArg.maxCharacters };
+  if (attachment.kind === "image" || documentHandling.mode === "attach") {
+    const bytes = attachment.kind === "image" ? attachment.bytes : fileBytes;
+    if (!bytes) throw new Error("Internal error: missing file bytes for document attachment");
+    return {
+      promptText: buildFileSummaryPrompt({
+        ...promptOptions,
+        mediaType: attachment.mediaType,
+        contentLength: textContent?.content.length ?? null,
+      }),
+      attachments: [
+        {
+          kind: attachment.kind === "image" ? "image" : "document",
+          mediaType: attachment.mediaType,
+          bytes,
+          filename: attachment.filename,
+        },
+      ],
+      assetFooterParts: [],
+      textContent,
+    };
+  }
 
-  let promptText = "";
-  let attachments: Attachment[] = [];
+  let inline = textContent
+    ? { content: textContent.content, mediaType: attachment.mediaType }
+    : null;
   const assetFooterParts: string[] = [];
-
-  const buildImageAttachment = () => {
-    if (attachment.kind !== "image") {
-      throw new Error("Internal error: tried to attach non-image as image");
-    }
-    promptText = buildFileSummaryPrompt({
-      filename: attachment.filename,
-      mediaType: attachment.mediaType,
-      summaryLength: summaryLengthTarget,
-      contentLength: textContent?.content.length ?? null,
-      outputLanguage: ctx.outputLanguage,
-      promptOverride: ctx.promptOverride ?? null,
-      lengthInstruction: ctx.lengthInstruction ?? null,
-      languageInstruction: ctx.languageInstruction ?? null,
-    });
-    attachments = [
-      {
-        kind: "image",
-        mediaType: attachment.mediaType,
-        bytes: attachment.bytes,
-        filename: attachment.filename,
-      },
-    ];
-  };
-
-  const buildInlinePromptText = ({
-    content,
-    contentMediaType,
-    originalMediaType,
-  }: {
-    content: string;
-    contentMediaType: string;
-    originalMediaType: string | null;
-  }) => {
-    promptText = buildFileTextSummaryPrompt({
-      filename: attachment.filename,
-      originalMediaType,
-      contentMediaType,
-      summaryLength: summaryLengthTarget,
-      contentLength: content.length,
-      outputLanguage: ctx.outputLanguage,
-      content,
-      promptOverride: ctx.promptOverride ?? null,
-      lengthInstruction: ctx.lengthInstruction ?? null,
-      languageInstruction: ctx.languageInstruction ?? null,
-    });
-  };
-
-  let preprocessedMarkdown: string | null = null;
-  let preprocessedOcrUsed = false;
-  let usingPreprocessedMarkdown = false;
-
-  const documentHandling =
-    attachment.kind === "file"
-      ? resolveDocumentHandling({
-          attachment,
-          textContent,
-          fileBytes,
-          preprocessMode: ctx.preprocessMode,
-          fixedModelSpec: ctx.fixedModelSpec,
-          openaiApiKey: ctx.openaiApiKey ?? (ctx.envForRun.OPENAI_API_KEY?.trim() || null),
-          openrouterApiKey:
-            ctx.openrouterApiKey ?? (ctx.envForRun.OPENROUTER_API_KEY?.trim() || null),
-          openaiBaseUrl: ctx.openaiBaseUrl ?? (ctx.envForRun.OPENAI_BASE_URL?.trim() || null),
-        })
-      : { mode: "inline" as const };
-
-  if (documentHandling.mode === "error") {
-    throw documentHandling.error;
-  }
-
-  if (documentHandling.mode === "attach") {
-    if (!fileBytes) {
-      throw new Error("Internal error: missing file bytes for document attachment");
-    }
-    promptText = buildFileSummaryPrompt({
-      filename: attachment.filename,
-      mediaType: attachment.mediaType,
-      summaryLength: summaryLengthTarget,
-      contentLength: textContent?.content.length ?? null,
-      outputLanguage: ctx.outputLanguage,
-      promptOverride: ctx.promptOverride ?? null,
-      lengthInstruction: ctx.lengthInstruction ?? null,
-      languageInstruction: ctx.languageInstruction ?? null,
-    });
-    attachments = [
-      {
-        kind: "document",
-        mediaType: attachment.mediaType,
-        bytes: fileBytes,
-        filename: attachment.filename,
-      },
-    ];
-    return { promptText, attachments, assetFooterParts, textContent };
-  }
-
-  // Non-text file attachments require preprocessing (pi-ai message format supports images, but not generic files).
-  if (attachment.kind === "file" && !textContent && documentHandling.mode === "preprocess") {
-    if (!fileBytes) {
+  if (documentHandling.mode === "preprocess") {
+    if (!fileBytes)
       throw new Error("Internal error: missing file bytes for markitdown preprocessing");
-    }
     if (!shouldMarkitdownConvertMediaType(attachment.mediaType)) {
       throw new Error(
         `Unsupported file type: ${attachment.filename ?? "file"} (${attachment.mediaType})\n` +
-          `This build can only send text or images to the model. Try a text-like file, an image, or convert this file to text first.`,
+          "This build can only send text or images to the model. Try a text-like file, an image, or convert this file to text first.",
       );
     }
-    if (!hasUvxCli(ctx.env)) {
-      throw withUvxTip(
-        new Error(`Missing uvx/markitdown for preprocessing ${attachment.mediaType}.`),
-        ctx.env,
-      );
-    }
-
-    try {
-      ({ markdown: preprocessedMarkdown, usedOcr: preprocessedOcrUsed } =
-        await convertToMarkdownWithMarkitdown({
-          bytes: fileBytes,
-          filenameHint: attachment.filename,
-          mediaTypeHint: attachment.mediaType,
-          uvxCommand: ctx.envForRun.UVX_PATH,
-          timeoutMs: ctx.timeoutMs,
-          env: ctx.env,
-          execFileImpl: ctx.execFileImpl,
-          ocrFallback: true,
-        }));
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to preprocess ${attachment.mediaType} with markitdown: ${message}.`);
-    }
-    if (Buffer.byteLength(preprocessedMarkdown, "utf8") > MAX_TEXT_BYTES_DEFAULT) {
-      throw new Error(
-        `Preprocessed Markdown too large (${formatBytes(Buffer.byteLength(preprocessedMarkdown, "utf8"))}). Limit is ${formatBytes(MAX_TEXT_BYTES_DEFAULT)}.`,
-      );
-    }
-    usingPreprocessedMarkdown = true;
-    assetFooterParts.push(
-      `markitdown${preprocessedOcrUsed ? "+ocr" : ""}(${attachment.mediaType})`,
-    );
+    const { markdown, usedOcr } = await convertAssetToMarkdown(ctx, attachment, fileBytes);
+    if (!markdown) throw new Error("Internal error: missing markitdown content for preprocessing");
+    inline = { content: markdown, mediaType: "text/markdown" };
+    assetFooterParts.push(`markitdown${usedOcr ? "+ocr" : ""}(${attachment.mediaType})`);
   }
-
-  if (attachment.kind === "image") {
-    buildImageAttachment();
-  } else if (usingPreprocessedMarkdown) {
-    if (!preprocessedMarkdown)
-      throw new Error("Internal error: missing markitdown content for preprocessing");
-    buildInlinePromptText({
-      content: preprocessedMarkdown,
-      contentMediaType: "text/markdown",
+  if (!inline) throw new Error("Internal error: no prompt text could be built for asset");
+  return {
+    promptText: buildFileTextSummaryPrompt({
+      ...promptOptions,
       originalMediaType: attachment.mediaType,
-    });
-  } else if (textContent) {
-    buildInlinePromptText({
-      content: textContent.content,
-      contentMediaType: attachment.mediaType,
-      originalMediaType: attachment.mediaType,
-    });
-  } else {
-    throw new Error("Internal error: no prompt text could be built for asset");
-  }
-
-  void ctx.fixedModelSpec;
-
-  return { promptText, attachments, assetFooterParts, textContent };
+      contentMediaType: inline.mediaType,
+      contentLength: inline.content.length,
+      content: inline.content,
+    }),
+    attachments: [],
+    assetFooterParts,
+    textContent,
+  };
 }

--- a/tests/daemon.agent.test.ts
+++ b/tests/daemon.agent.test.ts
@@ -498,33 +498,51 @@ describe("daemon/agent", () => {
     }
   });
 
-  it("runs fixed CLI agent models through the CLI transport", async () => {
-    const home = makeTempHome();
+  it.each(["complete", "stream"] as const)(
+    "runs %s CLI agent models through the CLI transport",
+    async (mode) => {
+      const home = makeTempHome();
+      const signal = new AbortController().signal;
+      const request = {
+        env: { HOME: home },
+        pageUrl: "https://example.com",
+        pageTitle: "Example",
+        pageContent: "Hello world",
+        messages: [{ role: "user", content: "Hi" }],
+        modelOverride: "cli/codex/gpt-5.2",
+        tools: [],
+        automationEnabled: false,
+        signal,
+      };
+      if (mode === "complete") {
+        expect((await completeAgentResponse(request)).content).toBe("cli agent");
+      } else {
+        const onChunk = vi.fn();
+        const onAssistant = vi.fn();
+        await streamAgentResponse({ ...request, onChunk, onAssistant });
+        expect(onChunk).toHaveBeenCalledExactlyOnceWith("cli agent");
+        expect(onAssistant).toHaveBeenCalledExactlyOnceWith({
+          role: "assistant",
+          content: "cli agent",
+        });
+      }
 
-    const assistant = await completeAgentResponse({
-      env: { HOME: home },
-      pageUrl: "https://example.com",
-      pageTitle: "Example",
-      pageContent: "Hello world",
-      messages: [{ role: "user", content: "Hi" }],
-      modelOverride: "cli/codex/gpt-5.2",
-      tools: [],
-      automationEnabled: false,
-    });
-
-    expect(runCliModel).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "codex",
-        model: "gpt-5.2",
-        allowTools: false,
-      }),
-    );
-    const args = vi.mocked(runCliModel).mock.calls[0]?.[0] as { prompt: string };
-    expect(args.prompt).toContain("You are Summarize Chat, not Claude.");
-    expect(args.prompt).toContain("User: Hi");
-    expect(mockCompleteSimple).not.toHaveBeenCalled();
-    expect(assistant.content).toBe("cli agent");
-  });
+      expect(runCliModel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "codex",
+          model: "gpt-5.2",
+          allowTools: false,
+          signal,
+          timeoutMs: 120_000,
+        }),
+      );
+      const args = vi.mocked(runCliModel).mock.calls[0]?.[0] as { prompt: string };
+      expect(args.prompt).toContain("You are Summarize Chat, not Claude.");
+      expect(args.prompt).toContain("User: Hi");
+      expect(mockCompleteSimple).not.toHaveBeenCalled();
+      expect(mockStreamSimple).not.toHaveBeenCalled();
+    },
+  );
 
   it("falls back to CLI auto attempts when no API-key agent model is available", async () => {
     const home = makeTempHome();


### PR DESCRIPTION
## Summary

Asset summary preparation maintained mutable prompt/attachment closures and repeated the same binary-to-Markdown conversion pipeline used by extraction. Both paths now share text-size validation, conversion options, OCR handling, and conversion errors. Prompt preparation directly returns an attachment prompt or inline content while retaining native-document eligibility and the distinction between original text and converted Markdown used by summary bypass/cache policy.

Daemon SSE and JSON agent responses now share request normalization, prompt/tool selection, model resolution, provider options, and CLI execution. Native streaming and completion keep their separate compatibility-retry boundaries. The CLI regression test exercises both response modes, including abort propagation and disabled tool execution. Documentation now distinguishes daemon-backed automation from the extension's existing Direct mode.

Net reduction: 142 production lines and 119 lines overall across eight files. Existing command behavior and prompt text are preserved; no dependencies are added.

## Validation

- Independent Codex review: scoped-clean at P0–P2 for the final formatted tree.
- Root build, formatting, lint, and all three TypeScript layers passed.
- Focused run: 171 tests passed; two pre-existing audio-setup tests hit the host's slow Whisper CLI probe. The executable's help probe independently exceeded a three-second deadline even though these cases have no local model installed; the unnecessary probe is being addressed separately.
- A stable-artifact rerun passes the full local gate: 3,168 tests passed, 43 skipped, 94.44% line coverage and 85.45% branch coverage.
- CI is green at the exact PR head: Node 24 unit/coverage and type checks, Chromium extension E2E, Firefox smoke, and GitGuardian.
