### PR TITLE
refactor: simplify stream and transcription lifecycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Transcription: skip probing the local Whisper executable when no usable model is installed, avoiding unnecessary process startup and delays on cloud-only or unconfigured systems.
 - Browser settings: retain a dismissed local-companion hint when saving other Options preferences.
 - Browser chat: normalize partial or malformed saved usage metadata and unknown stop reasons when restoring assistant history.
 - Slides: drain ignored subprocess output so a verbose media tool cannot stall on a full stdout pipe.
@@ -19,6 +20,7 @@
 
 ### Dependencies and maintenance
 
+- Remove the unused chat mode from summary streaming, share SSE idle deadlines, and consolidate FFmpeg execution and OpenAI transcription HTTP handling while retaining format and response-specific policy.
 - Share asset text validation and Markdown conversion across extraction and summaries; simplify prompt construction and prepare daemon agent requests once for streaming and completion without changing retry boundaries.
 - Share podcast feed transcript resolution, media download/progress completion, and Apple URL parsing; collapse Spotify's duplicated episode-search fallback while preserving provider order and failure metadata.
 - Type-check the entire extension in the local gate and CI using browser/bundler settings; remove stale copies of session, settings, API, and callback contracts.

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-stream-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-stream-controller.ts
@@ -1,7 +1,8 @@
-import { parseSseStream, type RawSseMessage } from "@steipete/summarize-core/runtime";
+import { parseSseStream } from "@steipete/summarize-core/runtime";
 import { daemonFetch } from "../../lib/daemon-fetch";
 import { getDaemonOrigin } from "../../lib/daemon-url";
 import { parseSseEvent, type SseSlidesData } from "../../lib/runtime-contracts";
+import { nextSseMessage } from "../../lib/sse-reader";
 
 export type SlidesStreamController = {
   start: (runId: string) => Promise<void>;
@@ -87,26 +88,12 @@ export function createSlidesStreamController(
       if (!res.body) throw new Error("Missing stream body");
 
       const iterator = parseSseStream(res.body);
-      const useIdleTimeout = Number.isFinite(idleTimeoutMs) && idleTimeoutMs > 0;
-      const nextWithTimeout = async () => {
-        if (!useIdleTimeout) return iterator.next();
-        let timer: ReturnType<typeof setTimeout> | null = null;
-        const timeoutPromise = new Promise<IteratorResult<RawSseMessage>>((_, reject) => {
-          timer = setTimeout(() => {
-            const error = new Error(idleTimeoutMessage);
-            error.name = "IdleTimeoutError";
-            reject(error);
-          }, idleTimeoutMs);
-        });
-        try {
-          return await Promise.race([iterator.next(), timeoutPromise]);
-        } finally {
-          if (timer) clearTimeout(timer);
-        }
-      };
-
       while (true) {
-        const { value: msg, done } = await nextWithTimeout();
+        const { value: msg, done } = await nextSseMessage(
+          iterator,
+          idleTimeoutMs,
+          idleTimeoutMessage,
+        );
         if (done) break;
         if (generation !== activeGeneration) return;
         if (nextController.signal.aborted) return;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/stream-controller-policy.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/stream-controller-policy.ts
@@ -1,13 +1,3 @@
-import { mergeStreamingChunk } from "../../lib/runtime-contracts";
-
-export function accumulateSummarizeChunk(markdown: string, chunk: string): string {
-  return mergeStreamingChunk(markdown, chunk).next;
-}
-
-export function accumulateChatChunk(chatContent: string, chunk: string): string {
-  return `${chatContent}${chunk}`;
-}
-
 export function shouldSurfaceStreamingStatus({
   streamedAnyNonWhitespace,
   statusText,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/stream-controller.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/stream-controller.ts
@@ -1,13 +1,14 @@
-import { parseSseStream, type RawSseMessage } from "@steipete/summarize-core/runtime";
+import { parseSseStream } from "@steipete/summarize-core/runtime";
 import { daemonFetch } from "../../lib/daemon-fetch";
 import { getDaemonOrigin } from "../../lib/daemon-url";
-import { parseSseEvent, type SseMetaData, type SseSlidesData } from "../../lib/runtime-contracts";
 import {
-  accumulateChatChunk,
-  accumulateSummarizeChunk,
-  getTerminalStreamError,
-  shouldSurfaceStreamingStatus,
-} from "./stream-controller-policy";
+  mergeStreamingChunk,
+  parseSseEvent,
+  type SseMetaData,
+  type SseSlidesData,
+} from "../../lib/runtime-contracts";
+import { nextSseMessage } from "../../lib/sse-reader";
+import { getTerminalStreamError, shouldSurfaceStreamingStatus } from "./stream-controller-policy";
 import type { PanelPhase, RunStart } from "./types";
 
 export type StreamController = {
@@ -26,7 +27,6 @@ export type StreamControllerOptions = {
   fetchImpl?: typeof fetch;
   idleTimeoutMs?: number;
   idleTimeoutMessage?: string;
-  // Summarize mode callbacks (optional for chat mode)
   onReset?: (() => void) | null;
   onBaseTitle?: ((text: string) => void) | null;
   onBaseSubtitle?: ((text: string) => void) | null;
@@ -35,12 +35,7 @@ export type StreamControllerOptions = {
   onMetrics?: ((summary: string) => void) | null;
   onRender?: ((markdown: string) => void) | null;
   onSyncWithActiveTab?: (() => Promise<void>) | null;
-  // Chat mode callbacks (optional for summarize mode)
-  onChunk?: ((accumulatedContent: string) => void) | null;
   onDone?: (() => void) | null;
-  // Mode-specific options
-  mode?: "summarize" | "chat";
-  streamingStatusText?: string;
 };
 
 export function createStreamController(options: StreamControllerOptions): StreamController {
@@ -60,17 +55,13 @@ export function createStreamController(options: StreamControllerOptions): Stream
     onMetrics,
     onRender,
     onSyncWithActiveTab,
-    onChunk,
     onDone,
-    mode = "summarize",
-    streamingStatusText,
     idleTimeoutMs = 120_000,
     idleTimeoutMessage = "No response from the daemon for a while. It may have stopped. Click “Try again”.",
   } = options;
   let controller: AbortController | null = null;
   let activeAbortState: { reason: "manual" | "timeout" | null } | null = null;
   let markdown = "";
-  let chatContent = "";
   let renderQueued = 0;
   let streamedAnyNonWhitespace = false;
   let rememberedUrl = false;
@@ -88,14 +79,6 @@ export function createStreamController(options: StreamControllerOptions): Stream
     }, 80);
   };
 
-  const queueChunkUpdate = () => {
-    if (renderQueued || !onChunk) return;
-    renderQueued = window.setTimeout(() => {
-      renderQueued = 0;
-      onChunk(chatContent);
-    }, 80);
-  };
-
   const clearQueuedRender = () => {
     if (!renderQueued) return;
     window.clearTimeout(renderQueued);
@@ -106,10 +89,6 @@ export function createStreamController(options: StreamControllerOptions): Stream
     if (!renderQueued) return;
     window.clearTimeout(renderQueued);
     renderQueued = 0;
-    if (mode === "chat") {
-      onChunk?.(chatContent);
-      return;
-    }
     onRender?.(markdown);
   };
 
@@ -166,7 +145,6 @@ export function createStreamController(options: StreamControllerOptions): Stream
     rememberedUrl = false;
     sawDone = false;
     markdown = "";
-    chatContent = "";
     onPhaseChange("connecting");
     onSummaryFromCache?.(null);
     onReset?.();
@@ -185,30 +163,16 @@ export function createStreamController(options: StreamControllerOptions): Stream
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
       if (!res.body) throw new Error("Missing stream body");
 
-      onStatus(streamingStatusText ?? (mode === "chat" ? "" : "Summarizing…"));
+      onStatus("Summarizing…");
       onPhaseChange("streaming");
 
       const iterator = parseSseStream(res.body);
-      const useIdleTimeout = Number.isFinite(idleTimeoutMs) && idleTimeoutMs > 0;
-      const nextWithTimeout = async () => {
-        if (!useIdleTimeout) return iterator.next();
-        let timer: ReturnType<typeof setTimeout> | null = null;
-        const timeoutPromise = new Promise<IteratorResult<RawSseMessage>>((_, reject) => {
-          timer = setTimeout(() => {
-            const error = new Error(idleTimeoutMessage);
-            error.name = "IdleTimeoutError";
-            reject(error);
-          }, idleTimeoutMs);
-        });
-        try {
-          return await Promise.race([iterator.next(), timeoutPromise]);
-        } finally {
-          if (timer) clearTimeout(timer);
-        }
-      };
-
       while (true) {
-        const { value: msg, done } = await nextWithTimeout();
+        const { value: msg, done } = await nextSseMessage(
+          iterator,
+          idleTimeoutMs,
+          idleTimeoutMessage,
+        );
         if (done) break;
         if (generation !== activeGeneration) return;
         if (nextController.signal.aborted) return;
@@ -217,15 +181,10 @@ export function createStreamController(options: StreamControllerOptions): Stream
         if (!event) continue;
 
         if (event.event === "chunk") {
-          if (mode === "chat") {
-            chatContent = accumulateChatChunk(chatContent, event.data.text);
-            queueChunkUpdate();
-          } else {
-            const merged = accumulateSummarizeChunk(markdown, event.data.text);
-            if (merged !== markdown) {
-              markdown = merged;
-              queueRender();
-            }
+          const merged = mergeStreamingChunk(markdown, event.data.text).next;
+          if (merged !== markdown) {
+            markdown = merged;
+            queueRender();
           }
 
           if (!streamedAnyNonWhitespace && event.data.text.trim().length > 0) {

--- a/apps/chrome-extension/src/lib/sse-reader.ts
+++ b/apps/chrome-extension/src/lib/sse-reader.ts
@@ -1,0 +1,22 @@
+import type { RawSseMessage } from "@steipete/summarize-core/runtime";
+
+export async function nextSseMessage(
+  iterator: AsyncIterator<RawSseMessage>,
+  idleTimeoutMs: number,
+  idleTimeoutMessage: string,
+): Promise<IteratorResult<RawSseMessage>> {
+  if (!Number.isFinite(idleTimeoutMs) || idleTimeoutMs <= 0) return iterator.next();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<IteratorResult<RawSseMessage>>((_, reject) => {
+    timer = setTimeout(() => {
+      const error = new Error(idleTimeoutMessage);
+      error.name = "IdleTimeoutError";
+      reject(error);
+    }, idleTimeoutMs);
+  });
+  try {
+    return await Promise.race([iterator.next(), timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -92,6 +92,8 @@ Dev (repo checkout):
 
 The sidepanel owns one plain `PanelState` object. Simple fields update directly; phase, run attachment, restoration, and reset use named transitions in `panel-state-store.ts`. Nested-slice updates replace the slice so previously captured navigation/chat/slide snapshots remain unchanged. There is no secondary action bus or optional dispatch path.
 
+Summary and slide streams share SSE idle-deadline reads, including keepalive comments, but retain separate rendering, cancellation, and completion policies. Chat runs through the agent loop, not a second mode in the summary stream controller.
+
 - **Extension (MV3, WXT)**
   - Side Panel UI: length + typography controls (font family + size), auto/manual toggle.
   - Background service worker: tab + navigation tracking, content extraction, starts summarize runs.

--- a/docs/transcript-provider-flow.md
+++ b/docs/transcript-provider-flow.md
@@ -48,6 +48,7 @@ Goal: keep provider entrypoints thin; keep provider policy explicit.
 - `transcription-start.ts`
   Runtime availability only.
   Local whisper, ONNX, cloud presence, display hints.
+- Local Whisper readiness checks for a usable model before starting the executable probe. FFmpeg segmentation and transcoding share process completion/error handling; MP3/WAV and lenient recovery retain their own arguments. OpenAI plain and diarized transcripts share HTTP submission but keep separate payload validation.
 
 ## Remote fallback
 

--- a/packages/core/src/transcription/whisper/ffmpeg.ts
+++ b/packages/core/src/transcription/whisper/ffmpeg.ts
@@ -82,65 +82,8 @@ export async function runFfmpegSegment({
   outputPattern: string;
   segmentSeconds: number;
 }): Promise<void> {
-  const resolved = await resolvePreferredTool("ffmpeg", [
-    "-hide_banner",
-    "-loglevel",
-    "error",
-    "-i",
-    inputPath,
-    "-vn",
-    "-ac",
-    "1",
-    "-ar",
-    "16000",
-    "-b:a",
-    "32k",
-    "-f",
-    "segment",
-    "-segment_time",
-    String(segmentSeconds),
-    "-reset_timestamps",
-    "1",
-    outputPattern,
-  ]);
-  const { proc } = spawnTracked(resolved.command, resolved.args, {
-    stdio: ["ignore", "ignore", "pipe"],
-    label: "ffmpeg",
-    kind: "ffmpeg",
-  });
-  await new Promise<void>((resolve, reject) => {
-    let stderr = "";
-    proc.stderr?.setEncoding("utf8");
-    proc.stderr?.on("data", (chunk: string) => {
-      if (stderr.length > 8192) return;
-      stderr += chunk;
-    });
-    proc.on("error", (error) => reject(error));
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      const detail = stderr.trim();
-      reject(new Error(`ffmpeg failed (${code ?? "unknown"}): ${detail || "unknown error"}`));
-    });
-  });
-}
-
-export async function runFfmpegTranscodeToMp3({
-  inputPath,
-  outputPath,
-  bitrateKbps = 64,
-}: {
-  inputPath: string;
-  outputPath: string;
-  bitrateKbps?: number;
-}): Promise<void> {
-  await runFfmpegTranscode({
-    inputPath,
-    outputPath,
-    mode: "strict",
-    args: [
+  await runFfmpeg(
+    [
       "-hide_banner",
       "-loglevel",
       "error",
@@ -152,76 +95,51 @@ export async function runFfmpegTranscodeToMp3({
       "-ar",
       "16000",
       "-b:a",
-      `${bitrateKbps}k`,
-      outputPath,
+      "32k",
+      "-f",
+      "segment",
+      "-segment_time",
+      String(segmentSeconds),
+      "-reset_timestamps",
+      "1",
+      outputPattern,
     ],
+    (code, detail) => `ffmpeg failed (${code ?? "unknown"}): ${detail}`,
+  );
+}
+
+type TranscodePaths = { inputPath: string; outputPath: string };
+
+export async function runFfmpegTranscodeToMp3({
+  inputPath,
+  outputPath,
+  bitrateKbps = 64,
+}: TranscodePaths & { bitrateKbps?: number }): Promise<void> {
+  await runFfmpegTranscode({
+    inputPath,
+    outputPath,
+    mode: "strict",
+    audioArgs: ["-b:a", `${bitrateKbps}k`],
   });
 }
 
 export async function runFfmpegTranscodeToWav({
   inputPath,
   outputPath,
-}: {
-  inputPath: string;
-  outputPath: string;
-}): Promise<void> {
+}: TranscodePaths): Promise<void> {
   await runFfmpegTranscode({
     inputPath,
     outputPath,
     mode: "strict",
-    args: [
-      "-hide_banner",
-      "-loglevel",
-      "error",
-      "-i",
-      inputPath,
-      "-vn",
-      "-ac",
-      "1",
-      "-ar",
-      "16000",
-      "-sample_fmt",
-      "s16",
-      outputPath,
-    ],
+    audioArgs: ["-sample_fmt", "s16"],
   });
 }
 
 export async function runFfmpegTranscodeToMp3Lenient({
   inputPath,
   outputPath,
-}: {
-  inputPath: string;
-  outputPath: string;
-}): Promise<void> {
-  await runFfmpegTranscode({
-    inputPath,
-    outputPath,
-    mode: "lenient",
-    args: [
-      "-hide_banner",
-      "-loglevel",
-      "error",
-      "-err_detect",
-      "ignore_err",
-      "-fflags",
-      "+genpts",
-      "-i",
-      inputPath,
-      "-vn",
-      "-sn",
-      "-dn",
-      "-map",
-      "0:a:0?",
-      "-ac",
-      "1",
-      "-ar",
-      "16000",
-      "-b:a",
-      "64k",
-      outputPath,
-    ],
-  });
+}: TranscodePaths): Promise<void> {
+  await runFfmpegTranscode({ inputPath, outputPath, mode: "lenient", audioArgs: ["-b:a", "64k"] });
 }
 
 export async function transcodeBytesToMp3(bytes: Uint8Array): Promise<Uint8Array> {
@@ -245,13 +163,37 @@ async function runFfmpegTranscode({
   inputPath,
   outputPath,
   mode,
-  args,
-}: {
-  inputPath: string;
-  outputPath: string;
+  audioArgs,
+}: TranscodePaths & {
   mode: "strict" | "lenient";
-  args: string[];
+  audioArgs: string[];
 }): Promise<void> {
+  await runFfmpeg(
+    [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      ...(mode === "lenient" ? ["-err_detect", "ignore_err", "-fflags", "+genpts"] : []),
+      "-i",
+      inputPath,
+      "-vn",
+      ...(mode === "lenient" ? ["-sn", "-dn", "-map", "0:a:0?"] : []),
+      "-ac",
+      "1",
+      "-ar",
+      "16000",
+      ...audioArgs,
+      outputPath,
+    ],
+    (code, detail) =>
+      `ffmpeg ${mode} transcode failed (${code ?? "unknown"}) for ${inputPath} -> ${outputPath}: ${detail}`,
+  );
+}
+
+async function runFfmpeg(
+  args: string[],
+  errorMessage: (code: number | null, detail: string) => string,
+): Promise<void> {
   const resolved = await resolvePreferredTool("ffmpeg", args);
   const { proc } = spawnTracked(resolved.command, resolved.args, {
     stdio: ["ignore", "ignore", "pipe"],
@@ -271,14 +213,7 @@ async function runFfmpegTranscode({
         resolve();
         return;
       }
-      const detail = stderr.trim();
-      reject(
-        new Error(
-          `ffmpeg ${mode} transcode failed (${code ?? "unknown"}) for ${inputPath} -> ${outputPath}: ${
-            detail || "unknown error"
-          }`,
-        ),
-      );
+      reject(new Error(errorMessage(code, stderr.trim() || "unknown error")));
     });
   });
 }

--- a/packages/core/src/transcription/whisper/openai.ts
+++ b/packages/core/src/transcription/whisper/openai.ts
@@ -38,28 +38,7 @@ export async function transcribeWithOpenAi(
   form.append("file", new Blob([toArrayBuffer(bytes)], { type: mediaType }), safeName);
   form.append("model", "whisper-1");
 
-  const effectiveBaseUrl = resolveOpenAiWhisperBaseUrl({
-    explicitBaseUrl: options?.baseUrl,
-    env: options?.env,
-  });
-  const transcriptionUrl = `${effectiveBaseUrl.replace(/\/+$/, "")}/audio/transcriptions`;
-
-  const response = await globalThis.fetch(transcriptionUrl, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${apiKey}` },
-    body: form,
-    signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
-  });
-
-  if (!response.ok) {
-    const detail = await readErrorDetail(response);
-    throw new OpenAiTranscriptionHttpError(
-      response.status,
-      resolveRetryAfterMs(response.headers, response.status, detail),
-      detail,
-    );
-  }
-
+  const response = await requestOpenAiTranscription(form, apiKey, options);
   const payload = (await response.json()) as { text?: unknown };
   if (typeof payload?.text !== "string") return null;
   const trimmed = payload.text.trim();
@@ -90,26 +69,7 @@ export async function transcribeFileWithOpenAiDiarization({
   form.append("response_format", "diarized_json");
   form.append("chunking_strategy", "auto");
 
-  const effectiveBaseUrl = resolveOpenAiWhisperBaseUrl({
-    explicitBaseUrl: options?.baseUrl,
-    env: options?.env,
-  });
-  const transcriptionUrl = `${effectiveBaseUrl.replace(/\/+$/, "")}/audio/transcriptions`;
-  const response = await globalThis.fetch(transcriptionUrl, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${apiKey}` },
-    body: form,
-    signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
-  });
-  if (!response.ok) {
-    const detail = await readErrorDetail(response);
-    throw new OpenAiTranscriptionHttpError(
-      response.status,
-      resolveRetryAfterMs(response.headers, response.status, detail),
-      detail,
-    );
-  }
-
+  const response = await requestOpenAiTranscription(form, apiKey, options);
   const payload = (await response.json()) as { segments?: unknown; text?: unknown };
   if (!Array.isArray(payload.segments)) {
     throw new Error("OpenAI transcription returned an invalid diarized segment payload");
@@ -244,4 +204,34 @@ function parseRateLimitDurationMs(value: string | null): number | null {
       amount * (unit === "ms" ? 1 : unit === "s" ? 1_000 : unit === "m" ? 60_000 : 3_600_000);
   }
   return consumed === trimmed && total >= 0 ? total : null;
+}
+
+async function requestOpenAiTranscription(
+  form: FormData,
+  apiKey: string,
+  options?: { baseUrl?: string | null; env?: Env },
+): Promise<Response> {
+  const effectiveBaseUrl = resolveOpenAiWhisperBaseUrl({
+    explicitBaseUrl: options?.baseUrl,
+    env: options?.env,
+  });
+  const transcriptionUrl = `${effectiveBaseUrl.replace(/\/+$/, "")}/audio/transcriptions`;
+
+  const response = await globalThis.fetch(transcriptionUrl, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
+    signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new OpenAiTranscriptionHttpError(
+      response.status,
+      resolveRetryAfterMs(response.headers, response.status, detail),
+      detail,
+    );
+  }
+
+  return response;
 }

--- a/packages/core/src/transcription/whisper/whisper-cpp.ts
+++ b/packages/core/src/transcription/whisper/whisper-cpp.ts
@@ -20,9 +20,8 @@ export async function isWhisperCppReady(
   env?: Record<string, string | undefined>,
 ): Promise<boolean> {
   if (!isWhisperCppEnabled(env)) return false;
-  if (!(await isWhisperCliAvailable(env))) return false;
   const model = await resolveWhisperCppModelPath(env);
-  return Boolean(model);
+  return Boolean(model) && (await isWhisperCliAvailable(env));
 }
 
 export async function resolveWhisperCppModelNameForDisplay(

--- a/tests/ffmpeg-wasm.test.ts
+++ b/tests/ffmpeg-wasm.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveBundledFfmpegCommand } from "../packages/core/src/ffmpeg.js";
-import { runFfmpegTranscodeToMp3 } from "../packages/core/src/transcription/whisper/ffmpeg.js";
+import {
+  runFfmpegTranscodeToMp3,
+  runFfmpegTranscodeToMp3Lenient,
+  runFfmpegTranscodeToWav,
+} from "../packages/core/src/transcription/whisper/ffmpeg.js";
 import { runProcess, runProcessCapture } from "../src/slides/process.js";
 
 const fixture = resolve(
@@ -71,17 +75,28 @@ describe("bundled ffmpeg wasm", () => {
     expect((await stat(outputPath)).size).toBeGreaterThan(0);
   }, 60_000);
 
-  it("extracts diarization audio without a native ffmpeg command", async () => {
-    const outputDir = await mkdtemp(join(tmpdir(), "summarize-ffmpeg-wasm-audio-"));
-    const outputPath = join(outputDir, "audio.mp3");
-    vi.stubEnv("PATH", outputDir);
-    await runFfmpegTranscodeToMp3({
-      inputPath: fixture,
-      outputPath,
-      bitrateKbps: 24,
-    });
-    const output = await stat(outputPath);
-    expect(output.size).toBeGreaterThan(0);
-    expect(output.size).toBeLessThan((await stat(fixture)).size);
-  }, 60_000);
+  it.each(["mp3", "wav", "lenient"] as const)(
+    "extracts %s audio without a native ffmpeg command",
+    async (format) => {
+      const outputDir = await mkdtemp(join(tmpdir(), "summarize-ffmpeg-wasm-audio-"));
+      const outputPath = join(outputDir, format === "wav" ? "audio.wav" : "audio.mp3");
+      vi.stubEnv("PATH", outputDir);
+      const transcode =
+        format === "wav"
+          ? runFfmpegTranscodeToWav
+          : format === "lenient"
+            ? runFfmpegTranscodeToMp3Lenient
+            : runFfmpegTranscodeToMp3;
+      const options = {
+        inputPath: fixture,
+        outputPath,
+        bitrateKbps: 24,
+      };
+      await transcode(options);
+      const output = await stat(outputPath);
+      expect(output.size).toBeGreaterThan(0);
+      if (format !== "wav") expect(output.size).toBeLessThan((await stat(fixture)).size);
+    },
+    60_000,
+  );
 });

--- a/tests/sidepanel.stream-controller.policy.test.ts
+++ b/tests/sidepanel.stream-controller.policy.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  accumulateChatChunk,
-  accumulateSummarizeChunk,
   getTerminalStreamError,
   shouldSurfaceStreamingStatus,
 } from "../apps/chrome-extension/src/entrypoints/sidepanel/stream-controller-policy";
@@ -20,11 +18,6 @@ describe("sidepanel stream controller policy", () => {
         statusText: "fetching article",
       }),
     ).toBe(false);
-  });
-
-  it("accumulates summarize and chat chunks via pure helpers", () => {
-    expect(accumulateChatChunk("Hello", " world")).toBe("Hello world");
-    expect(accumulateSummarizeChunk("Hello", " world")).toContain("Hello world");
   });
 
   it("normalizes terminal stream completion errors", () => {

--- a/tests/transcription.whisper-cpp.test.ts
+++ b/tests/transcription.whisper-cpp.test.ts
@@ -350,19 +350,8 @@ describe("transcription/whisper local whisper.cpp", () => {
     vi.stubEnv("SUMMARIZE_WHISPER_CPP_MODEL_PATH", "/nope/does-not-exist.bin");
     vi.stubEnv("SUMMARIZE_WHISPER_CPP_BINARY", "whisper-cli");
 
-    const spawn = vi.fn((_cmd: string, args: string[]) => {
-      if (_cmd !== "whisper-cli" || !args.includes("--help")) {
-        throw new Error(`Unexpected spawn: ${_cmd} ${args.join(" ")}`);
-      }
-      const handlers = new Map<string, (value?: unknown) => void>();
-      const proc = {
-        on(event: string, handler: (value?: unknown) => void) {
-          handlers.set(event, handler);
-          if (event === "close") queueMicrotask(() => handler(0));
-          return proc;
-        },
-      } as unknown;
-      return proc;
+    const spawn = vi.fn(() => {
+      throw new Error("No process should start without a model");
     });
     vi.doMock("node:child_process", () => ({ spawn }));
 
@@ -382,7 +371,7 @@ describe("transcription/whisper local whisper.cpp", () => {
     expect(result.error?.message).toContain(
       "GROQ_API_KEY, ASSEMBLYAI_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, FAL_KEY, or DEEPGRAM_API_KEY",
     );
-    expect(spawn).toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   it("falls back to OpenAI when mediaType is unsupported and ffmpeg is missing", async () => {
@@ -700,21 +689,9 @@ describe("transcription/whisper local whisper.cpp", () => {
     vi.stubEnv("SUMMARIZE_WHISPER_CPP_MODEL_PATH", root);
     vi.stubEnv("SUMMARIZE_WHISPER_CPP_BINARY", "whisper-cli");
 
-    const spawn = vi.fn((_cmd: string, args: string[]) => {
-      if (_cmd !== "whisper-cli" || !args.includes("--help")) {
-        throw new Error(`Unexpected spawn: ${_cmd} ${args.join(" ")}`);
-      }
-      const handlers = new Map<string, (value?: unknown) => void>();
-      const proc = {
-        on(event: string, handler: (value?: unknown) => void) {
-          handlers.set(event, handler);
-          if (event === "close") queueMicrotask(() => handler(0));
-          return proc;
-        },
-      } as unknown;
-      return proc;
+    const spawn = vi.fn(() => {
+      throw new Error("No process should start without a model");
     });
-
     vi.doMock("node:child_process", () => ({ spawn }));
 
     const { isWhisperCppReady, transcribeMediaWithWhisper } =
@@ -735,6 +712,6 @@ describe("transcription/whisper local whisper.cpp", () => {
     expect(result.error?.message).toContain(
       "GROQ_API_KEY, ASSEMBLYAI_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, FAL_KEY, or DEEPGRAM_API_KEY",
     );
-    expect(spawn).toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
   });
 });

--- a/tests/whisper.whispercpp-ready.test.ts
+++ b/tests/whisper.whispercpp-ready.test.ts
@@ -1,140 +1,98 @@
+import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isWhisperCppReady,
+  resolveWhisperCppModelNameForDisplay,
+} from "../packages/core/src/transcription/whisper.js";
 
-type MockProc = EventEmitter & {
-  stderr: EventEmitter & { setEncoding: () => void };
-};
+const mock = vi.hoisted(() => ({ mode: "ok" as "ok" | "error" | "nonzero" }));
 
-vi.mock("node:child_process", () => {
-  return {
-    spawn: (_bin: string, args: string[]) => {
-      const proc: MockProc = Object.assign(new EventEmitter(), {
-        stderr: Object.assign(new EventEmitter(), { setEncoding: () => {} }),
-      });
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn((_binary: string, args: string[]) => {
+    expect(args).toEqual(["--help"]);
+    const proc = new EventEmitter();
+    process.nextTick(() => {
+      if (mock.mode === "error") proc.emit("error", new Error("spawn failed"));
+      else proc.emit("close", mock.mode === "nonzero" ? 1 : 0);
+    });
+    return proc;
+  }),
+}));
 
-      // Validate we only use this mock for availability checks in these tests.
-      if (!args.includes("--help")) {
-        throw new Error(`Unexpected whisper-cli invocation in test: ${args.join(" ")}`);
-      }
-
-      process.nextTick(() => {
-        const mode = (process.env.VITEST_WHISPER_SPAWN_MODE ?? "ok").trim();
-        if (mode === "error") {
-          proc.emit("error", new Error("spawn failed"));
-          return;
-        }
-        proc.emit("close", mode === "nonzero" ? 1 : 0);
-      });
-
-      return proc;
-    },
-  };
-});
-
-const ENV_KEYS = [
-  "SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP",
-  "SUMMARIZE_WHISPER_CPP_BINARY",
-  "SUMMARIZE_WHISPER_CPP_MODEL_PATH",
-  "VITEST_WHISPER_SPAWN_MODE",
-  "HOME",
-  "USERPROFILE",
-];
-
-function snapshotEnv(): Record<string, string | undefined> {
-  return Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
-}
-
-function restoreEnv(snapshot: Record<string, string | undefined>) {
-  for (const k of ENV_KEYS) {
-    const v = snapshot[k];
-    if (v === undefined) delete process.env[k];
-    else process.env[k] = v;
-  }
+function createModel() {
+  const modelPath = join(
+    mkdtempSync(join(tmpdir(), "summarize-whisper-ready-")),
+    "ggml-base.en.bin",
+  );
+  writeFileSync(modelPath, "fixture");
+  return modelPath;
 }
 
 describe("whisper.cpp readiness", () => {
-  const envSnapshot = snapshotEnv();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mock.mode = "ok";
+  });
+  afterEach(() => vi.unstubAllEnvs());
 
-  afterEach(() => {
-    restoreEnv(envSnapshot);
+  it("does not probe disabled local whisper.cpp", async () => {
+    expect(
+      await isWhisperCppReady({
+        SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP: "1",
+        SUMMARIZE_WHISPER_CPP_MODEL_PATH: createModel(),
+      }),
+    ).toBe(false);
+    expect(spawn).not.toHaveBeenCalled();
   });
 
-  it("returns false when local whisper.cpp is disabled", async () => {
-    process.env.SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP = "1";
-    process.env.VITEST_WHISPER_SPAWN_MODE = "ok";
-
-    const mod = await import("../packages/core/src/transcription/whisper");
-    expect(await mod.isWhisperCppReady()).toBe(false);
+  it.each(["error", "nonzero"] as const)("rejects an unavailable executable: %s", async (mode) => {
+    mock.mode = mode;
+    expect(await isWhisperCppReady({ SUMMARIZE_WHISPER_CPP_MODEL_PATH: createModel() })).toBe(
+      false,
+    );
+    expect(spawn).toHaveBeenCalledOnce();
   });
 
-  it("returns false when whisper-cli is not available (spawn error)", async () => {
-    process.env.SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP = "0";
-    process.env.VITEST_WHISPER_SPAWN_MODE = "error";
+  it.each(["unset", "missing", "directory"] as const)(
+    "does not probe without a usable model: %s",
+    async (kind) => {
+      const root = mkdtempSync(join(tmpdir(), "summarize-whisper-no-model-"));
+      const env =
+        kind === "unset"
+          ? {}
+          : {
+              SUMMARIZE_WHISPER_CPP_MODEL_PATH:
+                kind === "directory" ? root : join(root, "missing.bin"),
+            };
+      expect(await isWhisperCppReady(env)).toBe(false);
+      expect(spawn).not.toHaveBeenCalled();
+    },
+  );
 
-    const mod = await import("../packages/core/src/transcription/whisper");
-    expect(await mod.isWhisperCppReady()).toBe(false);
+  it("accepts a valid model and derives its display name", async () => {
+    const env = { SUMMARIZE_WHISPER_CPP_MODEL_PATH: createModel() };
+    expect(await isWhisperCppReady(env)).toBe(true);
+    expect(await resolveWhisperCppModelNameForDisplay(env)).toBe("base");
   });
 
-  it("returns false when whisper-cli exists but model is missing", async () => {
-    process.env.SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP = "0";
-    process.env.VITEST_WHISPER_SPAWN_MODE = "ok";
-    process.env.SUMMARIZE_WHISPER_CPP_MODEL_PATH = join(tmpdir(), `missing-${Date.now()}.bin`);
-
-    const mod = await import("../packages/core/src/transcription/whisper");
-    expect(await mod.isWhisperCppReady()).toBe(false);
+  it("discovers cached models under HOME", async () => {
+    const home = mkdtempSync(join(tmpdir(), "summarize-whisper-home-"));
+    const directory = join(home, ".summarize", "cache", "whisper-cpp", "models");
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, "ggml-base.bin"), "fixture");
+    expect(await isWhisperCppReady({ HOME: home })).toBe(true);
+    expect(await resolveWhisperCppModelNameForDisplay({ HOME: home })).toBe("base");
   });
 
-  it("returns true when whisper-cli exists and model path is valid", async () => {
-    process.env.SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP = "0";
-    process.env.VITEST_WHISPER_SPAWN_MODE = "ok";
-
-    const dir = mkdtempSync(join(tmpdir(), "summarize-whisper-test-"));
-    const modelPath = join(dir, "ggml-base.en.bin");
-    writeFileSync(modelPath, "x");
-    process.env.SUMMARIZE_WHISPER_CPP_MODEL_PATH = modelPath;
-
-    const mod = await import("../packages/core/src/transcription/whisper");
-    expect(await mod.isWhisperCppReady()).toBe(true);
-    expect(await mod.resolveWhisperCppModelNameForDisplay()).toBe("base");
-  });
-
-  it("supports fallback model discovery under ~/.summarize/cache/whisper-cpp/models", async () => {
-    process.env.SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP = "0";
-    process.env.VITEST_WHISPER_SPAWN_MODE = "ok";
-    delete process.env.SUMMARIZE_WHISPER_CPP_MODEL_PATH;
-
-    const home = mkdtempSync(join(tmpdir(), "summarize-home-"));
-    process.env.HOME = home;
-    delete process.env.USERPROFILE;
-
-    const modelPath = join(home, ".summarize", "cache", "whisper-cpp", "models", "ggml-base.bin");
-    mkdirSync(join(home, ".summarize", "cache", "whisper-cpp", "models"), { recursive: true });
-    writeFileSync(modelPath, "x");
-
-    const mod = await import("../packages/core/src/transcription/whisper");
-    expect(await mod.isWhisperCppReady()).toBe(true);
-    expect(await mod.resolveWhisperCppModelNameForDisplay()).toBe("base");
-  });
-
-  it("accepts explicit env overrides without reading process.env model settings", async () => {
-    process.env.SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP = "0";
-    process.env.VITEST_WHISPER_SPAWN_MODE = "ok";
-    delete process.env.SUMMARIZE_WHISPER_CPP_MODEL_PATH;
-
-    const dir = mkdtempSync(join(tmpdir(), "summarize-whisper-env-"));
-    const modelPath = join(dir, "ggml-base.en.bin");
-    writeFileSync(modelPath, "x");
-
-    const env = {
-      SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP: "0",
-      SUMMARIZE_WHISPER_CPP_MODEL_PATH: modelPath,
-    };
-
-    const mod = await import("../packages/core/src/transcription/whisper");
-    expect(await mod.isWhisperCppReady(env)).toBe(true);
-    expect(await mod.resolveWhisperCppModelNameForDisplay(env)).toBe("base");
+  it("uses explicit env instead of process model settings", async () => {
+    vi.stubEnv("SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP", "1");
+    vi.stubEnv("SUMMARIZE_WHISPER_CPP_MODEL_PATH", "/missing/process/model.bin");
+    const env = { SUMMARIZE_WHISPER_CPP_MODEL_PATH: createModel() };
+    expect(await isWhisperCppReady(env)).toBe(true);
+    expect(await resolveWhisperCppModelNameForDisplay(env)).toBe("base");
   });
 });


### PR DESCRIPTION
## Summary

Remove the private, unused chat mode from the summary stream controller. Active chat runs through the agent loop; the two production summary-controller callers use only summary rendering. Summary and slide controllers now share idle-deadline reads, including keepalive handling, while retaining their separate rendering, abort/generation, and completion policies. No visual UI changes are intended.

Consolidate FFmpeg process completion and transcode argument construction without changing strict, lenient, WAV, MP3, or segmentation arguments/errors. Plain and diarized OpenAI transcription share HTTP submission, base-URL routing, timeout, and structured HTTP errors, while preserving their distinct form payloads, lazy file upload, and response validation.

Fix an unnecessary local Whisper executable probe: first establish that a usable model exists. The host's help probe exceeded a three-second deadline even without a model; the built no-model readiness path now returns false in 3 ms. Configured executables are still checked. Readiness tests now use explicit environments instead of snapshotting and mutating ambient settings.

Net reduction: 118 production lines and 170 lines overall across 14 files. No new dependencies.

## Validation

- New readiness assertions failed in all three unconfigured-model cases before the fix, then passed. Configured success, spawn error, nonzero exit, cached models, and explicit environment isolation are covered.
- 186 focused transcription/streaming tests passed; the two obsolete assertions expecting pointless probes were updated and the affected 46-test group passed. Final readiness suite: nine passed.
- Bundled FFmpeg integration exercises MP3, WAV, and lenient MP3 without a native executable.
- Full local gate: 3,172 passed, 43 skipped; 94.44% line and 85.47% branch coverage. Root and extension builds/typechecks pass.
- Independent Codex review: scoped-clean at P0–P2 for the final tree.
- Supported Chromium E2E passes: three native-transport cases and 114 HTTP-transport cases, with seven expected HTTP skips.
- Exact-head CI is green: Node 24 unit/coverage and extension typechecks, Chromium extension E2E, Firefox smoke, and GitGuardian.
