### PR TITLE
refactor(runtime): share service commands and executable policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Dependencies and maintenance
 
+- Share daemon service-command execution, executable override lookup, and environment-state types without changing platform-specific service behavior or the JSON environment whitelist.
 - Remove the unused chat mode from summary streaming, share SSE idle deadlines, and consolidate FFmpeg execution and OpenAI transcription HTTP handling while retaining format and response-specific policy.
 - Share asset text validation and Markdown conversion across extraction and summaries; simplify prompt construction and prepare daemon agent requests once for streaming and completion without changing retry boundaries.
 - Share podcast feed transcript resolution, media download/progress completion, and Apple URL parsing; collapse Spotify's duplicated episode-search fallback while preserving provider order and failure metadata.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -42,6 +42,8 @@ The daemon prepares message history, tools, prompts, model selection, and CLI ex
 
 The daemon **never** executes tools. It only returns the next assistant message.
 
+Service installation keeps launchd, systemd, and Scheduled Task policy in separate adapters. They share command output/error normalization in `src/daemon/command.ts`; only Windows commands request hidden windows. Executable overrides use the application environment resolver, while public JSON environment output retains its explicit whitelist.
+
 ## Settings + Permissions
 
 ### Settings

--- a/src/application/environment-state.ts
+++ b/src/application/environment-state.ts
@@ -1,44 +1,12 @@
 import { isOpenRouterBaseUrl, resolveConfiguredBaseUrl } from "@steipete/summarize-core";
 import type { CliProvider, SummarizeConfig } from "../config.js";
 import { DEFAULT_MINIMAX_BASE_URL, DEFAULT_OLLAMA_BASE_URL } from "../llm/provider-registry.js";
+import type { RunApiStatus } from "../shared/run-api-status.js";
 import { resolveCliAvailability, resolveExecutableInPath } from "./environment.js";
 
-export type EnvState = {
-  apiKey: string | null;
-  openrouterApiKey: string | null;
-  openrouterConfigured: boolean;
-  groqApiKey: string | null;
-  assemblyaiApiKey: string | null;
-  deepgramApiKey: string | null;
-  elevenlabsApiKey: string | null;
-  openaiApiKey: string | null;
-  xaiApiKey: string | null;
-  googleApiKey: string | null;
-  anthropicApiKey: string | null;
-  zaiApiKey: string | null;
-  zaiBaseUrl: string;
-  nvidiaApiKey: string | null;
-  nvidiaBaseUrl: string;
-  minimaxApiKey: string | null;
-  minimaxBaseUrl: string;
-  ollamaBaseUrl: string;
-  firecrawlApiKey: string | null;
-  firecrawlConfigured: boolean;
-  googleConfigured: boolean;
-  anthropicConfigured: boolean;
-  apifyToken: string | null;
-  ytDlpPath: string | null;
-  ytDlpCookiesFromBrowser: string | null;
-  falApiKey: string | null;
+export type EnvState = RunApiStatus & {
   cliAvailability: Partial<Record<CliProvider, boolean>>;
   envForAuto: Record<string, string | undefined>;
-  providerBaseUrls: {
-    openai: string | null;
-    nvidia: string | null;
-    anthropic: string | null;
-    google: string | null;
-    xai: string | null;
-  };
 };
 
 export function resolveEnvState({

--- a/src/application/environment.ts
+++ b/src/application/environment.ts
@@ -15,7 +15,11 @@ function isExecutable(filePath: string): boolean {
 export function resolveExecutableInPath(
   binary: string,
   env: Record<string, string | undefined>,
+  explicitEnvKey?: string,
 ): string | null {
+  const explicit =
+    explicitEnvKey && typeof env[explicitEnvKey] === "string" ? env[explicitEnvKey]?.trim() : "";
+  if (explicit) binary = explicit;
   if (!binary) return null;
   if (path.isAbsolute(binary)) {
     return isExecutable(binary) ? binary : null;

--- a/src/daemon/command.ts
+++ b/src/daemon/command.ts
@@ -1,0 +1,34 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type DaemonCommandResult = { stdout: string; stderr: string; code: number };
+
+export async function execDaemonCommand(
+  file: string,
+  args: string[],
+  options: { windowsHide?: boolean } = {},
+): Promise<DaemonCommandResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(file, args, { encoding: "utf8", ...options });
+    return { stdout: String(stdout ?? ""), stderr: String(stderr ?? ""), code: 0 };
+  } catch (error) {
+    const failure = error as {
+      stdout?: unknown;
+      stderr?: unknown;
+      code?: unknown;
+      message?: unknown;
+    };
+    return {
+      stdout: typeof failure.stdout === "string" ? failure.stdout : "",
+      stderr:
+        typeof failure.stderr === "string"
+          ? failure.stderr
+          : typeof failure.message === "string"
+            ? failure.message
+            : "",
+      code: typeof failure.code === "number" ? failure.code : 1,
+    };
+  }
+}

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,10 +1,7 @@
-import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
+import { execDaemonCommand, type DaemonCommandResult } from "./command.js";
 import { DAEMON_LAUNCH_AGENT_LABEL } from "./constants.js";
-
-const execFileAsync = promisify(execFile);
 
 function resolveHomeDir(env: Record<string, string | undefined>): string {
   const home = env.HOME?.trim() || env.USERPROFILE?.trim();
@@ -117,22 +114,7 @@ export function buildLaunchAgentPlist({
 `;
 }
 
-async function execLaunchctl(
-  args: string[],
-): Promise<{ stdout: string; stderr: string; code: number }> {
-  try {
-    const { stdout, stderr } = await execFileAsync("launchctl", args, { encoding: "utf8" });
-    return { stdout: String(stdout ?? ""), stderr: String(stderr ?? ""), code: 0 };
-  } catch (error) {
-    const e = error as { stdout?: unknown; stderr?: unknown; code?: unknown; message?: unknown };
-    return {
-      stdout: typeof e.stdout === "string" ? e.stdout : "",
-      stderr:
-        typeof e.stderr === "string" ? e.stderr : typeof e.message === "string" ? e.message : "",
-      code: typeof e.code === "number" ? e.code : 1,
-    };
-  }
-}
+const execLaunchctl = (args: string[]) => execDaemonCommand("launchctl", args);
 
 function parseUid(raw: string | undefined): number | null {
   if (!raw) return null;
@@ -246,7 +228,7 @@ export async function installLaunchAgent({
   }
   await execLaunchctl(["unload", plistPath]);
   let installedDomain: string | null = null;
-  let lastBootstrap: { stdout: string; stderr: string; code: number } | null = null;
+  let lastBootstrap: DaemonCommandResult | null = null;
   for (const domain of domains) {
     const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
     if (boot.code === 0) {
@@ -275,7 +257,7 @@ export async function restartLaunchAgent({
 }): Promise<void> {
   const label = DAEMON_LAUNCH_AGENT_LABEL;
   const domains = resolveLaunchctlDomains();
-  let lastResult: { stdout: string; stderr: string; code: number } | null = null;
+  let lastResult: DaemonCommandResult | null = null;
   for (const domain of domains) {
     const res = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
     if (res.code === 0) {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1,11 +1,8 @@
-import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
+import { execDaemonCommand } from "./command.js";
 import { readDaemonConfig } from "./config.js";
 import { DAEMON_HOST, DAEMON_WINDOWS_TASK_NAME } from "./constants.js";
-
-const execFileAsync = promisify(execFile);
 
 function resolveHomeDir(env: Record<string, string | undefined>): string {
   const home = env.USERPROFILE?.trim() || env.HOME?.trim();
@@ -229,38 +226,8 @@ function buildLauncherVbs({
   return lines.join("\r\n");
 }
 
-async function execWindowsCommand(
-  file: string,
-  args: string[],
-): Promise<{ stdout: string; stderr: string; code: number }> {
-  try {
-    const { stdout, stderr } = await execFileAsync(file, args, {
-      encoding: "utf8",
-      windowsHide: true,
-    });
-    return { stdout: String(stdout ?? ""), stderr: String(stderr ?? ""), code: 0 };
-  } catch (error) {
-    const e = error as { stdout?: unknown; stderr?: unknown; code?: unknown; message?: unknown };
-    return {
-      stdout: typeof e.stdout === "string" ? e.stdout : "",
-      stderr:
-        typeof e.stderr === "string" ? e.stderr : typeof e.message === "string" ? e.message : "",
-      code: typeof e.code === "number" ? e.code : 1,
-    };
-  }
-}
-
-async function execSchtasks(
-  args: string[],
-): Promise<{ stdout: string; stderr: string; code: number }> {
-  return execWindowsCommand("schtasks", args);
-}
-
-async function execTaskkill(
-  args: string[],
-): Promise<{ stdout: string; stderr: string; code: number }> {
-  return execWindowsCommand("taskkill", args);
-}
+const execSchtasks = (args: string[]) => execDaemonCommand("schtasks", args, { windowsHide: true });
+const execTaskkill = (args: string[]) => execDaemonCommand("taskkill", args, { windowsHide: true });
 
 function isMissingProcessError(detail: string): boolean {
   return /not found|not running|no running instance|does not exist/i.test(detail);

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -35,17 +35,6 @@ export function resolveDaemonListenHost(env: Record<string, string | undefined>)
     : DAEMON_HOST;
 }
 
-function resolveToolPath(
-  binary: string,
-  env: Record<string, string | undefined>,
-  explicitEnvKey?: string,
-): string | null {
-  const explicit =
-    explicitEnvKey && typeof env[explicitEnvKey] === "string" ? env[explicitEnvKey]?.trim() : "";
-  if (explicit) return resolveExecutableInPath(explicit, env);
-  return resolveExecutableInPath(binary, env);
-}
-
 export function buildHealthPayload(importMetaUrl?: string) {
   return { ok: true, pid: process.pid, version: resolvePackageVersion(importMetaUrl) };
 }
@@ -130,7 +119,7 @@ export async function runDaemonServer({
           daemonLogFile,
           daemonLogPaths,
           processRegistry,
-          resolveToolPath,
+          resolveToolPath: resolveExecutableInPath,
         })
       ) {
         return;
@@ -165,7 +154,7 @@ export async function runDaemonServer({
           runtime,
           port,
           daemonLogger,
-          resolveToolPath,
+          resolveToolPath: resolveExecutableInPath,
           createSessionId: randomUUID,
           onSessionEvent,
         })

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1,10 +1,7 @@
-import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
+import { execDaemonCommand } from "./command.js";
 import { DAEMON_SYSTEMD_SERVICE_NAME } from "./constants.js";
-
-const execFileAsync = promisify(execFile);
 
 function resolveHomeDir(env: Record<string, string | undefined>): string {
   const home = env.HOME?.trim() || env.USERPROFILE?.trim();
@@ -111,22 +108,7 @@ export async function readSystemdServiceExecStart(
   }
 }
 
-async function execSystemctl(
-  args: string[],
-): Promise<{ stdout: string; stderr: string; code: number }> {
-  try {
-    const { stdout, stderr } = await execFileAsync("systemctl", args, { encoding: "utf8" });
-    return { stdout: String(stdout ?? ""), stderr: String(stderr ?? ""), code: 0 };
-  } catch (error) {
-    const e = error as { stdout?: unknown; stderr?: unknown; code?: unknown; message?: unknown };
-    return {
-      stdout: typeof e.stdout === "string" ? e.stdout : "",
-      stderr:
-        typeof e.stderr === "string" ? e.stderr : typeof e.message === "string" ? e.message : "",
-      code: typeof e.code === "number" ? e.code : 1,
-    };
-  }
-}
+const execSystemctl = (args: string[]) => execDaemonCommand("systemctl", args);
 
 async function assertSystemdAvailable() {
   const res = await execSystemctl(["--user", "status"]);

--- a/src/slides/extract.ts
+++ b/src/slides/extract.ts
@@ -103,17 +103,6 @@ function resolveSlidesStreamFallback(env: Record<string, string | undefined>): b
   return raw === "1" || raw === "true" || raw === "yes";
 }
 
-function resolveToolPath(
-  binary: string,
-  env: Record<string, string | undefined>,
-  explicitEnvKey?: string,
-): string | null {
-  const explicit =
-    explicitEnvKey && typeof env[explicitEnvKey] === "string" ? env[explicitEnvKey]?.trim() : "";
-  if (explicit) return resolveExecutableInPath(explicit, env);
-  return resolveExecutableInPath(binary, env);
-}
-
 type ResolveRunnableToolArgs = {
   binary: string;
   env: Record<string, string | undefined>;
@@ -136,7 +125,7 @@ async function resolveRunnableTool({
   if (explicit) {
     return (await canSpawnCommand({ command: explicit, args: probeArgs, env })) ? explicit : null;
   }
-  const resolved = resolveToolPath(binary, env, explicitEnvKey);
+  const resolved = resolveExecutableInPath(binary, env, explicitEnvKey);
   if (resolved) return resolved;
   if (await canSpawnCommand({ command: binary, args: probeArgs, env })) return binary;
   if (binary === "ffmpeg" || binary === "ffprobe") {

--- a/tests/daemon.command.test.ts
+++ b/tests/daemon.command.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { execDaemonCommand } from "../src/daemon/command.js";
+
+describe("daemon command execution", () => {
+  it.each([{}, { windowsHide: true }])("captures successful output with %j", async (options) => {
+    const result = await execDaemonCommand(
+      process.execPath,
+      ["-e", 'process.stdout.write("output"); process.stderr.write("detail");'],
+      options,
+    );
+    expect(result).toEqual({ stdout: "output", stderr: "detail", code: 0 });
+  });
+
+  it("preserves output and numeric exit codes on failure", async () => {
+    const result = await execDaemonCommand(process.execPath, [
+      "-e",
+      'process.stdout.write("partial"); process.stderr.write("failed"); process.exit(7);',
+    ]);
+    expect(result).toEqual({ stdout: "partial", stderr: "failed", code: 7 });
+  });
+
+  it("preserves empty stderr from asynchronous spawn failures", async () => {
+    const result = await execDaemonCommand(join(dirname(process.execPath), randomUUID()), []);
+    expect(result).toEqual({ stdout: "", stderr: "", code: 1 });
+  });
+
+  it("uses the diagnostic for synchronous errors without captured stderr", async () => {
+    const result = await execDaemonCommand("", []);
+    expect(result).toEqual({ stdout: "", stderr: expect.stringContaining("file"), code: 1 });
+  });
+});
+import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";

--- a/tests/run.env.test.ts
+++ b/tests/run.env.test.ts
@@ -30,6 +30,18 @@ describe("run/env", () => {
     expect(resolveExecutableInPath(uvx.file, { PATH: "" })).toBe(uvx.file);
     expect(resolveExecutableInPath("missing", { PATH: uvx.dir })).toBeNull();
     expect(resolveExecutableInPath("", { PATH: uvx.dir })).toBeNull();
+    expect(resolveExecutableInPath("missing", { TOOL_PATH: ` ${uvx.file} ` }, "TOOL_PATH")).toBe(
+      uvx.file,
+    );
+    expect(
+      resolveExecutableInPath("missing", { PATH: uvx.dir, TOOL_PATH: "uvx" }, "TOOL_PATH"),
+    ).toBe(uvx.file);
+    expect(resolveExecutableInPath("uvx", { PATH: uvx.dir, TOOL_PATH: " " }, "TOOL_PATH")).toBe(
+      uvx.file,
+    );
+    expect(
+      resolveExecutableInPath("uvx", { PATH: uvx.dir, TOOL_PATH: "missing" }, "TOOL_PATH"),
+    ).toBeNull();
   });
 
   it("detects uvx from either UVX_PATH or PATH", () => {


### PR DESCRIPTION
## Summary

The launchd, systemd, and Scheduled Task adapters copied the same subprocess result/error normalization. They now share one private command runner, while each platform retains its command order, home-directory preference, service definition, and failure policy. Only Windows requests hidden subprocess windows.

Daemon and slide extraction now use the existing executable resolver directly, including explicit environment overrides. A missing explicit override still fails instead of silently falling back to PATH. EnvState derives its common fields from RunApiStatus; runtime JSON output keeps the same explicit whitelist rather than spreading credential-bearing state.

This removes 85 production lines and 37 lines overall across 12 files. No public CLI/config behavior or dependencies change.

## Validation

- 25 focused service, daemon CLI, and architecture tests passed.
- Twelve focused command/environment tests passed, including real subprocess output, numeric exit codes, asynchronous missing-command errors, synchronous validation errors, and executable override precedence.
- A review caught an OS-specific assumption in the new spawn-error test. The test now distinguishes empty stderr from asynchronous failures and diagnostic fallback from synchronous failures without changing runtime behavior.
- Independent Codex review of the final tree: scoped-clean at P0–P2.
- Root build and the final full gate pass: 3,177 tests passed, 43 skipped; 94.44% line and 85.46% branch coverage. Formatting, lint, and all TypeScript layers pass.
- Exact-head CI is green: Node 24 unit/coverage and type checks, Chromium extension E2E, Firefox smoke, and GitGuardian.
