### PR TITLE
refactor(llm): share OpenAI request and response lifecycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Dependencies and maintenance
 
+- Share OpenAI-compatible request submission, completion validation, and stream usage settlement while retaining protocol-specific payloads and strict document routing/header behavior.
 - Share picker fields, popup rendering, and Preact mounting across Options, the side panel, and checkboxes; derive theme choices from the existing theme registry and remove unused modes and empty hidden select controls.
 - Share daemon service-command execution, executable override lookup, and environment-state types without changing platform-specific service behavior or the JSON environment whitelist.
 - Remove the unused chat mode from summary streaming, share SSE idle deadlines, and consolidate FFmpeg execution and OpenAI transcription HTTP handling while retaining format and response-specific policy.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -14,6 +14,7 @@ installed, auto mode can use local CLI models via `cli.enabled` or implicit auto
 
 ## Defaults
 
+- OpenAI-compatible transports share HTTP submission, completion validation, and streaming usage settlement. Responses and Chat Completions keep distinct payload/event adapters; PDF documents retain the `api.openai.com` restriction and their separate header policy.
 - Default model: `auto`
 - Override with `SUMMARIZE_MODEL`, config file (`model`), or `--model`.
 

--- a/src/llm/providers/openai/chat-completions.ts
+++ b/src/llm/providers/openai/chat-completions.ts
@@ -1,10 +1,10 @@
 import { normalizeOpenAiUsage } from "../../usage.js";
 import { buildOpenAiChatRequestOptions } from "./request-options.js";
-import { createDeferredUsage, createOpenAiSseError, parseOpenAiSseJsonStream } from "./sse.js";
+import { createOpenAiSseError, createOpenAiTextStream } from "./sse.js";
 import {
-  buildOpenAiRequestHeaders,
   contextToChatCompletionMessages,
-  createOpenAiHttpError,
+  postOpenAiJson,
+  readOpenAiCompletion,
   resolveOpenAiChatCompletionsUrl,
 } from "./transport.js";
 import type {
@@ -34,97 +34,42 @@ function extractChatCompletionText(payload: {
     .trim();
 }
 
-export async function completeOpenAiChatText({
-  modelId,
-  openaiConfig,
-  context,
-  temperature,
-  maxOutputTokens,
-  signal,
-  fetchImpl,
-}: OpenAiTextRequest): Promise<OpenAiTextCompletionResult> {
-  const baseUrl = openaiConfig.baseURL ?? "https://api.openai.com/v1";
-  const response = await fetchImpl(String(resolveOpenAiChatCompletionsUrl(baseUrl)), {
-    method: "POST",
-    headers: buildOpenAiRequestHeaders(openaiConfig),
-    body: JSON.stringify({
-      model: modelId,
-      messages: contextToChatCompletionMessages(context),
-      ...buildOpenAiChatRequestOptions(openaiConfig.requestOptions),
-      ...(typeof maxOutputTokens === "number" ? { max_tokens: maxOutputTokens } : {}),
-      ...(typeof temperature === "number" ? { temperature } : {}),
-    }),
-    signal,
+function requestChatCompletion(request: OpenAiTextRequest, stream = false) {
+  const { modelId, context, openaiConfig, maxOutputTokens, temperature } = request;
+  const url = resolveOpenAiChatCompletionsUrl(openaiConfig.baseURL ?? "https://api.openai.com/v1");
+  return postOpenAiJson(request, url, {
+    model: modelId,
+    messages: contextToChatCompletionMessages(context),
+    ...buildOpenAiChatRequestOptions(openaiConfig.requestOptions),
+    ...(stream ? { stream: true, stream_options: { include_usage: true } } : {}),
+    ...(typeof maxOutputTokens === "number" ? { max_tokens: maxOutputTokens } : {}),
+    ...(typeof temperature === "number" ? { temperature } : {}),
   });
-
-  const bodyText = await response.text();
-  if (!response.ok) {
-    throw createOpenAiHttpError({ baseUrl, status: response.status, bodyText });
-  }
-
-  const data = JSON.parse(bodyText) as {
-    choices?: Array<{ message?: { content?: unknown } }>;
-    usage?: unknown;
-  };
-  const text = extractChatCompletionText(data);
-  if (!text) throw new Error(`LLM returned an empty summary (model openai/${modelId}).`);
-  return { text, usage: normalizeOpenAiUsage(data.usage), resolvedModelId: modelId };
 }
 
-export async function streamOpenAiChatText({
-  modelId,
-  openaiConfig,
-  context,
-  temperature,
-  maxOutputTokens,
-  signal,
-  fetchImpl,
-}: OpenAiTextRequest): Promise<OpenAiTextStreamResult> {
-  const baseUrl = openaiConfig.baseURL ?? "https://api.openai.com/v1";
-  const response = await fetchImpl(String(resolveOpenAiChatCompletionsUrl(baseUrl)), {
-    method: "POST",
-    headers: buildOpenAiRequestHeaders(openaiConfig),
-    body: JSON.stringify({
-      model: modelId,
-      messages: contextToChatCompletionMessages(context),
-      ...buildOpenAiChatRequestOptions(openaiConfig.requestOptions),
-      stream: true,
-      stream_options: { include_usage: true },
-      ...(typeof maxOutputTokens === "number" ? { max_tokens: maxOutputTokens } : {}),
-      ...(typeof temperature === "number" ? { temperature } : {}),
-    }),
-    signal,
+export async function completeOpenAiChatText(
+  request: OpenAiTextRequest,
+): Promise<OpenAiTextCompletionResult> {
+  const { modelId } = request;
+  const response = await requestChatCompletion(request);
+  const result = await readOpenAiCompletion(response, modelId, extractChatCompletionText);
+  return { ...result, resolvedModelId: modelId };
+}
+
+export async function streamOpenAiChatText(
+  request: OpenAiTextRequest,
+): Promise<OpenAiTextStreamResult> {
+  const { modelId } = request;
+  const response = await requestChatCompletion(request, true);
+  return createOpenAiTextStream(response, modelId, (event) => {
+    if (event.error) throw createOpenAiSseError(event);
+    const choices = Array.isArray(event.choices) ? event.choices : [];
+    const delta = choices[0]?.delta;
+    const content =
+      delta && typeof delta === "object" ? (delta as { content?: unknown }).content : null;
+    return {
+      ...(event.usage ? { usage: normalizeOpenAiUsage(event.usage) } : {}),
+      ...(typeof content === "string" ? { text: content } : {}),
+    };
   });
-
-  if (!response.ok) {
-    const bodyText = await response.text();
-    throw createOpenAiHttpError({ baseUrl, status: response.status, bodyText });
-  }
-  if (!response.body) {
-    throw new Error("OpenAI stream response was empty.");
-  }
-
-  const usage = createDeferredUsage();
-  const textStream = {
-    async *[Symbol.asyncIterator]() {
-      let finalUsage = null;
-      try {
-        for await (const event of parseOpenAiSseJsonStream(response.body!)) {
-          if (event.error) {
-            throw createOpenAiSseError(event);
-          }
-          if (event.usage) finalUsage = normalizeOpenAiUsage(event.usage);
-          const choices = Array.isArray(event.choices) ? event.choices : [];
-          const delta = choices[0]?.delta;
-          const content =
-            delta && typeof delta === "object" ? (delta as { content?: unknown }).content : null;
-          if (typeof content === "string") yield content;
-        }
-      } finally {
-        usage.resolve(finalUsage);
-      }
-    },
-  };
-
-  return { textStream, usage: usage.promise, resolvedModelId: modelId };
 }

--- a/src/llm/providers/openai/responses.ts
+++ b/src/llm/providers/openai/responses.ts
@@ -5,11 +5,11 @@ import { normalizeOpenAiUsage } from "../../usage.js";
 import { bytesToBase64 } from "../shared.js";
 import type { OpenAiClientConfig } from "../types.js";
 import { buildOpenAiResponsesRequestOptions } from "./request-options.js";
-import { createDeferredUsage, createOpenAiSseError, parseOpenAiSseJsonStream } from "./sse.js";
+import { createOpenAiSseError, createOpenAiTextStream } from "./sse.js";
 import {
-  buildOpenAiRequestHeaders,
   contextToResponsesInput,
-  createOpenAiHttpError,
+  postOpenAiJson,
+  readOpenAiCompletion,
   resolveOpenAiResponsesUrl,
 } from "./transport.js";
 import type {
@@ -42,107 +42,51 @@ function extractOpenAiResponsesStreamUsage(payload: Record<string, unknown>): Ll
   return normalizeOpenAiUsage(usage);
 }
 
-export async function completeOpenAiResponsesText({
-  modelId,
-  openaiConfig,
-  context,
-  temperature,
-  maxOutputTokens,
-  signal,
-  fetchImpl,
-  structuredOutput,
-}: OpenAiTextRequest & {
-  structuredOutput?: OpenAiStructuredOutput;
-}): Promise<OpenAiTextCompletionResult> {
-  const baseUrl = openaiConfig.baseURL ?? "https://api.openai.com/v1";
-  const response = await fetchImpl(String(resolveOpenAiResponsesUrl(baseUrl)), {
-    method: "POST",
-    headers: buildOpenAiRequestHeaders(openaiConfig),
-    body: JSON.stringify({
-      model: modelId,
-      input: contextToResponsesInput(context),
-      ...(context.systemPrompt?.trim() ? { instructions: context.systemPrompt.trim() } : {}),
-      ...buildOpenAiResponsesRequestOptions(openaiConfig.requestOptions, structuredOutput),
-      ...(typeof maxOutputTokens === "number" ? { max_output_tokens: maxOutputTokens } : {}),
-      ...(typeof temperature === "number" ? { temperature } : {}),
-    }),
-    signal,
+type ResponsesTextRequest = OpenAiTextRequest & { structuredOutput?: OpenAiStructuredOutput };
+
+function requestResponsesText(request: ResponsesTextRequest, stream = false) {
+  const { modelId, context, openaiConfig, maxOutputTokens, temperature, structuredOutput } =
+    request;
+  const url = resolveOpenAiResponsesUrl(openaiConfig.baseURL ?? "https://api.openai.com/v1");
+  return postOpenAiJson(request, url, {
+    model: modelId,
+    input: contextToResponsesInput(context),
+    ...(context.systemPrompt?.trim() ? { instructions: context.systemPrompt.trim() } : {}),
+    ...buildOpenAiResponsesRequestOptions(
+      openaiConfig.requestOptions,
+      stream ? undefined : structuredOutput,
+    ),
+    ...(stream ? { stream: true } : {}),
+    ...(typeof maxOutputTokens === "number" ? { max_output_tokens: maxOutputTokens } : {}),
+    ...(typeof temperature === "number" ? { temperature } : {}),
   });
-
-  const bodyText = await response.text();
-  if (!response.ok) {
-    throw createOpenAiHttpError({ baseUrl, status: response.status, bodyText });
-  }
-
-  const data = JSON.parse(bodyText) as {
-    output_text?: unknown;
-    output?: Array<{ content?: Array<{ text?: string }> }>;
-    usage?: unknown;
-  };
-  const text = extractOpenAiResponseText(data);
-  if (!text) throw new Error(`LLM returned an empty summary (model openai/${modelId}).`);
-  return { text, usage: normalizeOpenAiUsage(data.usage), resolvedModelId: modelId };
 }
 
-export async function streamOpenAiResponsesText({
-  modelId,
-  openaiConfig,
-  context,
-  temperature,
-  maxOutputTokens,
-  signal,
-  fetchImpl,
-}: OpenAiTextRequest): Promise<OpenAiTextStreamResult> {
-  const baseUrl = openaiConfig.baseURL ?? "https://api.openai.com/v1";
-  const response = await fetchImpl(String(resolveOpenAiResponsesUrl(baseUrl)), {
-    method: "POST",
-    headers: buildOpenAiRequestHeaders(openaiConfig),
-    body: JSON.stringify({
-      model: modelId,
-      input: contextToResponsesInput(context),
-      ...(context.systemPrompt?.trim() ? { instructions: context.systemPrompt.trim() } : {}),
-      ...buildOpenAiResponsesRequestOptions(openaiConfig.requestOptions),
-      stream: true,
-      ...(typeof maxOutputTokens === "number" ? { max_output_tokens: maxOutputTokens } : {}),
-      ...(typeof temperature === "number" ? { temperature } : {}),
-    }),
-    signal,
+export async function completeOpenAiResponsesText(
+  request: ResponsesTextRequest,
+): Promise<OpenAiTextCompletionResult> {
+  const { modelId } = request;
+  const response = await requestResponsesText(request);
+  const result = await readOpenAiCompletion(response, modelId, extractOpenAiResponseText);
+  return { ...result, resolvedModelId: modelId };
+}
+
+export async function streamOpenAiResponsesText(
+  request: OpenAiTextRequest,
+): Promise<OpenAiTextStreamResult> {
+  const { modelId } = request;
+  const response = await requestResponsesText(request, true);
+  return createOpenAiTextStream(response, modelId, (event) => {
+    if (event.type === "response.output_text.delta" && typeof event.delta === "string") {
+      return { text: event.delta };
+    }
+    if (event.type === "response.completed") {
+      return { usage: extractOpenAiResponsesStreamUsage(event) };
+    }
+    if (event.type === "response.failed" || event.type === "error")
+      throw createOpenAiSseError(event);
+    return null;
   });
-
-  if (!response.ok) {
-    const bodyText = await response.text();
-    throw createOpenAiHttpError({ baseUrl, status: response.status, bodyText });
-  }
-  if (!response.body) {
-    throw new Error("OpenAI stream response was empty.");
-  }
-
-  const usage = createDeferredUsage();
-  const textStream = {
-    async *[Symbol.asyncIterator]() {
-      let finalUsage: LlmTokenUsage | null = null;
-      try {
-        for await (const event of parseOpenAiSseJsonStream(response.body!)) {
-          const type = typeof event.type === "string" ? event.type : "";
-          if (type === "response.output_text.delta" && typeof event.delta === "string") {
-            yield event.delta;
-            continue;
-          }
-          if (type === "response.completed") {
-            finalUsage = extractOpenAiResponsesStreamUsage(event);
-            continue;
-          }
-          if (type === "response.failed" || type === "error") {
-            throw createOpenAiSseError(event);
-          }
-        }
-      } finally {
-        usage.resolve(finalUsage);
-      }
-    },
-  };
-
-  return { textStream, usage: usage.promise, resolvedModelId: modelId };
 }
 
 export async function completeOpenAiDocument({
@@ -205,31 +149,13 @@ export async function completeOpenAiDocument({
   };
 
   try {
-    const response = await fetchImpl(String(url), {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${openaiConfig.apiKey}`,
-      },
-      body: JSON.stringify(payload),
-      signal: controller.signal,
-    });
-
-    const bodyText = await response.text();
-    if (!response.ok) {
-      throw createOpenAiHttpError({ baseUrl, status: response.status, bodyText });
-    }
-
-    const data = JSON.parse(bodyText) as {
-      output_text?: unknown;
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-      usage?: unknown;
-    };
-    const text = extractOpenAiResponseText(data);
-    if (!text) {
-      throw new Error(`LLM returned an empty summary (model openai/${modelId}).`);
-    }
-    return { text, usage: normalizeOpenAiUsage(data.usage) };
+    const response = await postOpenAiJson(
+      { openaiConfig, fetchImpl, signal: controller.signal },
+      url,
+      payload,
+      { "content-type": "application/json", authorization: `Bearer ${openaiConfig.apiKey}` },
+    );
+    return await readOpenAiCompletion(response, modelId, extractOpenAiResponseText);
   } finally {
     clearTimeout(timeout);
   }

--- a/src/llm/providers/openai/sse.ts
+++ b/src/llm/providers/openai/sse.ts
@@ -1,5 +1,33 @@
 import { parseSseStream } from "@steipete/summarize-core/runtime";
 import type { LlmTokenUsage } from "../../types.js";
+import type { OpenAiTextStreamResult } from "./types.js";
+
+export function createOpenAiTextStream(
+  response: Response,
+  modelId: string,
+  readEvent: (
+    event: Record<string, unknown>,
+  ) => { text?: string; usage?: LlmTokenUsage | null } | null,
+): OpenAiTextStreamResult {
+  const body = response.body;
+  if (!body) throw new Error("OpenAI stream response was empty.");
+  const usage = createDeferredUsage();
+  const textStream = {
+    async *[Symbol.asyncIterator]() {
+      let finalUsage: LlmTokenUsage | null = null;
+      try {
+        for await (const event of parseOpenAiSseJsonStream(body)) {
+          const parsed = readEvent(event);
+          if (parsed?.usage !== undefined) finalUsage = parsed.usage;
+          if (typeof parsed?.text === "string") yield parsed.text;
+        }
+      } finally {
+        usage.resolve(finalUsage);
+      }
+    },
+  };
+  return { textStream, usage: usage.promise, resolvedModelId: modelId };
+}
 
 export async function* parseOpenAiSseJsonStream(
   body: ReadableStream<Uint8Array>,
@@ -35,7 +63,7 @@ export function createOpenAiSseError(event: Record<string, unknown>): Error {
   return error;
 }
 
-export function createDeferredUsage(): {
+function createDeferredUsage(): {
   promise: Promise<LlmTokenUsage | null>;
   resolve: (value: LlmTokenUsage | null) => void;
 } {

--- a/src/llm/providers/openai/transport.ts
+++ b/src/llm/providers/openai/transport.ts
@@ -1,5 +1,45 @@
 import type { Context } from "@earendil-works/pi-ai";
+import { normalizeOpenAiUsage } from "../../usage.js";
 import type { OpenAiClientConfig } from "../types.js";
+import type { OpenAiTextCompletionResult, OpenAiTextRequest } from "./types.js";
+
+export async function postOpenAiJson(
+  {
+    openaiConfig,
+    fetchImpl,
+    signal,
+  }: Pick<OpenAiTextRequest, "openaiConfig" | "fetchImpl" | "signal">,
+  url: URL,
+  payload: Record<string, unknown>,
+  headers = buildOpenAiRequestHeaders(openaiConfig),
+): Promise<Response> {
+  const requestUrl = String(url);
+  const response = await fetchImpl(requestUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+    signal,
+  });
+  if (!response.ok) {
+    throw createOpenAiHttpError({
+      baseUrl: requestUrl,
+      status: response.status,
+      bodyText: await response.text(),
+    });
+  }
+  return response;
+}
+
+export async function readOpenAiCompletion<Payload>(
+  response: Response,
+  modelId: string,
+  extractText: (payload: Payload) => string,
+): Promise<OpenAiTextCompletionResult> {
+  const payload = JSON.parse(await response.text()) as Payload & { usage?: unknown };
+  const text = extractText(payload);
+  if (!text) throw new Error(`LLM returned an empty summary (model openai/${modelId}).`);
+  return { text, usage: normalizeOpenAiUsage(payload.usage) };
+}
 
 export function isGitHubModelsBaseUrl(baseUrl: string | undefined): boolean {
   if (!baseUrl) return false;

--- a/tests/llm.openai-chat-completions.coverage.test.ts
+++ b/tests/llm.openai-chat-completions.coverage.test.ts
@@ -78,23 +78,29 @@ describe("OpenAI chat-completions coverage", () => {
     await expect(completeOpenAiChatText(request(emptyFetch))).rejects.toThrow("empty summary");
   });
 
-  it("streams deltas and resolves final usage", async () => {
-    const body = [
-      `data: ${JSON.stringify({ choices: [{ delta: { content: "one" } }] })}\n\n`,
-      `data: ${JSON.stringify({ choices: [null], usage: { input_tokens: 2, output_tokens: 3, total_tokens: 5 } })}\n\n`,
-      "data: [DONE]\n\n",
-    ].join("");
-    const fetchImpl = vi.fn(async () => new Response(body)) as typeof fetch;
-    const result = await streamOpenAiChatText(request(fetchImpl));
-    const chunks: string[] = [];
-    for await (const chunk of result.textStream) chunks.push(chunk);
-    expect(chunks).toEqual(["one"]);
-    await expect(result.usage).resolves.toEqual({
-      promptTokens: 2,
-      completionTokens: 3,
-      totalTokens: 5,
-    });
-  });
+  it.each([false, true])(
+    "resolves usage when streaming ends (early close: %s)",
+    async (earlyClose) => {
+      const textEvent = `data: ${JSON.stringify({ choices: [{ delta: { content: "one" } }] })}\n\n`;
+      const usageEvent = `data: ${JSON.stringify({ choices: [null], usage: { input_tokens: 2, output_tokens: 3, total_tokens: 5 } })}\n\n`;
+      const events = earlyClose ? [usageEvent, textEvent] : [textEvent, usageEvent];
+      const response = new Response(events.join("") + "data: [DONE]\n\n");
+      const fetchImpl = vi.fn(async () => response) as typeof fetch;
+      const result = await streamOpenAiChatText(request(fetchImpl));
+      const chunks: string[] = [];
+      for await (const chunk of result.textStream) {
+        chunks.push(chunk);
+        if (earlyClose) break;
+      }
+      expect(chunks).toEqual(["one"]);
+      expect(response.body?.locked).toBe(false);
+      await expect(result.usage).resolves.toEqual({
+        promptTokens: 2,
+        completionTokens: 3,
+        totalTokens: 5,
+      });
+    },
+  );
 
   it("handles stream HTTP, missing-body, structured, and generic errors", async () => {
     const errorFetch = vi.fn(async () => new Response("bad", { status: 429 })) as typeof fetch;

--- a/tests/llm.openai-responses.coverage.test.ts
+++ b/tests/llm.openai-responses.coverage.test.ts
@@ -78,89 +78,102 @@ describe("OpenAI Responses coverage", () => {
     ).rejects.toThrow("empty summary");
   });
 
-  it("streams deltas, nested and top-level usage, failures, and missing bodies", async () => {
-    const stream = [
-      `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "one" })}\n\n`,
-      `data: ${JSON.stringify({ type: "response.completed", response: { usage: { input_tokens: 2, output_tokens: 3 } } })}\n\n`,
-    ].join("");
-    const result = await streamOpenAiResponsesText(
-      request(vi.fn(async () => new Response(stream)) as typeof fetch),
-    );
-    const chunks: string[] = [];
-    for await (const chunk of result.textStream) chunks.push(chunk);
-    expect(chunks).toEqual(["one"]);
-    await expect(result.usage).resolves.toEqual({
-      promptTokens: 2,
-      completionTokens: 3,
-      totalTokens: 5,
-    });
-
-    await expect(
-      streamOpenAiResponsesText(
-        request(vi.fn(async () => new Response("bad", { status: 500 })) as typeof fetch),
-      ),
-    ).rejects.toThrow("OpenAI API error");
-    await expect(
-      streamOpenAiResponsesText(
-        request(vi.fn(async () => ({ ok: true, body: null }) as Response) as typeof fetch),
-      ),
-    ).rejects.toThrow("stream response was empty");
-
-    for (const { event, message, retryable } of [
-      {
-        event: {
-          type: "response.failed",
-          response: { error: { code: "server_error", message: "specific" } },
-        },
-        message: "specific",
-        retryable: true,
-      },
-      {
-        event: { type: "error", code: "rate_limit_exceeded", message: "slow down" },
-        message: "slow down",
-        retryable: true,
-      },
-      {
-        event: { type: "error", error: "bad" },
-        message: "stream failed",
-        retryable: false,
-      },
-    ]) {
-      const failed = await streamOpenAiResponsesText(
-        request(
-          vi.fn(async () => new Response(`data: ${JSON.stringify(event)}\n\n`)) as typeof fetch,
-        ),
+  it.each([false, true])(
+    "streams deltas and usage with failures (early close: %s)",
+    async (earlyClose) => {
+      const stream = [
+        `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "one" })}\n\n`,
+        `data: ${JSON.stringify({ type: "response.completed", response: { usage: { input_tokens: 2, output_tokens: 3 } } })}\n\n`,
+      ];
+      if (earlyClose) stream.reverse();
+      const response = new Response(stream.join(""));
+      const result = await streamOpenAiResponsesText(
+        request(vi.fn(async () => response) as typeof fetch),
       );
-      const error = await (async () => {
-        try {
-          for await (const _chunk of failed.textStream) {
-            // consume
+      const chunks: string[] = [];
+      for await (const chunk of result.textStream) {
+        chunks.push(chunk);
+        if (earlyClose) break;
+      }
+      expect(chunks).toEqual(["one"]);
+      expect(response.body?.locked).toBe(false);
+      await expect(result.usage).resolves.toEqual({
+        promptTokens: 2,
+        completionTokens: 3,
+        totalTokens: 5,
+      });
+
+      await expect(
+        streamOpenAiResponsesText(
+          request(vi.fn(async () => new Response("bad", { status: 500 })) as typeof fetch),
+        ),
+      ).rejects.toThrow("OpenAI API error");
+      await expect(
+        streamOpenAiResponsesText(
+          request(vi.fn(async () => ({ ok: true, body: null }) as Response) as typeof fetch),
+        ),
+      ).rejects.toThrow("stream response was empty");
+
+      for (const { event, message, retryable } of [
+        {
+          event: {
+            type: "response.failed",
+            response: { error: { code: "server_error", message: "specific" } },
+          },
+          message: "specific",
+          retryable: true,
+        },
+        {
+          event: { type: "error", code: "rate_limit_exceeded", message: "slow down" },
+          message: "slow down",
+          retryable: true,
+        },
+        {
+          event: { type: "error", error: "bad" },
+          message: "stream failed",
+          retryable: false,
+        },
+      ]) {
+        const failed = await streamOpenAiResponsesText(
+          request(
+            vi.fn(async () => new Response(`data: ${JSON.stringify(event)}\n\n`)) as typeof fetch,
+          ),
+        );
+        const error = await (async () => {
+          try {
+            for await (const _chunk of failed.textStream) {
+              // consume
+            }
+          } catch (caught) {
+            return caught;
           }
-        } catch (caught) {
-          return caught;
-        }
-        throw new Error("Expected stream failure");
-      })();
-      expect(error).toMatchObject({ message: expect.stringContaining(message) });
-      expect(isRetryableLlmError(error)).toBe(retryable);
-      await expect(failed.usage).resolves.toBeNull();
-    }
-  });
+          throw new Error("Expected stream failure");
+        })();
+        expect(error).toMatchObject({ message: expect.stringContaining(message) });
+        expect(isRetryableLlmError(error)).toBe(retryable);
+        await expect(failed.usage).resolves.toBeNull();
+      }
+    },
+  );
 
   it("validates and completes PDF document requests", async () => {
     const base = {
       modelId: "gpt-5",
-      openaiConfig: config,
+      openaiConfig: { ...config, extraHeaders: { authorization: "override", "X-Extra": "value" } },
       promptText: "summarize",
       maxOutputTokens: 100,
       temperature: 0,
       timeoutMs: 1_000,
-      fetchImpl: vi.fn(async () =>
-        Response.json({
+      fetchImpl: vi.fn(async (_input, init) => {
+        expect(init?.headers).toEqual({
+          "content-type": "application/json",
+          authorization: "Bearer key",
+        });
+        return Response.json({
           output_text: "document result",
           usage: { input_tokens: 1, output_tokens: 2 },
-        }),
-      ) as typeof fetch,
+        });
+      }) as typeof fetch,
     };
     await expect(
       completeOpenAiDocument({


### PR DESCRIPTION
## Summary

The OpenAI-compatible adapters duplicated HTTP submission/error handling, completion parsing, and stream usage settlement. They now share these lifecycles, while Responses and Chat Completions retain separate request and event adapters. Requested model IDs and target URLs are captured before asynchronous work.

Document requests retain their api.openai.com restriction, deliberately limited headers, and timeout coverage through response-body consumption. Text requests retain configured extra-header precedence. Payload keys, endpoint normalization, structured output, empty-result errors, and partial-stream usage behavior remain unchanged.

Net reduction: 61 production lines and 40 lines overall across eight files. No new dependencies or public CLI/config changes.

## Validation

- Focused OpenAI/provider/architecture checks passed; the final focused provider run passed 28 tests.
- Added early-close coverage for both streaming protocols verifies usage settlement and reader release. Document coverage verifies extra headers cannot override the document path's existing header policy.
- Root build and full gate passed: 3,179 tests, 43 skipped. Final model/URL capture changes also passed the focused run and independent review.
- Independent Codex review: scoped-clean at P0–P2.
- Exact-head CI is green: Node 24 unit/coverage and type checks, Chromium E2E, Firefox smoke, and GitGuardian.
