### PR TITLE
fix(slides): unify download progress and clean failed downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Slides: parse ordinary yt-dlp percentage lines correctly and remove partial download directories after process or output-inspection failures.
 - Transcription: skip probing the local Whisper executable when no usable model is installed, avoiding unnecessary process startup and delays on cloud-only or unconfigured systems.
 - Browser settings: retain a dismissed local-companion hint when saving other Options preferences.
 - Browser chat: normalize partial or malformed saved usage metadata and unknown stop reasons when restoring assistant history.
@@ -20,6 +21,7 @@
 
 ### Dependencies and maintenance
 
+- Share stdout/stderr download-progress handling and one temporary-directory lifecycle for YouTube and direct-video downloads, retaining successful-download cleanup ownership with the caller.
 - Share OpenAI-compatible request submission, completion validation, and stream usage settlement while retaining protocol-specific payloads and strict document routing/header behavior.
 - Share picker fields, popup rendering, and Preact mounting across Options, the side panel, and checkboxes; derive theme choices from the existing theme registry and remove unused modes and empty hidden select controls.
 - Share daemon service-command execution, executable override lookup, and environment-state types without changing platform-specific service behavior or the JSON environment whitelist.

--- a/docs/slides-rendering-flow.md
+++ b/docs/slides-rendering-flow.md
@@ -30,6 +30,8 @@ Rule: keep terminal I/O in render helpers; keep state mutations in the state sto
 
 `src/slides/process.ts` owns media-tool spawning, deadlines, exit errors, and output collection. Line callbacks, text capture, and binary capture share that lifecycle; OCR uses binary capture to avoid logging recognized text. Ignored stdout is drained so child processes cannot block on a full pipe.
 
+`src/slides/download.ts` owns temporary download directories through success or failure. Failures remove partial output without replacing the original error; successful downloads return cleanup to the caller. Structured yt-dlp progress shares one parser on stdout and stderr, while ordinary percentage/speed/ETA lines remain stderr-only.
+
 ## Chrome extension
 
 `background/content-script-bridge.ts` shares retry/reinjection handling across extraction, seeking, and frame preparation. Only extraction has a message deadline; capture startup and restoration keep their separate recovery policies and self-contained main-world scripts.

--- a/src/slides/download.ts
+++ b/src/slides/download.ts
@@ -1,8 +1,8 @@
-import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { buildSharedVideoMediaCacheKey } from "@steipete/summarize-core/content";
+import type { ProcessHandle } from "../processes.js";
 import { runProcess, runProcessCapture } from "./process.js";
 
 const YT_DLP_TIMEOUT_MS = 300_000;
@@ -38,29 +38,24 @@ export async function downloadYoutubeVideo(options: {
   onProgress?: ((percent: number, detail?: string) => void) | null;
 }): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
   const { ytDlpPath, url, timeoutMs, format, cookiesFromBrowser, onProgress } = options;
-  const dir = await fs.mkdtemp(path.join(tmpdir(), `summarize-slides-${randomUUID()}-`));
-  const outputTemplate = path.join(dir, "video.%(ext)s");
-  const progressTemplate =
-    "progress:%(progress.downloaded_bytes)s|%(progress.total_bytes)s|%(progress.total_bytes_estimate)s";
-  const args = [
-    "-f",
-    format,
-    "--no-playlist",
-    "--no-warnings",
-    "--concurrent-fragments",
-    "4",
-    ...buildYtDlpCookiesArgs(cookiesFromBrowser),
-    ...(onProgress ? ["--progress", "--newline", "--progress-template", progressTemplate] : []),
-    "-o",
-    outputTemplate,
-    url,
-  ];
-  await runProcess({
-    command: ytDlpPath,
-    args,
-    timeoutMs: Math.max(timeoutMs, YT_DLP_TIMEOUT_MS),
-    errorLabel: "yt-dlp",
-    onStderrLine: (line, handle) => {
+  return withDownloadDirectory(async (dir) => {
+    const outputTemplate = path.join(dir, "video.%(ext)s");
+    const progressTemplate =
+      "progress:%(progress.downloaded_bytes)s|%(progress.total_bytes)s|%(progress.total_bytes_estimate)s";
+    const args = [
+      "-f",
+      format,
+      "--no-playlist",
+      "--no-warnings",
+      "--concurrent-fragments",
+      "4",
+      ...buildYtDlpCookiesArgs(cookiesFromBrowser),
+      ...(onProgress ? ["--progress", "--newline", "--progress-template", progressTemplate] : []),
+      "-o",
+      outputTemplate,
+      url,
+    ];
+    const reportProgress = (line: string, handle: ProcessHandle | null, allowStandard = false) => {
       if (!onProgress) return;
       const trimmed = line.trim();
       if (trimmed.startsWith("progress:")) {
@@ -83,8 +78,8 @@ export async function downloadYoutubeVideo(options: {
         handle?.setProgress(percent, detail);
         return;
       }
-      if (!trimmed.startsWith("[download]")) return;
-      const percentMatch = trimmed.match(/\b(\d{1,3}(?:\.\d+)?)%\b/);
+      if (!allowStandard || !trimmed.startsWith("[download]")) return;
+      const percentMatch = trimmed.match(/\b(\d{1,3}(?:\.\d+)?)%(?=\s|$)/);
       if (!percentMatch) return;
       const percent = Number(percentMatch[1]);
       if (!Number.isFinite(percent) || percent < 0 || percent > 100) return;
@@ -97,53 +92,32 @@ export async function downloadYoutubeVideo(options: {
       const detail = detailParts.length ? detailParts.join(" ") : undefined;
       onProgress(percent, detail);
       handle?.setProgress(percent, detail ?? null);
-    },
-    onStdoutLine: onProgress
-      ? (line, handle) => {
-          if (!line.trim().startsWith("progress:")) return;
-          const payload = line.trim().slice("progress:".length);
-          const [downloadedRaw, totalRaw, estimateRaw] = payload.split("|");
-          const downloaded = Number.parseFloat(downloadedRaw);
-          if (!Number.isFinite(downloaded) || downloaded < 0) return;
-          const totalCandidate = Number.parseFloat(totalRaw);
-          const estimateCandidate = Number.parseFloat(estimateRaw);
-          const totalBytes =
-            Number.isFinite(totalCandidate) && totalCandidate > 0
-              ? totalCandidate
-              : Number.isFinite(estimateCandidate) && estimateCandidate > 0
-                ? estimateCandidate
-                : null;
-          if (!totalBytes || totalBytes <= 0) return;
-          const percent = Math.max(0, Math.min(100, Math.round((downloaded / totalBytes) * 100)));
-          const detail = `(${formatBytes(downloaded)}/${formatBytes(totalBytes)})`;
-          onProgress(percent, detail);
-          handle?.setProgress(percent, detail);
-        }
-      : undefined,
-  });
+    };
+    await runProcess({
+      command: ytDlpPath,
+      args,
+      timeoutMs: Math.max(timeoutMs, YT_DLP_TIMEOUT_MS),
+      errorLabel: "yt-dlp",
+      onStderrLine: (line, handle) => reportProgress(line, handle, true),
+      onStdoutLine: onProgress ? reportProgress : undefined,
+    });
 
-  const files = await fs.readdir(dir);
-  const candidates = [];
-  for (const entry of files) {
-    if (entry.endsWith(".part") || entry.endsWith(".ytdl")) continue;
-    const filePath = path.join(dir, entry);
-    const stat = await fs.stat(filePath).catch(() => null);
-    if (stat?.isFile()) {
-      candidates.push({ filePath, size: stat.size });
+    const files = await fs.readdir(dir);
+    const candidates = [];
+    for (const entry of files) {
+      if (entry.endsWith(".part") || entry.endsWith(".ytdl")) continue;
+      const filePath = path.join(dir, entry);
+      const stat = await fs.stat(filePath).catch(() => null);
+      if (stat?.isFile()) {
+        candidates.push({ filePath, size: stat.size });
+      }
     }
-  }
-  if (candidates.length === 0) {
-    await fs.rm(dir, { recursive: true, force: true });
-    throw new Error("yt-dlp completed but no video file was downloaded.");
-  }
-  candidates.sort((a, b) => b.size - a.size);
-  const filePath = candidates[0].filePath;
-  return {
-    filePath,
-    cleanup: async () => {
-      await fs.rm(dir, { recursive: true, force: true });
-    },
-  };
+    if (candidates.length === 0) {
+      throw new Error("yt-dlp completed but no video file was downloaded.");
+    }
+    candidates.sort((a, b) => b.size - a.size);
+    return candidates[0].filePath;
+  });
 }
 
 export async function downloadRemoteVideo(options: {
@@ -153,75 +127,68 @@ export async function downloadRemoteVideo(options: {
   onProgress?: ((percent: number, detail?: string) => void) | null;
 }): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
   const { url, timeoutMs, fetchImpl = fetch, onProgress } = options;
-  const dir = await fs.mkdtemp(path.join(tmpdir(), `summarize-slides-${randomUUID()}-`));
-  let suffix = ".bin";
-  try {
-    const parsed = new URL(url);
-    const ext = path.extname(parsed.pathname);
-    if (ext) suffix = ext;
-  } catch {
-    // ignore
-  }
-  const filePath = path.join(dir, `video${suffix}`);
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetchImpl(url, { signal: controller.signal });
-    if (!res.ok) {
-      throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-    }
-    const totalRaw = res.headers.get("content-length");
-    const total = totalRaw ? Number(totalRaw) : 0;
-    const hasTotal = Number.isFinite(total) && total > 0;
-    const reader = res.body?.getReader();
-    if (!reader) {
-      throw new Error("Download failed: missing response body");
-    }
-    const handle = await fs.open(filePath, "w");
-    let downloaded = 0;
-    let lastPercent = -1;
-    let lastReportedBytes = 0;
-    const reportProgress = () => {
-      if (!onProgress) return;
-      if (hasTotal) {
-        const percent = Math.max(0, Math.min(100, Math.round((downloaded / total) * 100)));
-        if (percent === lastPercent) return;
-        lastPercent = percent;
-        const detail = `(${formatBytes(downloaded)}/${formatBytes(total)})`;
-        onProgress(percent, detail);
-        return;
-      }
-      if (downloaded - lastReportedBytes < 2 * 1024 * 1024) return;
-      lastReportedBytes = downloaded;
-      onProgress(0, `(${formatBytes(downloaded)})`);
-    };
+  return withDownloadDirectory(async (dir) => {
+    let suffix = ".bin";
     try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (!value) continue;
-        await handle.write(value);
-        downloaded += value.byteLength;
-        reportProgress();
+      const parsed = new URL(url);
+      const ext = path.extname(parsed.pathname);
+      if (ext) suffix = ext;
+    } catch {
+      // ignore
+    }
+    const filePath = path.join(dir, `video${suffix}`);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetchImpl(url, { signal: controller.signal });
+      if (!res.ok) {
+        throw new Error(`Download failed: ${res.status} ${res.statusText}`);
       }
+      const totalRaw = res.headers.get("content-length");
+      const total = totalRaw ? Number(totalRaw) : 0;
+      const hasTotal = Number.isFinite(total) && total > 0;
+      const reader = res.body?.getReader();
+      if (!reader) {
+        throw new Error("Download failed: missing response body");
+      }
+      const handle = await fs.open(filePath, "w");
+      let downloaded = 0;
+      let lastPercent = -1;
+      let lastReportedBytes = 0;
+      const reportProgress = () => {
+        if (!onProgress) return;
+        if (hasTotal) {
+          const percent = Math.max(0, Math.min(100, Math.round((downloaded / total) * 100)));
+          if (percent === lastPercent) return;
+          lastPercent = percent;
+          const detail = `(${formatBytes(downloaded)}/${formatBytes(total)})`;
+          onProgress(percent, detail);
+          return;
+        }
+        if (downloaded - lastReportedBytes < 2 * 1024 * 1024) return;
+        lastReportedBytes = downloaded;
+        onProgress(0, `(${formatBytes(downloaded)})`);
+      };
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (!value) continue;
+          await handle.write(value);
+          downloaded += value.byteLength;
+          reportProgress();
+        }
+      } finally {
+        await handle.close();
+      }
+      if (hasTotal) {
+        onProgress?.(100, `(${formatBytes(downloaded)}/${formatBytes(total)})`);
+      }
+      return filePath;
     } finally {
-      await handle.close();
+      clearTimeout(timeout);
     }
-    if (hasTotal) {
-      onProgress?.(100, `(${formatBytes(downloaded)}/${formatBytes(total)})`);
-    }
-    return {
-      filePath,
-      cleanup: async () => {
-        await fs.rm(dir, { recursive: true, force: true });
-      },
-    };
-  } catch (error) {
-    await fs.rm(dir, { recursive: true, force: true }).catch(() => null);
-    throw error;
-  } finally {
-    clearTimeout(timeout);
-  }
+  });
 }
 
 export async function resolveYoutubeStreamUrl(options: {
@@ -247,4 +214,15 @@ export async function resolveYoutubeStreamUrl(options: {
     throw new Error("yt-dlp did not return a stream URL.");
   }
   return lines[0];
+}
+
+async function withDownloadDirectory(download: (directory: string) => Promise<string>) {
+  const directory = await fs.mkdtemp(path.join(tmpdir(), "summarize-slides-"));
+  const cleanup = () => fs.rm(directory, { recursive: true, force: true });
+  try {
+    return { filePath: await download(directory), cleanup };
+  } catch (error) {
+    await cleanup().catch(() => {});
+    throw error;
+  }
 }

--- a/tests/slides.download.test.ts
+++ b/tests/slides.download.test.ts
@@ -1,9 +1,77 @@
-import { existsSync } from "node:fs";
-import { readFile, rm } from "node:fs/promises";
-import { describe, expect, it, vi } from "vitest";
-import { downloadRemoteVideo } from "../src/slides/download.js";
+import { existsSync, promises as fs } from "node:fs";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProcessHandle } from "../src/processes.js";
+import { downloadRemoteVideo, downloadYoutubeVideo } from "../src/slides/download.js";
+import { runProcess } from "../src/slides/process.js";
+
+vi.mock("../src/slides/process.js", () => ({ runProcess: vi.fn(), runProcessCapture: vi.fn() }));
+
+const youtubeOptions = {
+  ytDlpPath: "yt-dlp",
+  url: "https://youtube.com/watch?v=test",
+  timeoutMs: 1_000,
+  format: "bestvideo",
+};
+const outputDirectory = (args: string[]) => dirname(args[args.indexOf("-o") + 1]);
 
 describe("slides download", () => {
+  afterEach(() => {
+    vi.mocked(runProcess).mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["stdout", "progress:512|1024|NA", 50, "(512B/1KB)"],
+    ["stderr", "progress:128|NA|256", 50, "(128B/256B)"],
+    ["stderr", "[download] 25.0% of 1MiB at 100KiB/s ETA 00:04", 25, "at 100KiB/s ETA 00:04"],
+    ["stderr", "[download] 100%", 100, undefined],
+    ["stdout", "[download] 25%", null, undefined],
+    ["stdout", "progress:-1|10|10", null, undefined],
+    ["stderr", "progress:1|0|0", null, undefined],
+  ] as const)("handles %s progress %s", async (stream, line, percent, detail) => {
+    const onProgress = vi.fn();
+    const setProgress = vi.fn();
+    vi.mocked(runProcess).mockImplementationOnce(async (options) => {
+      await writeFile(join(outputDirectory(options.args), "video.mp4"), "video");
+      const handler = stream === "stdout" ? options.onStdoutLine : options.onStderrLine;
+      handler?.(line, { setProgress } as unknown as ProcessHandle);
+    });
+    const result = await downloadYoutubeVideo({ ...youtubeOptions, onProgress });
+    try {
+      if (percent === null) {
+        expect(onProgress).not.toHaveBeenCalled();
+        expect(setProgress).not.toHaveBeenCalled();
+      } else {
+        expect(onProgress).toHaveBeenCalledExactlyOnceWith(percent, detail);
+        expect(setProgress).toHaveBeenCalledExactlyOnceWith(percent, detail ?? null);
+      }
+      expect(existsSync(result.filePath)).toBe(true);
+    } finally {
+      await result.cleanup();
+    }
+  });
+
+  it.each(["download", "inspection"])(
+    "removes partial downloads after %s failure",
+    async (stage) => {
+      let directory = "";
+      const failure = new Error("synthetic failure");
+      vi.mocked(runProcess).mockImplementationOnce(async ({ args }) => {
+        directory = outputDirectory(args);
+        await writeFile(join(directory, "video.mp4.part"), "partial");
+        if (stage === "download") throw failure;
+        vi.spyOn(fs, "readdir").mockRejectedValueOnce(failure);
+      });
+      try {
+        await expect(downloadYoutubeVideo(youtubeOptions)).rejects.toBe(failure);
+        expect(existsSync(directory)).toBe(false);
+      } finally {
+        if (directory) await rm(directory, { recursive: true, force: true });
+      }
+    },
+  );
   it("uses the injected fetch implementation for remote videos", async () => {
     const fetchImpl = vi.fn(async () => {
       return new Response(new Uint8Array([1, 2, 3]), {


### PR DESCRIPTION
## Summary

Use one temporary-directory lifecycle for YouTube and direct-video downloads. Successful downloads still hand cleanup to the caller; failures clean partial output and preserve the original exception. This fixes leaked directories when yt-dlp fails or downloaded output cannot be inspected, and removes the redundant UUID prefix from securely created mkdtemp directories.

Structured stdout/stderr progress now shares one parser. Standard yt-dlp percentage/speed/ETA text remains stderr-only; its old regex required a word character after `%`, so normal whitespace/end-of-line percentages were silently ignored. The corrected boundary accepts ordinary progress lines.

Production code drops 22 lines. The PR adds 50 lines overall because it adds regression coverage for the two bugs and stream-specific progress behavior. No dependency changes.

## Validation

- Four regression cases failed before the fix (ordinary percentage lines and both failure-cleanup paths); all pass after it.
- Twenty-six focused download/process tests pass, including progress callbacks, process observer values, ignored invalid lines, successful cleanup handoff, and original-error preservation.
- Root build and full gate pass: 3,188 tests passed, 43 skipped; 94.42% line and 85.47% branch coverage.
- Independent Codex review: scoped-clean at P0–P2.
- Exact-head CI is green: Node 24 unit/coverage and type checks, Chromium E2E, Firefox smoke, and GitGuardian.
