### PR TITLE
refactor(slides): share summary distribution and live render inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Dependencies and maintenance
 
+- Share slide-summary paragraph distribution and live rendering inputs while preserving intro handling, interludes, duplicate indexes, and fallback precedence.
 - Give shared pickers and checkboxes one base stylesheet; retain Options and side-panel layout, sizing, backgrounds, and focus overrides in their own stylesheets.
 - Share stdout/stderr download-progress handling and one temporary-directory lifecycle for YouTube and direct-video downloads, retaining successful-download cleanup ownership with the caller.
 - Share OpenAI-compatible request submission, completion validation, and stream usage settlement while retaining protocol-specific payloads and strict document routing/header behavior.

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-view-runtime.ts
@@ -153,7 +153,7 @@ export function createSlidesViewRuntime({
     slidesRenderer.renderInline(container, opts);
   };
 
-  const renderMarkdownDisplay = () => {
+  const renderSummaryDisplay = (markdown: string) => {
     renderSummaryMarkdownDisplay({
       activeTabUrl: panelState.navigation.activeTabUrl,
       autoSummarize: panelState.panelSession.autoSummarize,
@@ -164,7 +164,7 @@ export function createSlidesViewRuntime({
       hostEl: renderMarkdownHostEl,
       copyButtonEl: summaryCopyBtn,
       inputMode: resolveSlidesInputMode(panelState.slidesSession),
-      markdown: panelState.summaryMarkdown ?? "",
+      markdown,
       md,
       phase: panelState.phase,
       renderInlineSlides,
@@ -175,27 +175,8 @@ export function createSlidesViewRuntime({
     });
   };
 
-  const renderEmptySummaryState = () => {
-    renderSummaryMarkdownDisplay({
-      activeTabUrl: panelState.navigation.activeTabUrl,
-      autoSummarize: panelState.panelSession.autoSummarize,
-      currentSourceTitle: panelState.currentSource?.title ?? null,
-      currentSourceUrl: panelState.currentSource?.url ?? null,
-      hasSlides: Boolean(panelState.slides?.slides.length),
-      headerSetStatus,
-      hostEl: renderMarkdownHostEl,
-      copyButtonEl: summaryCopyBtn,
-      inputMode: resolveSlidesInputMode(panelState.slidesSession),
-      markdown: "",
-      md,
-      phase: panelState.phase,
-      renderInlineSlides,
-      slidesEnabled: panelState.slidesSession.slidesEnabled,
-      slidesLayout: panelState.slidesSession.slidesLayout,
-      tabTitle: panelState.ui?.tab.title ?? null,
-      tabUrl: panelState.ui?.tab.url ?? null,
-    });
-  };
+  const renderMarkdownDisplay = () => renderSummaryDisplay(panelState.summaryMarkdown ?? "");
+  const renderEmptySummaryState = () => renderSummaryDisplay("");
 
   const updateSlideSummaryFromMarkdown = (
     markdown: string,

--- a/docs/slides-rendering-flow.md
+++ b/docs/slides-rendering-flow.md
@@ -47,6 +47,8 @@ Rule: keep terminal I/O in render helpers; keep state mutations in the state sto
 
 Rule: push pure status/log logic out of adapters first.
 
+Slide-summary coercion shares paragraph selection and distribution, while retaining separate explicit-summary and fallback text policies. Normal and empty-summary rendering build the same display inputs from live panel state; rendering an empty state does not erase stored Markdown.
+
 ## When debugging
 
 1. Check state transitions before DOM issues.

--- a/packages/core/src/slides/text-markdown.ts
+++ b/packages/core/src/slides/text-markdown.ts
@@ -472,37 +472,33 @@ export function coerceSummaryWithSlides({
     lengthArg,
   });
 
-  if (slideSummaries.size > 0 && !titleOnlySlideSummaries) {
+  const hasDetailedSummaries = slideSummaries.size > 0 && !titleOnlySlideSummaries;
+  const paragraphs = splitMarkdownParagraphs(hasDetailedSummaries ? summary : distributionMarkdown);
+  if (!hasDetailedSummaries && paragraphs.length === 0) return markdown;
+  if (!hasDetailedSummaries && ordered.every((slide) => interludeSlideIndexes.has(slide.index))) {
+    return [intro.trim(), ...ordered.map((slide) => `[slide:${slide.index}]\n## Interlude`)]
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  const introParagraph = reserveIntro ? intro || paragraphs[0] || "" : "";
+  const introIndex = introParagraph ? paragraphs.indexOf(introParagraph) : -1;
+  const remaining = reserveIntro
+    ? introIndex >= 0
+      ? paragraphs.filter((_, index) => index !== introIndex)
+      : paragraphs.slice(1)
+    : paragraphs;
+  const distributableSlides = ordered.filter((slide) => !interludeSlideIndexes.has(slide.index));
+  const total = (distributableSlides.length > 0 ? distributableSlides : ordered).length;
+
+  if (hasDetailedSummaries) {
     const parts: string[] = [];
     if (intro) parts.push(intro);
-    const paragraphs = splitMarkdownParagraphs(summary);
-    const introParagraph = reserveIntro ? intro || paragraphs[0] || "" : "";
-    const introIndex = introParagraph ? paragraphs.indexOf(introParagraph) : -1;
-    const remaining = reserveIntro
-      ? introIndex >= 0
-        ? paragraphs.filter((_, index) => index !== introIndex)
-        : paragraphs.slice(1)
-      : paragraphs;
     const distributedSummaries = new Map<number, string>();
     if (remaining.length > 0) {
-      const distributableSlides = ordered.filter(
-        (slide) => !interludeSlideIndexes.has(slide.index),
-      );
-      const distributionSlides = distributableSlides.length > 0 ? distributableSlides : ordered;
-      const total = distributionSlides.length;
       let distributionIndex = 0;
       for (const slide of ordered) {
         if (interludeSlideIndexes.has(slide.index) && distributableSlides.length > 0) continue;
-        const segmentIndex = distributionIndex;
-        const start = Math.round((segmentIndex * remaining.length) / total);
-        const end = Math.round(((segmentIndex + 1) * remaining.length) / total);
-        distributionIndex += 1;
-        const segment =
-          remaining.slice(start, end).join("\n\n").trim() ||
-          remaining[
-            Math.min(remaining.length - 1, Math.floor((segmentIndex * remaining.length) / total))
-          ]?.trim() ||
-          "";
+        const segment = distributeParagraphs(remaining, distributionIndex++, total);
         if (segment) distributedSummaries.set(slide.index, segment);
       }
     }
@@ -527,43 +523,8 @@ export function coerceSummaryWithSlides({
     return parts.join("\n\n");
   }
 
-  const paragraphs = splitMarkdownParagraphs(distributionMarkdown);
-  if (paragraphs.length === 0) return markdown;
   const parts: string[] = [];
-  const allOrderedSlidesAreInterludes =
-    ordered.length > 0 && ordered.every((slide) => interludeSlideIndexes.has(slide.index));
-  if (allOrderedSlidesAreInterludes) {
-    if (intro) parts.push(intro.trim());
-    for (const slide of ordered) {
-      parts.push(`[slide:${slide.index}]\n## Interlude`);
-    }
-    return parts.join("\n\n");
-  }
-  const introParagraph = reserveIntro ? intro || paragraphs[0] || "" : "";
-  const introIndex = introParagraph ? paragraphs.indexOf(introParagraph) : -1;
-  const remaining = reserveIntro
-    ? introIndex >= 0
-      ? paragraphs.filter((_, index) => index !== introIndex)
-      : paragraphs.slice(1)
-    : paragraphs;
   if (introParagraph) parts.push(introParagraph.trim());
-  if (remaining.length === 0) {
-    for (const slide of ordered) {
-      if (interludeSlideIndexes.has(slide.index)) {
-        parts.push(`[slide:${slide.index}]\n## Interlude`);
-        continue;
-      }
-      const fallback = fallbackSummaries.get(slide.index) ?? "";
-      const withTitle = fallback
-        ? ensureSlideTitleLine({ text: fallback, slide, total: ordered.length })
-        : "";
-      parts.push(withTitle ? `[slide:${slide.index}]\n${withTitle}` : `[slide:${slide.index}]`);
-    }
-    return parts.join("\n\n");
-  }
-  const distributableSlides = ordered.filter((slide) => !interludeSlideIndexes.has(slide.index));
-  const distributionSlides = distributableSlides.length > 0 ? distributableSlides : ordered;
-  const total = distributionSlides.length;
   const slideTotal = ordered.length;
   let distributionIndex = 0;
   for (const slide of ordered) {
@@ -572,20 +533,23 @@ export function coerceSummaryWithSlides({
       parts.push(`[slide:${slideIndex}]\n## Interlude`);
       continue;
     }
-    const segmentIndex = distributionIndex;
-    const start = Math.round((segmentIndex * remaining.length) / total);
-    const end = Math.round(((segmentIndex + 1) * remaining.length) / total);
-    distributionIndex += 1;
-    const segment =
-      remaining.slice(start, end).join("\n\n").trim() ||
-      remaining[
-        Math.min(remaining.length - 1, Math.floor((segmentIndex * remaining.length) / total))
-      ]?.trim() ||
-      "";
+    const segment = distributeParagraphs(remaining, distributionIndex++, total);
     const fallback = fallbackSummaries.get(slideIndex) ?? "";
     const text = segment || fallback;
     const withTitle = text ? ensureSlideTitleLine({ text, slide, total: slideTotal }) : "";
     parts.push(withTitle ? `[slide:${slideIndex}]\n${withTitle}` : `[slide:${slideIndex}]`);
   }
   return parts.join("\n\n");
+}
+
+function distributeParagraphs(paragraphs: string[], index: number, total: number): string {
+  const start = Math.round((index * paragraphs.length) / total);
+  const end = Math.round(((index + 1) * paragraphs.length) / total);
+  return (
+    paragraphs.slice(start, end).join("\n\n").trim() ||
+    paragraphs[
+      Math.min(paragraphs.length - 1, Math.floor((index * paragraphs.length) / total))
+    ]?.trim() ||
+    ""
+  );
 }

--- a/tests/sidepanel.slides-view-runtime.test.ts
+++ b/tests/sidepanel.slides-view-runtime.test.ts
@@ -47,7 +47,6 @@ function createSlidePayload(
 
 function createHarness(
   options: {
-    dispatch?: boolean;
     fallbackSummary?: string | null;
     panelState?: PanelState;
     summaryChanged?: boolean;
@@ -57,7 +56,6 @@ function createHarness(
   const panelState = options.panelState ?? createInitialPanelState();
   panelState.currentSource ??= { url: "https://example.com/video", title: "Video" };
   panelState.slides ??= createSlidePayload();
-  const store = panelState;
   const send = vi.fn(async () => {});
   const refreshSummarizeControl = vi.fn();
   const headerSetProgressOverride = vi.fn();
@@ -228,8 +226,8 @@ describe("slides view runtime", () => {
     expect(harness.send).toHaveBeenCalledWith({ type: "panel:seek", seconds: 65 });
   });
 
-  it("writes rendered markdown through an injected panel dispatcher", () => {
-    const harness = createHarness({ dispatch: true, summaryChanged: true });
+  it("writes rendered markdown to canonical panel state", () => {
+    const harness = createHarness({ summaryChanged: true });
 
     harness.runtime.renderMarkdown("Updated summary");
 
@@ -251,11 +249,19 @@ describe("slides view runtime", () => {
     const harness = createHarness({ panelState });
     harness.panelState.currentSource = null;
     harness.panelState.slides = null;
+    harness.panelState.summaryMarkdown = "Retained summary";
 
     harness.runtime.renderEmptySummaryState();
-    harness.runtime.renderMarkdownDisplay();
-
     expect(harness.renderMarkdownHostEl.textContent).toContain("Loading");
+    expect(harness.panelState.summaryMarkdown).toBe("Retained summary");
+
+    harness.runtime.renderMarkdownDisplay();
+    expect(harness.renderMarkdownHostEl.textContent).toContain("Retained summary");
+
+    harness.panelState.navigation.activeTabUrl = null;
+    harness.panelState.panelSession.autoSummarize = false;
+    harness.runtime.renderEmptySummaryState();
+    expect(harness.renderMarkdownHostEl.textContent).not.toContain("Loading");
   });
 
   it("applies a seeded payload with transcript and fallback summary", () => {


### PR DESCRIPTION
## Summary

Slide-summary coercion repeated paragraph selection and proportional distribution in its explicit-summary and fallback paths. Shared preparation and one distribution helper now own that arithmetic, while the two paths retain their distinct direct-text, interlude, and transcript-fallback rules. The redundant empty-remainder rendering loop is removed.

The side panel now builds normal and empty-summary display inputs through one function using live panel state. Both public render callbacks remain zero-argument functions, and empty-state rendering does not erase stored Markdown. A stale test-only dispatcher option is also removed.

Net reduction: 55 production lines and 46 lines overall across five files.

## Validation

- A captured pre-change baseline matches all 3,920 deterministic combinations after refactoring: intro reservation, detailed/title-only summaries, mixed/all interludes, absent transcripts, ordering, and duplicate indexes.
- Seventy-one focused tests pass. Extended renderer coverage verifies stored Markdown survives empty rendering and later state changes are read live.
- Root build, formatting, lint, and all TypeScript layers pass.
- Final full gate passes: 3,188 tests passed, 43 skipped; 94.41% line and 85.50% branch coverage. Four suites affected by initial CLI timeouts and a mock mismatch also pass in isolation (21 tests).
- Supported Chromium E2E passes: three native cases and 115 HTTP cases, with seven expected HTTP skips.
- Independent Codex review: scoped-clean at P0–P2.
- GitHub metadata reads recovered. The branch is rebased onto current main; the sole conflict was resolved by preserving both changelog entries. Implementation and test files are unchanged by the rebase, and exact-head CI passes Node 24 unit/coverage and type checks, Chromium E2E, Firefox smoke, and GitGuardian.
