### PR TITLE
refactor: consolidate request metadata and retry reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Dependencies and maintenance
 
+- Share retry-message formatting, URL output input types, and YouTube request headers while retaining renderer, endpoint, and credential-specific policies.
 - Share slide-summary paragraph distribution and live rendering inputs while preserving intro handling, interludes, duplicate indexes, and fallback precedence.
 - Give shared pickers and checkboxes one base stylesheet; retain Options and side-panel layout, sizing, backgrounds, and focus overrides in their own stylesheets.
 - Share stdout/stderr download-progress handling and one temporary-directory lifecycle for YouTube and direct-video downloads, retaining successful-download cleanup ownership with the caller.

--- a/docs/transcript-provider-flow.md
+++ b/docs/transcript-provider-flow.md
@@ -35,6 +35,7 @@ Goal: keep provider entrypoints thin; keep provider policy explicit.
 
 ## Shared policy
 
+- YouTube transcript and web-player requests share header construction in `youtube/api.ts`. Android-player headers remain separate, and the identity token remains web-player-only.
 - `podcast/feed-flow.ts` owns RSS transcript lookup, timestamp selection, and result shaping for direct feeds, Apple, and Spotify. Each source retains feed fetching, fallback decisions, and failure metadata; Apple's iTunes path still records the feed attempt before fetching.
 - `podcast/media.ts` shares download progress, transcription options, and completion across in-memory and temporary-file sources. Size limits and duration probing remain source-specific; temporary files are removed after success or failure.
 - `content/link-preview/content/page-media.ts`

--- a/packages/core/src/content/transcript/providers/youtube/api.ts
+++ b/packages/core/src/content/transcript/providers/youtube/api.ts
@@ -3,16 +3,7 @@ import { fetchWithTimeout } from "../../../link-preview/fetch-with-timeout.js";
 import type { TranscriptSegment } from "../../../link-preview/types.js";
 import { parseTimestampToMs } from "../../timestamps.js";
 import { extractYoutubeBootstrapConfig, isRecord } from "../../utils.js";
-
-const REQUEST_HEADERS: Record<string, string> = {
-  "User-Agent":
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
-  Accept:
-    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-  "Accept-Language": "en-US,en;q=0.9",
-  "Cache-Control": "no-cache",
-  Pragma: "no-cache",
-};
+import { REQUEST_HEADERS } from "./captions-shared.js";
 
 export interface YoutubeTranscriptConfig {
   apiKey: string;
@@ -23,6 +14,45 @@ export interface YoutubeTranscriptConfig {
   clientVersion?: string | null;
   pageCl?: number | null;
   pageLabel?: string | null;
+}
+
+export function buildYoutubeiHeaders(
+  originalUrl: string,
+  config: Pick<
+    YoutubeTranscriptConfig,
+    "clientName" | "clientVersion" | "visitorData" | "pageCl" | "pageLabel"
+  >,
+): Record<string, string> {
+  const userAgent =
+    REQUEST_HEADERS["User-Agent"] ??
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36";
+  const headers: Record<string, string> = withBunCompressionHeaders({
+    "Content-Type": "application/json",
+    "User-Agent": userAgent,
+    Accept: "application/json",
+    Origin: "https://www.youtube.com",
+    Referer: originalUrl,
+    "X-Goog-AuthUser": "0",
+    "X-Youtube-Bootstrap-Logged-In": "false",
+  });
+
+  if (config.clientName) {
+    headers["X-Youtube-Client-Name"] = config.clientName;
+  }
+  if (config.clientVersion) {
+    headers["X-Youtube-Client-Version"] = config.clientVersion;
+  }
+  if (config.visitorData) {
+    headers["X-Goog-Visitor-Id"] = config.visitorData;
+  }
+  if (typeof config.pageCl === "number" && Number.isFinite(config.pageCl)) {
+    headers["X-Youtube-Page-CL"] = String(config.pageCl);
+  }
+  if (config.pageLabel) {
+    headers["X-Youtube-Page-Label"] = config.pageLabel;
+  }
+
+  return headers;
 }
 
 type YoutubeBootstrapConfig = Record<string, unknown> & {
@@ -137,34 +167,7 @@ export const fetchTranscriptFromTranscriptEndpoint = async (
   };
 
   try {
-    const userAgent =
-      REQUEST_HEADERS["User-Agent"] ??
-      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36";
-    const headers: Record<string, string> = withBunCompressionHeaders({
-      "Content-Type": "application/json",
-      "User-Agent": userAgent,
-      Accept: "application/json",
-      Origin: "https://www.youtube.com",
-      Referer: originalUrl,
-      "X-Goog-AuthUser": "0",
-      "X-Youtube-Bootstrap-Logged-In": "false",
-    });
-
-    if (config.clientName) {
-      headers["X-Youtube-Client-Name"] = config.clientName;
-    }
-    if (config.clientVersion) {
-      headers["X-Youtube-Client-Version"] = config.clientVersion;
-    }
-    if (config.visitorData) {
-      headers["X-Goog-Visitor-Id"] = config.visitorData;
-    }
-    if (typeof config.pageCl === "number" && Number.isFinite(config.pageCl)) {
-      headers["X-Youtube-Page-CL"] = String(config.pageCl);
-    }
-    if (config.pageLabel) {
-      headers["X-Youtube-Page-Label"] = config.pageLabel;
-    }
+    const headers = buildYoutubeiHeaders(originalUrl, config);
 
     const response = await fetchWithTimeout(
       fetchImpl,

--- a/packages/core/src/content/transcript/providers/youtube/captions-transcript.ts
+++ b/packages/core/src/content/transcript/providers/youtube/captions-transcript.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../youtube-captions.js";
 import { sanitizeYoutubeJsonResponse } from "../../utils.js";
 import { extractInitialPlayerResponse } from "../../utils.js";
-import { extractYoutubeiBootstrap } from "./api.js";
+import { buildYoutubeiHeaders, extractYoutubeiBootstrap } from "./api.js";
 import { extractInnertubeApiKey } from "./captions-player.js";
 import {
   REQUEST_HEADERS,
@@ -130,26 +130,13 @@ export const fetchTranscriptFromCaptionTracks = async (
   };
 
   try {
-    const userAgent =
-      REQUEST_HEADERS["User-Agent"] ??
-      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36";
-    const headers: Record<string, string> = withBunCompressionHeaders({
-      "Content-Type": "application/json",
-      "User-Agent": userAgent,
-      Accept: "application/json",
-      Origin: "https://www.youtube.com",
-      Referer: originalUrl,
-      "X-Goog-AuthUser": "0",
-      "X-Youtube-Bootstrap-Logged-In": "false",
+    const headers = buildYoutubeiHeaders(originalUrl, {
+      clientName,
+      clientVersion,
+      visitorData,
+      pageCl,
+      pageLabel,
     });
-
-    if (clientName) headers["X-Youtube-Client-Name"] = clientName;
-    if (clientVersion) headers["X-Youtube-Client-Version"] = clientVersion;
-    if (visitorData) headers["X-Goog-Visitor-Id"] = visitorData;
-    if (typeof pageCl === "number" && Number.isFinite(pageCl)) {
-      headers["X-Youtube-Page-CL"] = String(pageCl);
-    }
-    if (pageLabel) headers["X-Youtube-Page-Label"] = pageLabel;
     if (xsrfToken) headers["X-Youtube-Identity-Token"] = xsrfToken;
 
     const response = await fetchWithTimeout(

--- a/src/engine/model-executor.ts
+++ b/src/engine/model-executor.ts
@@ -1,7 +1,11 @@
 import type { CliProvider } from "../config.js";
 import type { LlmCall } from "../costs.js";
 import { isCliDisabled, runCliModel } from "../llm/cli.js";
-import { isRetryableLlmError, resolveLlmErrorMessage } from "../llm/generate-text-shared.js";
+import {
+  formatLlmRetryNotice,
+  isRetryableLlmError,
+  resolveLlmErrorMessage,
+} from "../llm/generate-text-shared.js";
 import { generateTextWithModelId, streamTextWithModelId } from "../llm/generate-text.js";
 import { parseGatewayStyleModelId } from "../llm/model-id.js";
 import { mergeRequestOptionsForProvider } from "../llm/model-options.js";
@@ -146,26 +150,9 @@ async function consumeSummaryStream(
 export function createModelExecutor(deps: ModelExecutorDeps) {
   const providerRuntime = deps.providerRuntime;
 
-  const createRetryLogger = (modelId: string) => {
-    return (notice: { attempt: number; maxRetries: number; delayMs: number; error?: unknown }) => {
-      const message =
-        typeof notice.error === "string"
-          ? notice.error
-          : notice.error instanceof Error
-            ? notice.error.message
-            : typeof (notice.error as { message?: unknown } | null)?.message === "string"
-              ? String((notice.error as { message?: unknown }).message)
-              : "";
-      const reason = /empty summary/i.test(message)
-        ? "empty output"
-        : /timed out/i.test(message)
-          ? "timeout"
-          : "error";
-      deps.log?.(
-        `LLM ${reason} for ${modelId}; retry ${notice.attempt}/${notice.maxRetries} in ${notice.delayMs}ms.`,
-      );
-    };
-  };
+  const createRetryLogger =
+    (modelId: string) => (notice: Parameters<typeof formatLlmRetryNotice>[1]) =>
+      deps.log?.(formatLlmRetryNotice(modelId, notice));
 
   const envHasKeyFor = (requiredEnv: ModelAttempt["requiredEnv"]) => {
     const cliProvider = cliProviderForRequiredEnv(requiredEnv);

--- a/src/llm/generate-text-shared.ts
+++ b/src/llm/generate-text-shared.ts
@@ -4,6 +4,26 @@ import { userTextAndImageMessage } from "./prompt.js";
 import type { LlmTokenUsage } from "./types.js";
 import { normalizeTokenUsage } from "./usage.js";
 
+export function formatLlmRetryNotice(
+  modelId: string,
+  notice: { attempt: number; maxRetries: number; delayMs: number; error?: unknown },
+): string {
+  const message =
+    typeof notice.error === "string"
+      ? notice.error
+      : notice.error instanceof Error
+        ? notice.error.message
+        : typeof (notice.error as { message?: unknown } | null)?.message === "string"
+          ? String((notice.error as { message?: unknown }).message)
+          : "";
+  const reason = /empty summary/i.test(message)
+    ? "empty output"
+    : /timed out/i.test(message)
+      ? "timeout"
+      : "error";
+  return `LLM ${reason} for ${modelId}; retry ${notice.attempt}/${notice.maxRetries} in ${notice.delayMs}ms.`;
+}
+
 export function promptToContext(prompt: Prompt): Context {
   const attachments = prompt.attachments ?? [];
   if (attachments.some((attachment) => attachment.kind === "document")) {

--- a/src/run/flows/url/summary.ts
+++ b/src/run/flows/url/summary.ts
@@ -35,6 +35,17 @@ type SlidesResult = Awaited<
   ReturnType<typeof import("../../../slides/index.js").extractSlidesForSource>
 >;
 
+type ExtractedUrlOutputArgs = {
+  ctx: UrlFlowContext;
+  url: string;
+  extracted: ExtractedLinkContent;
+  extractionUi: UrlExtractionUi;
+  prompt: string;
+  effectiveMarkdownMode: "off" | "auto" | "llm" | "readability";
+  transcriptionCostLabel: string | null;
+  slides?: SlidesResult | null;
+};
+
 async function writeUrlJsonOutput({
   ctx,
   url,
@@ -137,17 +148,7 @@ async function outputSummaryFromExtractedContent({
   slides,
   footerLabel,
   verboseMessage,
-}: {
-  ctx: UrlFlowContext;
-  url: string;
-  extracted: ExtractedLinkContent;
-  extractionUi: UrlExtractionUi;
-  prompt: string;
-  effectiveMarkdownMode: "off" | "auto" | "llm" | "readability";
-  transcriptionCostLabel: string | null;
-  slides?: Awaited<
-    ReturnType<typeof import("../../../slides/index.js").extractSlidesForSource>
-  > | null;
+}: ExtractedUrlOutputArgs & {
   footerLabel?: string | null;
   verboseMessage?: string | null;
 }) {
@@ -202,17 +203,7 @@ export async function outputExtractedUrl({
   transcriptionCostLabel,
   slides,
   slidesOutput,
-}: {
-  ctx: UrlFlowContext;
-  url: string;
-  extracted: ExtractedLinkContent;
-  extractionUi: UrlExtractionUi;
-  prompt: string;
-  effectiveMarkdownMode: "off" | "auto" | "llm" | "readability";
-  transcriptionCostLabel: string | null;
-  slides?: Awaited<
-    ReturnType<typeof import("../../../slides/index.js").extractSlidesForSource>
-  > | null;
+}: ExtractedUrlOutputArgs & {
   slidesOutput?: SlidesTerminalOutput | null;
 }) {
   const { io, flags, model, hooks } = ctx;

--- a/src/run/logging.ts
+++ b/src/run/logging.ts
@@ -1,3 +1,4 @@
+import { formatLlmRetryNotice } from "../llm/generate-text-shared.js";
 import {
   createThemeRenderer,
   resolveThemeNameFromSources,
@@ -41,26 +42,7 @@ export function createRetryLogger({
   modelId: string;
   env?: Record<string, string | undefined>;
 }) {
-  return (notice: { attempt: number; maxRetries: number; delayMs: number; error?: unknown }) => {
-    const message =
-      typeof notice.error === "string"
-        ? notice.error
-        : notice.error instanceof Error
-          ? notice.error.message
-          : typeof (notice.error as { message?: unknown } | null)?.message === "string"
-            ? String((notice.error as { message?: unknown }).message)
-            : "";
-    const reason = /empty summary/i.test(message)
-      ? "empty output"
-      : /timed out/i.test(message)
-        ? "timeout"
-        : "error";
-    writeVerbose(
-      stderr,
-      verbose,
-      `LLM ${reason} for ${modelId}; retry ${notice.attempt}/${notice.maxRetries} in ${notice.delayMs}ms.`,
-      color,
-      env,
-    );
+  return (notice: Parameters<typeof formatLlmRetryNotice>[1]) => {
+    writeVerbose(stderr, verbose, formatLlmRetryNotice(modelId, notice), color, env);
   };
 }

--- a/tests/run.logging.test.ts
+++ b/tests/run.logging.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
+import { formatLlmRetryNotice } from "../src/llm/generate-text-shared.js";
 import { createRetryLogger } from "../src/run/logging.js";
 
 describe("run/logging", () => {
-  it("formats retry reasons", () => {
+  it.each([
+    ["Empty summary", "empty output"],
+    [new Error("timed out"), "timeout"],
+    [{ message: "something else" }, "error"],
+    [{ errorMessage: "timed out" }, "error"],
+    [undefined, "error"],
+  ])("formats retry reason for %j", (error, reason) => {
     const stderr = { write: vi.fn() } as unknown as NodeJS.WritableStream;
 
     const log = createRetryLogger({
@@ -12,19 +19,10 @@ describe("run/logging", () => {
       modelId: "openai/gpt-test",
     });
 
-    log({ attempt: 1, maxRetries: 2, delayMs: 10, error: "Empty summary" });
-    expect((stderr.write as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toContain(
-      "LLM empty output",
-    );
-
-    log({ attempt: 2, maxRetries: 2, delayMs: 10, error: new Error("timed out") });
-    expect((stderr.write as unknown as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]).toContain(
-      "LLM timeout",
-    );
-
-    log({ attempt: 3, maxRetries: 4, delayMs: 10, error: { message: "something else" } });
-    expect((stderr.write as unknown as ReturnType<typeof vi.fn>).mock.calls[2]?.[0]).toContain(
-      "LLM error",
-    );
+    const notice = { attempt: 1, maxRetries: 2, delayMs: 10, error };
+    const expected = `LLM ${reason} for openai/gpt-test; retry 1/2 in 10ms.`;
+    expect(formatLlmRetryNotice("openai/gpt-test", notice)).toBe(expected);
+    log(notice);
+    expect(stderr.write).toHaveBeenCalledExactlyOnceWith(expect.stringContaining(expected));
   });
 });

--- a/tests/youtube.api.test.ts
+++ b/tests/youtube.api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildYoutubeiHeaders,
   extractTranscriptFromTranscriptEndpoint,
   extractYoutubeiBootstrap,
   extractYoutubeiTranscriptConfig,
@@ -7,6 +8,26 @@ import {
 } from "../packages/core/src/content/transcript/providers/youtube/api.js";
 
 describe("YouTube transcript parsing", () => {
+  it("keeps optional and player-only metadata out of transcript headers", () => {
+    const config = {
+      clientName: "",
+      clientVersion: null,
+      pageCl: Number.NaN,
+      xsrfToken: "player-only",
+    };
+    const headers = buildYoutubeiHeaders("https://www.youtube.com/watch?v=test", config);
+    expect(headers).toMatchObject({
+      "Content-Type": "application/json",
+      Origin: "https://www.youtube.com",
+      Referer: "https://www.youtube.com/watch?v=test",
+      "X-Goog-AuthUser": "0",
+    });
+    expect(headers).not.toHaveProperty("X-Youtube-Client-Name");
+    expect(headers).not.toHaveProperty("X-Youtube-Client-Version");
+    expect(headers).not.toHaveProperty("X-Youtube-Page-CL");
+    expect(headers).not.toHaveProperty("X-Youtube-Identity-Token");
+  });
+
   it("extracts youtubei transcript config from bootstrap HTML", () => {
     const html =
       "<!doctype html><html><head>" +


### PR DESCRIPTION
## Summary

Give retry-message formatting one owner shared by the model executor and CLI logger, without changing reason priority, legacy error-message handling, verbosity, or TTY rendering. URL output paths share a named input type while retaining their distinct presentation behavior.

YouTube transcript and web-player requests now share header construction. Optional fields, finite page-CL conversion, and Bun compression remain unchanged. Android-player headers stay separate, and the identity token remains web-player-only. The unused private duplicate header inventory is removed.

Net reduction: 30 production lines and nine lines overall across ten files. No dependency or public behavior changes.

## Validation

- Seventy-seven focused logging, model-executor, YouTube, URL-output, and architecture tests pass.
- Regression coverage verifies retry reason precedence/legacy fields and omission of invalid or player-only transcript headers.
- Root build and full gate pass: 3,193 passed, 43 skipped; 94.42% line and 85.57% branch coverage.
- Independent Codex review: scoped-clean at P0–P2.
- Exact-head CI passed: [run 34010845228](https://github.com/steipete/summarize/actions/runs/34010845228), including Node 24, Chrome extension E2E, Firefox smoke, and the separate GitGuardian check.
