### PR TITLE
fix(extension): simplify request lifecycle and own prompt sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Browser AI: give overlapping Prompt API requests separate sessions and destroy sessions that finish loading after cancellation, so a stale request cannot tear down its replacement.
 - Slides: parse ordinary yt-dlp percentage lines correctly and remove partial download directories after process or output-inspection failures.
 - Transcription: skip probing the local Whisper executable when no usable model is installed, avoiding unnecessary process startup and delays on cloud-only or unconfigured systems.
 - Browser settings: retain a dismissed local-companion hint when saving other Options preferences.
@@ -21,6 +22,7 @@
 
 ### Dependencies and maintenance
 
+- Share browser AI request cancellation/status ownership and download monitoring; consolidate tab-navigation result metadata while retaining navigation, focus, and timeout policies.
 - Share retry-message formatting, URL output input types, and YouTube request headers while retaining renderer, endpoint, and credential-specific policies.
 - Share slide-summary paragraph distribution and live rendering inputs while preserving intro handling, interludes, duplicate indexes, and fallback precedence.
 - Give shared pickers and checkboxes one base stylesheet; retain Options and side-panel layout, sizing, backgrounds, and focus overrides in their own stylesheets.

--- a/apps/chrome-extension/src/automation/navigate.ts
+++ b/apps/chrome-extension/src/automation/navigate.ts
@@ -81,50 +81,31 @@ export async function executeNavigateTool(args: NavigateArgs): Promise<NavigateR
     if (!tab?.id) throw new Error("Tab not found");
     await chrome.tabs.update(tab.id, { active: true });
     await chrome.windows.update(tab.windowId, { focused: true });
-    const skills = tab.url ? await listSkills(tab.url) : [];
-    return {
-      switchedToTab: tab.id,
-      finalUrl: tab.url ?? null,
-      title: tab.title ?? null,
-      tabId: tab.id,
-      skills: skills.map((skill) => ({
-        name: skill.name,
-        shortDescription: skill.shortDescription,
-      })),
-    };
+    return { switchedToTab: tab.id, ...(await describeTab(tab, null)) };
   }
 
   const url = args.url?.trim();
   if (!url) throw new Error("Missing url");
 
-  if (args.newTab) {
-    const tab = await chrome.tabs.create({ url });
-    if (!tab.id) throw new Error("Failed to open new tab");
-    const finalTab = await waitForTabComplete(tab.id).catch(() => tab);
-    const skills = finalTab.url ? await listSkills(finalTab.url) : [];
-    return {
-      finalUrl: finalTab.url ?? url,
-      title: finalTab.title ?? null,
-      tabId: finalTab.id,
-      skills: skills.map((skill) => ({
-        name: skill.name,
-        shortDescription: skill.shortDescription,
-      })),
-    };
-  }
-
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  if (!tab?.id) throw new Error("No active tab");
-  await chrome.tabs.update(tab.id, { url });
+  const newTab = args.newTab;
+  const tab = newTab
+    ? await chrome.tabs.create({ url })
+    : (await chrome.tabs.query({ active: true, currentWindow: true }))[0];
+  if (!tab?.id) throw new Error(newTab ? "Failed to open new tab" : "No active tab");
+  if (!newTab) await chrome.tabs.update(tab.id, { url });
   const finalTab = await waitForTabComplete(tab.id).catch(() => tab);
-  const skills = finalTab.url ? await listSkills(finalTab.url) : [];
+  return describeTab(finalTab, url);
+}
+
+async function describeTab(
+  tab: chrome.tabs.Tab,
+  fallbackUrl: string | null,
+): Promise<NavigateResult> {
+  const skills = tab.url ? await listSkills(tab.url) : [];
   return {
-    finalUrl: finalTab.url ?? url,
-    title: finalTab.title ?? null,
-    tabId: finalTab.id,
-    skills: skills.map((skill) => ({
-      name: skill.name,
-      shortDescription: skill.shortDescription,
-    })),
+    finalUrl: tab.url ?? fallbackUrl,
+    title: tab.title ?? null,
+    tabId: tab.id,
+    skills: skills.map((skill) => ({ name: skill.name, shortDescription: skill.shortDescription })),
   };
 }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-summary-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-summary-runtime.ts
@@ -47,7 +47,6 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
   const isUserActive = options.isUserActive ?? defaultIsUserActive;
   const sessions = new Map<string, Promise<BrowserSummarizerSession | null>>();
   const promptSessions = new Map<string, Promise<BrowserLanguageModelSession | null>>();
-  const activeRequests = new Map<BrowserAiRequestKey, number>();
   const activeControllers = new Map<BrowserAiRequestKey, AbortController>();
   let statusOwner: { requestKey: BrowserAiRequestKey; token: symbol } | null = null;
 
@@ -65,6 +64,32 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
     options.setStatus("");
   };
 
+  const createDownloadMonitor =
+    (requestKey: BrowserAiRequestKey, statusToken: symbol) => (monitor: EventTarget) => {
+      monitor.addEventListener("downloadprogress", (event) => {
+        const loaded = (event as Event & { loaded?: number }).loaded;
+        const percent =
+          typeof loaded === "number" && Number.isFinite(loaded)
+            ? ` ${Math.round(loaded * 100)}%`
+            : "";
+        setOwnedStatus(requestKey, statusToken, `Downloading on-device AI…${percent}`);
+      });
+    };
+
+  const beginRequest = (requestKey: BrowserAiRequestKey, kind: "summary" | "prompt") => {
+    activeControllers.get(requestKey)?.abort();
+    const controller = new AbortController();
+    activeControllers.set(requestKey, controller);
+    const statusToken = Symbol(`browser-ai:${requestKey}:${kind}`);
+    const isCurrent = () => activeControllers.get(requestKey) === controller;
+    const finish = () => {
+      if (!isCurrent()) return;
+      activeControllers.delete(requestKey);
+      clearOwnedStatus(statusToken);
+    };
+    return { controller, statusToken, isCurrent, finish };
+  };
+
   const createSession = (
     api: BrowserSummarizerApi,
     length: BrowserAiSummaryInput["length"],
@@ -77,16 +102,7 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
         type: "key-points",
         format: "plain-text",
         length,
-        monitor(monitor) {
-          monitor.addEventListener("downloadprogress", (event) => {
-            const loaded = (event as Event & { loaded?: number }).loaded;
-            const percent =
-              typeof loaded === "number" && Number.isFinite(loaded)
-                ? ` ${Math.round(loaded * 100)}%`
-                : "";
-            setOwnedStatus(requestKey, statusToken, `Downloading on-device AI…${percent}`);
-          });
-        },
+        monitor: createDownloadMonitor(requestKey, statusToken),
       })
       .catch((error) => {
         logExtensionEvent({
@@ -132,20 +148,10 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
     imageInput: boolean,
     statusToken: symbol,
   ): Promise<BrowserLanguageModelSession | null> => {
-    const key = promptSessionKey(requestKey, imageInput);
-    const promise = api
+    return api
       .create({
         ...buildLanguageModelOptions(imageInput),
-        monitor(monitor) {
-          monitor.addEventListener("downloadprogress", (event) => {
-            const loaded = (event as Event & { loaded?: number }).loaded;
-            const percent =
-              typeof loaded === "number" && Number.isFinite(loaded)
-                ? ` ${Math.round(loaded * 100)}%`
-                : "";
-            setOwnedStatus(requestKey, statusToken, `Downloading on-device AI…${percent}`);
-          });
-        },
+        monitor: createDownloadMonitor(requestKey, statusToken),
       })
       .catch((error) => {
         logExtensionEvent({
@@ -154,11 +160,8 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
           scope: "sidepanel",
           detail: { imageInput, requestKey, ...browserAiErrorDetail(error) },
         });
-        promptSessions.delete(key);
         return null;
       });
-    promptSessions.set(key, promise);
-    return promise;
   };
 
   const ensurePromptSession = async (
@@ -168,7 +171,10 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
   ): Promise<BrowserLanguageModelSession | null> => {
     const key = promptSessionKey(requestKey, imageInput);
     const cached = promptSessions.get(key);
-    if (cached) return await cached;
+    if (cached) {
+      promptSessions.delete(key);
+      return await cached;
+    }
     const api = getLanguageModelApi();
     if (!api) return null;
     const availability = await api
@@ -211,7 +217,10 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
     const api = getLanguageModelApi();
     if (!api) return;
     const statusToken = Symbol(`browser-ai:${requestKey}:prompt-prepare`);
-    void createPromptSession(api, requestKey, imageInput, statusToken).then(() => {
+    const promise = createPromptSession(api, requestKey, imageInput, statusToken);
+    promptSessions.set(key, promise);
+    void promise.then((session) => {
+      if (!session && promptSessions.get(key) === promise) promptSessions.delete(key);
       clearOwnedStatus(statusToken);
     });
   };
@@ -221,7 +230,6 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
       ? [requestKey]
       : (["summary", "slides"] satisfies BrowserAiRequestKey[]);
     for (const key of requestKeys) {
-      activeRequests.set(key, (activeRequests.get(key) ?? 0) + 1);
       activeControllers.get(key)?.abort();
       activeControllers.delete(key);
     }
@@ -242,18 +250,10 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
     requestKey?: BrowserAiRequestKey;
     status?: string;
   }): Promise<string | null> => {
-    const request = (activeRequests.get(requestKey) ?? 0) + 1;
-    activeRequests.set(requestKey, request);
-    activeControllers.get(requestKey)?.abort();
-    const controller = new AbortController();
-    activeControllers.set(requestKey, controller);
-    const statusToken = Symbol(`browser-ai:${requestKey}:${request}`);
+    const { controller, statusToken, isCurrent, finish } = beginRequest(requestKey, "summary");
     const session = await ensureSession(input.length, requestKey, statusToken);
-    if (!session || request !== activeRequests.get(requestKey)) {
-      if (request === activeRequests.get(requestKey)) {
-        activeControllers.delete(requestKey);
-        clearOwnedStatus(statusToken);
-      }
+    if (!session || !isCurrent()) {
+      finish();
       return null;
     }
 
@@ -271,8 +271,7 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
         context,
         signal: controller.signal,
       });
-      const summary =
-        request === activeRequests.get(requestKey) && result.trim() ? result.trim() : null;
+      const summary = isCurrent() && result.trim() ? result.trim() : null;
       logExtensionEvent({
         event: summary ? "browser-ai:summarize-done" : "browser-ai:summarize-discarded",
         level: summary ? "verbose" : "warn",
@@ -299,10 +298,7 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
       });
       return null;
     } finally {
-      if (request === activeRequests.get(requestKey)) {
-        activeControllers.delete(requestKey);
-        clearOwnedStatus(statusToken);
-      }
+      finish();
     }
   };
 
@@ -317,21 +313,13 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
     requestKey?: BrowserAiRequestKey;
     status?: string;
   }): Promise<BrowserAiPromptResult | null> => {
-    const request = (activeRequests.get(requestKey) ?? 0) + 1;
-    activeRequests.set(requestKey, request);
-    activeControllers.get(requestKey)?.abort();
-    const controller = new AbortController();
-    activeControllers.set(requestKey, controller);
-    const statusToken = Symbol(`browser-ai:${requestKey}:prompt:${request}`);
+    const { controller, statusToken, isCurrent, finish } = beginRequest(requestKey, "prompt");
     const imageInput = promptUsesImages(input);
-    const key = promptSessionKey(requestKey, imageInput);
     const chars = promptTextLength(input);
     const session = await ensurePromptSession(requestKey, imageInput, statusToken);
-    if (!session || request !== activeRequests.get(requestKey)) {
-      if (request === activeRequests.get(requestKey)) {
-        activeControllers.delete(requestKey);
-        clearOwnedStatus(statusToken);
-      }
+    if (!session || !isCurrent()) {
+      session?.destroy?.();
+      finish();
       return null;
     }
 
@@ -367,7 +355,7 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
         }
       }
       const result = await session.prompt(input, promptOptions);
-      const text = request === activeRequests.get(requestKey) && result.trim() ? result.trim() : "";
+      const text = isCurrent() && result.trim() ? result.trim() : "";
       if (!text) return null;
       logExtensionEvent({
         event: "browser-ai:prompt-done",
@@ -402,14 +390,7 @@ export function createBrowserAiSummaryRuntime(options: RuntimeOptions) {
       return null;
     } finally {
       session.destroy?.();
-      const cached = promptSessions.get(key);
-      if (cached && (await cached) === session) {
-        promptSessions.delete(key);
-      }
-      if (request === activeRequests.get(requestKey)) {
-        activeControllers.delete(requestKey);
-        clearOwnedStatus(statusToken);
-      }
+      finish();
     }
   };
 

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -198,6 +198,7 @@ See `docs/media.md` for detection and transcript rules.
 - Process manager: live list of daemon-spawned tools (ffmpeg, yt-dlp, tesseract, etc.) with logs.
 - Extension includes current settings in request; daemon treats them like CLI flags (`--model`, `--length`, `--language`, `--prompt`).
 - Options and the side panel share model-discovery and selection state in `src/lib/model-presets.ts`; each screen supplies its presets, hints, and presentation behavior.
+- Browser AI keeps reusable Summarizer sessions by request key and length. Prompt API prewarming supplies one session to one request; that request destroys it on completion or cancellation. Replacing a request aborts the previous request for the same key without cancelling the other summary/slide key.
 
 ## Token Pairing / Setup Mode
 

--- a/tests/automation.navigate.test.ts
+++ b/tests/automation.navigate.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeNavigateTool } from "../apps/chrome-extension/src/automation/navigate";
+import { listSkills } from "../apps/chrome-extension/src/automation/skills-store";
+
+vi.mock("../apps/chrome-extension/src/automation/skills-store", () => ({ listSkills: vi.fn() }));
+
+const originalTab = { id: 12, windowId: 3, url: "https://example.com/old", title: "Old" };
+const finalTab = { ...originalTab, url: "https://example.com/final", title: "Final" };
+const tabs = {
+  create: vi.fn(),
+  query: vi.fn(),
+  update: vi.fn(),
+  get: vi.fn(),
+  onUpdated: { addListener: vi.fn(), removeListener: vi.fn() },
+};
+const windows = { update: vi.fn() };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.resetAllMocks();
+  vi.stubGlobal("chrome", { tabs, windows });
+  tabs.create.mockResolvedValue(originalTab);
+  tabs.query.mockResolvedValue([originalTab]);
+  tabs.get.mockResolvedValue(finalTab);
+  vi.mocked(listSkills).mockResolvedValue([
+    {
+      name: "Example",
+      shortDescription: "Example actions",
+      description: "Full instructions",
+      domainPatterns: ["example.com"],
+      createdAt: "",
+      lastUpdated: "",
+      examples: "",
+      library: "",
+    },
+  ]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("automation navigation", () => {
+  it.each([false, true])("returns completed-tab metadata (newTab=%s)", async (newTab) => {
+    const result = executeNavigateTool({ url: " https://example.com/start ", newTab });
+    await vi.advanceTimersByTimeAsync(0);
+    const listener = tabs.onUpdated.addListener.mock.calls[0][0];
+    listener(99, { status: "complete" });
+    listener(12, { status: "loading" });
+    expect(tabs.get).not.toHaveBeenCalled();
+    listener(12, { status: "complete" });
+
+    await expect(result).resolves.toEqual({
+      finalUrl: finalTab.url,
+      title: finalTab.title,
+      tabId: 12,
+      skills: [{ name: "Example", shortDescription: "Example actions" }],
+    });
+    expect(listSkills).toHaveBeenCalledWith(finalTab.url);
+    expect(tabs.onUpdated.removeListener).toHaveBeenCalledWith(listener);
+    expect(vi.getTimerCount()).toBe(0);
+    if (newTab) {
+      expect(tabs.create).toHaveBeenCalledWith({ url: "https://example.com/start" });
+      expect(tabs.update).not.toHaveBeenCalled();
+    } else {
+      expect(tabs.query).toHaveBeenCalledWith({ active: true, currentWindow: true });
+      expect(tabs.update).toHaveBeenCalledWith(12, { url: "https://example.com/start" });
+      expect(tabs.create).not.toHaveBeenCalled();
+    }
+    expect(windows.update).not.toHaveBeenCalled();
+  });
+
+  it.each([originalTab.url, undefined])(
+    "preserves timeout fallback for tab URL %s",
+    async (url) => {
+      tabs.create.mockResolvedValue({ id: 12, windowId: 3, url });
+      const result = executeNavigateTool({ url: "https://example.com/start", newTab: true });
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await expect(result).resolves.toMatchObject({
+        finalUrl: url ?? "https://example.com/start",
+        title: null,
+        tabId: 12,
+      });
+      expect(vi.mocked(listSkills).mock.calls).toEqual(url ? [[url]] : []);
+      expect(tabs.onUpdated.removeListener).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("switches and focuses the requested tab before describing it", async () => {
+    await expect(executeNavigateTool({ switchToTab: 12 })).resolves.toMatchObject({
+      switchedToTab: 12,
+      tabId: 12,
+      finalUrl: finalTab.url,
+    });
+    expect(tabs.update).toHaveBeenCalledWith(12, { active: true });
+    expect(windows.update).toHaveBeenCalledWith(3, { focused: true });
+    expect(tabs.update.mock.invocationCallOrder[0]).toBeLessThan(
+      windows.update.mock.invocationCallOrder[0],
+    );
+    expect(windows.update.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(listSkills).mock.invocationCallOrder[0],
+    );
+  });
+
+  it.each([
+    [false, "No active tab"],
+    [true, "Failed to open new tab"],
+  ] as const)("keeps missing-tab errors specific (newTab=%s)", async (newTab, message) => {
+    tabs.create.mockResolvedValue({});
+    tabs.query.mockResolvedValue([]);
+    await expect(executeNavigateTool({ url: "https://example.com", newTab })).rejects.toThrow(
+      message,
+    );
+    expect(tabs.onUpdated.addListener).not.toHaveBeenCalled();
+  });
+});

--- a/tests/sidepanel.browser-ai-summary-runtime.test.ts
+++ b/tests/sidepanel.browser-ai-summary-runtime.test.ts
@@ -267,6 +267,69 @@ describe("sidepanel browser AI summary runtime", () => {
     );
   });
 
+  it("gives overlapping prompts separate sessions and preserves the newer request's status", async () => {
+    const firstResult = Promise.withResolvers<string>();
+    const secondResult = Promise.withResolvers<string>();
+    const firstSession = { prompt: vi.fn(() => firstResult.promise), destroy: vi.fn() };
+    const secondSession = { prompt: vi.fn(() => secondResult.promise), destroy: vi.fn() };
+    const create = vi.fn().mockResolvedValueOnce(firstSession).mockResolvedValueOnce(secondSession);
+    const setStatus = vi.fn();
+    const runtime = createBrowserAiSummaryRuntime({
+      getLanguageModelApi: () => ({ availability: async () => "available", create }),
+      isUserActive: () => true,
+      setStatus,
+    });
+
+    runtime.preparePrompt();
+    const first = runtime.prompt({ input: "First", responseConstraint: /^.+$/ });
+    await vi.waitFor(() => expect(firstSession.prompt).toHaveBeenCalledOnce());
+    const second = runtime.prompt({
+      input: "Second",
+      responseConstraint: /^.+$/,
+      status: "Newer prompt",
+    });
+    await vi.waitFor(() => expect(secondSession.prompt).toHaveBeenCalledOnce());
+    expect(firstSession.prompt).toHaveBeenCalledWith(
+      "First",
+      expect.objectContaining({ signal: expect.objectContaining({ aborted: true }) }),
+    );
+
+    firstResult.resolve("Stale result");
+    await expect(first).resolves.toBeNull();
+    expect(firstSession.destroy).toHaveBeenCalledOnce();
+    expect(secondSession.destroy).not.toHaveBeenCalled();
+    expect(setStatus).toHaveBeenLastCalledWith("Newer prompt");
+    secondResult.resolve("Fresh result");
+    await expect(second).resolves.toMatchObject({ kind: "success", text: "Fresh result" });
+    expect(secondSession.destroy).toHaveBeenCalledOnce();
+    expect(setStatus).toHaveBeenLastCalledWith("");
+  });
+
+  it("destroys a prompt session that finishes loading after cancellation", async () => {
+    const pendingSession = Promise.withResolvers<{
+      prompt: ReturnType<typeof vi.fn>;
+      destroy: ReturnType<typeof vi.fn>;
+    }>();
+    const session = { prompt: vi.fn(), destroy: vi.fn() };
+    const runtime = createBrowserAiSummaryRuntime({
+      getLanguageModelApi: () => ({
+        availability: async () => "available",
+        create: () => pendingSession.promise,
+      }),
+      isUserActive: () => true,
+      setStatus: vi.fn(),
+    });
+
+    runtime.preparePrompt();
+    const result = runtime.prompt({ input: "Source", responseConstraint: /^.+$/ });
+    runtime.cancel("slides");
+    pendingSession.resolve(session);
+
+    await expect(result).resolves.toBeNull();
+    expect(session.prompt).not.toHaveBeenCalled();
+    expect(session.destroy).toHaveBeenCalledOnce();
+  });
+
   it("reports context pressure before prompting", async () => {
     const session = {
       contextWindow: 1_000,


### PR DESCRIPTION
## Summary

Browser AI cancellation and status cleanup now use one request owner: the active AbortController. This removes a parallel generation map and duplicated lifecycle/download-monitor code while keeping summary and slide requests independent.

Prompt API prewarming now hands a session to exactly one request. Previously an overlapping replacement could reuse a session that its cancelled predecessor would destroy. A session that finishes loading after cancellation is also destroyed. Both regressions failed before the fix and pass now; reusable Summarizer sessions remain cached.

Tab navigation shares result metadata and skill projection without changing navigation commands, event-only completion waiting, timeout fallbacks, or window focus ordering. No markup, styling, or visual presentation changes.

Production code is 38 lines smaller. Overall LOC increases by 146 lines because this adds direct navigation coverage and cancellation regressions rather than deleting tests to meet a line-count target.

## Validation

- 25 focused browser AI and navigation tests pass, including the two red-before/green-after regressions.
- Root build and full gate pass: 3,202 passed, 43 skipped; 94.42% line and 85.57% branch coverage.
- Independent Codex review: scoped-clean at P0–P2.
- Rebased onto merged main with an identical final tree.
- Supported local Chrome suite passes: three native-transport tests and 115 HTTP-transport tests, with seven expected skips.
- Exact-head CI passed: [run 34011543563](https://github.com/steipete/summarize/actions/runs/34011543563), including Node 24, Chrome E2E, Firefox smoke, and the separate GitGuardian check.
