### PR TITLE
fix(slides): own stream and cache-handoff cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Slides: stop direct-video response streams after download failures and remove downloaded temporary files if the media-cache handoff fails; preserve the original failure when cleanup also fails.
 - Browser AI: give overlapping Prompt API requests separate sessions and destroy sessions that finish loading after cancellation, so a stale request cannot tear down its replacement.
 - Slides: parse ordinary yt-dlp percentage lines correctly and remove partial download directories after process or output-inspection failures.
 - Transcription: skip probing the local Whisper executable when no usable model is installed, avoiding unnecessary process startup and delays on cloud-only or unconfigured systems.

--- a/docs/commands/slides.md
+++ b/docs/commands/slides.md
@@ -58,7 +58,7 @@ If a required tool is missing, summarize prints a clear warning and exits non-ze
 : Pick a CLI theme.
 
 `--timeout <duration>`
-: Cap the download + extraction. Default `2m`.
+: Per-operation timeout setting. Default `2m`; not an overall wall-clock deadline. yt-dlp downloads and FFmpeg scene detection allow at least `5m`, and individual extraction/probe steps have their own limits.
 
 `--no-cache`
 : Force re-download and re-extraction (bypasses both caches).

--- a/docs/slides-rendering-flow.md
+++ b/docs/slides-rendering-flow.md
@@ -32,6 +32,8 @@ Rule: keep terminal I/O in render helpers; keep state mutations in the state sto
 
 `src/slides/download.ts` owns temporary download directories through success or failure. Failures remove partial output without replacing the original error; successful downloads return cleanup to the caller. Structured yt-dlp progress shares one parser on stdout and stderr, while ordinary percentage/speed/ETA lines remain stderr-only.
 
+Direct-video downloads use a Node stream pipeline for backpressure, file closure, and stream teardown. The download owner also cancels rejected HTTP bodies and aborts settled fetches. `src/slides/ingest.ts` owns downloaded-file cleanup until cache handoff succeeds, then transfers cleanup to extraction.
+
 ## Chrome extension
 
 `background/content-script-bridge.ts` shares retry/reinjection handling across extraction, seeking, and frame preparation. Only extraction has a message deadline; capture startup and restoration keep their separate recovery policies and self-contained main-world scripts.

--- a/docs/slides.md
+++ b/docs/slides.md
@@ -1,59 +1,14 @@
 ---
 title: "Slides"
 kicker: "modes"
-summary: "Plan for slide-first UX without model usage."
+summary: "Slide extraction, model summaries, and transcript/OCR fallbacks in the CLI and browser."
 read_when:
   - "When changing slide summaries, slide UI, or slide/seek behavior in the side panel."
 ---
 
-# Slides plan (no model)
+# Slides
 
-## Goals
-
-- Expanded slides view = full-width cards, top of summary.
-- Click slide = seek video timestamp (no modal).
-- Descriptions scale with length setting.
-- Always show all slides (even if text missing).
-- No model call for slide descriptions.
-
-## Data sources
-
-- Primary: transcript timed text (already available with timestamps).
-- Secondary: OCR text from slides (truncate, selectable).
-- Tertiary: empty description (still render card).
-
-## Description generation (no model)
-
-- For each slide timestamp `t`:
-  - Pull transcript segments within a time window around `t`.
-  - Concatenate into plain text (no bullets).
-  - If no transcript: use OCR text (trim).
-  - If neither: empty string.
-- Always render all slide cards; missing text → show slide only.
-
-## Length scaling
-
-- Map summary length to per-slide target chars.
-- Use existing length presets (short/medium/long/xl/xxl + custom):
-  - `short`: ~120 chars/slide
-  - `medium`: ~200 chars/slide
-  - `long`: ~320 chars/slide
-  - `xl`: ~480 chars/slide
-  - `xxl`: ~700 chars/slide
-  - custom: derive from maxCharacters (e.g. `maxChars / min(slideCount, 10)`, clamp).
-- Clamp per-slide text: `[80, 900]` chars.
-- Window size should expand with length (e.g. 20s → 90s).
-
-## UI behavior
-
-- Side panel slide mode is slide-first:
-  - vertical full-width cards by default
-  - thumbnail + timestamp + text
-  - transcript/OCR text appears before slide images finish extracting
-- No giant summary block under active slide cards.
-- Slide click: seek only (no modal).
-- OCR toggle appears near summarize control only when OCR is significant
-  (enough slides + total OCR chars); otherwise hide it.
+Slides mode pairs video keyframes with timestamped text. Extraction itself does not require a model; summaries can use the configured provider or on-device Gemini Nano. Sources include YouTube URLs, direct video URLs, and local video files.
 
 ## CLI
 
@@ -66,19 +21,20 @@ read_when:
 - `summarize slides <source>` extracts slides without summarizing (use `--render auto|kitty|iterm` for inline thumbnails).
 - Defaults to writing images under `./slides/<sourceId>/` (override via `--slides-dir` / `--output`).
 
-## Implementation notes
+See [the slides command](commands/slides.md) for extraction flags and requirements.
 
-- Build `slideDescriptions` map in panel:
-  - Use `summary.timedText` when available.
-  - Split transcript into segments with timestamps (already in payload).
-- Store per-slide text on client (no daemon model calls).
-- Ensure summary cache keys untouched; only client-only rendering.
-- Slide extraction downloads the media once for detect+extract; set `SLIDES_EXTRACT_STREAM=1` to allow stream fallback (lower accuracy).
+## Browser side panel
 
-## Steps
+Slide mode shows vertical image/timestamp/text cards instead of the large summary block. Text can appear before extraction finishes, and cards remain visible without descriptions. Clicking a slide seeks the video, without opening a modal.
 
-1. Add slide-description builder in sidepanel using transcript timed text + OCR fallback.
-2. Add length-based per-slide char budget and window sizing.
-3. Render expanded card list with timestamps + text.
-4. Remove modal; click = seek only.
-5. Add tests for slide description + fallback.
+Generated slide summaries take precedence over transcript fallbacks. Gemini Nano can generate slide summaries locally using transcript context and available images; it falls back to text-only or smaller requests when needed. Other models use the configured summary runtime. Transcript windows supply missing descriptions, with enabled OCR as a fallback when no transcript is available. Selecting OCR mode prefers recognized text; the toggle appears only when enabled OCR has enough meaningful text.
+
+Fallback text budgets scale with `--length`: approximately 120/200/320/480/700 characters for `short`/`medium`/`long`/`xl`/`xxl`. Custom character targets are divided across at most ten slides and clamped to 80–900 characters per slide. Transcript windows grow from 30 to 180 seconds, stop at the next slide, and include a short lead-in. These are fallback-text budgets, not limits on model-generated summaries.
+
+Browser extraction uses MediaBunny/WebCodecs for fetchable videos and visible-tab capture as a fallback. Daemon extraction uses downloaded media with FFmpeg and optional Tesseract OCR. See [browser settings](chrome-extension.md) for runtime selection.
+
+## Ownership
+
+Core owns transcript parsing, fallback budgets, and slide-summary coercion. The side panel owns description selection and rendering state; browser AI owns on-device model sessions. CLI output owns terminal rendering and image support.
+
+Daemon/CLI extraction downloads media once for detection and frame extraction, reusing cached media when available. `SLIDES_EXTRACT_STREAM=1` permits lower-accuracy stream fallback after download failure. Failed downloads and failed cache handoffs clean their temporary files; successful handoffs return cleanup to the extraction caller. See [the rendering flow](slides-rendering-flow.md) for implementation entrypoints.

--- a/src/slides/download.ts
+++ b/src/slides/download.ts
@@ -1,6 +1,9 @@
-import { promises as fs } from "node:fs";
+import { createWriteStream, promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { buildSharedVideoMediaCacheKey } from "@steipete/summarize-core/content";
 import type { ProcessHandle } from "../processes.js";
 import { runProcess, runProcessCapture } from "./process.js";
@@ -139,19 +142,19 @@ export async function downloadRemoteVideo(options: {
     const filePath = path.join(dir, `video${suffix}`);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let body: Response["body"] = null;
     try {
       const res = await fetchImpl(url, { signal: controller.signal });
+      body = res.body;
       if (!res.ok) {
         throw new Error(`Download failed: ${res.status} ${res.statusText}`);
       }
       const totalRaw = res.headers.get("content-length");
       const total = totalRaw ? Number(totalRaw) : 0;
       const hasTotal = Number.isFinite(total) && total > 0;
-      const reader = res.body?.getReader();
-      if (!reader) {
+      if (!body) {
         throw new Error("Download failed: missing response body");
       }
-      const handle = await fs.open(filePath, "w");
       let downloaded = 0;
       let lastPercent = -1;
       let lastReportedBytes = 0;
@@ -169,24 +172,26 @@ export async function downloadRemoteVideo(options: {
         lastReportedBytes = downloaded;
         onProgress(0, `(${formatBytes(downloaded)})`);
       };
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          if (!value) continue;
-          await handle.write(value);
-          downloaded += value.byteLength;
-          reportProgress();
-        }
-      } finally {
-        await handle.close();
-      }
+      await pipeline(
+        Readable.fromWeb(body as NodeReadableStream<Uint8Array>),
+        async function* (source: AsyncIterable<Uint8Array>) {
+          for await (const value of source) {
+            yield value;
+            downloaded += value.byteLength;
+            reportProgress();
+          }
+        },
+        createWriteStream(filePath),
+        { signal: controller.signal },
+      );
       if (hasTotal) {
         onProgress?.(100, `(${formatBytes(downloaded)}/${formatBytes(total)})`);
       }
       return filePath;
     } finally {
       clearTimeout(timeout);
+      controller.abort();
+      await body?.cancel().catch(() => {});
     }
   });
 }

--- a/src/slides/ingest.ts
+++ b/src/slides/ingest.ts
@@ -115,10 +115,12 @@ export async function prepareSlidesInput({
 
   reportSlidesProgress?.("downloading video", 6);
   const downloadStartedAt = Date.now();
+  let inputCleanup: (() => Promise<void>) | null = null;
   try {
     const downloaded = ytDlpOptions
       ? await downloadYoutubeVideo({ ...ytDlpOptions, onProgress })
       : await downloadRemoteVideo({ url: source.url, timeoutMs, fetchImpl, onProgress });
+    inputCleanup = downloaded.cleanup;
     const cached = mediaCacheKey
       ? await mediaCache?.put({
           url: mediaCacheKey,
@@ -132,10 +134,11 @@ export async function prepareSlidesInput({
     );
     return {
       inputPath: cached?.filePath ?? downloaded.filePath,
-      inputCleanup: downloaded.cleanup,
+      inputCleanup,
       warnings,
     };
   } catch (error) {
+    await inputCleanup?.().catch(() => {});
     const remoteFallbackAllowed =
       allowRemoteUrlFallback || (needsYtDlp && source.kind !== "youtube");
     if (!allowStreamFallback || !remoteFallbackAllowed) throw error;

--- a/tests/slides.download.test.ts
+++ b/tests/slides.download.test.ts
@@ -97,4 +97,35 @@ describe("slides download", () => {
       await rm(result.filePath, { force: true });
     }
   });
+
+  it.each(["progress", "http", "timeout"])(
+    "cancels the response body after %s failure",
+    async (stage) => {
+      const cancel = vi.fn();
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+        },
+        cancel,
+      });
+      const response = new Response(body, {
+        status: stage === "http" ? 503 : 200,
+        headers: { "content-length": "6" },
+      });
+      const failure = new Error("progress failed");
+      await expect(
+        downloadRemoteVideo({
+          url: "https://cdn.example/video.mp4",
+          timeoutMs: stage === "timeout" ? 20 : 1000,
+          fetchImpl: vi.fn(async () => response),
+          onProgress: () => {
+            if (stage === "progress") throw failure;
+          },
+        }),
+      ).rejects.toThrow(
+        stage === "http" ? "Download failed: 503" : stage === "timeout" ? /abort/i : failure,
+      );
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
 });

--- a/tests/slides.ingest.test.ts
+++ b/tests/slides.ingest.test.ts
@@ -29,6 +29,30 @@ function ingestOptions(source: (typeof remoteSources)[number]) {
 }
 
 describe("slides ingest", () => {
+  it.each(remoteSources)("cleans downloaded media if caching fails for $url", async (source) => {
+    const options = ingestOptions(source);
+    const failure = new Error("cache write failed");
+    const cleanup = vi.fn(async () => {
+      throw new Error("cleanup failed");
+    });
+    const downloaded = { filePath: "/tmp/downloaded.mp4", cleanup };
+    options.downloadYoutubeVideo.mockResolvedValue(downloaded);
+    options.downloadRemoteVideo.mockResolvedValue(downloaded);
+    options.resolveSlidesStreamFallback = () => false;
+    await expect(
+      prepareSlidesInput({
+        ...options,
+        mediaCache: {
+          get: async () => null,
+          put: async () => {
+            throw failure;
+          },
+        } as never,
+      }),
+    ).rejects.toBe(failure);
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
   it.each(remoteSources)("shares cache, cleanup, and progress for $url", async (source) => {
     const options = ingestOptions(source);
     const cleanup = vi.fn(async () => {});


### PR DESCRIPTION
## Summary

Close two resource-ownership gaps in slide extraction. Direct-video downloads now use Node's explicit web-stream adapter and pipeline for backpressure, file closure, and teardown. The download owner also aborts settled fetches and cancels rejected HTTP bodies. Ingest retains cleanup ownership until downloaded media is successfully handed to extraction; failed cache writes clean the downloaded file before rethrowing or using the existing stream-fallback policy.

Replace the outdated “no model” slides plan with current CLI/browser behavior, model/transcript/OCR precedence, runtime ownership, and fallback budgets. Correct the timeout documentation: it is per operation, not a whole-run deadline.

## Validation

- 29 focused download/ingest tests pass. Five new cases fail on the baseline and pass after the fix.
- The new stalled-read timeout case caught an initial direct-web-stream pipeline mistake; using Readable.fromWeb fixes cancellation. No timeout was increased or assertion weakened.
- Root build, docs-site build, and full gate pass: 3,208 passed, 43 skipped; 94.42% line and 85.57% branch coverage.
- Final independent Codex review: scoped-clean at P0–P2.
- Rebased onto merged main with an identical final tree. Exact-head [CI run 34011993360](https://github.com/steipete/summarize/actions/runs/34011993360) passes Node 24, Chrome E2E, and Firefox smoke; the separate GitGuardian check also passes.

This adds eight production lines and 22 lines overall: the cleanup fixes and regression coverage are worth more than an artificial LOC decrease. No dependencies, release publication, or browser presentation changes.
