### PR TITLE
fix(openai): preserve image attachments in HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Images: preserve image attachments in OpenAI Responses and Chat Completions requests, including streaming, instead of silently sending only the text prompt.
 - Slides: stop direct-video response streams after download failures and remove downloaded temporary files if the media-cache handoff fails; preserve the original failure when cleanup also fails.
 - Browser AI: give overlapping Prompt API requests separate sessions and destroy sessions that finish loading after cancellation, so a stale request cannot tear down its replacement.
 - Slides: parse ordinary yt-dlp percentage lines correctly and remove partial download directories after process or output-inspection failures.

--- a/src/llm/providers/openai/transport.ts
+++ b/src/llm/providers/openai/transport.ts
@@ -97,15 +97,32 @@ export function resolveOpenAiChatCompletionsUrl(baseUrl: string): URL {
   return url;
 }
 
+type ChatContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
 export function contextToChatCompletionMessages(
   context: Context,
-): Array<{ role: string; content: string }> {
-  const messages: Array<{ role: string; content: string }> = [];
+): Array<{ role: string; content: string | ChatContentPart[] }> {
+  const messages: Array<{ role: string; content: string | ChatContentPart[] }> = [];
   const systemPrompt = context.systemPrompt?.trim();
   if (systemPrompt) {
     messages.push({ role: "system", content: systemPrompt });
   }
   for (const message of context.messages) {
+    if (Array.isArray(message.content) && message.content.some((part) => part.type === "image")) {
+      const content = message.content.flatMap<ChatContentPart>((part) => {
+        if (part.type === "text") return [{ type: "text", text: part.text }];
+        if (part.type === "image") {
+          return [
+            { type: "image_url", image_url: { url: `data:${part.mimeType};base64,${part.data}` } },
+          ];
+        }
+        return [];
+      });
+      messages.push({ role: message.role, content });
+      continue;
+    }
     const content =
       typeof message.content === "string"
         ? message.content.trim()
@@ -123,14 +140,24 @@ export function contextToChatCompletionMessages(
 
 export function contextToResponsesInput(context: Context): Array<{
   role: string;
-  content: Array<{ type: "input_text"; text: string }>;
+  content: Array<
+    | { type: "input_text"; text: string }
+    | { type: "input_image"; image_url: string; detail: "auto" }
+  >;
 }> {
   return contextToChatCompletionMessages({
     systemPrompt: undefined,
     messages: context.messages,
   }).map((message) => ({
     role: message.role,
-    content: [{ type: "input_text", text: message.content }],
+    content:
+      typeof message.content === "string"
+        ? [{ type: "input_text", text: message.content }]
+        : message.content.map((part) =>
+            part.type === "text"
+              ? { type: "input_text", text: part.text }
+              : { type: "input_image", image_url: part.image_url.url, detail: "auto" },
+          ),
   }));
 }
 

--- a/tests/llm.openai-images.test.ts
+++ b/tests/llm.openai-images.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { promptToContext } from "../src/llm/generate-text-shared.js";
+import { completeOpenAiText, streamOpenAiText } from "../src/llm/providers/openai.js";
+
+describe("OpenAI image requests", () => {
+  it.each([
+    [false, false],
+    [false, true],
+    [true, false],
+    [true, true],
+  ])("preserves image content (chat=%s, stream=%s)", async (chat, stream) => {
+    const bytes = new Uint8Array([137, 80, 78, 71]);
+    const imageUrl = `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`;
+    const fetchImpl = vi.fn(async () => {
+      const payload = stream
+        ? chat
+          ? 'data: {"choices":[{"delta":{"content":"Blue triangle"}}]}\n\ndata: [DONE]\n\n'
+          : 'data: {"type":"response.output_text.delta","delta":"Blue triangle"}\n\ndata: {"type":"response.completed","response":{}}\n\n'
+        : JSON.stringify(
+            chat
+              ? { choices: [{ message: { content: "Blue triangle" } }] }
+              : { output_text: "Blue triangle" },
+          );
+      return new Response(payload, {
+        headers: { "content-type": stream ? "text/event-stream" : "application/json" },
+      });
+    });
+    const request = {
+      modelId: "gpt-5-mini",
+      openaiConfig: {
+        apiKey: "test-key",
+        isOpenRouter: false,
+        useChatCompletions: chat,
+        requestOptions: {},
+      },
+      context: promptToContext({
+        system: "Describe the image.",
+        userText: "What is visible?",
+        attachments: [{ kind: "image", bytes, mediaType: "image/png" }],
+      }),
+      signal: new AbortController().signal,
+      fetchImpl,
+    };
+    if (stream) {
+      const result = await streamOpenAiText(request);
+      let text = "";
+      for await (const chunk of result.textStream) text += chunk;
+      expect(text).toBe("Blue triangle");
+    } else {
+      expect((await completeOpenAiText(request)).text).toBe("Blue triangle");
+    }
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(url).toContain(chat ? "/chat/completions" : "/responses");
+    expect(chat ? body.messages[1].content : body.input[0].content).toEqual(
+      chat
+        ? [
+            { type: "text", text: "What is visible?" },
+            { type: "image_url", image_url: { url: imageUrl } },
+          ]
+        : [
+            { type: "input_text", text: "What is visible?" },
+            { type: "input_image", image_url: imageUrl, detail: "auto" },
+          ],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Live-testing a synthetic labeled image exposed that the OpenAI HTTP adapters flattened all message content to text. The model received no image and returned an inability-to-view response with exit code zero.

Preserve image MIME/base64 content and part order in both Responses and Chat Completions, including streaming, while keeping text-only serialization unchanged.

## Proof

- Four request-payload regression cases fail before and pass after the fix.
- The real CLI on Node 24 now identifies the synthetic image's label and shapes through nonstreaming Responses, streaming Responses, and streaming Chat Completions. The baseline could not view it.
- 21 focused provider tests pass; build and typecheck pass.
- Full gate: 3,209 passed, 43 skipped; independent Codex P0–P2 review is clean.
- Exact-head [CI run 34014519421](https://github.com/steipete/summarize/actions/runs/34014519421) passes Node 24, Chrome E2E, and Firefox smoke; GitGuardian also passes. This is a fix for the upcoming patch release; nothing is published by this PR.
