### PR TITLE
test(browser): validate local speech against public media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Dependencies and maintenance
 
+- Repair browser-local speech validation with public audio fixtures, real decoding/inference, and immediate failure diagnostics instead of an unsupported loopback media source.
 - Remove the abandoned Homebrew-tap formula writer and its obsolete tests; keep formula ownership with Homebrew/core and use supported pnpm script invocations in release CI and instructions.
 - Share browser AI request cancellation/status ownership and download monitoring; consolidate tab-navigation result metadata while retaining navigation, focus, and timeout policies.
 - Share retry-message formatting, URL output input types, and YouTube request headers while retaining renderer, endpoint, and credential-specific policies.

--- a/apps/chrome-extension/tests/browser-media-local.live.spec.ts
+++ b/apps/chrome-extension/tests/browser-media-local.live.spec.ts
@@ -1,8 +1,3 @@
-import { spawnSync } from "node:child_process";
-import fs from "node:fs";
-import { createServer } from "node:http";
-import os from "node:os";
-import path from "node:path";
 import { expect, test } from "@playwright/test";
 import {
   activateTabByUrl,
@@ -13,121 +8,35 @@ import {
   openExtensionPage,
   seedSettings,
   sendPanelMessage,
-  waitForActiveTabUrl,
 } from "./helpers/extension-harness";
-import { getPanelModel, getPanelSummaryMarkdown } from "./helpers/panel-hooks";
+import { getPanelModel, getPanelPhase, getPanelSummaryMarkdown } from "./helpers/panel-hooks";
 
 const LIVE = process.env.SUMMARIZE_LIVE_BROWSER_MEDIA === "1";
-const SPEECH =
-  "Summarize browser media transcription works without a daemon. The purple telescope is beside the orange piano.";
+const AUDIO_URL =
+  "https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav";
+const PAGE_URL = "https://summarize-media.example/";
 
-test("transcribes embedded browser media through MediaBunny and local Whisper", async ({
-  browserName: _browserName,
-}, testInfo) => {
+test("transcribes public browser media through MediaBunny and local Whisper", async ({}, testInfo) => {
   test.skip(!LIVE, "Set SUMMARIZE_LIVE_BROWSER_MEDIA=1 to run local browser media transcription.");
   test.skip(testInfo.project.name !== "chromium", "Local browser Whisper is Chrome-only.");
-  test.skip(!hasCommand("say") || !hasCommand("ffmpeg"), "macOS say and ffmpeg are required.");
   test.setTimeout(10 * 60 * 1000);
 
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "summarize-browser-media-"));
-  const aiffPath = path.join(tmpDir, "speech.aiff");
-  const mediaPath = path.join(tmpDir, "speech.m4a");
-  const mp3Path = path.join(tmpDir, "speech.mp3");
-  const mp4Path = path.join(tmpDir, "speech.mp4");
-  run("say", ["-v", "Samantha", "-o", aiffPath, SPEECH]);
-  run("ffmpeg", [
-    "-y",
-    "-hide_banner",
-    "-loglevel",
-    "error",
-    "-i",
-    aiffPath,
-    "-c:a",
-    "aac",
-    "-b:a",
-    "96k",
-    mediaPath,
-  ]);
-  run("ffmpeg", [
-    "-y",
-    "-hide_banner",
-    "-loglevel",
-    "error",
-    "-i",
-    aiffPath,
-    "-c:a",
-    "libmp3lame",
-    "-b:a",
-    "96k",
-    mp3Path,
-  ]);
-  run("ffmpeg", [
-    "-y",
-    "-hide_banner",
-    "-loglevel",
-    "error",
-    "-i",
-    aiffPath,
-    "-c:a",
-    "aac",
-    "-b:a",
-    "96k",
-    "-movflags",
-    "+faststart",
-    mp4Path,
-  ]);
-
-  const mediaByPath = new Map([
-    ["/speech.m4a", { bytes: fs.readFileSync(mediaPath), contentType: "audio/mp4" }],
-    ["/speech.mp3", { bytes: fs.readFileSync(mp3Path), contentType: "audio/mpeg" }],
-    ["/speech.mp4", { bytes: fs.readFileSync(mp4Path), contentType: "video/mp4" }],
-  ]);
-  const html = `<!doctype html>
-<html>
-  <head><meta charset="utf-8"><title></title></head>
-  <body>
-    <audio controls preload="auto" src="/speech.m4a"></audio>
-  </body>
-</html>`;
-  const server = createServer((request, response) => {
-    const url = new URL(request.url ?? "/", "http://127.0.0.1");
-    const media = mediaByPath.get(url.pathname);
-    if (media) {
-      const range = request.headers.range?.match(/^bytes=(\d+)-(\d*)$/u);
-      if (range) {
-        const start = Number(range[1]);
-        const end = range[2]
-          ? Math.min(media.bytes.length - 1, Number(range[2]))
-          : media.bytes.length - 1;
-        const body = media.bytes.subarray(start, end + 1);
-        response.writeHead(206, {
-          "accept-ranges": "bytes",
-          "content-length": body.length,
-          "content-range": `bytes ${start}-${end}/${media.bytes.length}`,
-          "content-type": media.contentType,
-        });
-        response.end(body);
-        return;
-      }
-      response.writeHead(200, {
-        "accept-ranges": "bytes",
-        "content-length": media.bytes.length,
-        "content-type": media.contentType,
-      });
-      response.end(media.bytes);
-      return;
-    }
-    const body = Buffer.from(html);
-    response.writeHead(200, {
-      "content-length": body.length,
-      "content-type": "text/html; charset=utf-8",
-    });
-    response.end(body);
-  });
-  const serverUrl = await listen(server);
   const harness = await launchExtension(getBrowserFromProject(testInfo.project.name));
-
   try {
+    const body = `<!doctype html><html><head><title>Speech fixture</title></head><body><audio controls preload="auto" src="${AUDIO_URL}"></audio></body></html>`;
+    await harness.context.route(PAGE_URL, async (route) => {
+      await route.fulfill({
+        contentType: "text/html",
+        body,
+      });
+    });
+    await harness.context.route(AUDIO_URL, async (route) => {
+      if (route.request().isNavigationRequest()) {
+        await route.fulfill({ contentType: "text/html", body });
+      } else {
+        await route.continue();
+      }
+    });
     await seedSettings(harness, {
       token: "",
       autoSummarize: false,
@@ -137,25 +46,14 @@ test("transcribes embedded browser media through MediaBunny and local Whisper", 
       maxChars: 20_000,
     });
     const contentPage = await harness.context.newPage();
-    await contentPage.goto(serverUrl, { waitUntil: "domcontentloaded" });
+    await contentPage.goto(PAGE_URL, { waitUntil: "domcontentloaded" });
     await contentPage.waitForFunction(() => {
       const media = document.querySelector("audio");
       return Boolean(media && Number.isFinite(media.duration) && media.duration > 0);
     });
     const panel = await openExtensionPage(harness, "sidepanel.html", "#title");
-    await activateTabByUrl(harness, serverUrl);
-    await sendPanelMessage(panel, {
-      type: "panel:summarize",
-      refresh: true,
-      inputMode: "video",
-    });
-
-    await expect
-      .poll(async () => await getPanelModel(panel), { timeout: 8 * 60 * 1000 })
-      .toBe("Browser");
-
     const background = await getBackground(harness);
-    const readDiagnosticsNewestFirst = async () =>
+    const readDiagnostics = async () =>
       await background.evaluate(async () => {
         const stored = await chrome.storage.session.get("summarize:extension-logs");
         const lines = Array.isArray(stored["summarize:extension-logs"])
@@ -176,79 +74,50 @@ test("transcribes embedded browser media through MediaBunny and local Whisper", 
               entry?.event === "extract:browser-media:local-transcript-failed",
           );
       });
-    await expect
-      .poll(async () => (await readDiagnosticsNewestFirst()).length, { timeout: 5_000 })
-      .toBe(1);
-    const diagnostic = (await readDiagnosticsNewestFirst())[0];
-    if (diagnostic?.event === "extract:browser-media:local-transcript-failed") {
-      throw new Error(`Local browser media transcription failed: ${String(diagnostic.error)}`);
-    }
-    expect(diagnostic).toMatchObject({
-      decoder: "mediabunny-webcodecs",
-      mediaInput: "url-range",
-      mediaSource: "embedded",
-    });
 
-    const summary = (await getPanelSummaryMarkdown(panel)).toLowerCase();
-    expect(summary).toMatch(/purple|telescope|orange piano/u);
-
-    for (const pathname of ["speech.mp3", "speech.mp4"]) {
-      const directUrl = new URL(pathname, serverUrl).href;
-      const previousCount = (await readDiagnosticsNewestFirst()).length;
-      await contentPage.goto(directUrl, { waitUntil: "domcontentloaded" });
-      await activateTabByUrl(harness, directUrl);
-      await waitForActiveTabUrl(harness, directUrl);
-      await sendPanelMessage(panel, {
-        type: "panel:summarize",
-        refresh: true,
-        inputMode: "video",
-      });
-
-      await expect
-        .poll(async () => (await readDiagnosticsNewestFirst()).length, {
-          timeout: 8 * 60 * 1000,
-        })
-        .toBe(previousCount + 1);
-      const directDiagnostic = (await readDiagnosticsNewestFirst())[0];
-      if (directDiagnostic?.event === "extract:browser-media:local-transcript-failed") {
-        throw new Error(
-          `Local browser media transcription failed: ${String(directDiagnostic.error)}`,
-        );
+    for (const [source, url] of [
+      ["embedded", PAGE_URL],
+      ["direct", AUDIO_URL],
+    ] as const) {
+      const previousCount = (await readDiagnostics()).length;
+      if (source === "direct") {
+        await contentPage.goto(url, { waitUntil: "domcontentloaded" });
       }
-      expect(directDiagnostic).toMatchObject({
+      await activateTabByUrl(harness, url);
+      await sendPanelMessage(panel, { type: "panel:summarize", refresh: true, inputMode: "video" });
+      const deadline = Date.now() + 4 * 60 * 1000;
+      let diagnostic: Record<string, unknown> | null | undefined;
+      while (Date.now() < deadline) {
+        const diagnostics = await readDiagnostics();
+        diagnostic = diagnostics.length > previousCount ? diagnostics[0] : null;
+        const phase = await getPanelPhase(panel);
+        if (
+          phase === "error" ||
+          diagnostic?.event === "extract:browser-media:local-transcript-failed"
+        ) {
+          throw new Error(
+            JSON.stringify({
+              source,
+              phase,
+              status: await panel.locator("#subtitle").textContent(),
+              diagnostic,
+            }),
+          );
+        }
+        if (diagnostic && (await getPanelModel(panel)) === "Browser") break;
+        await panel.waitForTimeout(500);
+      }
+      expect(diagnostic).toMatchObject({
+        event: "extract:browser-media:transcript",
         decoder: "mediabunny-webcodecs",
         mediaInput: "url-range",
-        mediaSource: "direct",
+        mediaSource: source,
       });
+      expect(await getPanelModel(panel)).toBe("Browser");
+      expect(await getPanelSummaryMarkdown(panel)).toMatch(/fellow Americans/i);
+      expect(await getPanelSummaryMarkdown(panel)).toMatch(/country/i);
     }
   } finally {
     await closeExtension(harness.context, harness.userDataDir);
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-    fs.rmSync(tmpDir, { force: true, recursive: true });
   }
 });
-
-function hasCommand(command: string): boolean {
-  const locator = process.platform === "win32" ? "where" : "which";
-  return spawnSync(locator, [command], { stdio: "ignore" }).status === 0;
-}
-
-function run(command: string, args: string[]): void {
-  const result = spawnSync(command, args, { encoding: "utf8" });
-  if (result.status === 0) return;
-  throw new Error(`${command} failed: ${result.stderr || result.stdout}`);
-}
-
-async function listen(server: ReturnType<typeof createServer>): Promise<string> {
-  return await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("Failed to resolve local media server port."));
-        return;
-      }
-      resolve(`http://127.0.0.1:${address.port}/`);
-    });
-  });
-}

--- a/docs/manual-tests.md
+++ b/docs/manual-tests.md
@@ -55,6 +55,10 @@ Tip: use `--verbose` to see model attempts + the chosen model.
 - Local video understanding (requires Gemini video-capable model; otherwise expect an error or transcript-only behavior depending on input):
   - `summarize ./path/to/video.mp4 --max-output-tokens 200`
 
+## Browser-local transcription
+
+After building the extension, run `SUMMARIZE_LIVE_BROWSER_MEDIA=1 pnpm -C apps/chrome-extension exec playwright test tests/browser-media-local.live.spec.ts --project=chromium`. This downloads a public speech fixture and runs real MediaBunny decoding plus local Whisper inference for embedded and direct audio; no cloud transcription key is needed. Only the navigation documents are fixtures, not the media bytes or model output. Private media URLs remain rejected, and terminal extraction errors fail the test immediately rather than waiting for the success timeout.
+
 ## Z.AI
 
 - `summarize --model zai/glm-4.7 --max-output-tokens 200 https://example.com`


### PR DESCRIPTION
## Summary

The live browser-media test served a private loopback URL that the extension intentionally rejects. It therefore waited eight minutes without reaching speech inference. Replace that fixture with the public speech sample from the speech library's own documentation and fail immediately on terminal extraction errors.

Both embedded and direct audio paths now exercise real remote media, MediaBunny decoding, and local Whisper inference. Only navigation documents are intercepted to present a controllable tab instead of starting a top-level file download. Media requests and model output are not mocked, and private-URL policy is unchanged.

This removes the macOS-only speech-generation requirement. It validates public WAV input rather than claiming AAC/MP3-specific coverage; the test and documentation say so through the public fixture and scope.

## Proof

- Before: private fixture rejected; eight-minute timeout.
- After: both real local-transcription paths pass in 13 seconds, asserting fresh diagnostics, decoding/source metadata, and recognizable speech text.
- Formatting and lint pass. Independent Codex P0–P2 review is clean.
- Exact-head [CI run 34015767116](https://github.com/steipete/summarize/actions/runs/34015767116) passes Node 24, Chrome E2E, and Firefox smoke; GitGuardian also passes. No runtime or visual presentation changes.
