### PR TITLE
fix(podcasts): route feed URLs through transcript extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Podcasts: route RSS and Atom feed URLs through content/transcript extraction instead of treating feed XML as a raw file, while preserving ordinary XML asset handling.
 - Images: preserve image attachments in OpenAI Responses and Chat Completions requests, including streaming, instead of silently sending only the text prompt.
 - Slides: stop direct-video response streams after download failures and remove downloaded temporary files if the media-cache handoff fails; preserve the original failure when cleanup also fails.
 - Browser AI: give overlapping Prompt API requests separate sessions and destroy sessions that finish loading after cancellation, so a stale request cannot tear down its replacement.

--- a/docs/media.md
+++ b/docs/media.md
@@ -21,6 +21,7 @@ read_when:
 
 ## CLI behavior
 
+- RSS and Atom feed URLs use the podcast/content pipeline rather than raw XML file handling. Published feed transcripts take precedence over media transcription; ordinary XML documents remain file inputs.
 - `--video-mode transcript` prefers transcript-first media handling even when a page has text.
 - Direct media URLs (mp4/webm/m4a/etc) skip HTML and transcribe.
 - Local audio/video files are routed through the same transcript-first pipeline.

--- a/src/content/asset.ts
+++ b/src/content/asset.ts
@@ -118,6 +118,10 @@ function parseContentDispositionFilename(header: string | null): string | null {
 function classifyResponseHeaders(headers: Headers): UrlKind | null {
   const mediaType = normalizeHeaderMediaType(headers.get("content-type"));
   if (isTranscribableMediaType(mediaType)) return { kind: "media", mediaType };
+  if (mediaType === "application/rss+xml" || mediaType === "application/atom+xml") {
+    return { kind: "website" };
+  }
+  if (mediaType === "application/xml" || mediaType === "text/xml") return null;
 
   const filename = parseContentDispositionFilename(headers.get("content-disposition"));
   const filenameMediaType = filename ? normalizeHeaderMediaType(mime.getType(filename)) : null;
@@ -135,6 +139,33 @@ function classifyResponseHeaders(headers: Headers): UrlKind | null {
 function looksLikeHtml(bytes: Uint8Array): boolean {
   const head = new TextDecoder().decode(bytes.slice(0, 256)).trimStart().toLowerCase();
   return head.startsWith("<!doctype html") || head.startsWith("<html") || head.startsWith("<head");
+}
+
+function looksLikeFeed(bytes: Uint8Array): boolean {
+  const head = new TextDecoder()
+    .decode(bytes)
+    .replace(/^(?:\s*<\?xml[\s\S]*?\?>|\s*<!--[\s\S]*?-->)*\s*/i, "");
+  return /^<(?:rss|feed)(?:\s|\/?>)/i.test(head);
+}
+
+async function readResponsePrefix(response: Response): Promise<Uint8Array> {
+  const reader = response.body?.getReader();
+  if (!reader) return new Uint8Array(0);
+  const prefix = new Uint8Array(2048);
+  let length = 0;
+  try {
+    while (length < prefix.length) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = value.subarray(0, prefix.length - length);
+      prefix.set(chunk, length);
+      length += chunk.length;
+    }
+    return prefix.subarray(0, length);
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
 }
 
 function looksLikePlainText(bytes: Uint8Array): boolean {
@@ -255,7 +286,7 @@ export async function classifyUrl({
   timeoutMs: number;
 }): Promise<UrlKind> {
   const parsed = new URL(url);
-  if (isLikelyAssetPathname(parsed.pathname)) {
+  if (isLikelyAssetPathname(parsed.pathname) && !/\.(?:xml|rss|atom)$/i.test(parsed.pathname)) {
     return { kind: "asset" };
   }
 
@@ -285,12 +316,15 @@ export async function classifyUrl({
       if (!res.ok) return null;
       const headerKind = classifyResponseHeaders(res.headers);
       if (headerKind) return headerKind;
-      const buffer = new Uint8Array(await res.arrayBuffer());
-      return !looksLikeHtml(buffer) ? { kind: "asset" } : null;
+      const buffer = await readResponsePrefix(res);
+      return looksLikeHtml(buffer) || looksLikeFeed(buffer)
+        ? { kind: "website" }
+        : { kind: "asset" };
     } catch {
       return null;
     } finally {
       clearTimeout(timeout);
+      controller.abort();
     }
   };
 

--- a/tests/cli.extract.podcast-feed.test.ts
+++ b/tests/cli.extract.podcast-feed.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { runCli } from "../src/run.js";
+import { captureStream } from "./helpers/streams.js";
+
+describe("CLI podcast feed extraction", () => {
+  it("follows published RSS transcripts instead of printing the feed XML", async () => {
+    const feedUrl = "https://example.com/podcast.xml";
+    const transcriptUrl = "http://93.184.216.34/episode.vtt";
+    const feed = `<?xml version="1.0"?><rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0"><channel><title>Test podcast</title><item><title>Beacon-731</title><podcast:transcript url="${transcriptUrl}" type="text/vtt"/></item></channel></rss>`;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === feedUrl)
+        return new Response(feed, { headers: { "content-type": "application/xml" } });
+      if (url === transcriptUrl)
+        return new Response(
+          "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nSeventeen sensors are ready at North Pier.\n",
+          { headers: { "content-type": "text/vtt" } },
+        );
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    const stdout = captureStream();
+    await runCli([feedUrl, "--extract", "--plain", "--timeout", "2s"], {
+      env: {},
+      fetch: fetchImpl,
+      stdout: stdout.stream,
+      stderr: captureStream().stream,
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(transcriptUrl, expect.anything());
+    expect(stdout.getText()).toContain("Seventeen sensors are ready at North Pier.");
+    expect(stdout.getText()).not.toContain("<rss");
+  });
+});

--- a/tests/content.asset.test.ts
+++ b/tests/content.asset.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildAssetPromptMessages,
   classifyUrl,
@@ -193,6 +193,62 @@ describe("asset helpers", () => {
         timeoutMs: 10,
       }),
     ).resolves.toEqual({ kind: "media", mediaType: "audio/mpeg" });
+  });
+
+  it.each([
+    [
+      "feed.xml",
+      "application/xml",
+      '<?xml version="1.0"?><rss version="2.0"><channel/></rss>',
+      "website",
+    ],
+    ["feed.rss", "application/rss+xml", "<rss><channel/></rss>", "website"],
+    ["feed.atom", "application/atom+xml", '<feed xmlns="http://www.w3.org/2005/Atom"/>', "website"],
+    [
+      "feed",
+      "text/xml",
+      '<?xml version="1.0"?> <!-- Feed --> <feed xmlns="http://www.w3.org/2005/Atom"/>',
+      "website",
+    ],
+    [
+      "settings.xml",
+      "application/xml",
+      "<settings><feed>not a feed document</feed></settings>",
+      "asset",
+    ],
+  ])(
+    "classifies %s without treating feeds as raw files",
+    async (pathname, mediaType, body, kind) => {
+      await expect(
+        classifyUrl({
+          url: `https://example.com/${pathname}`,
+          fetchImpl: async () => new Response(body, { headers: { "content-type": mediaType } }),
+          timeoutMs: 1000,
+        }),
+      ).resolves.toEqual({ kind });
+    },
+  );
+
+  it("bounds feed sniffing when a server ignores the range request", async () => {
+    const cancel = vi.fn();
+    const fetchImpl: typeof fetch = async (_input, init) =>
+      new Response(
+        init?.method === "HEAD"
+          ? null
+          : new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(
+                  new TextEncoder().encode(`<rss><channel>${"entry ".repeat(2000)}`),
+                );
+              },
+              cancel,
+            }),
+        { headers: { "content-type": "application/xml" } },
+      );
+    await expect(
+      classifyUrl({ url: "https://example.com/feed.xml", fetchImpl, timeoutMs: 1000 }),
+    ).resolves.toEqual({ kind: "website" });
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it("builds prompt messages with attachments", () => {


### PR DESCRIPTION
## Summary

Live CLI validation exposed RSS URLs being classified as raw files solely because of their .xml extension. The CLI printed the feed XML rather than following its published transcript or episode media.

Recognize RSS/Atom MIME types and inspect a bounded prefix for feed roots on XML-like paths. Ordinary XML documents remain assets. Prefix readers are cancelled/released, and range-probe signals are aborted after classification, including when a server ignores Range.

## Proof

- Five new cases fail before the fix: four feed-routing variants and CLI extraction of a published RSS transcript.
- A separate bounded-reader test verifies stream cancellation when Range is ignored.
- 41 focused tests and the full gate pass: 3,216 passed, 43 skipped; 94.44% line and 85.64% branch coverage.
- Root build and independent Codex P0–P2 review pass. Rebase preserves the identical reviewed tree.
- The real CLI on Node 24 now follows the live NPR feed to episode transcription: 4m 40s of podcast audio, 834 words, and transcript-source metadata rather than raw XML.
- Exact-head [CI run 34016519921](https://github.com/steipete/summarize/actions/runs/34016519921) passes Node 24, Chrome E2E, and Firefox smoke; GitGuardian also passes. This PR does not publish a release.
