### PR TITLE
fix(test): own Firefox smoke runner and profile cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Dependencies and maintenance
 
+- Make Firefox smoke validation wait for actual extension installation and stop its browser runner directly, avoiding orphaned processes behind the package-manager wrapper.
 - Repair browser-local speech validation with public audio fixtures, real decoding/inference, and immediate failure diagnostics instead of an unsupported loopback media source.
 - Remove the abandoned Homebrew-tap formula writer and its obsolete tests; keep formula ownership with Homebrew/core and use supported pnpm script invocations in release CI and instructions.
 - Share browser AI request cancellation/status ownership and download monitoring; consolidate tab-navigation result metadata while retaining navigation, focus, and timeout policies.

--- a/apps/chrome-extension/scripts/firefox-smoke.mjs
+++ b/apps/chrome-extension/scripts/firefox-smoke.mjs
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -20,15 +21,18 @@ if (!firefoxBinary) {
   );
 }
 
-const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const webExtCli = fileURLToPath(new URL("./bin/web-ext.js", import.meta.resolve("web-ext")));
+const profileDir = fs.mkdtempSync(path.join(tmpdir(), "summarize-firefox-smoke-"));
 const args = [
-  "exec",
-  "web-ext",
+  webExtCli,
   "run",
   "--source-dir",
   sourceDir,
   "--firefox",
   firefoxBinary,
+  "--firefox-profile",
+  profileDir,
+  "--keep-profile-changes",
   "--no-reload",
   "--no-input",
   "--start-url",
@@ -37,7 +41,7 @@ const args = [
   "--pref=browser.shell.checkDefaultBrowser=false",
   "--pref=datareporting.policy.dataSubmissionEnabled=false",
 ];
-const child = spawn(pnpm, args, {
+const child = spawn(process.execPath, args, {
   cwd: appDir,
   env: { ...process.env, NO_COLOR: "1" },
   stdio: ["ignore", "pipe", "pipe"],
@@ -66,12 +70,7 @@ const onOutput = (chunk) => {
   const text = chunk.toString();
   output += text;
   process.stdout.write(text);
-  if (
-    !ready &&
-    /extension will reload|installed .*temporary|running web extension|launching firefox/i.test(
-      output,
-    )
-  ) {
+  if (!ready && /installed .*temporary/i.test(output)) {
     ready = true;
     holdTimer = setTimeout(() => finish(), readyHoldMs);
   }
@@ -79,6 +78,9 @@ const onOutput = (chunk) => {
 
 child.stdout.on("data", onOutput);
 child.stderr.on("data", onOutput);
+child.once("close", () => {
+  fs.rmSync(profileDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+});
 child.once("error", (error) => finish(error));
 child.once("exit", (code, signal) => {
   if (settled) return;

--- a/tests/firefox-smoke.test.ts
+++ b/tests/firefox-smoke.test.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ spawn: vi.fn(), spawnSync: vi.fn(), rmSync: vi.fn() }));
+vi.mock("node:child_process", () => mocks);
+vi.mock("node:fs", () => ({
+  default: {
+    existsSync: () => true,
+    mkdtempSync: () => "/synthetic/firefox-profile",
+    rmSync: mocks.rmSync,
+  },
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  mocks.spawn.mockReset();
+});
+
+describe("Firefox smoke lifecycle", () => {
+  it("owns the browser runner directly and waits for extension installation", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("FIREFOX_BINARY", "/synthetic/firefox");
+    const child = Object.assign(new EventEmitter(), {
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      killed: false,
+      kill: vi.fn((signal: string) => {
+        child.killed = true;
+        child.emit("exit", 0, signal);
+        child.emit("close", 0, signal);
+        return true;
+      }),
+    });
+    mocks.spawn.mockReturnValue(child);
+    const running = import("../apps/chrome-extension/scripts/firefox-smoke.mjs");
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+    try {
+      expect(mocks.spawn.mock.calls[0][0]).toBe(process.execPath);
+      expect(mocks.spawn.mock.calls[0][1][0]).toMatch(/web-ext[/\\]bin[/\\]web-ext\.js$/);
+      child.stdout.write("Running web extension\n");
+      await vi.advanceTimersByTimeAsync(3_100);
+      expect(child.kill).not.toHaveBeenCalled();
+      child.stdout.write("Installed fixture as a temporary add-on\n");
+      await vi.advanceTimersByTimeAsync(3_100);
+      expect(child.kill).toHaveBeenCalledExactlyOnceWith("SIGINT");
+      expect(mocks.rmSync).toHaveBeenCalledWith(
+        "/synthetic/firefox-profile",
+        expect.objectContaining({ recursive: true, force: true }),
+      );
+      await running;
+    } finally {
+      child.stdout.write("Installed fixture as a temporary add-on\n");
+      await vi.advanceTimersByTimeAsync(3_100);
+      await running;
+      child.stdout.destroy();
+      child.stderr.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The live Firefox smoke hung after installation because it signalled a package-manager wrapper while web-ext and Firefox retained its output pipes. Spawn the browser runner directly under the current Node runtime, and accept readiness only after the extension is actually installed.

The task now owns a fresh profile and removes it after child close with bounded retries. This avoids web-ext's exit-time profile deletion racing Firefox's final writes; no user profile is used or deleted.

## Proof

- Baseline regression fails; 12 focused smoke/package tests pass after the fix.
- Real Firefox installs the extension, holds it briefly, exits zero, removes its profile, and leaves no task-owned Firefox process. The initial direct-runner attempt revealed a profile cleanup race, which the final owned-profile approach resolves.
- Bun build and native/WebAssembly fallback smoke pass.
- Full gate: 3,217 passed, 43 skipped. Independent Codex P0–P2 review is clean.
- Rebase preserves the identical reviewed tree. Exact-head [CI run 34017217631](https://github.com/steipete/summarize/actions/runs/34017217631) passes Node 24, Chrome E2E, and the corrected Firefox smoke; GitGuardian also passes. No release is published by this PR.
