### PR TITLE
chore(deps): refresh stabilized runtime and browser packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 0.21.13 - Unreleased
 
+**Highlights:** browser media reliability fixes and stabilized dependency updates.
+
+### Fixes
+
+- Browser media: fix audio sample copying across browser versions and a BlobSource memory leak with MediaBunny 1.55.5.
+
+### Dependencies and maintenance
+
+- Refresh stabilized Pi AI, Undici, happy-dom, and pnpm dependencies while retaining Node 24 support and the seven-day release-age policy.
+
 ### Documentation
 
 - Correct Firefox signing guidance to match the extension ID in published packages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Focused fixes, tests, and documentation improvements are welcome.
 Requirements:
 
 - Node.js 24 or newer
-- pnpm 11.24.0 through Corepack
+- pnpm 11.25.0 through Corepack
 - Git
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Start with the [documentation index](docs/README.md), then follow the guide for 
 
 ## Development
 
-Requires Node.js 24 and pnpm 11.24.0.
+Requires Node.js 24 and pnpm 11.25.0.
 
 ```bash
 pnpm install --frozen-lockfile

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -26,7 +26,7 @@
     "@steipete/summarize-core": "workspace:*",
     "googlevideo": "4.1.1",
     "markdown-it": "^15.0.1",
-    "mediabunny": "1.55.3",
+    "mediabunny": "1.55.5",
     "preact": "10.29.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typecheck": "pnpm -C packages/core typecheck && tsc -p tsconfig.build.json --noEmit && pnpm -C apps/chrome-extension typecheck"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.84.3",
+    "@earendil-works/pi-ai": "^0.84.4",
     "@steipete/summarize-core": "workspace:*",
     "bpe-lite": "^0.5.2",
     "commander": "^15.0.0",
@@ -70,13 +70,13 @@
     "mime": "^4.1.0",
     "osc-progress": "^0.3.3",
     "tokentally": "^0.1.4",
-    "undici": "8.10.0"
+    "undici": "8.10.1"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
     "@types/sanitize-html": "^2.16.1",
     "@vitest/coverage-v8": "^4.1.11",
-    "happy-dom": "^20.11.12",
+    "happy-dom": "^20.12.0",
     "oxc-parser": "^0.147.0",
     "oxfmt": "0.65.0",
     "oxlint": "^1.80.0",
@@ -87,5 +87,5 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@11.24.0"
+  "packageManager": "pnpm@11.25.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,7 +78,7 @@
     "@mozilla/readability": "0.6.0",
     "linkedom": "^0.18.13",
     "sanitize-html": "^2.17.7",
-    "undici": "8.10.0"
+    "undici": "8.10.1"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
@@ -88,5 +88,5 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@11.24.0"
+  "packageManager": "pnpm@11.25.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
   .:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: ^0.84.3
-        version: 0.84.3(supports-color@10.2.2)(ws@8.21.3)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.4.3)
       '@steipete/summarize-core':
         specifier: workspace:*
         version: link:packages/core
@@ -56,8 +56,8 @@ importers:
         specifier: ^0.1.4
         version: 0.1.4
       undici:
-        specifier: 8.10.0
-        version: 8.10.0
+        specifier: 8.10.1
+        version: 8.10.1
     devDependencies:
       '@types/node':
         specifier: ^24.13.3
@@ -69,8 +69,8 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(vitest@4.1.11)
       happy-dom:
-        specifier: ^20.11.12
-        version: 20.11.12
+        specifier: ^20.12.0
+        version: 20.12.0
       oxc-parser:
         specifier: ^0.147.0
         version: 0.147.0
@@ -88,7 +88,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.12)(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0))
+        version: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0))
 
   apps/chrome-extension:
     dependencies:
@@ -108,8 +108,8 @@ importers:
         specifier: ^15.0.1
         version: 15.0.1
       mediabunny:
-        specifier: 1.55.3
-        version: 1.55.3
+        specifier: 1.55.5
+        version: 1.55.5
       preact:
         specifier: 10.29.8
         version: 10.29.8
@@ -142,8 +142,8 @@ importers:
         specifier: ^2.17.7
         version: 2.17.7
       undici:
-        specifier: 8.10.0
-        version: 8.10.0
+        specifier: 8.10.1
+        version: 8.10.1
     devDependencies:
       '@types/node':
         specifier: ^24.13.3
@@ -330,13 +330,13 @@ packages:
     engines: {node: '>= 0.10.4'}
     hasBin: true
 
-  '@earendil-works/pi-ai@0.84.3':
-    resolution: {integrity: sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ==}
+  '@earendil-works/pi-ai@0.84.4':
+    resolution: {integrity: sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-telemetry@0.84.3':
-    resolution: {integrity: sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g==}
+  '@earendil-works/pi-telemetry@0.84.4':
+    resolution: {integrity: sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/runtime@1.11.3':
@@ -2281,8 +2281,8 @@ packages:
   guid-typescript@1.0.9:
     resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
-  happy-dom@20.11.12:
-    resolution: {integrity: sha512-7+mrTTD+6fOG3dx0URrDLrCX8QDTE+YujSOQD4VPZcYze/yJ0vVhRKaIBTjqlk+R4NetxVz21odnevHYIjIJ+g==}
+  happy-dom@20.12.0:
+    resolution: {integrity: sha512-7uMYJu2SEwwL8vVcKp0C0lnt6d2LSGGe+T+oY79PiCJNNSgFpbxW8n5KuzpDQvrU4mt+fYiK1+Jy7Z2v39YR6g==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -2712,8 +2712,8 @@ packages:
   mdurl@2.1.0:
     resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
-  mediabunny@1.55.3:
-    resolution: {integrity: sha512-kpBhMiJHGmerizzObAT1XLZDyImO4ZEKXaxjjfxGVkycQ0U5of/xlLepm1Izp3P+3jlaedFSRI5fJnv3Q5xV6A==}
+  mediabunny@1.55.5:
+    resolution: {integrity: sha512-m0v6y8FGXiK+HKOc3AZqU+kJPLYsSKaLitmQNQIIHZKIGlTwQ34OF+X6Ul0K8iV4b03oPse10apwuoqbvmKeAA==}
 
   mime@4.1.0:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
@@ -3347,8 +3347,8 @@ packages:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+  undici@8.10.1:
+    resolution: {integrity: sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==}
     engines: {node: '>=22.19.0'}
 
   unimport@6.4.0:
@@ -3933,11 +3933,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@earendil-works/pi-ai@0.84.3(supports-color@10.2.2)(ws@8.21.3)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@earendil-works/pi-telemetry': 0.84.3
+      '@earendil-works/pi-telemetry': 0.84.4
       '@google/genai': 1.52.0(supports-color@10.2.2)
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2(supports-color@10.2.2)
@@ -3953,7 +3953,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-telemetry@0.84.3': {}
+  '@earendil-works/pi-telemetry@0.84.4': {}
 
   '@emnapi/runtime@1.11.3':
     dependencies:
@@ -4724,7 +4724,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.12)(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0))
+      vitest: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0))
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -5495,7 +5495,7 @@ snapshots:
 
   guid-typescript@1.0.9: {}
 
-  happy-dom@20.11.12:
+  happy-dom@20.12.0:
     dependencies:
       '@types/node': 24.13.3
       '@types/whatwg-mimetype': 3.0.2
@@ -5891,7 +5891,7 @@ snapshots:
 
   mdurl@2.1.0: {}
 
-  mediabunny@1.55.3:
+  mediabunny@1.55.5:
     dependencies:
       '@types/dom-mediacapture-transform': 0.1.12
       '@types/dom-webcodecs': 0.1.13
@@ -6616,7 +6616,7 @@ snapshots:
 
   undici@7.29.0: {}
 
-  undici@8.10.0: {}
+  undici@8.10.1: {}
 
   unimport@6.4.0(oxc-parser@0.147.0)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)):
     dependencies:
@@ -6699,7 +6699,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.12)(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)):
+  vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0))
@@ -6725,7 +6725,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/node': 24.13.3
       '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
-      happy-dom: 20.11.12
+      happy-dom: 20.12.0
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
Refresh the stable dependency versions that have passed the repository's seven-day release-age window:

- Pi AI 0.84.3 → 0.84.4, including its matching telemetry package.
- Undici 8.10.0 → 8.10.1 in the CLI and core library.
- MediaBunny 1.55.3 → 1.55.5 for browser audio-copy and BlobSource fixes.
- happy-dom 20.11.12 → 20.12.0.
- pnpm 11.24.0 → 11.25.0, with setup documentation aligned.

Node 24 typings, the release-age policy, and the existing security patches remain intact. This PR owns the complete next Unreleased notes; no other prepared PR edits the changelog.

Validation on 1276a801538c5e654399fe23f20d02d54ee04da2:

- Installation and CLI/core build pass with pnpm 11.25.0; a frozen-lockfile reinstall passes.
- `pnpm check` passes: 3,219 tests, 94.44% line coverage, and 85.65% branch coverage, including formatting, lint, and all workspace typechecks.
- The real built CLI extracts readable content from https://example.com with caching disabled.
- The production Chrome extension builds. The live browser media test transcribes public audio with MediaBunny/WebCodecs and local Whisper through embedded-player and direct-URL inputs.
- Independent Codex autoreview through P2 is clean for both the local candidate and committed branch.
- [Exact-head CI](https://github.com/steipete/summarize/actions/runs/34174601452) covers Node 24, Chromium E2E, Firefox smoke, and packaging.

[Commands and live proof](https://github.com/steipete/summarize/pull/444#issuecomment-5577395625).
