### PR TITLE
fix(podcasts): preserve Unicode episode title matching

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -22,6 +22,7 @@ read_when:
 ## CLI behavior
 
 - RSS and Atom feed URLs use the podcast/content pipeline rather than raw XML file handling. Published feed transcripts take precedence over media transcription; ordinary XML documents remain file inputs.
+- Podcast episode title matching preserves non-Latin letters and combining marks while ignoring case, punctuation, and Latin accents. Explicit titles without letters or numbers do not select an arbitrary RSS episode; feed requests without an episode title still use the first available transcript.
 - `--video-mode transcript` prefers transcript-first media handling even when a page has text.
 - Direct media URLs (mp4/webm/m4a/etc) skip HTML and transcribe.
 - Local audio/video files are routed through the same transcript-first pipeline.

--- a/packages/core/src/content/transcript/providers/podcast/itunes.ts
+++ b/packages/core/src/content/transcript/providers/podcast/itunes.ts
@@ -107,7 +107,8 @@ export async function resolvePodcastFeedUrlFromItunesSearch(
 
   const normalizedTarget = normalizeLooseTitle(showTitle);
   const exact = results.find(
-    (r) => normalizeLooseTitle(String(r.collectionName ?? "")) === normalizedTarget,
+    (r) =>
+      normalizedTarget && normalizeLooseTitle(String(r.collectionName ?? "")) === normalizedTarget,
   );
   const best = exact ?? results[0];
   const feedUrl = typeof best?.feedUrl === "string" ? best.feedUrl.trim() : "";
@@ -159,11 +160,13 @@ export async function resolvePodcastEpisodeFromItunesSearch(
 
   const exact = candidates.find(
     (entry) =>
+      normalizedEpisode &&
+      normalizedShow &&
       normalizeLooseTitle(entry.title ?? "") === normalizedEpisode &&
       normalizeLooseTitle(entry.collection ?? "") === normalizedShow,
   );
   const exactEpisode = candidates.find(
-    (entry) => normalizeLooseTitle(entry.title ?? "") === normalizedEpisode,
+    (entry) => normalizedEpisode && normalizeLooseTitle(entry.title ?? "") === normalizedEpisode,
   );
   const best = exact ?? exactEpisode ?? candidates[0];
   if (!best?.episodeUrl) return null;

--- a/packages/core/src/content/transcript/providers/podcast/rss-feed.ts
+++ b/packages/core/src/content/transcript/providers/podcast/rss-feed.ts
@@ -36,6 +36,7 @@ export function extractEnclosureForEpisode(
   episodeTitle: string,
 ): { enclosureUrl: string; durationSeconds: number | null } | null {
   const normalizedTarget = normalizeLooseTitle(episodeTitle);
+  if (!normalizedTarget) return null;
   const items = extractFeedItems(feedXml);
   for (const item of items) {
     const title = extractItemTitle(item);
@@ -94,12 +95,14 @@ export function decodeXmlEntities(value: string): string {
 }
 
 export function normalizeLooseTitle(value: string): string {
-  return value
+  const normalized = value
     .toLowerCase()
     .normalize("NFKD")
-    .replaceAll(/\p{Diacritic}+/gu, "")
-    .replaceAll(/[^a-z0-9]+/g, " ")
+    // Keep Latin accent folding, but preserve meaningful marks in other scripts.
+    .replaceAll(/(\p{Script=Latin})\p{M}+/gu, "$1")
+    .replaceAll(/[^\p{L}\p{M}\p{N}]+/gu, " ")
     .trim();
+  return /[\p{L}\p{N}]/u.test(normalized) ? normalized : "";
 }
 
 export function extractFeedItems(xml: string): string[] {

--- a/packages/core/src/content/transcript/providers/podcast/rss-transcript.ts
+++ b/packages/core/src/content/transcript/providers/podcast/rss-transcript.ts
@@ -39,6 +39,7 @@ export async function tryFetchTranscriptFromFeedXml({
 } | null> {
   const items = extractFeedItems(feedXml);
   const normalizedTarget = episodeTitle ? normalizeLooseTitle(episodeTitle) : null;
+  if (episodeTitle !== null && !normalizedTarget) return null;
 
   for (const item of items) {
     if (normalizedTarget) {

--- a/tests/transcript.podcast-title-matching.test.ts
+++ b/tests/transcript.podcast-title-matching.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchTranscript } from "../packages/core/src/content/transcript/providers/podcast.js";
+import {
+  resolvePodcastEpisodeFromItunesSearch,
+  resolvePodcastFeedUrlFromItunesSearch,
+} from "../packages/core/src/content/transcript/providers/podcast/itunes.js";
+import {
+  extractEnclosureForEpisode,
+  normalizeLooseTitle,
+} from "../packages/core/src/content/transcript/providers/podcast/rss-feed.js";
+import { tryFetchTranscriptFromFeedXml } from "../packages/core/src/content/transcript/providers/podcast/rss-transcript.js";
+
+const transcriptBase = "https://93.184.216.34";
+function feed(titles: string[]) {
+  return `<?xml version="1.0"?><rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0"><channel>${titles
+    .map(
+      (title, index) =>
+        `<item><title>${title}</title><enclosure url="https://example.com/${index}.mp3"/><podcast:transcript url="${transcriptBase}/${index}.txt" type="text/plain"/></item>`,
+    )
+    .join("")}</channel></rss>`;
+}
+
+const distinctTitles = [
+  ["城市生活", "宇宙探索"],
+  ["城市 12", "宇宙 12"],
+  ["か", "が"],
+  ["и", "й"],
+  ["مدينة", "علوم"],
+  ["कल", "कला"],
+  ["क", "क्"],
+];
+
+describe("podcast title matching", () => {
+  it.each(distinctTitles)("selects %s and %s as distinct episodes", async (first, target) => {
+    const xml = feed([first, target]);
+    expect(extractEnclosureForEpisode(xml, target)?.enclosureUrl).toBe("https://example.com/1.mp3");
+    const fetchImpl = vi.fn(async () => new Response("Requested episode"));
+    const result = await tryFetchTranscriptFromFeedXml({
+      fetchImpl,
+      feedXml: xml,
+      episodeTitle: target,
+      notes: [],
+    });
+    expect(result?.transcriptUrl).toBe(`${transcriptBase}/1.txt`);
+    expect(fetchImpl.mock.calls).toHaveLength(1);
+  });
+
+  it.each([
+    ["Café Ünicode", "Cafe Unicode"],
+    ["Hello – World", "hello - world"],
+    ["が", "か\u3099"],
+    ["й", "и\u0306"],
+  ])("preserves equivalent titles %s and %s", (first, target) => {
+    expect(extractEnclosureForEpisode(feed([first]), target)?.enclosureUrl).toBe(
+      "https://example.com/0.mp3",
+    );
+  });
+
+  it.each(["", "   ", "!!!", "😀", "\u0301", "不存在的标题"])(
+    "does not select an arbitrary episode for explicit title %j",
+    async (target) => {
+      const xml = feed(["😀", "城市生活"]);
+      expect(extractEnclosureForEpisode(xml, target)).toBeNull();
+      const fetchImpl = vi.fn(async () => new Response("Wrong episode"));
+      expect(
+        await tryFetchTranscriptFromFeedXml({
+          fetchImpl,
+          feedXml: xml,
+          episodeTitle: target,
+          notes: [],
+        }),
+      ).toBeNull();
+      expect(fetchImpl).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still selects the first transcript when no episode title was requested", async () => {
+    const result = await tryFetchTranscriptFromFeedXml({
+      fetchImpl: async () => new Response("First episode"),
+      feedXml: feed(["城市生活", "宇宙探索"]),
+      episodeTitle: null,
+      notes: [],
+    });
+    expect(result?.transcriptUrl).toBe(`${transcriptBase}/0.txt`);
+  });
+
+  it("normalizes mark-only titles to an empty key", () => {
+    expect(normalizeLooseTitle("\u0301")).toBe("");
+  });
+
+  it("selects later Unicode show and episode search matches", async () => {
+    const fetchShows = async () =>
+      Response.json({
+        results: [
+          { collectionName: "城市生活", feedUrl: "https://example.com/wrong.xml" },
+          { collectionName: "宇宙探索", feedUrl: "https://example.com/target.xml" },
+        ],
+      });
+    expect(await resolvePodcastFeedUrlFromItunesSearch(fetchShows, "宇宙探索")).toBe(
+      "https://example.com/target.xml",
+    );
+    const fetchEpisodes = async () =>
+      Response.json({
+        results: [
+          {
+            collectionName: "城市生活",
+            trackName: "宇宙探索",
+            episodeUrl: "https://example.com/wrong-show.mp3",
+          },
+          {
+            collectionName: "科学播客",
+            trackName: "城市生活",
+            episodeUrl: "https://example.com/wrong-episode.mp3",
+          },
+          {
+            collectionName: "科学播客",
+            trackName: "宇宙探索",
+            episodeUrl: "https://example.com/target.mp3",
+          },
+        ],
+      });
+    expect(
+      (await resolvePodcastEpisodeFromItunesSearch(fetchEpisodes, "科学播客", "宇宙探索"))
+        ?.episodeUrl,
+    ).toBe("https://example.com/target.mp3");
+  });
+
+  it("does not promote empty search keys above the existing first-result fallback", async () => {
+    const fetchImpl = async () =>
+      Response.json({
+        results: [
+          {
+            collectionName: "First",
+            trackName: "First",
+            feedUrl: "https://example.com/first.xml",
+            episodeUrl: "https://example.com/first.mp3",
+          },
+          {
+            collectionName: "!!!",
+            trackName: "!!!",
+            feedUrl: "https://example.com/empty.xml",
+            episodeUrl: "https://example.com/empty.mp3",
+          },
+        ],
+      });
+    expect(await resolvePodcastFeedUrlFromItunesSearch(fetchImpl, "😀")).toBe(
+      "https://example.com/first.xml",
+    );
+    expect((await resolvePodcastEpisodeFromItunesSearch(fetchImpl, "😀", "😀"))?.episodeUrl).toBe(
+      "https://example.com/first.mp3",
+    );
+  });
+
+  it.each(["apple-html", "apple-lookup", "spotify"])(
+    "returns the requested Chinese transcript through %s",
+    async (path) => {
+      const feedUrl = "https://example.com/feed.xml";
+      const title = "宇宙探索";
+      const calls: string[] = [];
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = input instanceof Request ? input.url : String(input);
+        calls.push(url);
+        if (url === feedUrl) return new Response(feed(["城市生活", title]));
+        if (url.startsWith(transcriptBase))
+          return new Response(url.endsWith("/1.txt") ? "Requested episode" : "Wrong episode");
+        if (url.startsWith("https://itunes.apple.com/lookup"))
+          return Response.json({
+            results: [
+              { wrapperType: "track", kind: "podcast", feedUrl },
+              {
+                wrapperType: "podcastEpisode",
+                trackId: 456,
+                trackName: title,
+                episodeUrl: "https://example.com/1.mp3",
+              },
+            ],
+          });
+        if (url.startsWith("https://itunes.apple.com/search"))
+          return Response.json({ results: [{ collectionName: "科学播客", feedUrl }] });
+        if (url.startsWith("https://open.spotify.com/embed/"))
+          return new Response(
+            `<script id="__NEXT_DATA__">${JSON.stringify({ props: { pageProps: { state: { data: { entity: { title, subtitle: "科学播客" } } } } } })}</script>`,
+          );
+        throw new Error(`Unexpected fetch: ${url}`);
+      });
+      const result = await fetchTranscript(
+        {
+          url:
+            path === "spotify"
+              ? "https://open.spotify.com/episode/abc"
+              : "https://podcasts.apple.com/us/podcast/test/id123?i=456",
+          html:
+            path === "apple-html"
+              ? `<html><meta name="apple:title" content="${title}"><script>{"feedUrl":"${feedUrl}"}</script></html>`
+              : null,
+          resourceKey: null,
+        },
+        {
+          fetch: fetchImpl,
+          scrapeWithFirecrawl: null,
+          apifyApiToken: null,
+          youtubeTranscriptMode: "auto",
+          ytDlpPath: null,
+          groqApiKey: null,
+          falApiKey: null,
+          openaiApiKey: null,
+        },
+      );
+      expect(result.text).toBe("Requested episode");
+      expect(result.source).toBe("podcastTranscript");
+      expect(result.metadata?.episodeTitle).toBe(title);
+      expect(result.metadata?.transcriptUrl).toBe(`${transcriptBase}/1.txt`);
+      expect(calls).not.toContain(`${transcriptBase}/0.txt`);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Podcast title matching currently removes all non-ASCII letters. Distinct titles can collapse to the same key, returning another episode's transcript while retaining the requested title in metadata. This also occurs after Apple lookup resolves the correct episode ID, and through Spotify's RSS fallback.

Preserve Unicode letters, numbers and combining marks, while keeping Latin accent folding and case/punctuation normalization. Reject empty matching keys for explicitly requested RSS episodes, and prevent empty keys from being treated as exact iTunes search matches. Feed requests without a title still select the first available transcript; existing best-result iTunes search fallback remains unchanged.

## Live before/after proof — 9 September 2026

Ran the built CLI at unchanged PR head `df3f4a2cac9f20727352200688a684b12827ac63` against this real [Apple Podcasts episode](https://podcasts.apple.com/jp/podcast/id1684187908?i=1000714914864): **ついにLISTENアプリβ版テスター募集します！！** from LISTEN NEWS. The run used live Apple lookup → [publisher RSS](https://rss.listen.style/p/listennews/rss) → publisher VTT. No injected HTTP responses, mocks, response replay, fetch overrides or local server.

```sh
env -i PATH=/usr/bin:/bin LANG=en_US.UTF-8 \
  SUMMARIZE_DISABLE_LOCAL_WHISPER_CPP=1 /opt/homebrew/bin/node dist/cli.js \
  'https://podcasts.apple.com/jp/podcast/id1684187908?i=1000714914864' \
  --extract --plain --json --no-cache --no-media-cache --timeout 30s
```

Use the absolute path to your Node installation in place of `/opt/homebrew/bin/node`. The clean environment supplied no credentials or HOME/USERPROFILE configuration/cache path. The CLI's transcript diagnostics confirmed `cacheStatus: bypassed`; it used `podcastTranscript`, with no paid transcription or model call.

Compared with a separate unchanged upstream `41375359` source snapshot running the same CLI arguments through the repository's original TypeScript loader and the same installed dependency set. Both runs performed live HTTP:

| | Upstream `41375359` | PR `df3f4a2c` |
|---|---|---|
| Requested Apple episode ID | `1000714914864` | `1000714914864` |
| Selected publisher episode | [Different live-stream archive](https://listen.style/p/listennews/dzkj1pvp) | [Requested beta-test announcement](https://listen.style/p/listennews/w4nsgzff) |
| Transcript URL suffix | `/dzkj1pvp/transcript.vtt` | `/w4nsgzff/transcript.vtt` |
| Matches requested episode | **false** | **true** |
| Transcript cache | bypassed | bypassed |

Independently downloaded both public VTTs and parsed cue text in Python. Each exactly matched its corresponding CLI output after removing the `Transcript:` prefix; the two transcripts differ. The selected RSS item's title also exactly matched the requested Apple title only after the fix.

```text
before.matchesRequestedEpisode=false
after.matchesRequestedEpisode=true
independentVttTextMatchesCli=true
before.textSha256=954ce64692d6d43157e0745c9f2ade11af8b4b259d6603cbe906d97fc8d1aaef
after.textSha256=73fa00f750877ee4d1348d43e301f00a62a72f366cdb9c73e8f3a3ab7dcd9352
```

No production source change was needed to obtain this evidence. Public episode transcripts are not reproduced here in full.

## Validation

- Added 24 regression cases covering Chinese titles, shared numeric suffixes, Japanese/Cyrillic distinctions and canonical equivalence, Indic marks, Arabic, Latin compatibility, empty keys, iTunes ranking, and Apple/Spotify provider paths. Before the production changes, 18 cases failed; all now pass.
- `pnpm -s build` passed.
- `pnpm -s check` passed: 565 test files passed, 29 skipped; 3,243 tests passed, 43 skipped. Formatting, lint, core/CLI/extension type checks and coverage thresholds passed.
- [Exact-head GitHub CI](https://github.com/steipete/summarize/actions/runs/34284574793) passed Node 24, Chromium extension E2E and Firefox smoke; GitGuardian passed.
- Local build/check and live proof used Node v26.0.0 with pinned pnpm 11.25.0 dependencies. Automated provider regressions still use controlled responses; the live Apple/RSS/VTT verification above is additional evidence. No public API or dependency changes; existing cached results are not invalidated.
