### PR TITLE
refactor(cli): share terminal output primitives

### DIFF
--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { CommanderError } from "commander";
 import { terminateTrackedProcesses } from "./processes.js";
 import { runCli } from "./run.js";
+import { isRichTty } from "./run/terminal.js";
 
 export type CliMainArgs = {
   argv: string[];
@@ -166,8 +167,7 @@ export async function runCliMain({
       return;
     }
 
-    const isTty = Boolean((stderr as unknown as { isTTY?: boolean }).isTTY);
-    if (isTty) stderr.write("\n");
+    if (isRichTty(stderr)) stderr.write("\n");
 
     if (verbose && error instanceof Error && typeof error.stack === "string") {
       stderr.write(`${error.stack}\n`);

--- a/src/refresh-free/presentation.ts
+++ b/src/refresh-free/presentation.ts
@@ -1,3 +1,4 @@
+import { ansi, isRichTty } from "../run/terminal.js";
 import type {
   BenchmarkedOpenRouterModel,
   BenchmarkFailureCounts,
@@ -10,14 +11,9 @@ function supportsColor(
 ): boolean {
   if (env.NO_COLOR) return false;
   if (env.FORCE_COLOR && env.FORCE_COLOR !== "0") return true;
-  if (!(stream as unknown as { isTTY?: boolean }).isTTY) return false;
+  if (!isRichTty(stream)) return false;
   const term = env.TERM?.toLowerCase();
   return Boolean(term && term !== "dumb");
-}
-
-function ansi(code: string, input: string, enabled: boolean): string {
-  if (!enabled) return input;
-  return `\u001b[${code}m${input}\u001b[0m`;
 }
 
 export function formatRefreshFreeDuration(ms: number): string {
@@ -51,7 +47,7 @@ export class RefreshFreeReporter {
     this.#stderr = stderr;
     this.#verbose = verbose;
     this.#color = supportsColor(stderr, env);
-    this.#isTty = Boolean((stderr as unknown as { isTTY?: boolean }).isTTY);
+    this.#isTty = isRichTty(stderr);
   }
 
   #ansi(code: string, text: string) {

--- a/src/run/stream-output.ts
+++ b/src/run/stream-output.ts
@@ -1,32 +1,8 @@
+import { terminalHeight, terminalWidth } from "./terminal.js";
+
 export type StreamOutputMode = "line" | "delta";
 
-function terminalColumns(stream: NodeJS.WritableStream): number {
-  const columns = (stream as unknown as { columns?: unknown }).columns;
-  return typeof columns === "number" && Number.isFinite(columns) && columns > 0
-    ? Math.floor(columns)
-    : 80;
-}
-
-function terminalRows(stream: NodeJS.WritableStream): number {
-  const rows = (stream as unknown as { rows?: unknown }).rows;
-  return typeof rows === "number" && Number.isFinite(rows) && rows > 0 ? Math.floor(rows) : 24;
-}
-
-type SegmenterLike = {
-  segment: (input: string) => Iterable<{ segment: string }>;
-};
-
-type SegmenterConstructor = new (
-  locales?: string | string[],
-  options?: { granularity?: "grapheme" },
-) => SegmenterLike;
-
-const splitGraphemes = (() => {
-  const Segmenter = (Intl as unknown as { Segmenter?: SegmenterConstructor }).Segmenter;
-  if (!Segmenter) return (input: string) => Array.from(input);
-  const segmenter = new Segmenter(undefined, { granularity: "grapheme" });
-  return (input: string) => Array.from(segmenter.segment(input), (part) => part.segment);
-})();
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 function isZeroWidthCodePoint(codePoint: number): boolean {
   return (
@@ -174,7 +150,7 @@ function displayCellWidth(grapheme: string): number {
 function visualLineCount(text: string, columns: number): number {
   let lines = 1;
   let column = 0;
-  for (const grapheme of splitGraphemes(text.replace(/\r\n?/g, "\n"))) {
+  for (const { segment: grapheme } of segmenter.segment(text.replace(/\r\n?/g, "\n"))) {
     if (grapheme === "\n") {
       lines += 1;
       column = 0;
@@ -220,8 +196,8 @@ export function createStreamOutputGate({
   let plainLeadingSkipLen = 0;
   let plainFlushedText = "";
   let pendingFinalReprint: string | null = null;
-  const columns = terminalColumns(stdout);
-  const rows = terminalRows(stdout);
+  const columns = terminalWidth(stdout);
+  const rows = terminalHeight(stdout);
 
   const ensureCleared = () => {
     if (cleared) return;

--- a/src/run/terminal.ts
+++ b/src/run/terminal.ts
@@ -1,5 +1,8 @@
+type TerminalStream = NodeJS.WritableStream &
+  Partial<Pick<NodeJS.WriteStream, "isTTY" | "columns" | "rows">>;
+
 export function isRichTty(stream: NodeJS.WritableStream): boolean {
-  return Boolean((stream as unknown as { isTTY?: boolean }).isTTY);
+  return Boolean((stream as TerminalStream).isTTY);
 }
 
 export function supportsColor(
@@ -17,32 +20,27 @@ export function supportsColor(
 
 export function terminalWidth(
   stream: NodeJS.WritableStream,
-  env: Record<string, string | undefined>,
+  env: Record<string, string | undefined> = {},
 ): number {
-  const cols = (stream as unknown as { columns?: unknown }).columns;
-  if (typeof cols === "number" && Number.isFinite(cols) && cols > 0) {
-    return Math.floor(cols);
-  }
-  const fromEnv = env.COLUMNS ? Number(env.COLUMNS) : NaN;
-  if (Number.isFinite(fromEnv) && fromEnv > 0) {
-    return Math.floor(fromEnv);
-  }
-  return 80;
+  return terminalDimension((stream as TerminalStream).columns, env.COLUMNS, 80);
 }
 
 export function terminalHeight(
   stream: NodeJS.WritableStream,
-  env: Record<string, string | undefined>,
+  env: Record<string, string | undefined> = {},
 ): number {
-  const rows = (stream as unknown as { rows?: unknown }).rows;
-  if (typeof rows === "number" && Number.isFinite(rows) && rows > 0) {
-    return Math.floor(rows);
+  return terminalDimension((stream as TerminalStream).rows, env.LINES, 24);
+}
+
+function terminalDimension(value: unknown, envValue: string | undefined, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
   }
-  const fromEnv = env.LINES ? Number(env.LINES) : NaN;
+  const fromEnv = envValue ? Number(envValue) : NaN;
   if (Number.isFinite(fromEnv) && fromEnv > 0) {
     return Math.floor(fromEnv);
   }
-  return 24;
+  return fallback;
 }
 
 /** Default max width for markdown rendering to keep text readable on wide terminals. */


### PR DESCRIPTION
Terminal rendering had separate copies of stream dimensions, TTY detection, and ANSI wrapping. Share those primitives and use the native grapheme segmenter supported by the existing Node 24 floor, without copying every segment into an intermediate array.

Streaming still derives dimensions from its output stream and falls back to 80×24; environment overrides remain explicit for the renderers that already use them. Color precedence is unchanged, including refresh-free's existing separate policy. No public flags, package APIs, formats, or runtime floors change.

Validation:
- Full build and repository check (formatting, type-aware lint, all workspace type checks, coverage tests): 565 test files and 3,243 tests passed; 94.39% line and 85.67% branch coverage. The 43 opt-in live tests remain skipped as before.
- Isolated Codex autoreview through P2: scoped-clean, no actionable findings.
- Built CLI against a local synthetic OpenAI-compatible SSE server through a 12-column PTY: one POST to `/v1/chat/completions`, streaming enabled, exit 0. Output preserves emoji grapheme clusters, combining accents, CJK, and the final newline:

```text
Unicode: 👩🏽‍💻 café 漢字
Streaming complete.
```
