### PR TITLE
chore(deps): refresh tooling and guard archive extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,14 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      - name: Check formatting
+        run: pnpm format:check
+
       - name: Lint
         run: pnpm lint
 
       - name: Tests (coverage)
         run: pnpm test:coverage
-
-      - name: Build
-        run: pnpm build
 
       - name: Typecheck extension
         run: pnpm -C apps/chrome-extension typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.4.0
+          bun-version: 1.4.2
 
       - name: Enable Corepack
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,16 +13,16 @@
 - Homebrew/core formula is not owned here; BrewTestBot autobumps releases about every 3h. Do not block or manually manage it; ship and continue.
 - Chrome Web Store: every release must upload the matching `dist-chrome/summarize-chrome-extension-v<version>.zip` to item `cejgnmmhbbpdmjnfppjdfkocebngehfg`, submit it for review with automatic publishing, and verify the exact pending/published version. Skip only when every shipped change is daemon-side and the packaged extension/companion contract is unchanged.
 - Dev:
-  - Build: `pnpm -s build` (builds core first)
-  - Gate: `pnpm -s check`
+  - Build: `pnpm run build` (builds core first; also runs during install via `prepare`)
+  - Gate: `pnpm run check`
   - Import from apps: prefer `@steipete/summarize-core` to avoid pulling CLI-only deps.
 - Dependencies: stable releases need a 7-day stabilization delay before adoption; prereleases remain excluded unless already adopted.
-- Daemon: restart with `pnpm -s summarize daemon restart`; verify via `pnpm -s summarize daemon status`.
+- Daemon: restart with `pnpm summarize daemon restart`; verify via `pnpm summarize daemon status`.
 - Rebuild (extension + daemon): run **both** in order:
   1. `pnpm -C apps/chrome-extension build`
   2. `pnpm summarize daemon restart`
 - Extension tests:
   - `pnpm -C apps/chrome-extension test:chrome` = supported automated path.
-  - Firefox Playwright extension tests are not reliable (`moz-extension://` limitation); default `test:firefox` skips.
+  - Firefox Playwright extension tests are not reliable (`moz-extension://` limitation); default `test:firefox` runs a temporary-install smoke test.
   - Use `pnpm -C apps/chrome-extension test:firefox:force` only for explicit diagnostics.
 - Commits: use `committer "type: message" <files...>` (Conventional Commits).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.21.15 - Unreleased
 
+- Security: backport the adm-zip destination-symlink extraction fix (GHSA-vwc7-r8mq-g2x9) while its new release completes the seven-day stabilization hold.
+- Maintenance: refresh stabilized Pi AI, tokentally, Playwright, and Bun tooling, enforce formatting in CI, and reuse the installation build.
+
 ## 0.21.14 - 2026-09-11
 
 **Highlights:** correct podcast episode selection for non-Latin titles and stabilized network/media reliability updates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ cd summarize
 corepack enable
 corepack install
 pnpm install --frozen-lockfile
-pnpm -s build
-pnpm -s check
+pnpm run build
+pnpm run check
 ```
 
 ## Repository Layout
@@ -34,16 +34,16 @@ Apps should import `@steipete/summarize-core` rather than the CLI package.
 ## Common Commands
 
 ```bash
-pnpm -s build
-pnpm -s check
-pnpm -s test
-pnpm -s test:coverage
-pnpm -s lint
-pnpm -s typecheck
-pnpm -s format
+pnpm run build
+pnpm run check
+pnpm run test
+pnpm run test:coverage
+pnpm run lint
+pnpm run typecheck
+pnpm run format
 ```
 
-`pnpm -s check` runs formatting, lint, type checking, and coverage tests. Run it before opening or updating a pull request.
+`pnpm run check` runs formatting, lint, type checking, and coverage tests. Run it before opening or updating a pull request. Installation already builds the CLI and core through `prepare`; run `pnpm run build` again after source changes.
 
 Extension:
 
@@ -67,12 +67,14 @@ docker run --rm summarize-test https://example.com --extract --plain
 
 The image uses the workspace's pinned pnpm version and frozen lockfile, including local dependency patches.
 
+Dependency patches live in `patches/` and have regression tests in `tests/dependency.*-security.test.ts`. The adm-zip 0.6.0 patch backports the destination-symlink extraction fix from 0.6.1 while that release completes the seven-day hold. It also stops asynchronous extraction after a directory rejection so the callback fires once; retain that correction until upstream fixes it, even after adopting 0.6.1. The image-size patch remains necessary until upstream publishes its parser-loop fixes. Registry audits still report patched versions by number, so verify the checked-in patches and tests rather than suppressing those advisories.
+
 Daemon after extension or daemon changes:
 
 ```bash
 pnpm -C apps/chrome-extension build
-pnpm -s summarize daemon restart
-pnpm -s summarize daemon status
+pnpm summarize daemon restart
+pnpm summarize daemon status
 ```
 
 ## Changes

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -30,7 +30,7 @@
     "preact": "10.29.8"
   },
   "devDependencies": {
-    "@playwright/test": "1.62.1",
+    "@playwright/test": "1.63.0",
     "@types/chrome": "^0.2.8",
     "typescript": "^7.0.2",
     "web-ext": "10.6.0",

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,4 +24,4 @@ summary: "Docs index for summarize behaviors and modes."
 
 ## Website
 
-- Jekyll site source: `docs/` (Markdown → HTML via GitHub Pages Actions)
+- Site source: `docs/`, rendered by `scripts/build-docs-site.mjs` and deployed through GitHub Pages Actions.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typecheck": "pnpm -C packages/core typecheck && tsc -p tsconfig.build.json --noEmit && pnpm -C apps/chrome-extension typecheck"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.85.0",
+    "@earendil-works/pi-ai": "^0.85.1",
     "@steipete/summarize-core": "workspace:*",
     "bpe-lite": "^0.5.2",
     "commander": "^15.0.0",
@@ -69,7 +69,7 @@
     "markdansi": "^0.3.3",
     "mime": "^4.1.0",
     "osc-progress": "^0.3.3",
-    "tokentally": "^0.1.4",
+    "tokentally": "^0.1.5",
     "undici": "8.10.2"
   },
   "devDependencies": {

--- a/patches/adm-zip@0.6.0.patch
+++ b/patches/adm-zip@0.6.0.patch
@@ -1,0 +1,97 @@
+diff --git a/adm-zip.js b/adm-zip.js
+index d62438b99ad2c8abb1c29506a87c36fd63573683..5bfa690160c81f6cc8ff6aeb94fff7da1c447d3d 100644
+--- a/adm-zip.js
++++ b/adm-zip.js
+@@ -709,6 +709,8 @@ module.exports = function (/**String*/ input, /** object */ options) {
+                     // collapsed subdirectories together (issue #306).
+                     var name = canonical(maintainEntryPath ? child.entryName : child.entryName.substring(item.entryName.length));
+                     var childName = sanitize(targetPath, name);
++                    // reject writing through a pre-existing symlink inside the target
++                    filetools.assertPathSafe(targetPath, childName);
+                     // The reverse operation for attr depend on method addFile()
+                     const fileAttr = keepOriginalPermission ? child.header.fileAttr : undefined;
+                     filetools.writeFileTo(childName, content, overwrite, fileAttr);
+@@ -719,6 +721,9 @@ module.exports = function (/**String*/ input, /** object */ options) {
+             var content = item.getData(_zip.password);
+             if (!content) throw Utils.Errors.CANT_EXTRACT_FILE();
+ 
++            // reject writing through a pre-existing symlink inside the target
++            filetools.assertPathSafe(targetPath, target);
++
+             if (filetools.fs.existsSync(target) && !overwrite) {
+                 throw Utils.Errors.CANT_OVERRIDE();
+             }
+@@ -775,6 +780,8 @@ module.exports = function (/**String*/ input, /** object */ options) {
+             const dirEntries = [];
+             _zip.entries.forEach(function (entry) {
+                 var entryName = sanitize(targetPath, canonical(entry.entryName));
++                // reject writing through a pre-existing symlink inside the target
++                filetools.assertPathSafe(targetPath, entryName);
+                 if (entry.isDirectory) {
+                     filetools.makeDir(entryName);
+                     // defer restoring the directory permission until its files are written
+@@ -854,10 +861,11 @@ module.exports = function (/**String*/ input, /** object */ options) {
+                 // The reverse operation for attr depend on method addFile()
+                 const dirAttr = keepOriginalPermission ? entry.header.fileAttr : undefined;
+                 try {
++                    // reject writing through a pre-existing symlink inside the target
++                    filetools.assertPathSafe(targetPath, dirPath);
+                     filetools.makeDir(dirPath);
+                 } catch (er) {
+-                    callback(getError("Unable to create folder", dirPath));
+-                    continue;
++                    return callback(getError("Unable to create folder", dirPath));
+                 }
+                 // defer restoring the directory permission until its files are written:
+                 // a restrictive mode applied now would block writing them
+@@ -890,6 +898,12 @@ module.exports = function (/**String*/ input, /** object */ options) {
+                     } else {
+                         const entryName = pth.normalize(canonical(entry.entryName));
+                         const filePath = sanitize(targetPath, entryName);
++                        try {
++                            // reject writing through a pre-existing symlink inside the target
++                            filetools.assertPathSafe(targetPath, filePath);
++                        } catch (er) {
++                            return next(er);
++                        }
+                         entry.getDataAsync(function (content, err_1) {
+                             if (err_1) {
+                                 next(err_1);
+diff --git a/util/utils.js b/util/utils.js
+index 8b8efaed31d64a4aa456d4b0905fac2599805ffe..6e7c067fad6b3a9d6d4945b655586cc8f7624631 100644
+--- a/util/utils.js
++++ b/util/utils.js
+@@ -159,6 +159,33 @@ Utils.prototype.writeFileToAsync = function (/*String*/ path, /*Buffer*/ content
+     });
+ };
+ 
++// Reject pre-existing destination symlinks below the caller-selected extraction root.
++Utils.prototype.assertPathSafe = function (/*String*/ root, /*String*/ target) {
++    const self = this;
++    if (typeof self.fs.lstatSync !== "function") return;
++
++    const resolvedRoot = pth.resolve(root);
++    const resolvedTarget = pth.resolve(target);
++    if (resolvedTarget === resolvedRoot) return;
++
++    const rel = pth.relative(resolvedRoot, resolvedTarget);
++    // Not under root: sanitize() is responsible for that case; nothing to walk.
++    if (!rel || rel === ".." || rel.startsWith(".." + pth.sep) || pth.isAbsolute(rel)) return;
++
++    let cur = resolvedRoot;
++    for (const part of rel.split(pth.sep)) {
++        if (!part || part === ".") continue;
++        cur = pth.join(cur, part);
++        let stat;
++        try {
++            stat = self.fs.lstatSync(cur);
++        } catch (e) {
++            break; // component does not exist yet: nothing below it can be a symlink
++        }
++        if (stat.isSymbolicLink()) throw Errors.FILE_IN_THE_WAY(`"${cur}"`);
++    }
++};
++
+ Utils.prototype.findFiles = function (/*String*/ path) {
+     const self = this;
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   wxt>esbuild: '-'
 
 patchedDependencies:
+  adm-zip@0.6.0: 8f90a48589f33f1bb6ba8f001bcafc7b71052e34fb0462e37c2a2b8137595f05
   image-size@2.0.2: 0d36cf6868094bf1a964e8ee431dfa1e791f841bf924bbb74cfb6b4c7894806e
 
 importers:
@@ -27,8 +28,8 @@ importers:
   .:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: ^0.85.0
-        version: 0.85.0(supports-color@10.2.2)(ws@8.21.3)(zod@4.4.3)
+        specifier: ^0.85.1
+        version: 0.85.1(supports-color@10.2.2)(ws@8.21.3)(zod@4.4.3)
       '@steipete/summarize-core':
         specifier: workspace:*
         version: link:packages/core
@@ -54,8 +55,8 @@ importers:
         specifier: ^0.3.3
         version: 0.3.3
       tokentally:
-        specifier: ^0.1.4
-        version: 0.1.4
+        specifier: ^0.1.5
+        version: 0.1.5
       undici:
         specifier: 8.10.2
         version: 8.10.2
@@ -116,8 +117,8 @@ importers:
         version: 10.29.8
     devDependencies:
       '@playwright/test':
-        specifier: 1.62.1
-        version: 1.62.1
+        specifier: 1.63.0
+        version: 1.63.0
       '@types/chrome':
         specifier: ^0.2.8
         version: 0.2.8
@@ -331,13 +332,13 @@ packages:
     engines: {node: '>= 0.10.4'}
     hasBin: true
 
-  '@earendil-works/pi-ai@0.85.0':
-    resolution: {integrity: sha512-CbeeZH3NHav7Rs182tYq0eoCAWfDd1MvOAXKzonIF4uN3uO99EB8iT1HfyGofJmPkAf8MeIwOBQtqqd0zgrPWA==}
+  '@earendil-works/pi-ai@0.85.1':
+    resolution: {integrity: sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-telemetry@0.85.0':
-    resolution: {integrity: sha512-gs8Zq1lySn8liq7U7CCSgWHJcA8c6+ZWk+CBPp7w0K+SN5LcLcsbs3+bh7zipm4CqNkVhcpwGAEGJp7qZqsVnA==}
+  '@earendil-works/pi-telemetry@0.85.1':
+    resolution: {integrity: sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/runtime@1.11.3':
@@ -1022,8 +1023,8 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
-  '@playwright/test@1.62.1':
-    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+  '@playwright/test@1.63.0':
+    resolution: {integrity: sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2193,11 +2194,6 @@ packages:
     resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
     engines: {node: '>=14.14'}
 
-  fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2926,13 +2922,13 @@ packages:
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
-  playwright-core@1.62.1:
-    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+  playwright-core@1.63.0:
+    resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
     engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.62.1:
-    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+  playwright@1.63.0:
+    resolution: {integrity: sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -3280,8 +3276,8 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
-  tokentally@0.1.4:
-    resolution: {integrity: sha512-+sfoN+uL47rbOQFZdiWhJqZmkimTMGwsDUryWfQDVHbRJaETGu+20iGtWG4a9d+GTEVwXPVg6vtUFnBk37Q6VQ==}
+  tokentally@0.1.5:
+    resolution: {integrity: sha512-BCO6WFjqd718vjlQvXgCuLiNAnCXSs6MRnRM+7EGrTUhM4fd1LwzNXBWVvEBk4CgG68dmxhegGq8FH7eGfVABQ==}
     engines: {node: '>=24'}
 
   ts-algebra@2.0.0:
@@ -3917,11 +3913,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@earendil-works/pi-ai@0.85.0(supports-color@10.2.2)(ws@8.21.3)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.85.1(supports-color@10.2.2)(ws@8.21.3)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.123.0(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@earendil-works/pi-telemetry': 0.85.0
+      '@earendil-works/pi-telemetry': 0.85.1
       '@google/genai': 1.52.0(supports-color@10.2.2)
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2(supports-color@10.2.2)
@@ -3937,7 +3933,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-telemetry@0.85.0': {}
+  '@earendil-works/pi-telemetry@0.85.1': {}
 
   '@emnapi/runtime@1.11.3':
     dependencies:
@@ -4362,9 +4358,9 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
-  '@playwright/test@1.62.1':
+  '@playwright/test@1.63.0':
     dependencies:
-      playwright: 1.62.1
+      playwright: 1.63.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -4796,7 +4792,7 @@ snapshots:
       upath: 3.0.7
       yauzl: 3.4.0
 
-  adm-zip@0.6.0: {}
+  adm-zip@0.6.0(patch_hash=8f90a48589f33f1bb6ba8f001bcafc7b71052e34fb0462e37c2a2b8137595f05): {}
 
   agent-base@7.1.4: {}
 
@@ -5340,7 +5336,7 @@ snapshots:
 
   firefox-profile@4.7.1:
     dependencies:
-      adm-zip: 0.6.0
+      adm-zip: 0.6.0(patch_hash=8f90a48589f33f1bb6ba8f001bcafc7b71052e34fb0462e37c2a2b8137595f05)
       fs-extra: 11.4.0
       ini: 4.1.3
       minimist: 1.2.8
@@ -5366,9 +5362,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
-
-  fsevents@2.3.2:
-    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -5901,7 +5894,7 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.6.0
+      adm-zip: 0.6.0(patch_hash=8f90a48589f33f1bb6ba8f001bcafc7b71052e34fb0462e37c2a2b8137595f05)
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 
@@ -6126,13 +6119,11 @@ snapshots:
 
   platform@1.3.6: {}
 
-  playwright-core@1.62.1: {}
+  playwright-core@1.63.0: {}
 
-  playwright@1.62.1:
+  playwright@1.63.0:
     dependencies:
-      playwright-core: 1.62.1
-    optionalDependencies:
-      fsevents: 2.3.2
+      playwright-core: 1.63.0
 
   postcss@8.5.26:
     dependencies:
@@ -6511,7 +6502,7 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
-  tokentally@0.1.4: {}
+  tokentally@0.1.5: {}
 
   ts-algebra@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,15 +9,6 @@ allowBuilds:
   protobufjs: true
 
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude:
-  - "@earendil-works/pi-ai@0.79.1"
-  - "@oxfmt/*"
-  - "@oxlint/*"
-  - "markdansi@0.3.1"
-  - "marked@18.0.5"
-  - "oxfmt@0.54.0"
-  - "oxlint@1.69.0"
-  - "undici@8.4.1"
 
 overrides:
   adm-zip: 0.6.0
@@ -36,6 +27,8 @@ overrides:
   "vitest>jsdom": "-"
   # WXT 0.20.26 declares esbuild but its shipped runtime does not import it.
   "wxt>esbuild": "-"
-# Upstream has no patched release; fix GHSA-w3rx-r6r6-pgpr and GHSA-5p2g-fcmc-qvqq.
 patchedDependencies:
+  # Backport only GHSA-vwc7-r8mq-g2x9 while 0.6.1 completes its seven-day hold.
+  adm-zip@0.6.0: patches/adm-zip@0.6.0.patch
+  # Upstream has no patched release for GHSA-w3rx-r6r6-pgpr and GHSA-5p2g-fcmc-qvqq.
   image-size@2.0.2: patches/image-size@2.0.2.patch

--- a/tests/dependency.adm-zip-security.test.ts
+++ b/tests/dependency.adm-zip-security.test.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, mkdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const extensionRequire = createRequire(resolve("apps/chrome-extension/package.json"));
+const webExtRequire = createRequire(extensionRequire.resolve("web-ext"));
+const profileRequire = createRequire(webExtRequire.resolve("firefox-profile"));
+const AdmZip = profileRequire("adm-zip");
+
+type Archive = {
+  extractEntryTo: (
+    entry: string,
+    target: string,
+    maintainPath: boolean,
+    overwrite: boolean,
+  ) => void;
+  extractAllTo: (target: string, overwrite: boolean) => void;
+  extractAllToAsync: (
+    target: string,
+    overwrite: boolean,
+    keepPermissions: boolean,
+    callback: (error?: Error) => void,
+  ) => void;
+};
+
+const modes = ["entry", "directory-entry", "sync", "async"] as const;
+async function extract(zip: Archive, target: string, mode: (typeof modes)[number]) {
+  if (mode === "entry") zip.extractEntryTo("link/payload.txt", target, true, true);
+  else if (mode === "directory-entry") zip.extractEntryTo("link/", target, true, true);
+  else if (mode === "sync") zip.extractAllTo(target, true);
+  else {
+    await new Promise<void>((resolve, reject) => {
+      zip.extractAllToAsync(target, true, false, (error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+describe("patched adm-zip dependency", () => {
+  it("stops asynchronous extraction after a rejected directory and calls back once", async () => {
+    const root = await mkdtemp(join(tmpdir(), "summarize-zip-security-"));
+    try {
+      const target = join(root, "target");
+      const outside = join(root, "outside");
+      await mkdir(target);
+      await mkdir(outside);
+      await symlink(outside, join(target, "link"), "dir");
+      const zip = new AdmZip();
+      zip.addFile("link/", Buffer.alloc(0));
+      zip.addFile("z-after/", Buffer.alloc(0));
+      const calls: Array<Error | undefined> = [];
+
+      zip.extractAllToAsync(target, true, false, (error?: Error) => calls.push(error));
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toBeInstanceOf(Error);
+      await expect(stat(join(target, "z-after"))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  for (const mode of modes) {
+    it.each(["directory", "file"])(`rejects a destination %s symlink (${mode})`, async (kind) => {
+      const root = await mkdtemp(join(tmpdir(), "summarize-zip-security-"));
+      try {
+        const target = join(root, "target");
+        const outside = join(root, "outside");
+        await mkdir(target);
+        await mkdir(outside);
+        const sentinel = join(outside, "payload.txt");
+        await writeFile(sentinel, "untouched");
+        if (kind === "directory") await symlink(outside, join(target, "link"), "dir");
+        else {
+          await mkdir(join(target, "link"));
+          await symlink(sentinel, join(target, "link/payload.txt"), "file");
+        }
+        const zip = new AdmZip();
+        zip.addFile("link/", Buffer.alloc(0));
+        zip.addFile("link/payload.txt", Buffer.from("overwritten"));
+
+        await expect(extract(zip, target, mode)).rejects.toThrow();
+        expect(await readFile(sentinel, "utf8")).toBe("untouched");
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it(`allows a caller-selected symlink root (${mode})`, async () => {
+      const root = await mkdtemp(join(tmpdir(), "summarize-zip-security-"));
+      try {
+        const target = join(root, "target");
+        const alias = join(root, "alias");
+        await mkdir(target);
+        await symlink(target, alias, "dir");
+        const zip = new AdmZip();
+        zip.addFile("link/", Buffer.alloc(0));
+        zip.addFile("link/payload.txt", Buffer.from("safe"));
+
+        await extract(zip, alias, mode);
+        expect(await readFile(join(target, "link/payload.txt"), "utf8")).toBe("safe");
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+});


### PR DESCRIPTION
Backport adm-zip's destination-symlink extraction guard while 0.6.1 completes the repository's seven-day stabilization hold. Abort asynchronous extraction on a rejected directory so its callback fires once and later entries are not processed. Registry audits still report the patched version; regression tests verify the mitigation instead of suppressing advisories.

Update stabilized Pi AI to 0.85.1, tokentally to 0.1.5, Playwright to 1.63.0, and the Bun builder to 1.4.2. Remove obsolete release-age exceptions. Node 24, pnpm 11.25, SHA-pinned actions, and the existing image-size patch stay in place.

CI now checks formatting and reuses the CLI/core build already run by installation's `prepare` hook. Update pnpm command and browser-smoke guidance, and identify the actual Pages generator.

Validation:
- Six destination-symlink cases failed before the patch; the async callback test reproduced two callbacks before the control-flow correction. All 14 dependency-security regressions now pass, including the existing image-size tests.
- Full build and repository check: 566 test files and 3,256 tests passed; 94.38% line and 85.67% branch coverage. Existing opt-in live tests remain skipped.
- Isolated Codex autoreview through P2: scoped-clean after reproducing and fixing the callback finding.
- Built Node CLI: synthetic OpenAI-compatible Unicode stream through a narrow PTY, one HTTP streaming request, exit 0.
- Bun 1.4.2 built both macOS targets; the host binary passed help/version, HTTP extraction with SQLite caching, and FFmpeg WebAssembly slide extraction with native media tools absent from PATH. These were local build tests; no release, signing, notarization, or publication was performed.
- Docs site build and the synthetic macOS release-contract test passed.

Release ages verified against the npm registry on September 12: Playwright September 4; Pi AI, tokentally, and Bun September 5. adm-zip 0.6.1 was published September 11, so its unrelated release changes remain deferred. Its async callback correction must be retained until upstream fixes that path, even after the version update.
