### PR TITLE
fix(onnx): retain input and commit only complete model downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.21.15 - Unreleased
 
 - Security: backport the adm-zip destination-symlink extraction fix (GHSA-vwc7-r8mq-g2x9) while its new release completes the seven-day stabilization hold.
+- ONNX transcription: keep staged audio available until inference exits and discard interrupted model downloads so retries cannot reuse partial artifacts.
 - Maintenance: refresh stabilized Pi AI, tokentally, Playwright, and Bun tooling, enforce formatting in CI, and reuse the installation build.
 
 ## 0.21.14 - 2026-09-11

--- a/docs/nvidia-onnx-transcription.md
+++ b/docs/nvidia-onnx-transcription.md
@@ -44,12 +44,14 @@ For the Chrome extension, you can pick a permanent default under **Settings → 
 - Artifacts are stored under `${SUMMARIZE_ONNX_CACHE_DIR || $XDG_CACHE_HOME || ~/.cache}/summarize/onnx/<model>/`.
 - Set `SUMMARIZE_ONNX_MODEL_BASE_URL` to point at a mirror (defaults to the Hugging Face repo for the chosen model).
 - The first run downloads `model.onnx` and `vocab.txt`; subsequent runs reuse cached files.
+- Downloads are committed to the cache only after the full response is written. Failed downloads remove their temporary files, so the next run retries instead of using a partial model. If an older version left a corrupt cached artifact, remove that artifact once to download it again.
 
 ## Behavior
 
 - Input audio is transcoded to 16kHz mono WAV via `ffmpeg` when available; otherwise the original file is passed to the CLI.
 - Onnx errors (missing command, non-zero exit, empty output) fall back to the existing Whisper flow with a note recorded in the transcript metadata.
 - Progress UI shows "ONNX (Parakeet/Canary)" while the external transcriber runs.
+- In-memory audio is staged until the external transcriber exits, then removed on success or failure.
 
 ## Notes
 

--- a/packages/core/src/transcription/onnx-cli.ts
+++ b/packages/core/src/transcription/onnx-cli.ts
@@ -179,7 +179,13 @@ async function downloadFile(url: string, destination: string) {
   // `fetch` Response.body is typed as DOM `ReadableStream` but Node's `Readable.fromWeb` expects
   // `node:stream/web`'s `ReadableStream` (which includes async-iterator helpers). Runtime is fine.
   const body = response.body as unknown as NodeReadableStream;
-  await pipeline(Readable.fromWeb(body), createWriteStream(destination));
+  const temporaryPath = `${destination}.${randomUUID()}.tmp`;
+  try {
+    await pipeline(Readable.fromWeb(body), createWriteStream(temporaryPath, { flags: "wx" }));
+    await fs.rename(temporaryPath, destination);
+  } finally {
+    await fs.rm(temporaryPath, { force: true }).catch(() => {});
+  }
 }
 
 async function ensureModelArtifactsDownloaded({
@@ -285,7 +291,7 @@ export async function transcribeWithOnnxCli({
   const tempFile = join(tmpdir(), `summarize-onnx-${randomUUID()}-${safeName}`);
   try {
     await fs.writeFile(tempFile, bytes);
-    return transcribeWithOnnxCliFile({
+    return await transcribeWithOnnxCliFile({
       model,
       filePath: tempFile,
       mediaType,

--- a/tests/transcription.onnx-cli.test.ts
+++ b/tests/transcription.onnx-cli.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   resolvePreferredOnnxModel,
+  transcribeWithOnnxCli,
   transcribeWithOnnxCliFile,
 } from "../packages/core/src/transcription/onnx-cli.js";
 
@@ -16,6 +17,106 @@ afterEach(() => {
 });
 
 describe("onnx cli transcriber", () => {
+  it("retries an interrupted model download without reusing a partial artifact", async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), "onnx-download-"));
+    try {
+      const filePath = join(root, "input.wav");
+      await fs.writeFile(filePath, "audio");
+      const env = {
+        SUMMARIZE_ONNX_CACHE_DIR: join(root, "cache"),
+        SUMMARIZE_ONNX_MODEL_BASE_URL: "https://example.invalid/model",
+        SUMMARIZE_ONNX_PARAKEET_CMD: JSON.stringify([
+          process.execPath,
+          "-e",
+          "process.stdout.write(require('node:fs').readFileSync(process.argv[1], 'utf8'))",
+          "{model}",
+        ]),
+      };
+      const interrupted = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("partial"));
+        },
+        pull(controller) {
+          controller.error(new Error("download interrupted"));
+        },
+      });
+      const fetchMock = vi
+        .spyOn(global, "fetch")
+        .mockResolvedValueOnce(new Response(interrupted))
+        .mockResolvedValueOnce(new Response("complete-model"))
+        .mockResolvedValueOnce(new Response("vocabulary"));
+      const options = { model: "parakeet" as const, filePath, mediaType: "audio/wav", env };
+
+      const failed = await transcribeWithOnnxCliFile(options);
+      expect(failed.error?.message).toContain("model download failed");
+      expect(await fs.readdir(join(root, "cache/parakeet"))).toEqual([]);
+
+      const retried = await transcribeWithOnnxCliFile(options);
+      expect(retried.error).toBeNull();
+      expect(retried.text).toBe("complete-model");
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect((await fs.readdir(join(root, "cache/parakeet"))).sort()).toEqual([
+        "model.onnx",
+        "vocab.txt",
+      ]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each([0, 1])(
+    "keeps byte input alive until the transcriber exits with %s",
+    async (exitCode) => {
+      const root = await fs.mkdtemp(join(tmpdir(), "onnx-input-"));
+      try {
+        const cacheDir = join(root, "cache");
+        const modelDir = join(cacheDir, "parakeet");
+        await fs.mkdir(modelDir, { recursive: true });
+        await fs.writeFile(join(modelDir, "model.onnx"), "model");
+        await fs.writeFile(join(modelDir, "vocab.txt"), "vocabulary");
+        const recordPath = join(root, "observed-input.json");
+        const env = {
+          SUMMARIZE_ONNX_CACHE_DIR: cacheDir,
+          SUMMARIZE_ONNX_PARAKEET_CMD: JSON.stringify([
+            process.execPath,
+            "-e",
+            `const fs = require('node:fs');
+           const input = process.argv[1];
+           const content = fs.readFileSync(input, 'utf8');
+           fs.writeFileSync(process.argv[2], JSON.stringify({ input, content }));
+           process.stdout.write(content);
+           process.exitCode = ${exitCode};`,
+            "{input}",
+            recordPath,
+          ]),
+        };
+
+        const result = await transcribeWithOnnxCli({
+          model: "parakeet",
+          bytes: new TextEncoder().encode("synthetic audio"),
+          mediaType: "audio/wav",
+          filename: "source.wav",
+          env,
+        });
+
+        const record = JSON.parse(await fs.readFile(recordPath, "utf8")) as {
+          input: string;
+          content: string;
+        };
+        expect(record.content).toBe("synthetic audio");
+        await expect(fs.stat(record.input)).rejects.toThrow();
+        if (exitCode === 0) {
+          expect(result.error).toBeNull();
+          expect(result.text).toBe("synthetic audio");
+        } else {
+          expect(result.error?.message).toContain("failed (1)");
+        }
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("downloads huggingface artifacts on first run and substitutes placeholders", async () => {
     const cacheDir = join(tmpdir(), `onnx-cache-${randomUUID()}`);
     process.env.SUMMARIZE_ONNX_CACHE_DIR = cacheDir;


### PR DESCRIPTION
ONNX transcription could delete staged audio before its asynchronous transcriber read it. Model downloads also wrote directly to the cache filename, so an interrupted response left a partial file that later runs treated as complete.

Keep ownership of staged audio until transcription settles, and download each artifact to an exclusive temporary sibling before atomically renaming it into the cache. Failed downloads clean their temporary files. Existing completed caches remain compatible; the guide explains how to remove an artifact corrupted by an older version.

Validation:
- Three regressions failed before the change: partial-cache retention and premature input deletion for successful and failed child exits. All ten ONNX tests pass afterward.
- Isolated Codex autoreview through P2: scoped-clean, no actionable findings.
- Full build and repository check passed: 566 test files, 3,259 tests, 94.38% line and 85.66% branch coverage. Existing opt-in live tests remain skipped.
- Live proof used the built CLI, a local HTTP model mirror, a synthetic WAV, and a configured synthetic transcriber. The server deliberately disconnected during the first model response. The next CLI invocation fetched the model again and succeeded. A separate run through the built byte-input adapter confirmed that the child could read the staged WAV and that it was removed afterward. This verifies download and process lifetimes, not neural inference quality.

```text
Interrupted-download CLI exit: 1 cached model exists: False
Retry CLI exit: 0 output: Transcript:
ONNX file ownership proof.
Built byte-input adapter exit: 0 staged file cleaned: True
HTTP requests: ['/model/model.onnx', '/model/model.onnx', '/model/vocab.txt']
```
