### PR TITLE
fix(cli): honor shared color overrides in refresh-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Security: backport the adm-zip destination-symlink extraction fix (GHSA-vwc7-r8mq-g2x9) while its new release completes the seven-day stabilization hold.
 - ONNX transcription: keep staged audio available until inference exits and discard interrupted model downloads so retries cannot reuse partial artifacts.
+- Refresh Free: honor `FORCE_COLOR=0` and use the same color-override precedence as the rest of the CLI.
 - Maintenance: refresh stabilized Pi AI, tokentally, Playwright, and Bun tooling, enforce formatting in CI, and reuse the installation build.
 
 ## 0.21.14 - 2026-09-11

--- a/docs/commands/refresh-free.md
+++ b/docs/commands/refresh-free.md
@@ -76,6 +76,8 @@ summarize refresh-free --runs 3 --smart 5 --verbose
 
 A short summary of survivors and rejected candidates is printed on stdout.
 
+Color follows the rest of the CLI: `FORCE_COLOR=0` disables it, while a nonzero `FORCE_COLOR` takes precedence over `NO_COLOR`. Without an override, color requires a capable terminal.
+
 ## See also
 
 - [LLM overview](../llm.md) — `--model` syntax, including `free`.

--- a/src/refresh-free/presentation.ts
+++ b/src/refresh-free/presentation.ts
@@ -1,20 +1,9 @@
-import { ansi, isRichTty } from "../run/terminal.js";
+import { ansi, isRichTty, supportsColor } from "../run/terminal.js";
 import type {
   BenchmarkedOpenRouterModel,
   BenchmarkFailureCounts,
   BenchmarkFailureKind,
 } from "./benchmark.js";
-
-function supportsColor(
-  stream: NodeJS.WritableStream,
-  env: Record<string, string | undefined>,
-): boolean {
-  if (env.NO_COLOR) return false;
-  if (env.FORCE_COLOR && env.FORCE_COLOR !== "0") return true;
-  if (!isRichTty(stream)) return false;
-  const term = env.TERM?.toLowerCase();
-  return Boolean(term && term !== "dumb");
-}
 
 export function formatRefreshFreeDuration(ms: number): string {
   if (!Number.isFinite(ms)) return `${ms}`;

--- a/tests/refresh-free.presentation.test.ts
+++ b/tests/refresh-free.presentation.test.ts
@@ -34,6 +34,34 @@ function model(): BenchmarkedOpenRouterModel {
 }
 
 describe("refresh-free presentation", () => {
+  it.each([
+    {
+      label: "FORCE_COLOR=0 on a TTY",
+      env: { FORCE_COLOR: "0", TERM: "xterm" },
+      isTTY: true,
+      color: false,
+    },
+    {
+      label: "FORCE_COLOR over NO_COLOR",
+      env: { FORCE_COLOR: "1", NO_COLOR: "1" },
+      isTTY: false,
+      color: true,
+    },
+    {
+      label: "NO_COLOR on a TTY",
+      env: { NO_COLOR: "1", TERM: "xterm" },
+      isTTY: true,
+      color: false,
+    },
+    { label: "a normal TTY", env: { TERM: "xterm" }, isTTY: true, color: true },
+    { label: "redirected output", env: { TERM: "xterm" }, isTTY: false, color: false },
+  ])("respects $label", ({ env, isTTY, color }) => {
+    const capture = createCaptureStream(isTTY);
+    const reporter = new RefreshFreeReporter({ stderr: capture.stream, env, verbose: false });
+    reporter.fetchingCatalog();
+    expect(/\u001b\[[\d;]+m/.test(capture.output())).toBe(color);
+  });
+
   it("formats benchmark durations", () => {
     expect(formatRefreshFreeDuration(149)).toBe("149ms");
     expect(formatRefreshFreeDuration(1550)).toBe("1.6s");


### PR DESCRIPTION
Refresh Free had a separate color policy that enabled ANSI colors with `FORCE_COLOR=0` on a TTY and let `NO_COLOR` defeat an explicit `FORCE_COLOR=1`. Use the shared CLI terminal policy, preserving the existing TTY redraw behavior.

Both precedence cases failed before the change and pass afterward, alongside normal terminal, redirected-output, and NO_COLOR coverage. The built CLI was run through a real PTY with a synthetic empty OpenRouter catalog to exercise the reporter without changing configuration or calling providers:

| Environment | Before | After |
| --- | --- | --- |
| `FORCE_COLOR=0` | Colored label | Plain label |
| `FORCE_COLOR=1 NO_COLOR=1` | Plain label | Colored label |

The expected empty-catalog error ended both runs after the reporter output. No model call was made.

Validation: build, full repository check (566 test files, 3,264 tests; 94.39% line and 85.68% branch coverage), 15 targeted terminal/reporting tests, and isolated Codex autoreview through P2 (scoped-clean). Existing opt-in live tests remain skipped.

The attached images render the recorded reporter lines from built-CLI PTY runs, using the synthetic catalog. Before: `ce067d0f`; after: `186df7f3`.

![Before: recorded CLI reporter output](https://github.com/user-attachments/assets/e53184db-af1f-4542-8587-379004be1459)

![After: recorded CLI reporter output](https://github.com/user-attachments/assets/5cca544e-430e-4e00-9eae-bb3c81bbe747)