### PR TITLE
refactor(cache): separate storage binding and key ownership

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -10,6 +10,8 @@ read_when:
 
 Lightweight, CLI-only SQLite cache. Single DB file.
 
+`src/cache.ts` exposes cache configuration, keys, and maintenance operations. `cache-store.ts` owns SQLite rows, eviction, slide-file cleanup, and the transcript adapter; `cache-database.ts` isolates the Node/Bun database binding. Versioned key construction lives in `cache-keys.ts`.
+
 ## Goals
 
 - Avoid repeated transcripts/extractions/summaries.
@@ -97,6 +99,6 @@ Media cache eviction:
 ## Notes
 
 - Core owns the transcript-source inventory used by both extraction and SQLite reads, including embedded captions and native YouTube media. Cache hits retain their original source diagnostics.
-- No extension cache (daemon uses CLI cache).
+- The extension has a separate browser panel cache in `chrome.storage.local`: URL-keyed entries use a 30-day TTL and an 8 MB size limit. It shares portable row formatting with core; daemon extraction and summary caches still use SQLite.
 - No third-party SQLite deps.
 - Transcript namespace currently includes the YouTube mode (e.g. `yt:auto`, `yt:web`).

--- a/src/cache-database.ts
+++ b/src/cache-database.ts
@@ -1,0 +1,48 @@
+type SqliteStatement = {
+  get: (...args: unknown[]) => unknown;
+  all: (...args: unknown[]) => unknown[];
+  run: (...args: unknown[]) => unknown;
+};
+
+export type SqliteDatabase = {
+  exec: (sql: string) => void;
+  prepare: (sql: string) => SqliteStatement;
+  close: () => void;
+};
+
+const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+let warningFilterInstalled = false;
+
+const installSqliteWarningFilter = () => {
+  if (warningFilterInstalled) return;
+  warningFilterInstalled = true;
+  const original = process.emitWarning.bind(process);
+  process.emitWarning = ((warning: unknown, ...args: unknown[]) => {
+    const message =
+      typeof warning === "string"
+        ? warning
+        : warning && typeof (warning as { message?: unknown }).message === "string"
+          ? String((warning as { message?: unknown }).message)
+          : "";
+    const type =
+      typeof args[0] === "string" ? args[0] : (args[0] as { type?: unknown } | undefined)?.type;
+    const name = (warning as { name?: unknown } | undefined)?.name;
+    const normalizedType = typeof type === "string" ? type : typeof name === "string" ? name : "";
+    if (normalizedType === "ExperimentalWarning" && message.toLowerCase().includes("sqlite")) {
+      return;
+    }
+    return original(warning as never, ...(args as [never]));
+  }) as typeof process.emitWarning;
+};
+
+export async function openSqlite(path: string): Promise<SqliteDatabase> {
+  if (isBun) {
+    const mod = (await import("bun:sqlite")) as { Database: new (path: string) => SqliteDatabase };
+    return new mod.Database(path);
+  }
+  installSqliteWarningFilter();
+  const mod = (await import("node:sqlite")) as unknown as {
+    DatabaseSync: new (path: string) => SqliteDatabase;
+  };
+  return new mod.DatabaseSync(path);
+}

--- a/src/cache-keys.ts
+++ b/src/cache-keys.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { CACHE_FORMAT_VERSION } from "@steipete/summarize-core/runtime";
 import type { LengthArg } from "./flags.js";
 import type { OutputLanguage } from "./language.js";
 
@@ -167,5 +168,82 @@ export function buildTranscriptCacheKeyValue({
     namespace,
     fileMtime: fileMtime ?? null,
     formatVersion,
+  });
+}
+
+export function buildExtractCacheKey({
+  url,
+  options,
+}: {
+  url: string;
+  options: Record<string, unknown>;
+}): string {
+  return buildExtractCacheKeyValue({
+    url,
+    options,
+    formatVersion: CACHE_FORMAT_VERSION,
+  });
+}
+
+export function buildSummaryCacheKey({
+  contentHash,
+  promptHash,
+  model,
+  lengthKey,
+  languageKey,
+}: {
+  contentHash: string;
+  promptHash: string;
+  model: string;
+  lengthKey: string;
+  languageKey: string;
+}): string {
+  return buildSummaryCacheKeyValue({
+    contentHash,
+    promptHash,
+    model,
+    lengthKey,
+    languageKey,
+    formatVersion: CACHE_FORMAT_VERSION,
+  });
+}
+
+export function buildSlidesCacheKey({
+  url,
+  settings,
+}: {
+  url: string;
+  settings: {
+    ocr: boolean;
+    outputDir: string;
+    sceneThreshold: number;
+    autoTuneThreshold: boolean;
+    maxSlides: number;
+    minDurationSeconds: number;
+  };
+}): string {
+  return buildSlidesCacheKeyValue({
+    url,
+    settings,
+    formatVersion: CACHE_FORMAT_VERSION,
+  });
+}
+
+export function buildTranscriptCacheKey({
+  url,
+  namespace,
+  formatVersion,
+  fileMtime,
+}: {
+  url: string;
+  namespace: string | null;
+  formatVersion?: number;
+  fileMtime?: number | null;
+}): string {
+  return buildTranscriptCacheKeyValue({
+    url,
+    namespace,
+    fileMtime,
+    formatVersion: formatVersion ?? CACHE_FORMAT_VERSION,
   });
 }

--- a/src/cache-store.ts
+++ b/src/cache-store.ts
@@ -1,0 +1,275 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  CACHE_FORMAT_VERSION,
+  buildPortableCacheRow,
+  parseCacheJson,
+  type CacheKind,
+} from "@steipete/summarize-core/runtime";
+import { openSqlite } from "./cache-database.js";
+import { buildTranscriptCacheKey } from "./cache-keys.js";
+import { cleanupSlidesPayload, collectSlidesPayloadArtifactPaths } from "./cache-slides-cleanup.js";
+import {
+  TRANSCRIPT_SOURCES,
+  type TranscriptCache,
+  type TranscriptSource,
+} from "./content/index.js";
+
+type CacheRow = {
+  value: string;
+  expires_at: number | null;
+  size_bytes: number;
+  created_at: number;
+};
+
+function normalizeTranscriptSource(value: unknown): TranscriptSource | null {
+  return TRANSCRIPT_SOURCES.find((candidate) => candidate === value) ?? null;
+}
+
+export type CacheStore = {
+  getText: (kind: CacheKind, key: string) => string | null;
+  getJson: <T>(kind: CacheKind, key: string) => T | null;
+  setText: (kind: CacheKind, key: string, value: string, ttlMs: number | null) => void;
+  setJson: (kind: CacheKind, key: string, value: unknown, ttlMs: number | null) => void;
+  clear: () => void;
+  close: () => void;
+  transcriptCache: TranscriptCache;
+};
+
+export async function createCacheStore({
+  path,
+  maxBytes,
+  transcriptNamespace,
+}: {
+  path: string;
+  maxBytes: number;
+  transcriptNamespace?: string | null;
+}): Promise<CacheStore> {
+  mkdirSync(dirname(path), { recursive: true });
+  const db = await openSqlite(path);
+  db.exec("PRAGMA busy_timeout=5000");
+  db.exec("PRAGMA journal_mode=WAL");
+  db.exec("PRAGMA synchronous=NORMAL");
+  db.exec("PRAGMA auto_vacuum=INCREMENTAL");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cache_entries (
+      kind TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      last_accessed_at INTEGER NOT NULL,
+      expires_at INTEGER,
+      PRIMARY KEY (kind, key)
+    )
+  `);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_cache_accessed ON cache_entries(last_accessed_at)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_cache_expires ON cache_entries(expires_at)");
+
+  const stmtGet = db.prepare(
+    "SELECT value, expires_at, size_bytes, created_at FROM cache_entries WHERE kind = ? AND key = ?",
+  );
+  const stmtTouch = db.prepare(
+    "UPDATE cache_entries SET last_accessed_at = ? WHERE kind = ? AND key = ?",
+  );
+  const stmtDelete = db.prepare("DELETE FROM cache_entries WHERE kind = ? AND key = ?");
+  const stmtSelectExpired = db.prepare(
+    "SELECT kind, key, value, created_at FROM cache_entries WHERE expires_at IS NOT NULL AND expires_at <= ?",
+  );
+  const stmtUpsert = db.prepare(`
+    INSERT INTO cache_entries (
+      kind, key, value, size_bytes, created_at, last_accessed_at, expires_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(kind, key) DO UPDATE SET
+      value = excluded.value,
+      size_bytes = excluded.size_bytes,
+      created_at = excluded.created_at,
+      last_accessed_at = excluded.last_accessed_at,
+      expires_at = excluded.expires_at
+  `);
+  const stmtTotalSize = db.prepare(
+    "SELECT COALESCE(SUM(size_bytes), 0) AS total FROM cache_entries",
+  );
+  const stmtOldest = db.prepare(
+    "SELECT kind, key, value, size_bytes, created_at FROM cache_entries ORDER BY last_accessed_at ASC LIMIT ?",
+  );
+  const stmtSlides = db.prepare("SELECT kind, key, value FROM cache_entries WHERE kind = 'slides'");
+  const stmtClear = db.prepare("DELETE FROM cache_entries");
+
+  const buildReferencedSlideArtifacts = (excludingKey: string): Set<string> => {
+    const rows = stmtSlides.all() as Array<{ key: string; value: string }>;
+    const referenced = new Set<string>();
+    for (const row of rows) {
+      if (row.key === excludingKey) continue;
+      for (const filePath of collectSlidesPayloadArtifactPaths(row.value)) {
+        referenced.add(filePath);
+      }
+    }
+    return referenced;
+  };
+
+  const deleteEntry = (kind: string, key: string, value: string, createdAt?: number | null) => {
+    if (kind === "slides") {
+      const referenced = buildReferencedSlideArtifacts(key);
+      cleanupSlidesPayload(value, { preservePaths: referenced, preserveNewerThanMs: createdAt });
+    }
+    stmtDelete.run(kind, key);
+  };
+
+  const sweepExpired = (now: number) => {
+    const rows = stmtSelectExpired.all(now) as Array<{
+      kind: string;
+      key: string;
+      value: string;
+      created_at: number;
+    }>;
+    for (const row of rows) {
+      deleteEntry(row.kind, row.key, row.value, row.created_at);
+    }
+  };
+
+  const enforceSize = () => {
+    if (!Number.isFinite(maxBytes) || maxBytes <= 0) return;
+    const row = stmtTotalSize.get() as { total?: number | null } | undefined;
+    let total = typeof row?.total === "number" ? row.total : 0;
+    if (total <= maxBytes) return;
+    const batchSize = 50;
+    while (total > maxBytes) {
+      const rows = stmtOldest.all(batchSize) as Array<{
+        kind: string;
+        key: string;
+        value: string;
+        size_bytes: number;
+        created_at: number;
+      }>;
+      if (rows.length === 0) break;
+      for (const row of rows) {
+        if (total <= maxBytes) break;
+        deleteEntry(row.kind, row.key, row.value, row.created_at);
+        total -= row.size_bytes ?? 0;
+      }
+      if (total <= maxBytes) break;
+    }
+    db.exec("PRAGMA incremental_vacuum");
+  };
+
+  const readEntry = (kind: CacheKind, key: string, now: number): CacheRow | null => {
+    const row = stmtGet.get(kind, key) as CacheRow | undefined;
+    if (!row) return null;
+    const expiresAt = row.expires_at;
+    if (typeof expiresAt === "number" && expiresAt <= now) {
+      deleteEntry(kind, key, row.value, row.created_at);
+      return { ...row, expires_at: expiresAt };
+    }
+    stmtTouch.run(now, kind, key);
+    return row;
+  };
+
+  const getText = (kind: CacheKind, key: string): string | null => {
+    const now = Date.now();
+    const row = readEntry(kind, key, now);
+    if (!row) return null;
+    const expiresAt = row.expires_at;
+    if (typeof expiresAt === "number" && expiresAt <= now) return null;
+    return row.value;
+  };
+
+  const getJson = <T>(kind: CacheKind, key: string): T | null => {
+    return parseCacheJson<T>(getText(kind, key));
+  };
+
+  const setText = (kind: CacheKind, key: string, value: string, ttlMs: number | null) => {
+    const now = Date.now();
+    sweepExpired(now);
+    const row = buildPortableCacheRow({ kind, key, value, ttlMs, now });
+    stmtUpsert.run(
+      row.kind,
+      row.key,
+      row.value,
+      row.sizeBytes,
+      row.createdAt,
+      row.lastAccessedAt,
+      row.expiresAt,
+    );
+    enforceSize();
+  };
+
+  const setJson = (kind: CacheKind, key: string, value: unknown, ttlMs: number | null) => {
+    setText(kind, key, JSON.stringify(value), ttlMs);
+  };
+
+  const clear = () => {
+    const rows = stmtSlides.all() as Array<{ value: string }>;
+    for (const row of rows) {
+      cleanupSlidesPayload(row.value);
+    }
+    stmtClear.run();
+    db.exec("PRAGMA incremental_vacuum");
+  };
+
+  const close = () => {
+    try {
+      db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    } catch {
+      // ignore
+    }
+    db.close();
+  };
+
+  const normalizedTranscriptNamespace =
+    typeof transcriptNamespace === "string" && transcriptNamespace.trim().length > 0
+      ? transcriptNamespace.trim()
+      : null;
+  const getTranscriptKey = (url: string, fileMtime?: number | null): string =>
+    buildTranscriptCacheKey({
+      url,
+      namespace: normalizedTranscriptNamespace,
+      fileMtime,
+    });
+
+  const transcriptCache: TranscriptCache = {
+    get: async ({ url, fileMtime }) => {
+      const now = Date.now();
+      const key = getTranscriptKey(url, fileMtime);
+      const row = readEntry("transcript", key, now);
+      if (!row) return null;
+      const expired = typeof row.expires_at === "number" && row.expires_at <= now;
+      const payload = parseCacheJson<{
+        content?: string | null;
+        source?: TranscriptSource | string | null;
+        metadata?: unknown;
+        resourceKey?: unknown;
+      }>(row.value);
+      const resourceKey =
+        typeof payload?.resourceKey === "string" && payload.resourceKey.trim().length > 0
+          ? payload.resourceKey.trim()
+          : null;
+      return {
+        content: payload?.content ?? null,
+        source: normalizeTranscriptSource(payload?.source) ?? null,
+        expired,
+        metadata: (payload?.metadata as Record<string, unknown> | null | undefined) ?? null,
+        resourceKey,
+      };
+    },
+    set: async ({ url, content, source, ttlMs, metadata, service, resourceKey, fileMtime }) => {
+      const key = getTranscriptKey(url, fileMtime);
+      setJson(
+        "transcript",
+        key,
+        {
+          content,
+          source,
+          metadata: metadata ?? null,
+          service,
+          resourceKey,
+          namespace: normalizedTranscriptNamespace,
+          formatVersion: CACHE_FORMAT_VERSION,
+        },
+        ttlMs,
+      );
+    },
+  };
+
+  return { getText, getJson, setText, setJson, clear, close, transcriptCache };
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,28 +1,26 @@
-import { existsSync, mkdirSync, rmSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
+import { existsSync, rmSync, statSync } from "node:fs";
+import { isAbsolute, join, resolve as resolvePath } from "node:path";
 import {
-  CACHE_FORMAT_VERSION,
-  buildPortableCacheRow,
   createEmptyCacheCounts,
-  parseCacheJson,
   type CacheKind,
   type CacheStats,
 } from "@steipete/summarize-core/runtime";
-import {
-  buildExtractCacheKeyValue,
-  buildSlidesCacheKeyValue,
-  buildSummaryCacheKeyValue,
-  buildTranscriptCacheKeyValue,
-} from "./cache-keys.js";
+import { openSqlite } from "./cache-database.js";
+import type { CacheStore } from "./cache-store.js";
+
 export {
   buildAttachmentContentHash,
+  buildExtractCacheKey,
   buildExtractCacheKeyValue,
   buildLanguageKey,
   buildLengthKey,
   buildPromptContentHash,
   buildPromptHash,
+  buildSlidesCacheKey,
   buildSlidesCacheKeyValue,
+  buildSummaryCacheKey,
   buildSummaryCacheKeyValue,
+  buildTranscriptCacheKey,
   buildTranscriptCacheKeyValue,
   hashJson,
   hashString,
@@ -37,51 +35,13 @@ export {
   type CacheKind,
   type CacheStats,
 } from "@steipete/summarize-core/runtime";
-import { cleanupSlidesPayload, collectSlidesPayloadArtifactPaths } from "./cache-slides-cleanup.js";
-import {
-  TRANSCRIPT_SOURCES,
-  type TranscriptCache,
-  type TranscriptSource,
-} from "./content/index.js";
+export { createCacheStore, type CacheStore } from "./cache-store.js";
 
 export type CacheConfig = {
   enabled?: boolean;
   maxMb?: number;
   ttlDays?: number;
   path?: string;
-};
-
-type SqliteStatement = {
-  get: (...args: unknown[]) => unknown;
-  all: (...args: unknown[]) => unknown[];
-  run: (...args: unknown[]) => { changes?: number } | unknown;
-};
-
-type SqliteDatabase = {
-  exec: (sql: string) => void;
-  prepare: (sql: string) => SqliteStatement;
-  close?: () => void;
-};
-
-type CacheRow = {
-  value: string;
-  expires_at: number | null;
-  size_bytes: number;
-  created_at: number;
-};
-
-function normalizeTranscriptSource(value: unknown): TranscriptSource | null {
-  return TRANSCRIPT_SOURCES.find((candidate) => candidate === value) ?? null;
-}
-
-export type CacheStore = {
-  getText: (kind: CacheKind, key: string) => string | null;
-  getJson: <T>(kind: CacheKind, key: string) => T | null;
-  setText: (kind: CacheKind, key: string, value: string, ttlMs: number | null) => void;
-  setJson: (kind: CacheKind, key: string, value: unknown, ttlMs: number | null) => void;
-  clear: () => void;
-  close: () => void;
-  transcriptCache: TranscriptCache;
 };
 
 export type CacheState = {
@@ -91,47 +51,6 @@ export type CacheState = {
   maxBytes: number;
   path: string | null;
 };
-
-const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
-let warningFilterInstalled = false;
-
-const installSqliteWarningFilter = () => {
-  if (warningFilterInstalled) return;
-  warningFilterInstalled = true;
-  const original = process.emitWarning.bind(process);
-  process.emitWarning = ((warning: unknown, ...args: unknown[]) => {
-    const message =
-      typeof warning === "string"
-        ? warning
-        : warning && typeof (warning as { message?: unknown }).message === "string"
-          ? String((warning as { message?: unknown }).message)
-          : "";
-    const type =
-      typeof args[0] === "string" ? args[0] : (args[0] as { type?: unknown } | undefined)?.type;
-    const name = (warning as { name?: unknown } | undefined)?.name;
-    const normalizedType = typeof type === "string" ? type : typeof name === "string" ? name : "";
-    if (normalizedType === "ExperimentalWarning" && message.toLowerCase().includes("sqlite")) {
-      return;
-    }
-    return original(warning as never, ...(args as [never]));
-  }) as typeof process.emitWarning;
-};
-
-async function openSqlite(path: string): Promise<SqliteDatabase> {
-  if (isBun) {
-    const mod = (await import("bun:sqlite")) as { Database: new (path: string) => SqliteDatabase };
-    return new mod.Database(path);
-  }
-  installSqliteWarningFilter();
-  const mod = (await import("node:sqlite")) as unknown as {
-    DatabaseSync: new (path: string) => SqliteDatabase;
-  };
-  return new mod.DatabaseSync(path);
-}
-
-function ensureDir(path: string) {
-  mkdirSync(path, { recursive: true });
-}
 
 function resolveHomeDir(env: Record<string, string | undefined>): string | null {
   const home = env.HOME?.trim() || env.USERPROFILE?.trim();
@@ -159,335 +78,10 @@ export function resolveCachePath({
   return join(home, ".summarize", "cache.sqlite");
 }
 
-export async function createCacheStore({
-  path,
-  maxBytes,
-  transcriptNamespace,
-}: {
-  path: string;
-  maxBytes: number;
-  transcriptNamespace?: string | null;
-}): Promise<CacheStore> {
-  ensureDir(dirname(path));
-  const db = await openSqlite(path);
-  db.exec("PRAGMA busy_timeout=5000");
-  db.exec("PRAGMA journal_mode=WAL");
-  db.exec("PRAGMA synchronous=NORMAL");
-  db.exec("PRAGMA auto_vacuum=INCREMENTAL");
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS cache_entries (
-      kind TEXT NOT NULL,
-      key TEXT NOT NULL,
-      value TEXT NOT NULL,
-      size_bytes INTEGER NOT NULL,
-      created_at INTEGER NOT NULL,
-      last_accessed_at INTEGER NOT NULL,
-      expires_at INTEGER,
-      PRIMARY KEY (kind, key)
-    )
-  `);
-  db.exec("CREATE INDEX IF NOT EXISTS idx_cache_accessed ON cache_entries(last_accessed_at)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_cache_expires ON cache_entries(expires_at)");
-
-  const stmtGet = db.prepare(
-    "SELECT value, expires_at, size_bytes, created_at FROM cache_entries WHERE kind = ? AND key = ?",
-  );
-  const stmtTouch = db.prepare(
-    "UPDATE cache_entries SET last_accessed_at = ? WHERE kind = ? AND key = ?",
-  );
-  const stmtDelete = db.prepare("DELETE FROM cache_entries WHERE kind = ? AND key = ?");
-  const stmtSelectExpired = db.prepare(
-    "SELECT kind, key, value, created_at FROM cache_entries WHERE expires_at IS NOT NULL AND expires_at <= ?",
-  );
-  const stmtUpsert = db.prepare(`
-    INSERT INTO cache_entries (
-      kind, key, value, size_bytes, created_at, last_accessed_at, expires_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(kind, key) DO UPDATE SET
-      value = excluded.value,
-      size_bytes = excluded.size_bytes,
-      created_at = excluded.created_at,
-      last_accessed_at = excluded.last_accessed_at,
-      expires_at = excluded.expires_at
-  `);
-  const stmtTotalSize = db.prepare(
-    "SELECT COALESCE(SUM(size_bytes), 0) AS total FROM cache_entries",
-  );
-  const stmtOldest = db.prepare(
-    "SELECT kind, key, value, size_bytes, created_at FROM cache_entries ORDER BY last_accessed_at ASC LIMIT ?",
-  );
-  const stmtSlides = db.prepare("SELECT kind, key, value FROM cache_entries WHERE kind = 'slides'");
-  const stmtClear = db.prepare("DELETE FROM cache_entries");
-
-  const buildReferencedSlideArtifacts = (excludingKey: string): Set<string> => {
-    const rows = stmtSlides.all() as Array<{ key: string; value: string }>;
-    const referenced = new Set<string>();
-    for (const row of rows) {
-      if (row.key === excludingKey) continue;
-      for (const filePath of collectSlidesPayloadArtifactPaths(row.value)) {
-        referenced.add(filePath);
-      }
-    }
-    return referenced;
-  };
-
-  const deleteEntry = (kind: string, key: string, value: string, createdAt?: number | null) => {
-    if (kind === "slides") {
-      const referenced = buildReferencedSlideArtifacts(key);
-      cleanupSlidesPayload(value, { preservePaths: referenced, preserveNewerThanMs: createdAt });
-    }
-    stmtDelete.run(kind, key);
-  };
-
-  const sweepExpired = (now: number) => {
-    const rows = stmtSelectExpired.all(now) as Array<{
-      kind: string;
-      key: string;
-      value: string;
-      created_at: number;
-    }>;
-    for (const row of rows) {
-      deleteEntry(row.kind, row.key, row.value, row.created_at);
-    }
-  };
-
-  const enforceSize = () => {
-    if (!Number.isFinite(maxBytes) || maxBytes <= 0) return;
-    const row = stmtTotalSize.get() as { total?: number | null } | undefined;
-    let total = typeof row?.total === "number" ? row.total : 0;
-    if (total <= maxBytes) return;
-    const batchSize = 50;
-    while (total > maxBytes) {
-      const rows = stmtOldest.all(batchSize) as Array<{
-        kind: string;
-        key: string;
-        value: string;
-        size_bytes: number;
-        created_at: number;
-      }>;
-      if (rows.length === 0) break;
-      for (const row of rows) {
-        if (total <= maxBytes) break;
-        deleteEntry(row.kind, row.key, row.value, row.created_at);
-        total -= row.size_bytes ?? 0;
-      }
-      if (total <= maxBytes) break;
-    }
-    db.exec("PRAGMA incremental_vacuum");
-  };
-
-  const readEntry = (kind: CacheKind, key: string, now: number): CacheRow | null => {
-    const row = stmtGet.get(kind, key) as CacheRow | undefined;
-    if (!row) return null;
-    const expiresAt = row.expires_at;
-    if (typeof expiresAt === "number" && expiresAt <= now) {
-      deleteEntry(kind, key, row.value, row.created_at);
-      return { ...row, expires_at: expiresAt };
-    }
-    stmtTouch.run(now, kind, key);
-    return row;
-  };
-
-  const getText = (kind: CacheKind, key: string): string | null => {
-    const now = Date.now();
-    const row = readEntry(kind, key, now);
-    if (!row) return null;
-    const expiresAt = row.expires_at;
-    if (typeof expiresAt === "number" && expiresAt <= now) return null;
-    return row.value;
-  };
-
-  const getJson = <T>(kind: CacheKind, key: string): T | null => {
-    return parseCacheJson<T>(getText(kind, key));
-  };
-
-  const setText = (kind: CacheKind, key: string, value: string, ttlMs: number | null) => {
-    const now = Date.now();
-    sweepExpired(now);
-    const row = buildPortableCacheRow({ kind, key, value, ttlMs, now });
-    stmtUpsert.run(
-      row.kind,
-      row.key,
-      row.value,
-      row.sizeBytes,
-      row.createdAt,
-      row.lastAccessedAt,
-      row.expiresAt,
-    );
-    enforceSize();
-  };
-
-  const setJson = (kind: CacheKind, key: string, value: unknown, ttlMs: number | null) => {
-    setText(kind, key, JSON.stringify(value), ttlMs);
-  };
-
-  const clear = () => {
-    const rows = stmtSlides.all() as Array<{ value: string }>;
-    for (const row of rows) {
-      cleanupSlidesPayload(row.value);
-    }
-    stmtClear.run();
-    db.exec("PRAGMA incremental_vacuum");
-  };
-
-  const close = () => {
-    try {
-      db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-    } catch {
-      // ignore
-    }
-    db.close?.();
-  };
-
-  const normalizedTranscriptNamespace =
-    typeof transcriptNamespace === "string" && transcriptNamespace.trim().length > 0
-      ? transcriptNamespace.trim()
-      : null;
-  const getTranscriptKey = (url: string, fileMtime?: number | null): string =>
-    buildTranscriptCacheKey({
-      url,
-      namespace: normalizedTranscriptNamespace,
-      fileMtime,
-    });
-
-  const transcriptCache: TranscriptCache = {
-    get: async ({ url, fileMtime }) => {
-      const now = Date.now();
-      const key = getTranscriptKey(url, fileMtime);
-      const row = readEntry("transcript", key, now);
-      if (!row) return null;
-      const expired = typeof row.expires_at === "number" && row.expires_at <= now;
-      let payload: {
-        content?: string | null;
-        source?: TranscriptSource | string | null;
-        metadata?: unknown;
-        resourceKey?: unknown;
-      } | null = null;
-      try {
-        payload = JSON.parse(row.value) as {
-          content?: string | null;
-          source?: TranscriptSource | string | null;
-          metadata?: unknown;
-          resourceKey?: unknown;
-        };
-      } catch {
-        payload = null;
-      }
-      const resourceKey =
-        typeof payload?.resourceKey === "string" && payload.resourceKey.trim().length > 0
-          ? payload.resourceKey.trim()
-          : null;
-      return {
-        content: payload?.content ?? null,
-        source: normalizeTranscriptSource(payload?.source) ?? null,
-        expired,
-        metadata: (payload?.metadata as Record<string, unknown> | null | undefined) ?? null,
-        resourceKey,
-      };
-    },
-    set: async ({ url, content, source, ttlMs, metadata, service, resourceKey, fileMtime }) => {
-      const key = getTranscriptKey(url, fileMtime);
-      setJson(
-        "transcript",
-        key,
-        {
-          content,
-          source,
-          metadata: metadata ?? null,
-          service,
-          resourceKey,
-          namespace: normalizedTranscriptNamespace,
-          formatVersion: CACHE_FORMAT_VERSION,
-        },
-        ttlMs,
-      );
-    },
-  };
-
-  return { getText, getJson, setText, setJson, clear, close, transcriptCache };
-}
-
 export function clearCacheFiles(path: string) {
   rmSync(path, { force: true });
   rmSync(`${path}-wal`, { force: true });
   rmSync(`${path}-shm`, { force: true });
-}
-
-export function buildExtractCacheKey({
-  url,
-  options,
-}: {
-  url: string;
-  options: Record<string, unknown>;
-}): string {
-  return buildExtractCacheKeyValue({
-    url,
-    options,
-    formatVersion: CACHE_FORMAT_VERSION,
-  });
-}
-
-export function buildSummaryCacheKey({
-  contentHash,
-  promptHash,
-  model,
-  lengthKey,
-  languageKey,
-}: {
-  contentHash: string;
-  promptHash: string;
-  model: string;
-  lengthKey: string;
-  languageKey: string;
-}): string {
-  return buildSummaryCacheKeyValue({
-    contentHash,
-    promptHash,
-    model,
-    lengthKey,
-    languageKey,
-    formatVersion: CACHE_FORMAT_VERSION,
-  });
-}
-
-export function buildSlidesCacheKey({
-  url,
-  settings,
-}: {
-  url: string;
-  settings: {
-    ocr: boolean;
-    outputDir: string;
-    sceneThreshold: number;
-    autoTuneThreshold: boolean;
-    maxSlides: number;
-    minDurationSeconds: number;
-  };
-}): string {
-  return buildSlidesCacheKeyValue({
-    url,
-    settings,
-    formatVersion: CACHE_FORMAT_VERSION,
-  });
-}
-
-export function buildTranscriptCacheKey({
-  url,
-  namespace,
-  formatVersion,
-  fileMtime,
-}: {
-  url: string;
-  namespace: string | null;
-  formatVersion?: number;
-  fileMtime?: number | null;
-}): string {
-  return buildTranscriptCacheKeyValue({
-    url,
-    namespace,
-    fileMtime,
-    formatVersion: formatVersion ?? CACHE_FORMAT_VERSION,
-  });
 }
 
 export async function readCacheStats(path: string): Promise<CacheStats | null> {
@@ -509,7 +103,7 @@ export async function readCacheStats(path: string): Promise<CacheStats | null> {
     | { count?: number }
     | undefined;
   const totalEntries = typeof totalRow?.count === "number" ? totalRow.count : 0;
-  db.close?.();
+  db.close();
   return {
     path,
     sizeBytes: getSqliteFileSizeBytes(path),
@@ -520,20 +114,12 @@ export async function readCacheStats(path: string): Promise<CacheStats | null> {
 
 export function getSqliteFileSizeBytes(path: string): number {
   let total = 0;
-  try {
-    total += statSync(path).size;
-  } catch {
-    // ignore
-  }
-  try {
-    total += statSync(`${path}-wal`).size;
-  } catch {
-    // ignore
-  }
-  try {
-    total += statSync(`${path}-shm`).size;
-  } catch {
-    // ignore
+  for (const filePath of [path, `${path}-wal`, `${path}-shm`]) {
+    try {
+      total += statSync(filePath).size;
+    } catch {
+      // SQLite sidecars may not exist, or may disappear during a checkpoint.
+    }
   }
   return total;
 }

--- a/tests/cache.keys.test.ts
+++ b/tests/cache.keys.test.ts
@@ -2,14 +2,49 @@ import { describe, expect, it } from "vitest";
 import {
   buildAttachmentContentHash,
   buildExtractCacheKey,
+  buildExtractCacheKeyValue,
   buildPromptContentHash,
   buildPromptHash,
   buildSummaryCacheKey,
+  buildSummaryCacheKeyValue,
+  buildSlidesCacheKeyValue,
+  buildTranscriptCacheKeyValue,
   extractTaggedBlock,
   hashString,
 } from "../src/cache.js";
 
 describe("cache keys and tags", () => {
+  it("preserves caller-selected format versions through the raw key facade", () => {
+    const input = {
+      url: "https://example.com/video",
+      options: {},
+      contentHash: "content",
+      promptHash: "prompt",
+      model: "provider/model",
+      lengthKey: "chars:140",
+      languageKey: "en",
+      namespace: null,
+      settings: {
+        ocr: false,
+        outputDir: "slides",
+        sceneThreshold: 0.3,
+        autoTuneThreshold: true,
+        maxSlides: 10,
+        minDurationSeconds: 5,
+      },
+      formatVersion: 100,
+    };
+    for (const buildKey of [
+      buildExtractCacheKeyValue,
+      buildSummaryCacheKeyValue,
+      buildSlidesCacheKeyValue,
+      buildTranscriptCacheKeyValue,
+    ]) {
+      expect(buildKey(input)).toBe(buildKey({ ...input }));
+      expect(buildKey(input)).not.toBe(buildKey({ ...input, formatVersion: 101 }));
+    }
+  });
+
   it("extracts tagged blocks", () => {
     const prompt = "<instructions>Do the thing.</instructions>\n<content>Body</content>";
     expect(extractTaggedBlock(prompt, "instructions")).toBe("Do the thing.");


### PR DESCRIPTION
The 551-line cache module combined public configuration/maintenance, versioned key construction, Node/Bun binding, row eviction, and transcript access. Separate the binding and row store, and keep all key construction together. The facade is now 125 lines; the store is 275 and the database binding 48. All 31 existing facade exports and the persisted cache format remain intact.

Reuse the existing JSON-cache parser for transcript payloads and one file-size loop for the database and sidecars. Both supported database APIs provide `close`, so the binding now makes that contract explicit. Correct the cache guide's stale claim that the extension has no cache: it maintains its own browser panel cache.

Validation: full build/check passed (566 files, 3,265 tests), 31 focused cache tests, and isolated Codex review through P2 passed after restoring four raw key-builder exports identified in the first review. A new compatibility test exercises caller-selected format versions through those exports.

Live Node and Bun probes both wrote/read real SQLite rows, preserved transcript metadata, reopened persisted state, invoked the built CLI's `--cache-stats`, and cleared the cache successfully. No public CLI, key, TTL, eviction, or serialization behavior changes are intended.
