### PR TITLE
refactor(cli): share option parsing and stream construction

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -46,6 +46,8 @@ Core owns file-summary instruction construction and timed-transcript parsing/for
 
 The engine never writes summary text to stdout.
 
+CLI summary and slide adapters share the terminal Markdown streamer factory in `src/run/markdown-streamer.ts`; each adapter retains its own progress and stream lifecycle. Standalone command preflight uses `src/cli-args.ts` for the same equals-form and separate-value option semantics.
+
 Each provider attempt resolves one request shared by streaming, direct completion, and fallback completion. Stream consumption owns output-handler lifecycle and marks visible or handler failures as interrupted; only an uncommitted provider failure can fall back to completion. Usage collection happens after successful stream consumption and does not trigger another model call.
 
 `SummaryStreamHandler` receives normalized chunks:

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,0 +1,9 @@
+export function readCliOptionValue(argv: readonly string[], name: string): string | null {
+  const eq = argv.find((a) => a.startsWith(`${name}=`));
+  if (eq) return eq.slice(`${name}=`.length).trim() || null;
+  const index = argv.indexOf(name);
+  if (index === -1) return null;
+  const next = argv[index + 1];
+  if (!next || next.startsWith("-")) return null;
+  return next.trim() || null;
+}

--- a/src/costs.ts
+++ b/src/costs.ts
@@ -1,5 +1,6 @@
 import type { LlmTokenUsage } from "./llm/generate-text.js";
 import type { LlmProvider as BaseLlmProvider } from "./llm/model-id.js";
+import { sumNumbersOrNull } from "./shared/numbers.js";
 
 export type LlmProvider = BaseLlmProvider | "cli";
 
@@ -25,18 +26,6 @@ export type RunMetricsReport = {
     apify: { requests: number };
   };
 };
-
-function sumOrNull(values: Array<number | null>): number | null {
-  let sum = 0;
-  let any = false;
-  for (const value of values) {
-    if (typeof value === "number" && Number.isFinite(value)) {
-      sum += value;
-      any = true;
-    }
-  }
-  return any ? sum : null;
-}
 
 export function buildRunMetricsReport({
   llmCalls,
@@ -83,9 +72,9 @@ export function buildRunMetricsReport({
   }
 
   const llm = Array.from(llmMap.values()).map((row) => {
-    const promptTokens = sumOrNull(row.promptTokens);
-    const completionTokens = sumOrNull(row.completionTokens);
-    const totalTokens = sumOrNull(row.totalTokens);
+    const promptTokens = sumNumbersOrNull(row.promptTokens);
+    const completionTokens = sumNumbersOrNull(row.completionTokens);
+    const totalTokens = sumNumbersOrNull(row.totalTokens);
     return {
       provider: row.provider,
       model: row.model,

--- a/src/daemon/cli.ts
+++ b/src/daemon/cli.ts
@@ -1,3 +1,4 @@
+import { readCliOptionValue } from "../cli-args.js";
 import { buildDaemonHelp } from "../run/help.js";
 import {
   checkAuth,
@@ -39,16 +40,6 @@ type DaemonCliContext = {
   stderr: NodeJS.WritableStream;
 };
 
-function readArgValue(argv: string[], name: string): string | null {
-  const eq = argv.find((a) => a.startsWith(`${name}=`));
-  if (eq) return eq.slice(`${name}=`.length).trim() || null;
-  const index = argv.indexOf(name);
-  if (index === -1) return null;
-  const next = argv[index + 1];
-  if (!next || next.startsWith("-")) return null;
-  return next.trim() || null;
-}
-
 function wantHelp(argv: string[]): boolean {
   return argv.includes("--help") || argv.includes("-h") || argv.includes("help");
 }
@@ -58,7 +49,7 @@ function hasArg(argv: string[], name: string): boolean {
 }
 
 function readPortArg(argv: string[]): number | null {
-  const portRaw = readArgValue(argv, "--port");
+  const portRaw = readCliOptionValue(argv, "--port");
   if (!portRaw) return null;
   const port = Number(portRaw);
   if (!Number.isFinite(port) || port <= 0 || port > 65535) throw new Error("Invalid --port");
@@ -66,7 +57,7 @@ function readPortArg(argv: string[]): number | null {
 }
 
 function readExtensionIdArg(argv: string[]): string | null {
-  const extensionId = readArgValue(argv, "--extension-id");
+  const extensionId = readCliOptionValue(argv, "--extension-id");
   if (!extensionId) return null;
   if (!/^[a-p]{32}$/.test(extensionId)) throw new Error("Invalid --extension-id");
   return extensionId;
@@ -114,7 +105,7 @@ export async function handleDaemonRequest({
   }
 
   if (sub === "install") {
-    const token = readArgValue(normalizedArgv, "--token");
+    const token = readCliOptionValue(normalizedArgv, "--token");
     if (!token) throw new Error("Missing --token");
     const requestedPort = readPortArg(normalizedArgv);
     const dev = hasArg(normalizedArgv, "--dev");
@@ -345,7 +336,7 @@ export async function handleDaemonRequest({
 
   if (sub === "run") {
     const existingConfig = await readDaemonConfig({ env: envForRun });
-    const tokenOverride = readArgValue(normalizedArgv, "--token")?.trim() || null;
+    const tokenOverride = readCliOptionValue(normalizedArgv, "--token")?.trim() || null;
     const port = readPortArg(normalizedArgv) ?? existingConfig?.port ?? DAEMON_PORT_DEFAULT;
     if (!existingConfig && !tokenOverride) {
       stderr.write("Missing ~/.summarize/daemon.json\n");

--- a/src/run/cli-preflight.ts
+++ b/src/run/cli-preflight.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { readCliOptionValue } from "../cli-args.js";
 import { handleDaemonRequest } from "../daemon/cli.js";
 import { refreshFree } from "../refresh-free.js";
 import {
@@ -96,20 +97,10 @@ export async function handleRefreshFreeRequest({
     normalizedArgv.includes("-h") ||
     normalizedArgv.includes("help");
 
-  const readArgValue = (name: string): string | null => {
-    const eq = normalizedArgv.find((a) => a.startsWith(`${name}=`));
-    if (eq) return eq.slice(`${name}=`.length).trim() || null;
-    const index = normalizedArgv.indexOf(name);
-    if (index === -1) return null;
-    const next = normalizedArgv[index + 1];
-    if (!next || next.startsWith("-")) return null;
-    return next.trim() || null;
-  };
-
-  const runsRaw = readArgValue("--runs");
-  const smartRaw = readArgValue("--smart");
-  const minParamsRaw = readArgValue("--min-params");
-  const maxAgeDaysRaw = readArgValue("--max-age-days");
+  const runsRaw = readCliOptionValue(normalizedArgv, "--runs");
+  const smartRaw = readCliOptionValue(normalizedArgv, "--smart");
+  const minParamsRaw = readCliOptionValue(normalizedArgv, "--min-params");
+  const maxAgeDaysRaw = readCliOptionValue(normalizedArgv, "--max-age-days");
   const runs = runsRaw ? Number(runsRaw) : 2;
   const smart = smartRaw ? Number(smartRaw) : 3;
   const minParams = (() => {

--- a/src/run/flows/url/slides-output-stream.ts
+++ b/src/run/flows/url/slides-output-stream.ts
@@ -1,9 +1,8 @@
 import { createSlidesPresentationStream } from "@steipete/summarize-core/slides";
-import { createMarkdownStreamer, render as renderMarkdownAnsi } from "markdansi";
 import type { SummaryStreamHandler } from "../../../engine/events.js";
-import { prepareMarkdownForTerminalStreaming } from "../../markdown.js";
+import { createTerminalMarkdownStreamer } from "../../markdown-streamer.js";
 import { createStreamOutputGate, type StreamOutputMode } from "../../stream-output.js";
-import { isRichTty, markdownRenderWidth, supportsColor } from "../../terminal.js";
+import { isRichTty } from "../../terminal.js";
 
 export function createSlidesSummaryStreamHandler({
   stdout,
@@ -41,18 +40,7 @@ export function createSlidesSummaryStreamHandler({
       })
     : null;
   const createStreamer = () =>
-    shouldRenderMarkdown
-      ? createMarkdownStreamer({
-          render: (markdown) =>
-            renderMarkdownAnsi(prepareMarkdownForTerminalStreaming(markdown), {
-              width: markdownRenderWidth(stdout, env),
-              wrap: true,
-              color: supportsColor(stdout, envForRun),
-              hyperlinks: true,
-            }),
-          spacing: "single",
-        })
-      : null;
+    shouldRenderMarkdown ? createTerminalMarkdownStreamer({ stdout, env, envForRun }) : null;
   let streamer = createStreamer();
 
   let wroteLeadingBlankLine = false;

--- a/src/run/format.ts
+++ b/src/run/format.ts
@@ -1,3 +1,4 @@
+export { sumNumbersOrNull } from "../shared/numbers.js";
 export { resolveTargetCharacters } from "../shared/summary-length.js";
 
 export function formatOptionalString(value: string | null | undefined): string {
@@ -12,18 +13,6 @@ export function formatOptionalNumber(value: number | null | undefined): string {
     return String(value);
   }
   return "none";
-}
-
-export function sumNumbersOrNull(values: Array<number | null>): number | null {
-  let sum = 0;
-  let any = false;
-  for (const value of values) {
-    if (typeof value === "number" && Number.isFinite(value)) {
-      sum += value;
-      any = true;
-    }
-  }
-  return any ? sum : null;
 }
 
 export function formatUSD(value: number): string {

--- a/src/run/markdown-streamer.ts
+++ b/src/run/markdown-streamer.ts
@@ -1,0 +1,24 @@
+import { createMarkdownStreamer, render as renderMarkdownAnsi } from "markdansi";
+import { prepareMarkdownForTerminalStreaming } from "./markdown.js";
+import { markdownRenderWidth, supportsColor } from "./terminal.js";
+
+export function createTerminalMarkdownStreamer({
+  stdout,
+  env,
+  envForRun,
+}: {
+  stdout: NodeJS.WritableStream;
+  env: Record<string, string | undefined>;
+  envForRun: Record<string, string | undefined>;
+}): ReturnType<typeof createMarkdownStreamer> {
+  return createMarkdownStreamer({
+    render: (markdown) =>
+      renderMarkdownAnsi(prepareMarkdownForTerminalStreaming(markdown), {
+        width: markdownRenderWidth(stdout, env),
+        wrap: true,
+        color: supportsColor(stdout, envForRun),
+        hyperlinks: true,
+      }),
+    spacing: "single",
+  });
+}

--- a/src/run/runner.ts
+++ b/src/run/runner.ts
@@ -72,7 +72,7 @@ export async function runCli(
 
     applyWidthOverride({ width: program.opts().width, env });
 
-    let promptOverride = await resolvePromptOverride({
+    const promptOverride = await resolvePromptOverride({
       prompt: program.opts().prompt,
       promptFile: program.opts().promptFile,
     });

--- a/src/run/summary-stream.ts
+++ b/src/run/summary-stream.ts
@@ -1,8 +1,7 @@
-import { createMarkdownStreamer, render as renderMarkdownAnsi } from "markdansi";
 import type { SummaryStreamHandler } from "../engine/events.js";
-import { prepareMarkdownForTerminalStreaming } from "./markdown.js";
+import { createTerminalMarkdownStreamer } from "./markdown-streamer.js";
 import { createStreamOutputGate, type StreamOutputMode } from "./stream-output.js";
-import { isRichTty, markdownRenderWidth, supportsColor } from "./terminal.js";
+import { isRichTty } from "./terminal.js";
 
 export function createTerminalSummaryStream({
   stdout,
@@ -37,18 +36,7 @@ export function createTerminalSummaryStream({
         restoreDuringStream: resolvedOutputMode !== "delta",
       });
   const createStreamer = () =>
-    shouldRenderMarkdown
-      ? createMarkdownStreamer({
-          render: (markdown) =>
-            renderMarkdownAnsi(prepareMarkdownForTerminalStreaming(markdown), {
-              width: markdownRenderWidth(stdout, env),
-              wrap: true,
-              color: supportsColor(stdout, envForRun),
-              hyperlinks: true,
-            }),
-          spacing: "single",
-        })
-      : null;
+    shouldRenderMarkdown ? createTerminalMarkdownStreamer({ stdout, env, envForRun }) : null;
   let streamer = createStreamer();
   let wroteLeadingBlankLine = false;
 

--- a/src/run/transcriber-cli.ts
+++ b/src/run/transcriber-cli.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { access } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
+import { readCliOptionValue } from "../cli-args.js";
 import { loadSummarizeConfig } from "../config.js";
 import {
   createThemeRenderer,
@@ -32,16 +33,6 @@ const parseModel = (value: string | null): OnnxModel => {
   const normalized = value.trim().toLowerCase();
   if (normalized === "parakeet" || normalized === "canary") return normalized;
   throw new Error(`Unsupported --model: ${value}`);
-};
-
-const readArgValue = (normalizedArgv: string[], name: string): string | null => {
-  const eq = normalizedArgv.find((arg) => arg.startsWith(`${name}=`));
-  if (eq) return eq.slice(`${name}=`.length).trim() || null;
-  const index = normalizedArgv.indexOf(name);
-  if (index === -1) return null;
-  const next = normalizedArgv[index + 1];
-  if (!next || next.startsWith("-")) return null;
-  return next.trim() || null;
 };
 
 const fileExists = async (filePath: string): Promise<boolean> => {
@@ -111,10 +102,10 @@ export async function handleTranscriberCliRequest({
     throw new Error(`Unknown transcriber command: ${subcommand}`);
   }
 
-  const model = parseModel(readArgValue(normalizedArgv, "--model"));
+  const model = parseModel(readCliOptionValue(normalizedArgv, "--model"));
   const { config } = loadSummarizeConfig({ env: envForRun });
   const themeName = resolveThemeNameFromSources({
-    cli: readArgValue(normalizedArgv, "--theme"),
+    cli: readCliOptionValue(normalizedArgv, "--theme"),
     env: envForRun.SUMMARIZE_THEME,
     config: config?.ui?.theme,
   });

--- a/src/shared/numbers.ts
+++ b/src/shared/numbers.ts
@@ -1,0 +1,11 @@
+export function sumNumbersOrNull(values: Array<number | null>): number | null {
+  let sum = 0;
+  let any = false;
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      sum += value;
+      any = true;
+    }
+  }
+  return any ? sum : null;
+}


### PR DESCRIPTION
Three standalone command adapters carried the same option reader, summary and slide adapters duplicated Markdown streamer construction, and metrics/formatting duplicated nullable numeric sums. Give each operation one implementation while preserving equals-form precedence, missing-value handling, finite-number behavior, per-render terminal width/color, and each adapter's own stream lifecycle.

The streamer factory has an explicit return type through markdansi's public function, keeping generated declarations portable. The never-reassigned prompt override is now constant.

Full build/check passed (566 test files, 3,265 tests), and isolated Codex review through P2 is scoped-clean. Live built-CLI probes exercised all three option readers through their existing validation failures and streamed Unicode through the rich Markdown path in a narrow PTY; wrapping and completion remained correct, with one synthetic provider request. No service was installed or modified by the validation probes.
