### PR TITLE
refactor(slides): separate runtime and calibration ownership

### DIFF
--- a/docs/slides-rendering-flow.md
+++ b/docs/slides-rendering-flow.md
@@ -30,6 +30,8 @@ Rule: keep terminal I/O in render helpers; keep state mutations in the state sto
 
 `src/slides/process.ts` owns media-tool spawning, deadlines, exit errors, and output collection. Line callbacks, text capture, and binary capture share that lifecycle; OCR uses binary capture to avoid logging recognized text. Ignored stdout is drained so child processes cannot block on a full pipe.
 
+`src/slides/runtime.ts` owns tool resolution, worker/sample settings, and progress/log adapters. `scene-calibration.ts` owns optional frame sampling and hash-based threshold calibration; `scene-detection.ts` owns scene timestamps and selection. Output-directory preparation and per-directory serialization live with cache paths in `store.ts`, keeping extraction orchestration focused on the pipeline.
+
 Frame extraction trims decoded input before collecting `showinfo` and signal statistics. Timestamp conversion uses the explicit input-seek origin, including zero, so pre-seek frames cannot move a later slide backward or cause final duration filtering to discard it.
 
 Completed slide results carry an extractor version in memory and `slides.json`. Cache validation rejects older/unversioned extraction results, including SQLite copies, so corrected timing regenerates stale frames without invalidating unrelated transcript or summary caches.

--- a/src/slides/extract.ts
+++ b/src/slides/extract.ts
@@ -1,9 +1,5 @@
 import { promises as fs } from "node:fs";
-import path from "node:path";
-import { resolveBundledFfmpegCommand } from "@steipete/summarize-core/ffmpeg";
-import { resolveExecutableInPath } from "../application/environment.js";
 import type { MediaCache } from "../content/index.js";
-import { canSpawnCommand } from "../run/env.js";
 import { downloadRemoteVideo, downloadYoutubeVideo, resolveYoutubeStreamUrl } from "./download.js";
 import {
   buildSlideTimeline,
@@ -17,107 +13,36 @@ import {
 import { detectSlideTimestamps, extractFramesAtTimestamps } from "./frame-extraction.js";
 import { prepareSlidesInput } from "./ingest.js";
 import { runOcrOnSlides } from "./ocr.js";
-import type { ProcessCommand } from "./process.js";
+import {
+  createSlidesLogger,
+  createSlidesProgress,
+  resolveRunnableTool,
+  resolveSlidesSampleCount,
+  resolveSlidesStreamFallback,
+  resolveSlidesWorkers,
+  resolveSlidesYtDlpExtractFormat,
+} from "./runtime.js";
 import {
   adjustTimestampWithinSegment,
   applyMaxSlidesFilter,
   applyMinDurationFilter,
   buildIntervalTimestamps,
   buildSceneSegments,
-  clamp,
   filterTimestampsByMinDuration,
   findSceneSegment,
   mergeTimestamps,
   selectTimestampTargets,
 } from "./scene-detection.js";
 import type { SlideSettings } from "./settings.js";
-import { readSlidesCacheIfValid, resolveSlidesDir } from "./store.js";
+import {
+  prepareSlidesDir,
+  withSlidesLock,
+  readSlidesCacheIfValid,
+  resolveSlidesDir,
+} from "./store.js";
 import type { SlideExtractionResult, SlideImage, SlideSource, SlideSourceKind } from "./types.js";
 
-const slidesLocks = new Map<string, Promise<void>>();
-const DEFAULT_SLIDES_WORKERS = 8;
-const DEFAULT_SLIDES_SAMPLE_COUNT = 8;
-// Prefer broadly-decodable H.264/MP4 for ffmpeg stability.
-// (Some "bestvideo" picks AV1 which can fail on certain ffmpeg builds / hwaccel setups.)
-const DEFAULT_YT_DLP_FORMAT_EXTRACT =
-  "bestvideo[height<=720][vcodec^=avc1][ext=mp4]/best[height<=720][vcodec^=avc1][ext=mp4]/bestvideo[height<=720][ext=mp4]/best[height<=720]";
-
-type SlidesLogger = ((message: string) => void) | null;
-
 export { parseShowinfoTimestamp, resolveExtractedTimestamp } from "./scene-detection.js";
-
-function createSlidesLogger(logger: SlidesLogger) {
-  const logSlides = (message: string) => {
-    if (!logger) return;
-    logger(message);
-  };
-  const logSlidesTiming = (label: string, startedAt: number) => {
-    const elapsedMs = Date.now() - startedAt;
-    logSlides(`${label} elapsedMs=${elapsedMs}`);
-    return elapsedMs;
-  };
-  return { logSlides, logSlidesTiming };
-}
-
-function resolveSlidesWorkers(env: Record<string, string | undefined>): number {
-  const raw = env.SUMMARIZE_SLIDES_WORKERS ?? env.SLIDES_WORKERS;
-  if (!raw) return DEFAULT_SLIDES_WORKERS;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SLIDES_WORKERS;
-  return Math.max(1, Math.min(16, Math.round(parsed)));
-}
-
-function resolveSlidesSampleCount(env: Record<string, string | undefined>): number {
-  const raw = env.SUMMARIZE_SLIDES_SAMPLES ?? env.SLIDES_SAMPLES;
-  if (!raw) return DEFAULT_SLIDES_SAMPLE_COUNT;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SLIDES_SAMPLE_COUNT;
-  return Math.max(3, Math.min(12, Math.round(parsed)));
-}
-
-function resolveSlidesYtDlpExtractFormat(env: Record<string, string | undefined>): string {
-  return (
-    env.SUMMARIZE_SLIDES_YTDLP_FORMAT_EXTRACT ??
-    env.SLIDES_YTDLP_FORMAT_EXTRACT ??
-    DEFAULT_YT_DLP_FORMAT_EXTRACT
-  ).trim();
-}
-
-function resolveSlidesStreamFallback(env: Record<string, string | undefined>): boolean {
-  const raw = env.SLIDES_EXTRACT_STREAM?.trim().toLowerCase();
-  return raw === "1" || raw === "true" || raw === "yes";
-}
-
-type ResolveRunnableToolArgs = {
-  binary: string;
-  env: Record<string, string | undefined>;
-  explicitEnvKey?: string;
-  probeArgs: string[];
-};
-
-function resolveRunnableTool(
-  args: ResolveRunnableToolArgs & { binary: "ffmpeg" | "ffprobe" },
-): Promise<ProcessCommand | null>;
-function resolveRunnableTool(args: ResolveRunnableToolArgs): Promise<string | null>;
-async function resolveRunnableTool({
-  binary,
-  env,
-  explicitEnvKey,
-  probeArgs,
-}: ResolveRunnableToolArgs): Promise<ProcessCommand | null> {
-  const explicit =
-    explicitEnvKey && typeof env[explicitEnvKey] === "string" ? env[explicitEnvKey]?.trim() : "";
-  if (explicit) {
-    return (await canSpawnCommand({ command: explicit, args: probeArgs, env })) ? explicit : null;
-  }
-  const resolved = resolveExecutableInPath(binary, env, explicitEnvKey);
-  if (resolved) return resolved;
-  if (await canSpawnCommand({ command: binary, args: probeArgs, env })) return binary;
-  if (binary === "ffmpeg" || binary === "ffprobe") {
-    return resolveBundledFfmpegCommand(binary);
-  }
-  return null;
-}
 
 type ExtractSlidesArgs = {
   source: SlideSource;
@@ -179,22 +104,7 @@ export async function extractSlidesForSource({
         }
       }
 
-      const reportSlidesProgress = (() => {
-        const onSlidesProgress = hooks?.onSlidesProgress;
-        if (!onSlidesProgress) return null;
-        let lastText = "";
-        let lastPercent = 0;
-        return (label: string, percent: number, detail?: string) => {
-          const clamped = clamp(Math.round(percent), 0, 100);
-          const nextPercent = Math.max(lastPercent, clamped);
-          const suffix = detail ? ` ${detail}` : "";
-          const text = `Slides: ${label}${suffix} ${nextPercent}%`;
-          if (text === lastText) return;
-          lastText = text;
-          lastPercent = nextPercent;
-          onSlidesProgress(text);
-        };
-      })();
+      const reportSlidesProgress = createSlidesProgress(hooks?.onSlidesProgress);
 
       const warnings: string[] = [];
       const totalStartedAt = Date.now();
@@ -415,12 +325,12 @@ export async function extractSlidesForSource({
           });
         const extractFramesStartedAt = Date.now();
         const extractedSlides: SlideImage[] = await extractFrames();
-        const extractElapsedMs = logSlidesTiming?.(
+        const extractElapsedMs = logSlidesTiming(
           `extract frames (count=${trimmed.length}, parallel=${workers})`,
           extractFramesStartedAt,
         );
-        if (trimmed.length > 0 && typeof extractElapsedMs === "number") {
-          logSlides?.(
+        if (trimmed.length > 0) {
+          logSlides(
             `extract frames avgMsPerFrame=${Math.round(extractElapsedMs / trimmed.length)}`,
           );
         }
@@ -436,7 +346,7 @@ export async function extractSlidesForSource({
 
         const renameStartedAt = Date.now();
         const renamedSlides = await renameSlidesWithTimestamps(rawSlides, slidesDir);
-        logSlidesTiming?.("rename slides", renameStartedAt);
+        logSlidesTiming("rename slides", renameStartedAt);
         if (renamedSlides.length === 0) {
           throw new Error("No slides extracted; try lowering --slides-scene-threshold.");
         }
@@ -444,7 +354,7 @@ export async function extractSlidesForSource({
         let slidesWithOcr = renamedSlides;
         if (ocrEnabled && tesseractPath) {
           const ocrStartedAt = Date.now();
-          logSlides?.(`ocr start count=${renamedSlides.length} mode=parallel workers=${workers}`);
+          logSlides(`ocr start count=${renamedSlides.length} mode=parallel workers=${workers}`);
           const ocrStartPercent = SLIDES_PROGRESS.OCR - 3;
           const reportOcrProgress = (completed: number, total: number) => {
             const ratio = total > 0 ? completed / total : 0;
@@ -461,9 +371,9 @@ export async function extractSlidesForSource({
             workers,
             reportOcrProgress,
           );
-          const elapsedMs = logSlidesTiming?.("ocr done", ocrStartedAt);
-          if (renamedSlides.length > 0 && typeof elapsedMs === "number") {
-            logSlides?.(`ocr avgMsPerSlide=${Math.round(elapsedMs / renamedSlides.length)}`);
+          const elapsedMs = logSlidesTiming("ocr done", ocrStartedAt);
+          if (renamedSlides.length > 0) {
+            logSlides(`ocr avgMsPerSlide=${Math.round(elapsedMs / renamedSlides.length)}`);
           }
         }
 
@@ -501,42 +411,4 @@ export async function extractSlidesForSource({
       hooks?.onSlidesProgress?.("Slides: queued");
     },
   );
-}
-
-async function prepareSlidesDir(slidesDir: string): Promise<void> {
-  await fs.mkdir(slidesDir, { recursive: true });
-  const entries = await fs.readdir(slidesDir);
-  await Promise.all(
-    entries.map(async (entry) => {
-      if (entry.startsWith("slide_") && entry.endsWith(".png")) {
-        await fs.rm(path.join(slidesDir, entry), { force: true });
-      }
-      if (entry === "slides.json") {
-        await fs.rm(path.join(slidesDir, entry), { force: true });
-      }
-    }),
-  );
-}
-
-async function withSlidesLock<T>(
-  key: string,
-  fn: () => Promise<T>,
-  onWait?: (() => void) | null,
-): Promise<T> {
-  const previous = slidesLocks.get(key) ?? null;
-  if (previous && onWait) onWait();
-  let release = () => {};
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  slidesLocks.set(key, current);
-  await (previous ?? Promise.resolve());
-  try {
-    return await fn();
-  } finally {
-    release();
-    if (slidesLocks.get(key) === current) {
-      slidesLocks.delete(key);
-    }
-  }
 }

--- a/src/slides/frame-extraction.ts
+++ b/src/slides/frame-extraction.ts
@@ -2,9 +2,9 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { resolveExecutableInPath } from "../application/environment.js";
 import { runProcess, runWithConcurrency, type ProcessCommand } from "./process.js";
+import { calibrateSceneThreshold } from "./scene-calibration.js";
 import {
   buildSegments,
-  calibrateSceneThreshold,
   clamp,
   detectSceneTimestamps,
   parseShowinfoTimestamp,

--- a/src/slides/runtime.ts
+++ b/src/slides/runtime.ts
@@ -1,0 +1,105 @@
+import { resolveBundledFfmpegCommand } from "@steipete/summarize-core/ffmpeg";
+import { resolveExecutableInPath } from "../application/environment.js";
+import { canSpawnCommand } from "../run/env.js";
+import type { ProcessCommand } from "./process.js";
+import { clamp } from "./scene-detection.js";
+
+const DEFAULT_SLIDES_WORKERS = 8;
+const DEFAULT_SLIDES_SAMPLE_COUNT = 8;
+// Prefer broadly-decodable H.264/MP4 for ffmpeg stability.
+// (Some "bestvideo" picks AV1 which can fail on certain ffmpeg builds / hwaccel setups.)
+const DEFAULT_YT_DLP_FORMAT_EXTRACT =
+  "bestvideo[height<=720][vcodec^=avc1][ext=mp4]/best[height<=720][vcodec^=avc1][ext=mp4]/bestvideo[height<=720][ext=mp4]/best[height<=720]";
+
+type SlidesLogger = ((message: string) => void) | null;
+
+export function createSlidesLogger(logger: SlidesLogger) {
+  const logSlides = (message: string) => {
+    if (!logger) return;
+    logger(message);
+  };
+  const logSlidesTiming = (label: string, startedAt: number) => {
+    const elapsedMs = Date.now() - startedAt;
+    logSlides(`${label} elapsedMs=${elapsedMs}`);
+    return elapsedMs;
+  };
+  return { logSlides, logSlidesTiming };
+}
+
+export function resolveSlidesWorkers(env: Record<string, string | undefined>): number {
+  const raw = env.SUMMARIZE_SLIDES_WORKERS ?? env.SLIDES_WORKERS;
+  if (!raw) return DEFAULT_SLIDES_WORKERS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SLIDES_WORKERS;
+  return Math.max(1, Math.min(16, Math.round(parsed)));
+}
+
+export function resolveSlidesSampleCount(env: Record<string, string | undefined>): number {
+  const raw = env.SUMMARIZE_SLIDES_SAMPLES ?? env.SLIDES_SAMPLES;
+  if (!raw) return DEFAULT_SLIDES_SAMPLE_COUNT;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SLIDES_SAMPLE_COUNT;
+  return Math.max(3, Math.min(12, Math.round(parsed)));
+}
+
+export function resolveSlidesYtDlpExtractFormat(env: Record<string, string | undefined>): string {
+  return (
+    env.SUMMARIZE_SLIDES_YTDLP_FORMAT_EXTRACT ??
+    env.SLIDES_YTDLP_FORMAT_EXTRACT ??
+    DEFAULT_YT_DLP_FORMAT_EXTRACT
+  ).trim();
+}
+
+export function resolveSlidesStreamFallback(env: Record<string, string | undefined>): boolean {
+  const raw = env.SLIDES_EXTRACT_STREAM?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+type ResolveRunnableToolArgs = {
+  binary: string;
+  env: Record<string, string | undefined>;
+  explicitEnvKey?: string;
+  probeArgs: string[];
+};
+
+export function resolveRunnableTool(
+  args: ResolveRunnableToolArgs & { binary: "ffmpeg" | "ffprobe" },
+): Promise<ProcessCommand | null>;
+export function resolveRunnableTool(args: ResolveRunnableToolArgs): Promise<string | null>;
+export async function resolveRunnableTool({
+  binary,
+  env,
+  explicitEnvKey,
+  probeArgs,
+}: ResolveRunnableToolArgs): Promise<ProcessCommand | null> {
+  const explicit =
+    explicitEnvKey && typeof env[explicitEnvKey] === "string" ? env[explicitEnvKey]?.trim() : "";
+  if (explicit) {
+    return (await canSpawnCommand({ command: explicit, args: probeArgs, env })) ? explicit : null;
+  }
+  const resolved = resolveExecutableInPath(binary, env, explicitEnvKey);
+  if (resolved) return resolved;
+  if (await canSpawnCommand({ command: binary, args: probeArgs, env })) return binary;
+  if (binary === "ffmpeg" || binary === "ffprobe") {
+    return resolveBundledFfmpegCommand(binary);
+  }
+  return null;
+}
+
+export function createSlidesProgress(
+  onSlidesProgress: ((text: string) => void) | null | undefined,
+) {
+  if (!onSlidesProgress) return null;
+  let lastText = "";
+  let lastPercent = 0;
+  return (label: string, percent: number, detail?: string) => {
+    const clamped = clamp(Math.round(percent), 0, 100);
+    const nextPercent = Math.max(lastPercent, clamped);
+    const suffix = detail ? ` ${detail}` : "";
+    const text = `Slides: ${label}${suffix} ${nextPercent}%`;
+    if (text === lastText) return;
+    lastText = text;
+    lastPercent = nextPercent;
+    onSlidesProgress(text);
+  };
+}

--- a/src/slides/scene-calibration.ts
+++ b/src/slides/scene-calibration.ts
@@ -1,0 +1,148 @@
+import { runProcessCaptureBuffer, type ProcessCommand } from "./process.js";
+import { clamp, roundThreshold } from "./scene-detection.js";
+
+const FFMPEG_CALIBRATION_SAMPLE_TIMEOUT_MS = 10_000;
+
+function buildCalibrationSampleTimestamps(
+  durationSeconds: number | null,
+  sampleCount: number,
+): number[] {
+  if (!durationSeconds || durationSeconds <= 0) return [0];
+  const clamped = Math.max(3, Math.min(12, Math.round(sampleCount)));
+  const startRatio = 0.05;
+  const endRatio = 0.95;
+  const step = (endRatio - startRatio) / (clamped - 1);
+  const points: number[] = [];
+  for (let i = 0; i < clamped; i += 1) {
+    const ratio = startRatio + step * i;
+    points.push(clamp(durationSeconds * ratio, 0, durationSeconds - 0.1));
+  }
+  return points;
+}
+
+function computeDiffStats(values: number[]): {
+  median: number;
+  p75: number;
+  p90: number;
+  max: number;
+} {
+  if (values.length === 0) return { median: 0, p75: 0, p90: 0, max: 0 };
+  const sorted = [...values].sort((a, b) => a - b);
+  const at = (p: number) => sorted[Math.min(sorted.length - 1, Math.max(0, Math.round(p)))] ?? 0;
+  return {
+    median: at((sorted.length - 1) * 0.5),
+    p75: at((sorted.length - 1) * 0.75),
+    p90: at((sorted.length - 1) * 0.9),
+    max: sorted[sorted.length - 1] ?? 0,
+  };
+}
+
+function buildAverageHash(pixels: Uint8Array): Uint8Array {
+  let sum = 0;
+  for (const value of pixels) sum += value;
+  const avg = sum / pixels.length;
+  const bits = new Uint8Array(pixels.length);
+  for (let i = 0; i < pixels.length; i += 1) {
+    bits[i] = pixels[i] >= avg ? 1 : 0;
+  }
+  return bits;
+}
+
+function computeHashDistanceRatio(a: Uint8Array, b: Uint8Array): number {
+  const len = Math.min(a.length, b.length);
+  let diff = 0;
+  for (let i = 0; i < len; i += 1) {
+    if (a[i] !== b[i]) diff += 1;
+  }
+  return len === 0 ? 0 : diff / len;
+}
+
+async function hashFrameAtTimestamp({
+  ffmpegPath,
+  inputPath,
+  timestamp,
+  timeoutMs,
+}: {
+  ffmpegPath: ProcessCommand;
+  inputPath: string;
+  timestamp: number;
+  timeoutMs: number;
+}): Promise<Uint8Array | null> {
+  try {
+    const buffer = await runProcessCaptureBuffer({
+      command: ffmpegPath,
+      args: [
+        "-hide_banner",
+        "-ss",
+        String(timestamp),
+        "-i",
+        inputPath,
+        "-frames:v",
+        "1",
+        "-vf",
+        "scale=32:32,format=gray",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "gray",
+        "-",
+      ],
+      // Calibration is optional. A bundled WebAssembly runner can finish the
+      // frame and then linger during Node/V8 shutdown, so do not let one sample
+      // consume the full request timeout and block the remaining slide work.
+      timeoutMs: Math.min(Math.max(timeoutMs, 1), FFMPEG_CALIBRATION_SAMPLE_TIMEOUT_MS),
+      errorLabel: "ffmpeg",
+    });
+    if (buffer.length < 1024) return null;
+    return buildAverageHash(buffer.subarray(0, 1024));
+  } catch {
+    return null;
+  }
+}
+
+export async function calibrateSceneThreshold({
+  ffmpegPath,
+  inputPath,
+  durationSeconds,
+  sampleCount,
+  timeoutMs,
+  logSlides,
+}: {
+  ffmpegPath: ProcessCommand;
+  inputPath: string;
+  durationSeconds: number | null;
+  sampleCount: number;
+  timeoutMs: number;
+  logSlides?: ((message: string) => void) | null;
+}): Promise<{ threshold: number; confidence: number }> {
+  const timestamps = buildCalibrationSampleTimestamps(durationSeconds, sampleCount);
+  if (timestamps.length < 2) return { threshold: 0.2, confidence: 0 };
+
+  const hashes: Uint8Array[] = [];
+  for (const timestamp of timestamps) {
+    const hash = await hashFrameAtTimestamp({ ffmpegPath, inputPath, timestamp, timeoutMs });
+    if (hash) hashes.push(hash);
+  }
+
+  const diffs: number[] = [];
+  for (let i = 1; i < hashes.length; i += 1) {
+    diffs.push(computeHashDistanceRatio(hashes[i - 1], hashes[i]));
+  }
+
+  const stats = computeDiffStats(diffs);
+  let threshold = roundThreshold(Math.max(stats.median * 0.15, stats.p75 * 0.2, stats.p90 * 0.25));
+  if (stats.p75 >= 0.12) {
+    threshold = Math.min(threshold, 0.05);
+  } else if (stats.p90 < 0.05) {
+    threshold = 0.05;
+  }
+  threshold = clamp(threshold, 0.05, 0.3);
+  const confidence =
+    diffs.length >= 2 ? clamp(stats.p75 / 0.25, 0, 1) : clamp(stats.max / 0.25, 0, 1);
+  logSlides?.(
+    `calibration samples=${timestamps.length} diffs=${diffs.length} median=${stats.median.toFixed(
+      3,
+    )} p75=${stats.p75.toFixed(3)} threshold=${threshold}`,
+  );
+  return { threshold, confidence };
+}

--- a/src/slides/scene-detection.ts
+++ b/src/slides/scene-detection.ts
@@ -1,14 +1,8 @@
-import {
-  runProcess,
-  runProcessCapture,
-  runProcessCaptureBuffer,
-  type ProcessCommand,
-} from "./process.js";
+import { runProcess, runProcessCapture, type ProcessCommand } from "./process.js";
 import type { SlideImage } from "./types.js";
 
 const FFMPEG_TIMEOUT_FALLBACK_MS = 300_000;
 const FFMPEG_CAPABILITY_TIMEOUT_MS = 10_000;
-const FFMPEG_CALIBRATION_SAMPLE_TIMEOUT_MS = 10_000;
 
 export type FfmpegVfrArgs = ["-fps_mode" | "-vsync", "vfr"];
 
@@ -74,152 +68,8 @@ export function resolveExtractedTimestamp({
     : candidateAbsolute;
 }
 
-function buildCalibrationSampleTimestamps(
-  durationSeconds: number | null,
-  sampleCount: number,
-): number[] {
-  if (!durationSeconds || durationSeconds <= 0) return [0];
-  const clamped = Math.max(3, Math.min(12, Math.round(sampleCount)));
-  const startRatio = 0.05;
-  const endRatio = 0.95;
-  const step = (endRatio - startRatio) / (clamped - 1);
-  const points: number[] = [];
-  for (let i = 0; i < clamped; i += 1) {
-    const ratio = startRatio + step * i;
-    points.push(clamp(durationSeconds * ratio, 0, durationSeconds - 0.1));
-  }
-  return points;
-}
-
-function computeDiffStats(values: number[]): {
-  median: number;
-  p75: number;
-  p90: number;
-  max: number;
-} {
-  if (values.length === 0) return { median: 0, p75: 0, p90: 0, max: 0 };
-  const sorted = [...values].sort((a, b) => a - b);
-  const at = (p: number) => sorted[Math.min(sorted.length - 1, Math.max(0, Math.round(p)))] ?? 0;
-  return {
-    median: at((sorted.length - 1) * 0.5),
-    p75: at((sorted.length - 1) * 0.75),
-    p90: at((sorted.length - 1) * 0.9),
-    max: sorted[sorted.length - 1] ?? 0,
-  };
-}
-
 export function roundThreshold(value: number): number {
   return Math.round(value * 100) / 100;
-}
-
-function buildAverageHash(pixels: Uint8Array): Uint8Array {
-  let sum = 0;
-  for (const value of pixels) sum += value;
-  const avg = sum / pixels.length;
-  const bits = new Uint8Array(pixels.length);
-  for (let i = 0; i < pixels.length; i += 1) {
-    bits[i] = pixels[i] >= avg ? 1 : 0;
-  }
-  return bits;
-}
-
-function computeHashDistanceRatio(a: Uint8Array, b: Uint8Array): number {
-  const len = Math.min(a.length, b.length);
-  let diff = 0;
-  for (let i = 0; i < len; i += 1) {
-    if (a[i] !== b[i]) diff += 1;
-  }
-  return len === 0 ? 0 : diff / len;
-}
-
-async function hashFrameAtTimestamp({
-  ffmpegPath,
-  inputPath,
-  timestamp,
-  timeoutMs,
-}: {
-  ffmpegPath: ProcessCommand;
-  inputPath: string;
-  timestamp: number;
-  timeoutMs: number;
-}): Promise<Uint8Array | null> {
-  try {
-    const buffer = await runProcessCaptureBuffer({
-      command: ffmpegPath,
-      args: [
-        "-hide_banner",
-        "-ss",
-        String(timestamp),
-        "-i",
-        inputPath,
-        "-frames:v",
-        "1",
-        "-vf",
-        "scale=32:32,format=gray",
-        "-f",
-        "rawvideo",
-        "-pix_fmt",
-        "gray",
-        "-",
-      ],
-      // Calibration is optional. A bundled WebAssembly runner can finish the
-      // frame and then linger during Node/V8 shutdown, so do not let one sample
-      // consume the full request timeout and block the remaining slide work.
-      timeoutMs: Math.min(Math.max(timeoutMs, 1), FFMPEG_CALIBRATION_SAMPLE_TIMEOUT_MS),
-      errorLabel: "ffmpeg",
-    });
-    if (buffer.length < 1024) return null;
-    return buildAverageHash(buffer.subarray(0, 1024));
-  } catch {
-    return null;
-  }
-}
-
-export async function calibrateSceneThreshold({
-  ffmpegPath,
-  inputPath,
-  durationSeconds,
-  sampleCount,
-  timeoutMs,
-  logSlides,
-}: {
-  ffmpegPath: ProcessCommand;
-  inputPath: string;
-  durationSeconds: number | null;
-  sampleCount: number;
-  timeoutMs: number;
-  logSlides?: ((message: string) => void) | null;
-}): Promise<{ threshold: number; confidence: number }> {
-  const timestamps = buildCalibrationSampleTimestamps(durationSeconds, sampleCount);
-  if (timestamps.length < 2) return { threshold: 0.2, confidence: 0 };
-
-  const hashes: Uint8Array[] = [];
-  for (const timestamp of timestamps) {
-    const hash = await hashFrameAtTimestamp({ ffmpegPath, inputPath, timestamp, timeoutMs });
-    if (hash) hashes.push(hash);
-  }
-
-  const diffs: number[] = [];
-  for (let i = 1; i < hashes.length; i += 1) {
-    diffs.push(computeHashDistanceRatio(hashes[i - 1], hashes[i]));
-  }
-
-  const stats = computeDiffStats(diffs);
-  let threshold = roundThreshold(Math.max(stats.median * 0.15, stats.p75 * 0.2, stats.p90 * 0.25));
-  if (stats.p75 >= 0.12) {
-    threshold = Math.min(threshold, 0.05);
-  } else if (stats.p90 < 0.05) {
-    threshold = 0.05;
-  }
-  threshold = clamp(threshold, 0.05, 0.3);
-  const confidence =
-    diffs.length >= 2 ? clamp(stats.p75 / 0.25, 0, 1) : clamp(stats.max / 0.25, 0, 1);
-  logSlides?.(
-    `calibration samples=${timestamps.length} diffs=${diffs.length} median=${stats.median.toFixed(
-      3,
-    )} p75=${stats.p75.toFixed(3)} threshold=${threshold}`,
-  );
-  return { threshold, confidence };
 }
 
 export function buildSegments(

--- a/src/slides/store.ts
+++ b/src/slides/store.ts
@@ -143,3 +143,43 @@ export async function readSlidesCacheIfValid({
   }
   return await validateSlidesCache({ cached: parsed, source, settings });
 }
+
+const slidesLocks = new Map<string, Promise<void>>();
+
+export async function prepareSlidesDir(slidesDir: string): Promise<void> {
+  await fs.mkdir(slidesDir, { recursive: true });
+  const entries = await fs.readdir(slidesDir);
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (entry.startsWith("slide_") && entry.endsWith(".png")) {
+        await fs.rm(path.join(slidesDir, entry), { force: true });
+      }
+      if (entry === "slides.json") {
+        await fs.rm(path.join(slidesDir, entry), { force: true });
+      }
+    }),
+  );
+}
+
+export async function withSlidesLock<T>(
+  key: string,
+  fn: () => Promise<T>,
+  onWait?: (() => void) | null,
+): Promise<T> {
+  const previous = slidesLocks.get(key) ?? null;
+  if (previous && onWait) onWait();
+  let release = () => {};
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  slidesLocks.set(key, current);
+  await (previous ?? Promise.resolve());
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (slidesLocks.get(key) === current) {
+      slidesLocks.delete(key);
+    }
+  }
+}

--- a/tests/slides.scene-detection.test.ts
+++ b/tests/slides.scene-detection.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { calibrateSceneThreshold } from "../src/slides/scene-calibration.js";
 
 const mocks = vi.hoisted(() => ({
   runProcess: vi.fn(),
@@ -22,7 +23,6 @@ import {
   buildIntervalTimestamps,
   buildSceneSegments,
   buildSegments,
-  calibrateSceneThreshold,
   clamp,
   detectSceneTimestamps,
   filterTimestampsByMinDuration,


### PR DESCRIPTION
Slide extraction mixed runtime setup, output locking, calibration, and frame selection in two files above 500 lines. Move environment/tool/worker setup into `runtime.ts`, frame sampling and threshold calibration into `scene-calibration.ts`, and directory preparation/locking into the existing store owner. The extractor now reads as the pipeline; detection owns detection.

Preserve probe order, cache-hit short circuit, lock lifetime, thresholds, deadlines, callbacks, and selected frames. Remove optional calls and type checks around guaranteed local logger functions. Public entrypoints and on-disk formats are unchanged.

Validation: `pnpm run build`, `pnpm run check` (566 files / 3,265 tests), 180 focused slide tests, and isolated Codex autoreview through P2 passed. Live built CLI before/after extraction of one synthetic three-color MP4 returned exactly the same selected frames: 0.32s (`b886c9bc6de09f9617b8286876d944ac26c530c5cbba75161ef13fa3276fb893`) and 4.20s (`03688c611cbfe6bbcfef1f6c3def7896cc3e879a26c9a6ae69433d157fd71b63`). Hashes are SHA-256 of the PNG bytes; both JSON envelopes and manifest field sets matched.
