### PR TITLE
refactor(slides): separate composition and share text truncation

### DIFF
--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-state.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-state.ts
@@ -5,6 +5,7 @@ import {
   buildSlideTextFallback,
   resolveSlideTextBudget,
   splitSummaryFromSlides,
+  truncateSlideText,
   type SlideTimelineEntry,
 } from "../../lib/slides-text";
 import { chooseSlideDescription, sanitizeSlideSummaryTitle } from "./slide-text-policy";
@@ -162,14 +163,6 @@ export function normalizeOcrText(raw: string | null | undefined): string {
   }
 
   return text;
-}
-
-function truncateSlideText(value: string, limit: number): string {
-  if (value.length <= limit) return value;
-  const truncated = value.slice(0, limit).trimEnd();
-  const clean = truncated.replace(/\s+\S*$/, "").trim();
-  const result = clean.length > 0 ? clean : truncated.trim();
-  return result.length > 0 ? `${result}...` : "";
 }
 
 function getOcrTextForSlide(slide: SlideLike, budget: number): string {

--- a/apps/chrome-extension/src/lib/slides-text.ts
+++ b/apps/chrome-extension/src/lib/slides-text.ts
@@ -6,5 +6,6 @@ export {
   resolveSlideTextBudget,
   splitSlideTitleFromText,
   splitSummaryFromSlides,
+  truncateSlideText,
   type SlideTimelineEntry,
 } from "@steipete/summarize-core/slides";

--- a/packages/core/src/slides/text-compose.ts
+++ b/packages/core/src/slides/text-compose.ts
@@ -1,0 +1,183 @@
+import type { SummaryLength } from "../shared/contracts.js";
+import {
+  ensureSlideTitleLine,
+  isInterludeSlideText,
+  isTitleOnlySlideText,
+  parseSlideSummariesFromMarkdown,
+  splitSlideTitleFromText,
+  splitSummaryFromSlides,
+  stripSlideTitleList,
+} from "./text-markdown.js";
+import {
+  getTranscriptTextForSlide,
+  parseTranscriptTimedText,
+  resolveSlideTextBudget,
+  resolveSlideWindowSeconds,
+} from "./text-transcript.js";
+import type { SlideTimelineEntry } from "./text-types.js";
+
+function splitMarkdownParagraphs(markdown: string): string[] {
+  return markdown
+    .split(/\n\s*\n+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function pickIntroParagraph(markdown: string): string {
+  const paragraphs = splitMarkdownParagraphs(markdown);
+  if (paragraphs.length === 0) return "";
+  const firstNonHeading =
+    paragraphs.find((paragraph) => !/^#{1,6}\s+\S/.test(paragraph.trim())) ?? paragraphs[0];
+  if (!firstNonHeading) return "";
+  const sentences = firstNonHeading.match(/[^.!?]+[.!?]+|[^.!?]+$/g) ?? [firstNonHeading];
+  if (sentences.length <= 3) return firstNonHeading.trim();
+  return sentences.slice(0, 3).join(" ").trim();
+}
+
+export function buildSlideTextFallback({
+  slides,
+  transcriptTimedText,
+  lengthArg,
+}: {
+  slides: SlideTimelineEntry[];
+  transcriptTimedText: string | null | undefined;
+  lengthArg: { kind: "preset"; preset: SummaryLength } | { kind: "chars"; maxCharacters: number };
+}): Map<number, string> {
+  const map = new Map<number, string>();
+  if (!transcriptTimedText || !transcriptTimedText.trim()) return map;
+  if (slides.length === 0) return map;
+  const segments = parseTranscriptTimedText(transcriptTimedText);
+  if (segments.length === 0) return map;
+  const ordered = slides.slice().sort((a, b) => a.index - b.index);
+  const budget = resolveSlideTextBudget({ lengthArg, slideCount: ordered.length });
+  const windowSeconds = resolveSlideWindowSeconds({ lengthArg });
+  for (let i = 0; i < ordered.length; i += 1) {
+    const slide = ordered[i];
+    if (!slide) continue;
+    const nextSlide = i + 1 < ordered.length ? (ordered[i + 1] ?? null) : null;
+    const text = getTranscriptTextForSlide({
+      slide,
+      nextSlide,
+      segments,
+      budget,
+      windowSeconds,
+    });
+    if (text) map.set(slide.index, text);
+  }
+  return map;
+}
+
+export function coerceSummaryWithSlides({
+  markdown,
+  slides,
+  transcriptTimedText,
+  lengthArg,
+  reserveIntro = true,
+}: {
+  markdown: string;
+  slides: SlideTimelineEntry[];
+  transcriptTimedText?: string | null;
+  lengthArg: { kind: "preset"; preset: SummaryLength } | { kind: "chars"; maxCharacters: number };
+  reserveIntro?: boolean;
+}): string {
+  if (!markdown.trim() || slides.length === 0) return markdown;
+  const ordered = slides.slice().sort((a, b) => a.index - b.index);
+  const { summary, slidesSection } = splitSummaryFromSlides(markdown);
+  const intro = reserveIntro ? pickIntroParagraph(summary) : "";
+  const slideSummaries = slidesSection ? parseSlideSummariesFromMarkdown(markdown) : new Map();
+  const interludeSlideIndexes = new Set(
+    Array.from(slideSummaries.entries())
+      .filter(([, text]) => isInterludeSlideText(text))
+      .map(([index]) => index),
+  );
+  const titleOnlySlideSummaries =
+    slideSummaries.size > 0 &&
+    Array.from(slideSummaries.values()).every((text) => isTitleOnlySlideText(text));
+  const distributionMarkdown = titleOnlySlideSummaries ? stripSlideTitleList(markdown) : markdown;
+  const fallbackSummaries = buildSlideTextFallback({
+    slides: ordered,
+    transcriptTimedText,
+    lengthArg,
+  });
+
+  const hasDetailedSummaries = slideSummaries.size > 0 && !titleOnlySlideSummaries;
+  const paragraphs = splitMarkdownParagraphs(hasDetailedSummaries ? summary : distributionMarkdown);
+  if (!hasDetailedSummaries && paragraphs.length === 0) return markdown;
+  if (!hasDetailedSummaries && ordered.every((slide) => interludeSlideIndexes.has(slide.index))) {
+    return [intro.trim(), ...ordered.map((slide) => `[slide:${slide.index}]\n## Interlude`)]
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  const introParagraph = reserveIntro ? intro || paragraphs[0] || "" : "";
+  const introIndex = introParagraph ? paragraphs.indexOf(introParagraph) : -1;
+  const remaining = reserveIntro
+    ? introIndex >= 0
+      ? paragraphs.filter((_, index) => index !== introIndex)
+      : paragraphs.slice(1)
+    : paragraphs;
+  const distributableSlides = ordered.filter((slide) => !interludeSlideIndexes.has(slide.index));
+  const total = (distributableSlides.length > 0 ? distributableSlides : ordered).length;
+
+  if (hasDetailedSummaries) {
+    const parts: string[] = [];
+    if (intro) parts.push(intro);
+    const distributedSummaries = new Map<number, string>();
+    if (remaining.length > 0) {
+      let distributionIndex = 0;
+      for (const slide of ordered) {
+        if (interludeSlideIndexes.has(slide.index) && distributableSlides.length > 0) continue;
+        const segment = distributeParagraphs(remaining, distributionIndex++, total);
+        if (segment) distributedSummaries.set(slide.index, segment);
+      }
+    }
+    for (const slide of ordered) {
+      const directText = slideSummaries.get(slide.index);
+      const directBody = directText
+        ? splitSlideTitleFromText({
+            text: directText,
+            slideIndex: slide.index,
+            total: ordered.length,
+          }).body.trim()
+        : "";
+      const distributedText = distributedSummaries.get(slide.index) ?? "";
+      const fallbackText = slideSummaries.has(slide.index)
+        ? ""
+        : (fallbackSummaries.get(slide.index) ?? "");
+      const directOutput = directBody || isInterludeSlideText(directText ?? "") ? directText : "";
+      const text = directOutput || distributedText || fallbackText;
+      const withTitle = text ? ensureSlideTitleLine({ text, slide, total: ordered.length }) : "";
+      parts.push(withTitle ? `[slide:${slide.index}]\n${withTitle}` : `[slide:${slide.index}]`);
+    }
+    return parts.join("\n\n");
+  }
+
+  const parts: string[] = [];
+  if (introParagraph) parts.push(introParagraph.trim());
+  const slideTotal = ordered.length;
+  let distributionIndex = 0;
+  for (const slide of ordered) {
+    const slideIndex = slide.index;
+    if (interludeSlideIndexes.has(slideIndex) && distributableSlides.length > 0) {
+      parts.push(`[slide:${slideIndex}]\n## Interlude`);
+      continue;
+    }
+    const segment = distributeParagraphs(remaining, distributionIndex++, total);
+    const fallback = fallbackSummaries.get(slideIndex) ?? "";
+    const text = segment || fallback;
+    const withTitle = text ? ensureSlideTitleLine({ text, slide, total: slideTotal }) : "";
+    parts.push(withTitle ? `[slide:${slideIndex}]\n${withTitle}` : `[slide:${slideIndex}]`);
+  }
+  return parts.join("\n\n");
+}
+
+function distributeParagraphs(paragraphs: string[], index: number, total: number): string {
+  const start = Math.round((index * paragraphs.length) / total);
+  const end = Math.round(((index + 1) * paragraphs.length) / total);
+  return (
+    paragraphs.slice(start, end).join("\n\n").trim() ||
+    paragraphs[
+      Math.min(paragraphs.length - 1, Math.floor((index * paragraphs.length) / total))
+    ]?.trim() ||
+    ""
+  );
+}

--- a/packages/core/src/slides/text-markdown.ts
+++ b/packages/core/src/slides/text-markdown.ts
@@ -1,10 +1,3 @@
-import type { SummaryLength } from "../shared/contracts.js";
-import {
-  getTranscriptTextForSlide,
-  parseTranscriptTimedText,
-  resolveSlideTextBudget,
-  resolveSlideWindowSeconds,
-} from "./text-transcript.js";
 import type { SlideTimelineEntry } from "./text-types.js";
 
 const SLIDE_TAG_PATTERN = /^\[[^\]]*slide[^\d\]]*(\d+)[^\]]*\]\s*(.*)$/i;
@@ -25,7 +18,7 @@ const deriveHeadlineFromBody = (body: string): string | null => {
   return title.replace(/[,:;-]+$/g, "").trim() || null;
 };
 
-const isTitleOnlySlideText = (value: string): boolean => {
+export const isTitleOnlySlideText = (value: string): boolean => {
   const trimmed = value.trim();
   if (!trimmed) return true;
   const lines = trimmed
@@ -38,7 +31,7 @@ const isTitleOnlySlideText = (value: string): boolean => {
   return true;
 };
 
-const isInterludeSlideText = (value: string): boolean => {
+export const isInterludeSlideText = (value: string): boolean => {
   const normalized = value
     .trim()
     .split("\n")
@@ -48,7 +41,7 @@ const isInterludeSlideText = (value: string): boolean => {
   return normalized.toLowerCase() === "interlude";
 };
 
-const stripSlideTitleList = (markdown: string): string => {
+export const stripSlideTitleList = (markdown: string): string => {
   if (!markdown.trim()) return markdown;
   const lines = markdown.split("\n");
   const out: string[] = [];
@@ -85,7 +78,6 @@ export const splitSlideTitleFromText = ({
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean);
-  if (lines.length === 0) return { title: null, body: "" };
   const cleaned = lines.slice();
   while (cleaned.length > 0) {
     const first = cleaned[0] ?? "";
@@ -172,15 +164,11 @@ export const splitSlideTitleFromText = ({
 
 export const ensureSlideTitleLine = ({
   text,
-  slide,
-  total,
 }: {
   text: string;
   slide: SlideTimelineEntry;
   total: number;
 }): string => {
-  void slide;
-  void total;
   return text
     .trim()
     .split("\n")
@@ -386,170 +374,4 @@ export function normalizeSummarySlideHeadings(markdown: string): string {
     }
   }
   return lines.filter((line) => line !== deleteMarker).join("\n");
-}
-
-function splitMarkdownParagraphs(markdown: string): string[] {
-  return markdown
-    .split(/\n\s*\n+/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-}
-
-function pickIntroParagraph(markdown: string): string {
-  const paragraphs = splitMarkdownParagraphs(markdown);
-  if (paragraphs.length === 0) return "";
-  const firstNonHeading =
-    paragraphs.find((paragraph) => !/^#{1,6}\s+\S/.test(paragraph.trim())) ?? paragraphs[0];
-  if (!firstNonHeading) return "";
-  const sentences = firstNonHeading.match(/[^.!?]+[.!?]+|[^.!?]+$/g) ?? [firstNonHeading];
-  if (sentences.length <= 3) return firstNonHeading.trim();
-  return sentences.slice(0, 3).join(" ").trim();
-}
-
-export function buildSlideTextFallback({
-  slides,
-  transcriptTimedText,
-  lengthArg,
-}: {
-  slides: SlideTimelineEntry[];
-  transcriptTimedText: string | null | undefined;
-  lengthArg: { kind: "preset"; preset: SummaryLength } | { kind: "chars"; maxCharacters: number };
-}): Map<number, string> {
-  const map = new Map<number, string>();
-  if (!transcriptTimedText || !transcriptTimedText.trim()) return map;
-  if (slides.length === 0) return map;
-  const segments = parseTranscriptTimedText(transcriptTimedText);
-  if (segments.length === 0) return map;
-  const ordered = slides.slice().sort((a, b) => a.index - b.index);
-  const budget = resolveSlideTextBudget({ lengthArg, slideCount: ordered.length });
-  const windowSeconds = resolveSlideWindowSeconds({ lengthArg });
-  for (let i = 0; i < ordered.length; i += 1) {
-    const slide = ordered[i];
-    if (!slide) continue;
-    const nextSlide = i + 1 < ordered.length ? (ordered[i + 1] ?? null) : null;
-    const text = getTranscriptTextForSlide({
-      slide,
-      nextSlide,
-      segments,
-      budget,
-      windowSeconds,
-    });
-    if (text) map.set(slide.index, text);
-  }
-  return map;
-}
-
-export function coerceSummaryWithSlides({
-  markdown,
-  slides,
-  transcriptTimedText,
-  lengthArg,
-  reserveIntro = true,
-}: {
-  markdown: string;
-  slides: SlideTimelineEntry[];
-  transcriptTimedText?: string | null;
-  lengthArg: { kind: "preset"; preset: SummaryLength } | { kind: "chars"; maxCharacters: number };
-  reserveIntro?: boolean;
-}): string {
-  if (!markdown.trim() || slides.length === 0) return markdown;
-  const ordered = slides.slice().sort((a, b) => a.index - b.index);
-  const { summary, slidesSection } = splitSummaryFromSlides(markdown);
-  const intro = reserveIntro ? pickIntroParagraph(summary) : "";
-  const slideSummaries = slidesSection ? parseSlideSummariesFromMarkdown(markdown) : new Map();
-  const interludeSlideIndexes = new Set(
-    Array.from(slideSummaries.entries())
-      .filter(([, text]) => isInterludeSlideText(text))
-      .map(([index]) => index),
-  );
-  const titleOnlySlideSummaries =
-    slideSummaries.size > 0 &&
-    Array.from(slideSummaries.values()).every((text) => isTitleOnlySlideText(text));
-  const distributionMarkdown = titleOnlySlideSummaries ? stripSlideTitleList(markdown) : markdown;
-  const fallbackSummaries = buildSlideTextFallback({
-    slides: ordered,
-    transcriptTimedText,
-    lengthArg,
-  });
-
-  const hasDetailedSummaries = slideSummaries.size > 0 && !titleOnlySlideSummaries;
-  const paragraphs = splitMarkdownParagraphs(hasDetailedSummaries ? summary : distributionMarkdown);
-  if (!hasDetailedSummaries && paragraphs.length === 0) return markdown;
-  if (!hasDetailedSummaries && ordered.every((slide) => interludeSlideIndexes.has(slide.index))) {
-    return [intro.trim(), ...ordered.map((slide) => `[slide:${slide.index}]\n## Interlude`)]
-      .filter(Boolean)
-      .join("\n\n");
-  }
-  const introParagraph = reserveIntro ? intro || paragraphs[0] || "" : "";
-  const introIndex = introParagraph ? paragraphs.indexOf(introParagraph) : -1;
-  const remaining = reserveIntro
-    ? introIndex >= 0
-      ? paragraphs.filter((_, index) => index !== introIndex)
-      : paragraphs.slice(1)
-    : paragraphs;
-  const distributableSlides = ordered.filter((slide) => !interludeSlideIndexes.has(slide.index));
-  const total = (distributableSlides.length > 0 ? distributableSlides : ordered).length;
-
-  if (hasDetailedSummaries) {
-    const parts: string[] = [];
-    if (intro) parts.push(intro);
-    const distributedSummaries = new Map<number, string>();
-    if (remaining.length > 0) {
-      let distributionIndex = 0;
-      for (const slide of ordered) {
-        if (interludeSlideIndexes.has(slide.index) && distributableSlides.length > 0) continue;
-        const segment = distributeParagraphs(remaining, distributionIndex++, total);
-        if (segment) distributedSummaries.set(slide.index, segment);
-      }
-    }
-    for (const slide of ordered) {
-      const directText = slideSummaries.get(slide.index);
-      const directBody = directText
-        ? splitSlideTitleFromText({
-            text: directText,
-            slideIndex: slide.index,
-            total: ordered.length,
-          }).body.trim()
-        : "";
-      const distributedText = distributedSummaries.get(slide.index) ?? "";
-      const fallbackText = slideSummaries.has(slide.index)
-        ? ""
-        : (fallbackSummaries.get(slide.index) ?? "");
-      const directOutput = directBody || isInterludeSlideText(directText ?? "") ? directText : "";
-      const text = directOutput || distributedText || fallbackText;
-      const withTitle = text ? ensureSlideTitleLine({ text, slide, total: ordered.length }) : "";
-      parts.push(withTitle ? `[slide:${slide.index}]\n${withTitle}` : `[slide:${slide.index}]`);
-    }
-    return parts.join("\n\n");
-  }
-
-  const parts: string[] = [];
-  if (introParagraph) parts.push(introParagraph.trim());
-  const slideTotal = ordered.length;
-  let distributionIndex = 0;
-  for (const slide of ordered) {
-    const slideIndex = slide.index;
-    if (interludeSlideIndexes.has(slideIndex) && distributableSlides.length > 0) {
-      parts.push(`[slide:${slideIndex}]\n## Interlude`);
-      continue;
-    }
-    const segment = distributeParagraphs(remaining, distributionIndex++, total);
-    const fallback = fallbackSummaries.get(slideIndex) ?? "";
-    const text = segment || fallback;
-    const withTitle = text ? ensureSlideTitleLine({ text, slide, total: slideTotal }) : "";
-    parts.push(withTitle ? `[slide:${slideIndex}]\n${withTitle}` : `[slide:${slideIndex}]`);
-  }
-  return parts.join("\n\n");
-}
-
-function distributeParagraphs(paragraphs: string[], index: number, total: number): string {
-  const start = Math.round((index * paragraphs.length) / total);
-  const end = Math.round(((index + 1) * paragraphs.length) / total);
-  return (
-    paragraphs.slice(start, end).join("\n\n").trim() ||
-    paragraphs[
-      Math.min(paragraphs.length - 1, Math.floor((index * paragraphs.length) / total))
-    ]?.trim() ||
-    ""
-  );
 }

--- a/packages/core/src/slides/text-transcript.ts
+++ b/packages/core/src/slides/text-transcript.ts
@@ -38,19 +38,16 @@ export function parseTimestampSeconds(value: string): number | null {
     if (seconds >= 60) return null;
     return minutes * 60 + seconds;
   }
-  if (parts.length === 3) {
-    const [hours, minutes, seconds] = parts;
-    if (minutes >= 60 || seconds >= 60) return null;
-    return hours * 3600 + minutes * 60 + seconds;
-  }
-  return null;
+  const [hours, minutes, seconds] = parts;
+  if (minutes >= 60 || seconds >= 60) return null;
+  return hours * 3600 + minutes * 60 + seconds;
 }
 
 function normalizeSlideText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
-function truncateSlideText(value: string, limit: number): string {
+export function truncateSlideText(value: string, limit: number): string {
   if (value.length <= limit) return value;
   const truncated = value.slice(0, limit).trimEnd();
   const clean = truncated.replace(/\s+\S*$/, "").trim();

--- a/packages/core/src/slides/text.ts
+++ b/packages/core/src/slides/text.ts
@@ -1,8 +1,8 @@
 export type { SlideTimelineEntry, TranscriptSegment } from "./text-types.js";
 
+export { buildSlideTextFallback, coerceSummaryWithSlides } from "./text-compose.js";
+
 export {
-  buildSlideTextFallback,
-  coerceSummaryWithSlides,
   ensureSlideTitleLine,
   extractSlideMarkers,
   findSlidesSectionStart,
@@ -22,4 +22,5 @@ export {
   parseTimestampSeconds,
   resolveSlideTextBudget,
   resolveSlideWindowSeconds,
+  truncateSlideText,
 } from "./text-transcript.js";

--- a/tests/slides.text-markdown.coverage.test.ts
+++ b/tests/slides.text-markdown.coverage.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildSlideTextFallback,
   coerceSummaryWithSlides,
+} from "../packages/core/src/slides/text-compose.js";
+import {
   ensureSlideTitleLine,
   extractSlideMarkers,
   findSlidesSectionStart,


### PR DESCRIPTION
The core slide-text module mixed Markdown parsing with summary composition and transcript fallback. Separate composition into its own module and share the existing truncation implementation with the extension instead of maintaining a copy. Preserve every previous public export and option shape; remove only unreachable validation paths and unused destructured bindings.

Validation: full build, extension production build, and `pnpm run check` passed (566 test files, 3,265 tests). The internal coverage test imports were moved with their functions; assertions are unchanged. Final isolated Codex autoreview through P2 is scoped-clean.

Live proof: a Node client and a bundled app in real Chrome both used the built core library to compose a two-slide summary, parse its markers, and generate transcript fallbacks. Both returned markers `[1,2]`, exactly the expected per-slide text, and identical rendered Markdown. The Chrome run used the shared daemon-backed browser relay and synthetic content. Existing UTF-16 truncation behavior is preserved here; the separately reproduced Unicode defect will be fixed in a bug PR.

CI note: the first Chromium run timed out before the initial request in an unchanged chat-queue test. Ten local repetitions passed, and the failed-job retry passed at the same head; no tests or thresholds were weakened.
