### PR TITLE
refactor: share source adapter policies

### DIFF
--- a/packages/core/src/transcription/whisper/core.ts
+++ b/packages/core/src/transcription/whisper/core.ts
@@ -10,7 +10,7 @@ import {
   transcribeMediaFileWithDiarization,
 } from "./diarization.js";
 import { isFfmpegAvailable } from "./ffmpeg.js";
-import { shouldRetryGroqViaFfmpeg, transcribeWithGroq } from "./groq.js";
+import { transcribeWithGroq } from "./groq.js";
 import { transcribeWithLocalOnnx, transcribeWithLocalWhisper } from "./local.js";
 import { transcribeWithRemoteFallbacks } from "./remote.js";
 import {
@@ -126,7 +126,6 @@ async function transcribe(
         notes: run.notes,
         transcribe: (input) =>
           transcribeWithGroq(input.bytes, input.mediaType, input.filename, settings.groqApiKey!),
-        shouldRetry: shouldRetryGroqViaFfmpeg,
       });
       run.source = attempt.source;
       if (attempt.kind === "result") return { ...attempt.result, notes: run.notes };

--- a/packages/core/src/transcription/whisper/decode-retry.ts
+++ b/packages/core/src/transcription/whisper/decode-retry.ts
@@ -2,18 +2,25 @@ import { isFfmpegAvailable, transcodeBytesToMp3 } from "./ffmpeg.js";
 import type { ProviderResult, TranscriptionBytes } from "./request.js";
 import { wrapError } from "./utils.js";
 
+export function isMediaDecodeError(error: Error): boolean {
+  const msg = error.message.toLowerCase();
+  return (
+    msg.includes("unrecognized file format") ||
+    msg.includes("could not be decoded") ||
+    msg.includes("format is not supported")
+  );
+}
+
 export async function transcribeWithDecodeRetry({
   source,
   provider,
   notes,
   transcribe,
-  shouldRetry,
 }: {
   source: TranscriptionBytes;
   provider: "groq" | "openai";
   notes: string[];
   transcribe: (source: TranscriptionBytes) => Promise<string | null>;
-  shouldRetry: (error: Error) => boolean;
 }): Promise<ProviderResult & { source: TranscriptionBytes }> {
   const label = provider === "groq" ? "Groq" : "OpenAI";
   const success = (
@@ -32,7 +39,7 @@ export async function transcribeWithDecodeRetry({
   } catch (error) {
     failure = wrapError(`${label} transcription failed`, error);
   }
-  if (shouldRetry(failure)) {
+  if (isMediaDecodeError(failure)) {
     if (await isFfmpegAvailable()) {
       try {
         notes.push(`${label} could not decode media; transcoding via ffmpeg and retrying`);

--- a/packages/core/src/transcription/whisper/groq.ts
+++ b/packages/core/src/transcription/whisper/groq.ts
@@ -41,15 +41,6 @@ export async function transcribeWithGroq(
   return trimmed.length > 0 ? trimmed : null;
 }
 
-export function shouldRetryGroqViaFfmpeg(error: Error): boolean {
-  const msg = error.message.toLowerCase();
-  return (
-    msg.includes("unrecognized file format") ||
-    msg.includes("could not be decoded") ||
-    msg.includes("format is not supported")
-  );
-}
-
 async function tryGroqCurlFallback({
   bytes,
   mediaType,

--- a/packages/core/src/transcription/whisper/openai.ts
+++ b/packages/core/src/transcription/whisper/openai.ts
@@ -140,15 +140,6 @@ function parseSecondsToMs(value: unknown): number | null {
   return Number.isFinite(numeric) && numeric >= 0 ? Math.round(numeric * 1000) : null;
 }
 
-export function shouldRetryOpenAiViaFfmpeg(error: Error): boolean {
-  const msg = error.message.toLowerCase();
-  return (
-    msg.includes("unrecognized file format") ||
-    msg.includes("could not be decoded") ||
-    msg.includes("format is not supported")
-  );
-}
-
 function resolveRetryAfterMs(
   headers: Headers,
   status: number,

--- a/packages/core/src/transcription/whisper/remote-provider-attempts.ts
+++ b/packages/core/src/transcription/whisper/remote-provider-attempts.ts
@@ -10,7 +10,7 @@ import {
 import { transcribeWithFal } from "./fal.js";
 import { isFfmpegAvailable } from "./ffmpeg.js";
 import { transcribeFileWithGemini, transcribeWithGemini } from "./gemini.js";
-import { shouldRetryOpenAiViaFfmpeg, transcribeWithOpenAi } from "./openai.js";
+import { transcribeWithOpenAi } from "./openai.js";
 import type {
   ProviderResult,
   TranscriptionBytes,
@@ -132,7 +132,6 @@ async function attemptOpenAi(
       transcribeWithOpenAi(input.bytes, input.mediaType, input.filename, options.openaiApiKey!, {
         env: options.env,
       }),
-    shouldRetry: shouldRetryOpenAiViaFfmpeg,
   });
   run.source = truncated && attempt.kind === "error" ? source : attempt.source;
   return attempt;

--- a/src/run/bird.ts
+++ b/src/run/bird.ts
@@ -1,3 +1,4 @@
+import { isTwitterStatusUrl } from "@steipete/summarize-core/content/url";
 import { execTweetCli } from "./bird/exec.js";
 import { parseBirdTweetPayload, parseXurlTweetPayload } from "./bird/parse.js";
 import type { BirdTweetPayload, TweetCliClient } from "./bird/types.js";
@@ -18,17 +19,6 @@ function parseTweetId(raw: string): string | null {
     return match?.[1] ?? null;
   } catch {
     return null;
-  }
-}
-
-function isTwitterStatusUrl(raw: string): boolean {
-  try {
-    const parsed = new URL(raw);
-    const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
-    if (!TWITTER_HOSTS.has(host)) return false;
-    return /\/status\/\d+/.test(parsed.pathname);
-  } catch {
-    return false;
   }
 }
 

--- a/tests/transcription.remote-run.test.ts
+++ b/tests/transcription.remote-run.test.ts
@@ -43,7 +43,6 @@ vi.mock("../packages/core/src/transcription/whisper/deepgram.js", () => ({
 }));
 vi.mock("../packages/core/src/transcription/whisper/openai.js", () => ({
   transcribeWithOpenAi: mocks.openai,
-  shouldRetryOpenAiViaFfmpeg: () => false,
 }));
 vi.mock("../packages/core/src/transcription/whisper/fal.js", () => ({
   transcribeWithFal: mocks.fal,
@@ -147,7 +146,7 @@ describe.each(["groq", "openai"] as const)("%s decode retry source ownership", (
       mocks.ffmpeg.mockResolvedValue(true);
       const converted = new Uint8Array([9]);
       mocks.transcode.mockResolvedValue(converted);
-      const transcribe = vi.fn().mockRejectedValueOnce(new Error("decode failure"));
+      const transcribe = vi.fn().mockRejectedValueOnce(new Error("could not be decoded"));
       if (throws) transcribe.mockRejectedValueOnce(new Error("retry unavailable"));
       else transcribe.mockResolvedValueOnce(null);
       const source = {
@@ -162,7 +161,6 @@ describe.each(["groq", "openai"] as const)("%s decode retry source ownership", (
         provider,
         notes,
         transcribe,
-        shouldRetry: () => true,
       });
       expect(attempt.kind).toBe("error");
       if (throws) {

--- a/tests/transcription.whisper.test.ts
+++ b/tests/transcription.whisper.test.ts
@@ -1273,13 +1273,13 @@ describe("transcription/whisper", () => {
     }
   });
 
-  it("shouldRetryGroqViaFfmpeg detects retryable errors", async () => {
-    const { shouldRetryGroqViaFfmpeg } =
-      await import("../packages/core/src/transcription/whisper/groq.js");
-    expect(shouldRetryGroqViaFfmpeg(new Error("Unrecognized file format"))).toBe(true);
-    expect(shouldRetryGroqViaFfmpeg(new Error("could not be decoded"))).toBe(true);
-    expect(shouldRetryGroqViaFfmpeg(new Error("format is not supported"))).toBe(true);
-    expect(shouldRetryGroqViaFfmpeg(new Error("rate limit exceeded"))).toBe(false);
+  it("isMediaDecodeError detects retryable errors", async () => {
+    const { isMediaDecodeError } =
+      await import("../packages/core/src/transcription/whisper/decode-retry.js");
+    expect(isMediaDecodeError(new Error("Unrecognized file format"))).toBe(true);
+    expect(isMediaDecodeError(new Error("could not be decoded"))).toBe(true);
+    expect(isMediaDecodeError(new Error("format is not supported"))).toBe(true);
+    expect(isMediaDecodeError(new Error("rate limit exceeded"))).toBe(false);
   });
 
   it("uses Groq with default filename when none provided", async () => {


### PR DESCRIPTION
Reuse the core Twitter status-URL policy in the CLI, and let the shared transcription retry path own its media-format error predicate. Groq and OpenAI previously carried identical predicates and passed them back into the shared retry routine. Remove that duplication and the redundant internal callback option; package export entrypoints are unchanged.

Existing retry tests now supply an actual recognized format error instead of overriding the predicate; assertions and provider fallback behavior remain intact. Validation: full build and `pnpm run check`; isolated Codex autoreview through P2 is scoped-clean. A live client exercised both provider adapters with real FFmpeg WAV-to-MP3 conversion, confirmed each retried exactly once, and verified the resulting MP3 codec with ffprobe. It also checked the CLI's tweet-tip policy for matching and unrelated hosts.
