### PR TITLE
refactor(extension): share panel URL policies

### DIFF
--- a/apps/chrome-extension/src/entrypoints/background.ts
+++ b/apps/chrome-extension/src/entrypoints/background.ts
@@ -6,13 +6,16 @@ import { createDaemonRecovery, isDaemonUnreachableError } from "../lib/daemon-re
 import { createDaemonStatusTracker } from "../lib/daemon-status";
 import { logExtensionEvent } from "../lib/extension-logs";
 import type { BgToPanel, PanelCachePayload, PanelToBg } from "../lib/panel-contracts";
+import {
+  isPanelContentUrl as canSummarizeUrl,
+  panelUrlsMatch as urlsMatch,
+} from "../lib/panel-url";
 import { loadSettings, patchSettings } from "../lib/settings";
 import { transcribeBrowserMediaInTab } from "./background/browser-local-transcript";
 import { runBrowserSlidesForTab, takeBrowserSlidesPayload } from "./background/browser-slides";
 import { createBrowserSlidesRuntime } from "./background/browser-slides-runtime";
 import {
   beginSlideFrameCaptureInTab,
-  canSummarizeUrl,
   extractFromTab,
   getPrimaryMediaInfoInTab,
   prepareCurrentSlideFrameInTab,
@@ -36,7 +39,7 @@ import {
 } from "./background/panel-session-actions";
 import { createPanelSessionStore, type PanelSession } from "./background/panel-session-store";
 import { handlePanelSlidesContextRequest } from "./background/panel-slides-context";
-import { getActiveTab, openOptionsWindow, urlsMatch } from "./background/panel-utils";
+import { getActiveTab, openOptionsWindow } from "./background/panel-utils";
 import {
   createRuntimeActionsHandler,
   type ArtifactsRequest,

--- a/apps/chrome-extension/src/entrypoints/background/content-script-bridge.ts
+++ b/apps/chrome-extension/src/entrypoints/background/content-script-bridge.ts
@@ -83,16 +83,6 @@ async function injectExtractScript(
   }
 }
 
-export function canSummarizeUrl(url: string | null | undefined): url is string {
-  if (!url) return false;
-  if (url.startsWith("chrome://")) return false;
-  if (url.startsWith("chrome-extension://")) return false;
-  if (url.startsWith("moz-extension://")) return false;
-  if (url.startsWith("edge://")) return false;
-  if (url.startsWith("about:")) return false;
-  return true;
-}
-
 function hasNoContentReceiver(message: string): boolean {
   return (
     message.includes("Receiving end does not exist") ||

--- a/apps/chrome-extension/src/entrypoints/background/panel-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-runtime.ts
@@ -16,8 +16,8 @@ export function createBackgroundPanelRuntime<
   getActiveTab: typeof import("./panel-utils").getActiveTab;
   daemonHealth: typeof import("./daemon-client").daemonHealth;
   daemonPing: typeof import("./daemon-client").daemonPing;
-  canSummarizeUrl: typeof import("./content-script-bridge").canSummarizeUrl;
-  urlsMatch: typeof import("./panel-utils").urlsMatch;
+  canSummarizeUrl: typeof import("../../lib/panel-url").isPanelContentUrl;
+  urlsMatch: typeof import("../../lib/panel-url").panelUrlsMatch;
   primeMediaHint: typeof import("./extract-cache").primeMediaHint;
   extractFromTab: typeof import("./content-script-bridge").extractFromTab;
   buildSummarizeRequestBody: typeof import("../../lib/daemon-payload").buildSummarizeRequestBody;

--- a/apps/chrome-extension/src/entrypoints/background/panel-slides-context.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-slides-context.ts
@@ -19,7 +19,7 @@ export async function handlePanelSlidesContextRequest<Recovery, Status>(options:
     getCachedExtract: (tabId: number, url?: string | null) => CachedExtract | null;
     setCachedExtract: (tabId: number, payload: CachedExtract) => void;
   };
-  urlsMatch: typeof import("./panel-utils").urlsMatch;
+  urlsMatch: typeof import("../../lib/panel-url").panelUrlsMatch;
   send: (message: SlidesContextResponse) => void;
   fetchImpl?: typeof fetch;
   resolveLogLevel: (event: string) => "verbose" | "warn" | "error";

--- a/apps/chrome-extension/src/entrypoints/background/panel-utils.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-utils.ts
@@ -1,4 +1,5 @@
 import type { OptionsTab } from "../../lib/options-tabs";
+import { isPanelContentUrl } from "../../lib/panel-url";
 import type { SummaryLength } from "../../lib/runtime-contracts";
 import {
   buildSlideTextFallback,
@@ -103,17 +104,6 @@ export function resolveOptionsUrl(tab?: OptionsTab): string {
   return url.toString();
 }
 
-function isContentTabUrl(url: string | null | undefined): url is string {
-  if (!url) return false;
-  return !(
-    url.startsWith("chrome-extension://") ||
-    url.startsWith("chrome://") ||
-    url.startsWith("moz-extension://") ||
-    url.startsWith("edge://") ||
-    url.startsWith("about:")
-  );
-}
-
 export async function openOptionsWindow(tab?: OptionsTab) {
   const url = resolveOptionsUrl(tab);
   try {
@@ -154,36 +144,13 @@ export async function getActiveTab(windowId?: number): Promise<chrome.tabs.Tab |
       ? { active: true, windowId }
       : { active: true, currentWindow: true };
   const [activeTab] = await chrome.tabs.query(query);
-  if (isContentTabUrl(activeTab?.url)) {
+  if (isPanelContentUrl(activeTab?.url)) {
     return activeTab;
   }
 
   const fallbackTabs = await chrome.tabs.query(
     typeof windowId === "number" ? { windowId } : { currentWindow: true },
   );
-  const contentTab = fallbackTabs.find((tab) => isContentTabUrl(tab.url)) ?? null;
+  const contentTab = fallbackTabs.find((tab) => isPanelContentUrl(tab.url)) ?? null;
   return contentTab;
-}
-
-export function normalizeUrl(value: string) {
-  try {
-    const url = new URL(value);
-    url.hash = "";
-    return url.toString();
-  } catch {
-    return value;
-  }
-}
-
-export function urlsMatch(a: string, b: string) {
-  const left = normalizeUrl(a);
-  const right = normalizeUrl(b);
-  if (left === right) return true;
-  const boundaryMatch = (longer: string, shorter: string) => {
-    if (!longer.startsWith(shorter)) return false;
-    if (longer.length === shorter.length) return true;
-    const next = longer[shorter.length];
-    return next === "/" || next === "?" || next === "&";
-  };
-  return boundaryMatch(left, right) || boundaryMatch(right, left);
 }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/active-tab-sync.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/active-tab-sync.ts
@@ -1,5 +1,5 @@
+import { isPanelContentUrl, panelUrlsMatch } from "../../lib/panel-url";
 import type { NavigationRuntime } from "./navigation-runtime";
-import { panelUrlsMatch } from "./session-policy";
 
 export type PanelSource = { url: string; title: string | null };
 
@@ -18,16 +18,6 @@ type ActiveTabSyncOptions = {
   queryActiveTab?: () => Promise<ActiveTab | null>;
 };
 
-function canSyncTabUrl(url: string | null | undefined): url is string {
-  if (!url) return false;
-  if (url.startsWith("chrome://")) return false;
-  if (url.startsWith("chrome-extension://")) return false;
-  if (url.startsWith("moz-extension://")) return false;
-  if (url.startsWith("edge://")) return false;
-  if (url.startsWith("about:")) return false;
-  return true;
-}
-
 export async function syncNavigationWithActiveTab(options: ActiveTabSyncOptions) {
   const currentSource = options.getCurrentSource();
   if (!currentSource) return;
@@ -36,7 +26,7 @@ export async function syncNavigationWithActiveTab(options: ActiveTabSyncOptions)
     const tab = options.queryActiveTab
       ? await options.queryActiveTab()
       : ((await chrome.tabs.query({ active: true, currentWindow: true }))[0] ?? null);
-    if (!tab?.url || !canSyncTabUrl(tab.url)) return;
+    if (!tab?.url || !isPanelContentUrl(tab.url)) return;
     if (!panelUrlsMatch(tab.url, currentSource.url)) {
       const preserveChat = options.navigationRuntime.isRecentAgentNavigation(
         tab.id ?? null,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/browser-ai-snapshot-runtime.ts
@@ -1,8 +1,8 @@
 import { buildBrowserAiSummaryMarkdown } from "../../lib/browser-summary";
 import { logExtensionEvent } from "../../lib/extension-logs";
 import type { BgToPanel } from "../../lib/panel-contracts";
+import { panelUrlsMatch } from "../../lib/panel-url";
 import type { BrowserAiRequestKey } from "./browser-ai-summary-runtime";
-import { panelUrlsMatch } from "./session-policy";
 import type { PanelState } from "./types";
 
 type BrowserSummarySnapshot = Extract<BgToPanel, { type: "run:snapshot" }>;

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-history-store.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage as Message } from "@steipete/summarize-core/runtime";
+import { normalizePanelUrl } from "../../lib/panel-url";
 import { compactChatHistory, type ChatHistoryLimits } from "./chat-state";
-import { normalizePanelUrl } from "./session-policy";
 import type { ChatMessage } from "./types";
 
 function getChatHistoryKey(tabId: number, url?: string | null) {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/navigation-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/navigation-runtime.ts
@@ -1,4 +1,4 @@
-import { panelUrlsMatch } from "./session-policy";
+import { panelUrlsMatch } from "../../lib/panel-url";
 import type { NavigationPolicyState } from "./types";
 
 export type NavigationRuntime = {

--- a/apps/chrome-extension/src/entrypoints/sidepanel/planned-slides-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/planned-slides-runtime.ts
@@ -1,6 +1,6 @@
 import { extractYouTubeVideoId } from "@steipete/summarize-core/content/url";
+import { panelUrlsMatch } from "../../lib/panel-url";
 import { patchPanelState } from "./panel-state-store";
-import { panelUrlsMatch } from "./session-policy";
 import { shouldSeedPlannedSlidesForRun } from "./slides-seed-policy";
 import { resolveSlidesInputMode } from "./slides-session-state";
 import type { PanelState, RunStart } from "./types";

--- a/apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/presentation-runtime.ts
@@ -1,6 +1,7 @@
 import MarkdownIt from "markdown-it";
 import { isGeminiNanoModel } from "../../lib/model-routing";
 import type { PanelToBg } from "../../lib/panel-contracts";
+import { panelUrlsMatch } from "../../lib/panel-url";
 import { loadSettings, patchSettings } from "../../lib/settings";
 import type { createAppearanceControls } from "./appearance-controls";
 import { createBrowserAiSummaryRuntime } from "./browser-ai-summary-runtime";
@@ -14,7 +15,6 @@ import {
   retainRenderedSlideSummary,
   selectRetainedSlideSummaryMarkdown,
 } from "./retained-slide-summary";
-import { panelUrlsMatch } from "./session-policy";
 import { friendlyFetchError } from "./setup-runtime";
 import { createSidepanelSlidesRuntime } from "./slides-runtime";
 import { createSlidesTextController } from "./slides-text-controller";

--- a/apps/chrome-extension/src/entrypoints/sidepanel/retained-slide-summary.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/retained-slide-summary.ts
@@ -1,4 +1,4 @@
-import { panelUrlsMatch } from "./session-policy";
+import { panelUrlsMatch } from "../../lib/panel-url";
 import type { PanelState } from "./types";
 
 const getSummaryScopeUrl = (panelState: PanelState) =>

--- a/apps/chrome-extension/src/entrypoints/sidepanel/session-policy.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/session-policy.ts
@@ -1,36 +1,4 @@
-export function normalizePanelUrl(value: string) {
-  try {
-    const url = new URL(value);
-    url.hash = "";
-    return url.toString();
-  } catch {
-    return value;
-  }
-}
-
-export function panelUrlsMatch(a: string, b: string) {
-  const left = normalizePanelUrl(a);
-  const right = normalizePanelUrl(b);
-  if (left === right) return true;
-  const boundaryMatch = (longer: string, shorter: string) => {
-    if (!longer.startsWith(shorter)) return false;
-    if (longer.length === shorter.length) return true;
-    const next = longer[shorter.length];
-    return next === "/" || next === "?" || next === "&";
-  };
-  return boundaryMatch(left, right) || boundaryMatch(right, left);
-}
-
-export function isMatchablePanelUrl(value: string | null) {
-  if (!value) return false;
-  return !(
-    value.startsWith("chrome://") ||
-    value.startsWith("chrome-extension://") ||
-    value.startsWith("moz-extension://") ||
-    value.startsWith("edge://") ||
-    value.startsWith("about:")
-  );
-}
+import { isPanelContentUrl as isMatchablePanelUrl, panelUrlsMatch } from "../../lib/panel-url";
 
 export function shouldIgnoreTransientPanelTabState({
   nextTabUrl,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/slides-run-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/slides-run-runtime.ts
@@ -1,5 +1,5 @@
+import { normalizePanelUrl } from "../../lib/panel-url";
 import { patchPanelState, setPendingSlidesRun } from "./panel-state-store";
-import { normalizePanelUrl } from "./session-policy";
 import { hasResolvedSlidesPayload } from "./slides-pending";
 import { resolveSlidesInputMode } from "./slides-session-state";
 import type { PanelState, RunStart } from "./types";

--- a/apps/chrome-extension/src/entrypoints/sidepanel/summary-run-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/summary-run-runtime.ts
@@ -1,11 +1,11 @@
 import type { BrowserAiSummaryInput } from "../../lib/panel-contracts";
+import { normalizePanelUrl, panelUrlsMatch } from "../../lib/panel-url";
 import {
   attachPanelRun,
   patchPanelState,
   restorePanelSession,
   setPendingSummaryRun,
 } from "./panel-state-store";
-import { normalizePanelUrl, panelUrlsMatch } from "./session-policy";
 import { resolveSlidesInputMode } from "./slides-session-state";
 import type { PanelPhase, PanelState, RunStart } from "./types";
 

--- a/apps/chrome-extension/src/lib/panel-url.ts
+++ b/apps/chrome-extension/src/lib/panel-url.ts
@@ -1,0 +1,32 @@
+export function normalizePanelUrl(value: string) {
+  try {
+    const url = new URL(value);
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+export function panelUrlsMatch(a: string, b: string) {
+  const left = normalizePanelUrl(a);
+  const right = normalizePanelUrl(b);
+  if (left === right) return true;
+  const boundaryMatch = (longer: string, shorter: string) => {
+    if (!longer.startsWith(shorter)) return false;
+    const next = longer[shorter.length];
+    return next === "/" || next === "?" || next === "&";
+  };
+  return boundaryMatch(left, right) || boundaryMatch(right, left);
+}
+
+export function isPanelContentUrl(value: string | null | undefined): value is string {
+  if (!value) return false;
+  return !(
+    value.startsWith("chrome://") ||
+    value.startsWith("chrome-extension://") ||
+    value.startsWith("moz-extension://") ||
+    value.startsWith("edge://") ||
+    value.startsWith("about:")
+  );
+}

--- a/tests/chrome.panel-utils.test.ts
+++ b/tests/chrome.panel-utils.test.ts
@@ -5,8 +5,8 @@ import {
   getActiveTab,
   openOptionsWindow,
   resolveOptionsUrl,
-  urlsMatch,
 } from "../apps/chrome-extension/src/entrypoints/background/panel-utils.js";
+import { panelUrlsMatch as urlsMatch } from "../apps/chrome-extension/src/lib/panel-url.js";
 
 describe("chrome panel utils", () => {
   beforeEach(() => {

--- a/tests/sidepanel.session-policy.test.ts
+++ b/tests/sidepanel.session-policy.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
-  isMatchablePanelUrl,
-  normalizePanelUrl,
-  panelUrlsMatch,
   resolvePanelNavigationDecision,
   shouldAcceptRunForCurrentPage,
   shouldAcceptSlidesForCurrentPage,
   shouldIgnoreTransientPanelTabState,
   shouldInvalidateCurrentSource,
 } from "../apps/chrome-extension/src/entrypoints/sidepanel/session-policy.js";
+import {
+  isPanelContentUrl as isMatchablePanelUrl,
+  normalizePanelUrl,
+  panelUrlsMatch,
+} from "../apps/chrome-extension/src/lib/panel-url.js";
 
 describe("sidepanel session policy", () => {
   it("preserves chat and migrates it on a tab switch when asked", () => {


### PR DESCRIPTION
Background and Sidepanel duplicated URL normalization, page matching, and internal-scheme exclusions. Give those policies one owner and import it directly from callers. Keep injection option names as local aliases, preserve permissive non-HTTP/malformed-input behavior, and remove an equality branch already handled before boundary matching.

Validation: full build/check (566 files, 3,265 tests), production extension build, and isolated Codex autoreview through P2 passed. A bundled app in real Chrome compared the original and shared implementations across 399 URL normalization, matching, and eligibility cases; every result matched. Existing test assertions were retained and imports now point to the shared owner.
