### PR TITLE
refactor(cli): move URL JSON serialization to its owner

### DIFF
--- a/src/run/flows/url/summary-json.ts
+++ b/src/run/flows/url/summary-json.ts
@@ -1,4 +1,7 @@
+import type { ExtractedLinkContent } from "../../../content/index.js";
+import type { RunMetricsReport } from "../../../costs.js";
 import { formatOutputLanguageForJson } from "../../../language.js";
+import { buildRunJsonEnv } from "../../../shared/run-api-status.js";
 import type { UrlFlowContext } from "./types.js";
 
 export function buildUrlJsonInput(options: {
@@ -27,4 +30,57 @@ export function buildUrlJsonInput(options: {
     model: modelLabel,
     language: formatOutputLanguageForJson(flags.outputLanguage),
   };
+}
+
+type SlidesResult = Awaited<
+  ReturnType<typeof import("../../../slides/index.js").extractSlidesForSource>
+>;
+
+export async function writeUrlJsonOutput({
+  ctx,
+  url,
+  extracted,
+  effectiveMarkdownMode,
+  prompt,
+  slides,
+  summary,
+  llm,
+}: {
+  ctx: UrlFlowContext;
+  url: string;
+  extracted: ExtractedLinkContent;
+  effectiveMarkdownMode: "off" | "auto" | "llm" | "readability";
+  prompt: string;
+  slides?: SlidesResult | null;
+  summary: string | null;
+  llm: {
+    provider: string;
+    model: string;
+    maxCompletionTokens: number | null;
+    strategy: "single";
+  } | null;
+}): Promise<RunMetricsReport | null> {
+  const { io, flags, model, hooks } = ctx;
+  hooks.clearProgressForStdout();
+  const finishReport = flags.shouldComputeReport ? await hooks.buildReport() : null;
+  const payload = {
+    input: {
+      ...buildUrlJsonInput({
+        flags,
+        url,
+        effectiveMarkdownMode,
+        modelLabel: model.requestedModelLabel,
+      }),
+    },
+    env: buildRunJsonEnv(model.apiStatus),
+    extracted,
+    slides,
+    prompt,
+    llm,
+    metrics: flags.metricsEnabled ? finishReport : null,
+    summary,
+  };
+  io.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  hooks.restoreProgressAfterStdout?.();
+  return finishReport;
 }

--- a/src/run/flows/url/summary.ts
+++ b/src/run/flows/url/summary.ts
@@ -17,7 +17,6 @@ import {
   resolveUrlSummaryExecution,
   type UrlSummaryResolution,
 } from "../../../engine/web-summary.js";
-import { buildRunJsonEnv } from "../../../shared/run-api-status.js";
 import { buildExtractFinishLabel, writeFinishLine } from "../../finish-line.js";
 import { writeVerbose } from "../../logging.js";
 import { prepareMarkdownForTerminal } from "../../markdown.js";
@@ -26,7 +25,7 @@ import type { UrlExtractionUi } from "./extract.js";
 import type { SlidesTerminalOutput } from "./slides-output.js";
 import { formatSourceMetricsHeader } from "./source-metrics.js";
 import { buildFinishExtras, pickModelForFinishLine } from "./summary-finish.js";
-import { buildUrlJsonInput } from "./summary-json.js";
+import { writeUrlJsonOutput } from "./summary-json.js";
 import type { UrlFlowContext } from "./types.js";
 
 type SlidesResult = Awaited<
@@ -43,55 +42,6 @@ type ExtractedUrlOutputArgs = {
   transcriptionCostLabel: string | null;
   slides?: SlidesResult | null;
 };
-
-async function writeUrlJsonOutput({
-  ctx,
-  url,
-  extracted,
-  effectiveMarkdownMode,
-  prompt,
-  slides,
-  summary,
-  llm,
-}: {
-  ctx: UrlFlowContext;
-  url: string;
-  extracted: ExtractedLinkContent;
-  effectiveMarkdownMode: "off" | "auto" | "llm" | "readability";
-  prompt: string;
-  slides?: SlidesResult | null;
-  summary: string | null;
-  llm: {
-    provider: string;
-    model: string;
-    maxCompletionTokens: number | null;
-    strategy: "single";
-  } | null;
-}): Promise<RunMetricsReport | null> {
-  const { io, flags, model, hooks } = ctx;
-  hooks.clearProgressForStdout();
-  const finishReport = flags.shouldComputeReport ? await hooks.buildReport() : null;
-  const payload = {
-    input: {
-      ...buildUrlJsonInput({
-        flags,
-        url,
-        effectiveMarkdownMode,
-        modelLabel: model.requestedModelLabel,
-      }),
-    },
-    env: buildRunJsonEnv(model.apiStatus),
-    extracted,
-    slides,
-    prompt,
-    llm,
-    metrics: flags.metricsEnabled ? finishReport : null,
-    summary,
-  };
-  io.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-  hooks.restoreProgressAfterStdout?.();
-  return finishReport;
-}
 
 async function writeUrlMetricsFinishLine({
   ctx,


### PR DESCRIPTION
The URL summary orchestrator also built the JSON envelope. Move that writer beside the existing JSON input formatter so the orchestrator owns flow and the JSON module owns serialization. The orchestrator drops below 500 lines.

Validation: full build and `pnpm run check` passed (566 files, 3,265 tests); isolated Codex autoreview through P2 is scoped-clean. Live built-CLI extraction of `https://example.com` verified JSON envelope fields and null summary/model values with metrics both disabled and enabled. Report gating and progress ordering are unchanged.
