### PR TITLE
refactor(extension): isolate direct summary requests

### DIFF
--- a/apps/chrome-extension/src/entrypoints/background/panel-direct-summary.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-direct-summary.ts
@@ -1,0 +1,46 @@
+import {
+  buildDirectSummaryPrompt,
+  DIRECT_SUMMARY_SYSTEM_PROMPT,
+  resolveDirectMaxTokens,
+} from "../../lib/direct-prompts";
+import { completeDirectText, providerLabel } from "../../lib/direct-provider";
+import { getProviderSettings, type Settings } from "../../lib/settings";
+import type { ExtractResponse } from "./content-script-bridge";
+
+export async function summarizePanelDirectly({
+  extracted,
+  title,
+  transcriptTimedText,
+  settings,
+  signal,
+  fetchImpl,
+}: {
+  extracted: ExtractResponse & { ok: true };
+  title: string | null;
+  transcriptTimedText: string | null;
+  settings: Settings;
+  signal: AbortSignal;
+  fetchImpl: typeof fetch;
+}): Promise<{ text: string; model: string }> {
+  const prompt = buildDirectSummaryPrompt({
+    url: extracted.url,
+    title,
+    text: extracted.text,
+    transcriptTimedText,
+    truncated: extracted.truncated,
+    settings,
+  });
+  const result = await completeDirectText({
+    model: settings.model,
+    providerSettings: getProviderSettings(settings),
+    system: DIRECT_SUMMARY_SYSTEM_PROMPT,
+    prompt,
+    maxTokens: resolveDirectMaxTokens(settings),
+    signal,
+    fetchImpl,
+  });
+  return {
+    text: result.text,
+    model: `${providerLabel(result.config.provider)} · ${result.config.model}`,
+  };
+}

--- a/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
+++ b/apps/chrome-extension/src/entrypoints/background/panel-summarize.ts
@@ -5,21 +5,16 @@ import {
   shouldPreferUrlMode,
 } from "@steipete/summarize-core/content/url";
 import { buildBrowserSummaryPayload } from "../../lib/browser-summary";
-import {
-  buildDirectSummaryPrompt,
-  DIRECT_SUMMARY_SYSTEM_PROMPT,
-  resolveDirectMaxTokens,
-} from "../../lib/direct-prompts";
-import { completeDirectText, providerLabel } from "../../lib/direct-provider";
 import { planMediaExtraction } from "../../lib/media-extraction-plan";
 import { resolveSummaryExecution } from "../../lib/model-routing";
 import type { BrowserAiSummaryInput, RunStart } from "../../lib/panel-contracts";
-import { getProviderSettings, type Settings } from "../../lib/settings";
+import type { Settings } from "../../lib/settings";
 import type { BrowserLocalMediaTranscript } from "./browser-local-transcript";
 import { createCachedExtract, type CachedExtract } from "./cached-extract";
 import type { ExtractResponse } from "./content-script-bridge";
 import type { ExtractorContext } from "./extractors/router";
 import { ensurePreparedPanelTranscript, preparePanelContent } from "./panel-content-preparation";
+import { summarizePanelDirectly } from "./panel-direct-summary";
 import { startPanelDaemonSummary } from "./panel-summary-daemon";
 import {
   beginSummaryRequest,
@@ -416,20 +411,11 @@ export async function summarizeActiveTab<Session extends BackgroundSummarizeSess
   if (summaryExecution === "direct") {
     sendStatus("Sending to provider…");
     try {
-      const prompt = buildDirectSummaryPrompt({
-        url: resolvedPayload.url,
+      const result = await summarizePanelDirectly({
+        extracted: resolvedPayload,
         title: resolvedTitle,
-        text: resolvedPayload.text,
         transcriptTimedText: browserTranscriptTimedText,
-        truncated: resolvedPayload.truncated,
         settings,
-      });
-      const result = await completeDirectText({
-        model: settings.model,
-        providerSettings: getProviderSettings(settings),
-        system: DIRECT_SUMMARY_SYSTEM_PROMPT,
-        prompt,
-        maxTokens: resolveDirectMaxTokens(settings),
         signal: controller.signal,
         fetchImpl,
       });
@@ -438,7 +424,7 @@ export async function summarizeActiveTab<Session extends BackgroundSummarizeSess
         id: createSummaryRunId("direct"),
         url: resolvedPayload.url,
         title: resolvedTitle,
-        model: `${providerLabel(result.config.provider)} · ${result.config.model}`,
+        model: result.model,
         reason,
         slides: wantsSlides,
       };
@@ -460,7 +446,6 @@ export async function summarizeActiveTab<Session extends BackgroundSummarizeSess
 
   sendStatus("Connecting…");
   session.inflightUrl = resolvedPayload.url;
-  const summarySlides = daemonSlidesConfig;
 
   let id: string;
   try {
@@ -474,7 +459,7 @@ export async function summarizeActiveTab<Session extends BackgroundSummarizeSess
       noCache: Boolean(opts?.refresh),
       inputMode: requestInputMode,
       timestamps: summaryTimestamps,
-      slides: summarySlides,
+      slides: daemonSlidesConfig,
       signal: controller.signal,
       fetchImpl: daemonFetchImpl,
       buildSummarizeRequestBody,

--- a/apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime.ts
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/chat-runtime.ts
@@ -87,9 +87,6 @@ export function createSidepanelChatRuntime({
   renderInlineSlides: () => void;
   seekToTimestamp: (seconds: number) => void;
 }) {
-  let chatUiRuntime: ReturnType<typeof createChatUiRuntime>;
-  let automationRuntime: ReturnType<typeof createAutomationRuntime>;
-
   const wrapMessage = (message: Message): ChatMessage => ({
     ...message,
     id: crypto.randomUUID(),
@@ -132,7 +129,7 @@ export function createSidepanelChatRuntime({
     setStatus,
   });
 
-  chatUiRuntime = createChatUiRuntime({
+  const chatUiRuntime = createChatUiRuntime({
     mainEl,
     chatJumpBtn,
     chatInputEl,
@@ -153,7 +150,7 @@ export function createSidepanelChatRuntime({
     resetChatSession: () => chatSession.reset(),
   });
 
-  automationRuntime = createAutomationRuntime({
+  const automationRuntime = createAutomationRuntime({
     panelState,
 
     automationNoticeActionBtn,


### PR DESCRIPTION
The panel session coordinator also built and executed direct-provider requests. Move that adapter into its own module while keeping supersession checks, snapshots, cancellation, and cleanup in the coordinator. Replace two never-reassigned runtime bindings with const at their construction sites; earlier constructors only retain their callbacks.

Validation: full check (566 files, 3,265 tests), production extension build, and isolated Codex autoreview through P2 passed. A bundled production adapter in real Chrome sent a synthetic article through a loopback streaming provider and returned the expected summary and `OpenAI · proof-model` label. The request retained its system/user roles and `/v1/chat/completions` path. Session and error ordering are unchanged.
