### PR TITLE
docs(slides): correct output and OCR examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - ONNX transcription: keep staged audio available until inference exits and discard interrupted model downloads so retries cannot reuse partial artifacts.
 - Refresh Free: honor `FORCE_COLOR=0` and use the same color-override precedence as the rest of the CLI.
 - Maintenance: refresh stabilized Pi AI, tokentally, Playwright, and Bun tooling, enforce formatting in CI, and reuse the installation build.
+- Docs: correct the slides command JSON envelope, image paths, and OCR manifest examples.
 
 ## 0.21.14 - 2026-09-11
 

--- a/docs/commands/slides.md
+++ b/docs/commands/slides.md
@@ -34,7 +34,7 @@ If a required tool is missing, summarize prints a clear warning and exits non-ze
 ## Flags
 
 `--slides-ocr`
-: Run OCR on every extracted slide. Saves a `.txt` next to each PNG.
+: Run OCR on every extracted slide. Stores `ocrText` and `ocrConfidence` in `slides.json` and the JSON response.
 
 `--slides-dir <dir>`
 : Output base directory. Default: `./slides`. A per-video subfolder is created inside.
@@ -77,20 +77,33 @@ If a required tool is missing, summarize prints a clear warning and exits non-ze
 Each run writes a directory like:
 
 ```text
-slides/<video-id>/
-  001.png
-  002.png
+slides/<source-id>/
+  slide_0001_18.60s.png
+  slide_0002_42.20s.png
   ...
-  001.txt    # only with --slides-ocr
+  slides.json
 ```
 
-In `--json` mode, stdout is:
+The filenames include the slide index and timestamp. `slides.json` records the manifest, including OCR results when requested; OCR does not create separate text files. `ocrConfidence` uses a 0–1 scale.
+
+In `--json` mode, stdout contains an envelope like this (additional extraction metadata omitted):
 
 ```json
 {
-  "url": "...",
-  "outDir": "slides/<id>",
-  "slides": [{ "index": 1, "path": "...001.png", "timeSeconds": 18.6, "ocr": "..." }]
+  "ok": true,
+  "slides": {
+    "sourceUrl": "https://example.com/lecture.mp4",
+    "slidesDir": "/absolute/path/slides/<id>",
+    "slides": [
+      {
+        "index": 1,
+        "timestamp": 18.6,
+        "imagePath": "/absolute/path/slides/<id>/slide_0001_18.60s.png",
+        "ocrText": "Recognized slide text",
+        "ocrConfidence": 0.92
+      }
+    ]
+  }
 }
 ```
 
@@ -109,7 +122,7 @@ summarize slides "https://youtu.be/..." \
   --slides-max 24 --slides-scene-threshold 0.2
 
 # Pipe-friendly JSON for an automation.
-summarize slides "https://youtu.be/..." --json | jq '.slides[].path'
+summarize slides "https://youtu.be/..." --json | jq '.slides.slides[].imagePath'
 
 # Force re-extraction after editing the source video.
 summarize slides "./talk.mp4" --no-cache -o ./out


### PR DESCRIPTION
The slides command guide showed an obsolete JSON shape, PNG names, jq selector, and text sidecars. Correct it to the current `ok`/`slides` envelope, timestamped `imagePath` fields, and OCR data in `slides.json`. Document the actual 0–1 OCR confidence scale.

Validation: generated docs build and internal-link validation passed. A live built CLI extracted a synthetic video with `--slides-ocr --json`, confirming the envelope/frame fields and a directory containing only the PNG and `slides.json`. Isolated Codex autoreview through P2 is scoped-clean after correcting its confidence-scale finding. No implementation or data format changed.
