### PR TITLE
refactor: finish browser compatibility and test cleanup

### DIFF
--- a/apps/chrome-extension/src/automation/repl-browser-js.ts
+++ b/apps/chrome-extension/src/automation/repl-browser-js.ts
@@ -45,27 +45,7 @@ export async function runBrowserJs(
     throw new Error(buildUserScriptsGuidance(status));
   }
 
-  const terminate =
-    // @ts-expect-error - terminate is not yet in the type definitions
-    typeof chrome.userScripts?.terminate === "function"
-      ? // @ts-expect-error - terminate is not yet in the type definitions
-        chrome.userScripts.terminate.bind(chrome.userScripts)
-      : null;
-  const executionId = terminate ? crypto.randomUUID() : undefined;
   const nativeInputCapability = nativeInputEnabled ? crypto.randomUUID() : "";
-  let abortHandler: (() => void) | null = null;
-
-  if (signal && executionId && terminate) {
-    abortHandler = () => {
-      try {
-        terminate(tab.id, executionId);
-      } catch {
-        // Ignore termination races.
-      }
-    };
-    signal.addEventListener("abort", abortHandler, { once: true });
-  }
-
   const wrapperCode = buildBrowserJsWrapper({
     fnSource,
     args,
@@ -84,33 +64,28 @@ export async function runBrowserJs(
     // World configuration may already exist.
   }
 
-  try {
-    return await withArtifactsArmedTab({
-      enabled: true,
-      tabId,
-      sendMessage: (message) => chrome.runtime.sendMessage(message),
-      run: async () =>
-        withNativeInputArmedTab({
-          enabled: nativeInputEnabled,
-          tabId,
-          sendMessage: (message) => chrome.runtime.sendMessage(message),
-          capability: nativeInputCapability,
-          run: async () => {
-            const results = await userScripts.execute!({
-              target: { tabId },
-              world: "USER_SCRIPT",
-              worldId: "summarize-browserjs",
-              injectImmediately: true,
-              js: [{ code: wrapperCode }],
-              ...(executionId ? { executionId } : {}),
-            });
-            if (signal?.aborted) return { ok: false, error: "Execution aborted" };
-            const result = results?.[0]?.result as BrowserJsResult | undefined;
-            return result ?? { ok: false, error: "No result from browserjs()" };
-          },
-        }),
-    });
-  } finally {
-    if (abortHandler) signal?.removeEventListener("abort", abortHandler);
-  }
+  return await withArtifactsArmedTab({
+    enabled: true,
+    tabId,
+    sendMessage: (message) => chrome.runtime.sendMessage(message),
+    run: async () =>
+      withNativeInputArmedTab({
+        enabled: nativeInputEnabled,
+        tabId,
+        sendMessage: (message) => chrome.runtime.sendMessage(message),
+        capability: nativeInputCapability,
+        run: async () => {
+          const results = await userScripts.execute!({
+            target: { tabId },
+            world: "USER_SCRIPT",
+            worldId: "summarize-browserjs",
+            injectImmediately: true,
+            js: [{ code: wrapperCode }],
+          });
+          if (signal?.aborted) return { ok: false, error: "Execution aborted" };
+          const result = results?.[0]?.result as BrowserJsResult | undefined;
+          return result ?? { ok: false, error: "No result from browserjs()" };
+        },
+      }),
+  });
 }

--- a/apps/chrome-extension/src/entrypoints/background.ts
+++ b/apps/chrome-extension/src/entrypoints/background.ts
@@ -375,10 +375,11 @@ export default defineBackground(() => {
   // Firefox supports sidebarAction.toggle() for programmatic control
   if (import.meta.env.BROWSER === "firefox") {
     chrome.action.onClicked.addListener(() => {
-      // @ts-expect-error - sidebarAction API exists in Firefox but not in Chrome types
-      if (typeof browser?.sidebarAction?.toggle === "function") {
-        // @ts-expect-error - Firefox-specific API
-        void browser.sidebarAction.toggle();
+      const firefoxBrowser = browser as typeof browser & {
+        sidebarAction?: { toggle?: () => Promise<void> };
+      };
+      if (typeof firefoxBrowser?.sidebarAction?.toggle === "function") {
+        void firefoxBrowser.sidebarAction.toggle();
       }
     });
   }

--- a/apps/chrome-extension/src/entrypoints/sidepanel/length-picker.tsx
+++ b/apps/chrome-extension/src/entrypoints/sidepanel/length-picker.tsx
@@ -5,7 +5,7 @@ import { readPresetOrCustomValue, resolvePresetOrCustom } from "../../lib/combo"
 import { defaultSettings } from "../../lib/settings";
 import { mountComponent } from "../../ui/mount";
 import { type SelectItem, useSelect } from "../../ui/select";
-import { SelectField, SelectPopup } from "../../ui/select-field";
+import { SelectPopup } from "../../ui/select-field";
 
 type SidepanelLengthPickerProps = {
   length: string;

--- a/tests/llm.generate-text.test.ts
+++ b/tests/llm.generate-text.test.ts
@@ -1,5 +1,5 @@
 import type { Api } from "@earendil-works/pi-ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { generateTextWithModelId, streamTextWithModelId } from "../src/llm/generate-text.js";
 import { buildDocumentPrompt } from "./helpers/document-prompt.js";
 import { buildMinimalPdf } from "./helpers/pdf.js";
@@ -15,19 +15,6 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-mocks.completeSimple.mockImplementation(async (model: MockModel) =>
-  makeAssistantMessage({
-    provider: model.provider,
-    model: model.id,
-    api: model.api,
-    text: "ok",
-    usage: { input: 1, output: 2, totalTokens: 3 },
-  }),
-);
-mocks.streamSimple.mockImplementation((_model: MockModel) =>
-  makeTextDeltaStream(["o", "k"], makeAssistantMessage({ text: "ok" })),
-);
-
 vi.mock("@earendil-works/pi-ai/compat", () => ({
   completeSimple: mocks.completeSimple,
   streamSimple: mocks.streamSimple,
@@ -35,13 +22,34 @@ vi.mock("@earendil-works/pi-ai/compat", () => ({
 }));
 
 describe("llm generate/stream", () => {
-  const originalBaseUrl = process.env.OPENAI_BASE_URL;
+  beforeEach(() => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://openai.example.com/v1");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("Unexpected network request in LLM fixture");
+      }),
+    );
+    mocks.completeSimple.mockReset().mockImplementation(async (model: MockModel) =>
+      makeAssistantMessage({
+        provider: model.provider,
+        model: model.id,
+        api: model.api,
+        text: "ok",
+        usage: { input: 1, output: 2, totalTokens: 3 },
+      }),
+    );
+    mocks.streamSimple
+      .mockReset()
+      .mockImplementation((_model: MockModel) =>
+        makeTextDeltaStream(["o", "k"], makeAssistantMessage({ text: "ok" })),
+      );
+  });
 
   afterEach(() => {
     vi.useRealTimers();
-    mocks.completeSimple.mockClear();
-    mocks.streamSimple.mockClear();
-    process.env.OPENAI_BASE_URL = originalBaseUrl;
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it("routes by provider (generateText) and includes maxOutputTokens when set", async () => {
@@ -151,7 +159,7 @@ describe("llm generate/stream", () => {
     expect(streamArgs).not.toHaveProperty("maxTokens");
   });
 
-  it("skips temperature for OpenAI GPT-5 models (generate/stream)", async () => {
+  it("skips temperature for GPT-5 models through compat generate/stream", async () => {
     mocks.completeSimple.mockClear();
     mocks.streamSimple.mockClear();
 
@@ -184,6 +192,9 @@ describe("llm generate/stream", () => {
       timeoutMs: 2000,
       fetchImpl: globalThis.fetch.bind(globalThis),
     });
+
+    expect(mocks.completeSimple).toHaveBeenCalledTimes(1);
+    expect(mocks.streamSimple).toHaveBeenCalledTimes(1);
 
     const generateArgs = (mocks.completeSimple.mock.calls[0]?.[2] ?? {}) as Record<string, unknown>;
     const streamArgs = (mocks.streamSimple.mock.calls[0]?.[2] ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
Finish the compatibility, type, and test fixture audit. Remove the unused length-field import, type Firefox's optional sidebar API explicitly, and delete speculative userScripts termination code. Chrome's current reference defines neither `terminate` nor an `executionId` injection option: https://developer.chrome.com/docs/extensions/reference/api/userScripts. Early-abort, late-result discard, and artifact cleanup remain unchanged.

The LLM test fixture previously restored an unset base URL as the string `"undefined"`, accidentally choosing a mocked transport. It also retained queued mock responses across cases. Give compatibility tests an explicit synthetic base URL, reset mocks per case, restore environment/global state, reject unexpected networking, and strengthen the temperature call-count assertions. Native Responses tests retain their explicit transport mocks and assertions.

Validation: full check and production extension build; isolated Codex autoreview through P2 is scoped-clean. All 34 LLM cases also pass in shuffled order (seed 42). A live Node probe confirmed correct restoration of an absent environment variable. A bundled client in real Chrome exercised supported userScripts execution, both abort outcomes, documented argument shape, and artifact cleanup using synthetic API responses. The control bundle remains byte-identical after import cleanup and renders the expected controls.
