### PR TITLE
ci: follow up survey with type updates and faster checks

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,8 +6,7 @@ on:
     paths:
       - "docs/**"
       - "scripts/build-docs-site.mjs"
-      - "scripts/docs-site-assets.mjs"
-      - "scripts/docs-site-markdown.mjs"
+      - "scripts/docs-site-*.mjs"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,5 +17,15 @@
   "rules": {
     "typescript/no-floating-promises": "error",
     "typescript/no-misused-promises": "error"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["src/**", "packages/core/src/**", "apps/chrome-extension/src/**", "scripts/**"],
+      "rules": {
+        "no-unused-vars": "error",
+        "no-unreachable": "error",
+        "no-constant-binary-expression": "error"
+      }
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - ONNX transcription: keep staged audio available until inference exits and discard interrupted model downloads so retries cannot reuse partial artifacts.
 - Refresh Free: honor `FORCE_COLOR=0` and use the same color-override precedence as the rest of the CLI.
 - Maintenance: refresh stabilized Pi AI, tokentally, Playwright, and Bun tooling, enforce formatting in CI, and reuse the installation build.
+- Development: update stabilized Chrome typings, reuse Vitest source transforms between runs, and keep automatic worker counts within the available CPU budget.
+- CI: enforce unused-code checks and rebuild Pages when any documentation helper changes.
 - Docs: correct the slides command JSON envelope, image paths, and OCR manifest examples.
 
 ## 0.21.14 - 2026-09-11

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,8 @@ pnpm run format
 
 `pnpm run check` runs formatting, lint, type checking, and coverage tests. Run it before opening or updating a pull request. Installation already builds the CLI and core through `prepare`; run `pnpm run build` again after source changes.
 
+Production lint also checks unused bindings, unreachable code, and constant binary expressions. Vitest reuses source transforms between runs while retaining test isolation. Automatic worker counts respect the available CPUs; `VITEST_MAX_THREADS` remains available for an explicit override.
+
 Extension:
 
 ```bash

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.63.0",
-    "@types/chrome": "^0.2.8",
+    "@types/chrome": "^0.2.9",
     "typescript": "^7.0.2",
     "web-ext": "10.6.0",
     "wxt": "0.21.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: 1.63.0
         version: 1.63.0
       '@types/chrome':
-        specifier: ^0.2.8
-        version: 0.2.8
+        specifier: ^0.2.9
+        version: 0.2.9
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -1355,8 +1355,8 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/chrome@0.2.8':
-    resolution: {integrity: sha512-dznDYMiJUyuc7b+78PxnWhaGOonmbX/OmcWu7NE42sg/yTLJMYnJ7Uah40SLPNFiCh8reqcthk7vOva2+MSvzw==}
+  '@types/chrome@0.2.9':
+    resolution: {integrity: sha512-6rXrDPkkWv4D2Q23HqT+iED4voODU5CpOSc2VFgKyecSFItuEsIBvz9CY6jUQ3dd+Q7zo1bnCE9pKRMtkYut5g==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -4584,7 +4584,7 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/chrome@0.2.8':
+  '@types/chrome@0.2.9':
     dependencies:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16

--- a/tests/vitest.config.test.ts
+++ b/tests/vitest.config.test.ts
@@ -14,7 +14,12 @@ describe("vitest config", () => {
     },
   );
 
-  it("wires VITEST_MAX_THREADS into Vitest 4 maxWorkers", () => {
+  it.each([1, 2, 3])("does not oversubscribe a %i-CPU machine by default", (availableCpus) => {
+    expect(resolveMaxThreads(undefined, availableCpus)).toBe(availableCpus);
+    expect(resolveMaxThreads("invalid", availableCpus)).toBe(availableCpus);
+  });
+
+  it("wires VITEST_MAX_THREADS into maxWorkers", () => {
     const config = createVitestConfig({
       env: { VITEST_MAX_THREADS: "1" },
       availableCpus: 16,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,8 @@ const cpuCount = Math.max(1, cpus().length);
 const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/u;
 
 export function resolveMaxThreads(raw: string | undefined, availableCpus = cpuCount): number {
-  const fallback = Math.min(8, Math.max(4, Math.floor(Math.max(1, availableCpus) / 2)));
+  const cpuBudget = Math.max(1, Math.floor(availableCpus));
+  const fallback = Math.min(cpuBudget, 8, Math.max(4, Math.floor(cpuBudget / 2)));
   const value = raw?.trim();
   if (!value || !POSITIVE_INTEGER_PATTERN.test(value)) return fallback;
   const parsed = Number.parseInt(value, 10);
@@ -63,6 +64,7 @@ export function createVitestConfig({
     },
     test: {
       maxWorkers,
+      fsModuleCache: true,
       environment: "node",
       include: ["tests/**/*.test.ts"],
       setupFiles: ["tests/setup.ts"],


### PR DESCRIPTION
Complete the separate dependency/CI follow-up after the codebase survey. Update Chrome typings to 0.2.9, include every docs helper in the Pages trigger, enforce production unused/unreachable-code checks, cache Vitest transforms, and cap automatic workers to available CPUs. Existing explicit worker overrides, test isolation, assertions, coverage thresholds, package versions, and runtime floors remain unchanged.

Chrome typings 0.2.9 was published 2026-09-05 20:04 UTC and adopted after the repository's seven-day hold. Other direct dependencies and the existing SHA-pinned Actions were checked; no additional eligible updates were needed. Patched image-size/adm-zip advisories remain covered by their existing security regressions.

Validation: full build and check passed (566 test files, 3,268 tests), production extension and docs builds passed, and isolated Codex autoreview through P2 is scoped-clean. Live built-CLI JSON extraction verified metrics-off/on behavior. The 97-test transform benchmark measured 2.19s without persistence, 1.74s cold, and 1.13s warm; a changed-source probe verified invalidation. A live config probe verified 1/2/3-CPU defaults and preserved explicit overrides. Pages filter checks include the new layout helper and exclude unrelated build scripts.
