### PR TITLE
fix(cache): close and validate statistics reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Security: backport the adm-zip destination-symlink extraction fix (GHSA-vwc7-r8mq-g2x9) while its new release completes the seven-day stabilization hold.
 - ONNX transcription: keep staged audio available until inference exits and discard interrupted model downloads so retries cannot reuse partial artifacts.
 - Refresh Free: honor `FORCE_COLOR=0` and use the same color-override precedence as the rest of the CLI.
+- Cache statistics: close SQLite connections after failed reads and ignore invalid cache-kind names.
 - Maintenance: refresh stabilized Pi AI, tokentally, Playwright, and Bun tooling, enforce formatting in CI, and reuse the installation build.
 - Development: update stabilized Chrome typings, reuse Vitest source transforms between runs, and keep automatic worker counts within the available CPU budget.
 - CI: enforce unused-code checks and rebuild Pages when any documentation helper changes.

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -86,24 +86,30 @@ export function clearCacheFiles(path: string) {
 
 export async function readCacheStats(path: string): Promise<CacheStats | null> {
   if (!existsSync(path)) return null;
+  const counts = createEmptyCacheCounts();
+  let totalEntries: number;
   const db = await openSqlite(path);
   try {
-    db.exec("PRAGMA query_only = ON");
-  } catch {
-    // ignore
-  }
-  const counts = createEmptyCacheCounts();
-  const rows = db.prepare("SELECT kind, COUNT(*) AS count FROM cache_entries GROUP BY kind").all();
-  for (const row of rows as Array<{ kind?: string; count?: number }>) {
-    if (row?.kind && typeof row.count === "number" && row.kind in counts) {
-      counts[row.kind as CacheKind] = row.count;
+    try {
+      db.exec("PRAGMA query_only = ON");
+    } catch {
+      // ignore
     }
+    const rows = db
+      .prepare("SELECT kind, COUNT(*) AS count FROM cache_entries GROUP BY kind")
+      .all();
+    for (const row of rows as Array<{ kind?: string; count?: number }>) {
+      if (row?.kind && typeof row.count === "number" && Object.hasOwn(counts, row.kind)) {
+        counts[row.kind as CacheKind] = row.count;
+      }
+    }
+    const totalRow = db.prepare("SELECT COUNT(*) AS count FROM cache_entries").get() as
+      | { count?: number }
+      | undefined;
+    totalEntries = typeof totalRow?.count === "number" ? totalRow.count : 0;
+  } finally {
+    db.close();
   }
-  const totalRow = db.prepare("SELECT COUNT(*) AS count FROM cache_entries").get() as
-    | { count?: number }
-    | undefined;
-  const totalEntries = typeof totalRow?.count === "number" ? totalRow.count : 0;
-  db.close();
   return {
     path,
     sizeBytes: getSqliteFileSizeBytes(path),

--- a/tests/cache.stats.test.ts
+++ b/tests/cache.stats.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readCacheStats } from "../src/cache.js";
+
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "summarize-cache-stats-"));
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("cache statistics connection ownership", () => {
+  it("closes the database after reading its counts", async () => {
+    const path = join(root, "cache.sqlite");
+    const db = new DatabaseSync(path);
+    db.exec("CREATE TABLE cache_entries (kind TEXT)");
+    db.exec("INSERT INTO cache_entries VALUES ('summary'), ('extract')");
+    db.close();
+    const close = vi.spyOn(DatabaseSync.prototype, "close");
+
+    const stats = await readCacheStats(path);
+
+    expect(stats).toMatchObject({ path, totalEntries: 2, counts: { summary: 1, extract: 1 } });
+    expect(stats?.sizeBytes).toBeGreaterThan(0);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores cache kinds that match inherited object properties", async () => {
+    const path = join(root, "cache.sqlite");
+    const db = new DatabaseSync(path);
+    db.exec("CREATE TABLE cache_entries (kind TEXT)");
+    db.exec("INSERT INTO cache_entries VALUES ('constructor')");
+    db.close();
+
+    const stats = await readCacheStats(path);
+
+    expect(stats?.totalEntries).toBe(1);
+    expect(Object.hasOwn(stats?.counts ?? {}, "constructor")).toBe(false);
+  });
+
+  it("closes the database when a statistics query fails", async () => {
+    const path = join(root, "cache.sqlite");
+    new DatabaseSync(path).close();
+    const close = vi.spyOn(DatabaseSync.prototype, "close");
+
+    await expect(readCacheStats(path)).rejects.toThrow("no such table: cache_entries");
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
A failed cache statistics query left its SQLite connection open. A malformed kind such as `constructor` also passed the inherited-property membership check and became an unexpected field in the counts object. Own the connection with `finally` and accept only declared own count keys. File-size measurement still occurs after close, and the original query error is preserved.

Regression tests use real SQLite: the failed-query close count and inherited-kind case both failed before the fix, while a healthy control passed. All three pass after the fix; full build/check and isolated Codex autoreview through P2 pass.

Live proof with the built library reproduced `no such table: cache_entries` with zero close calls before and one close afterward. A real SQLite/CLI client also verified persistent reads, transcript metadata, `--cache-stats`, and clearing. No cache format or valid count behavior changed.
