### PR TITLE
fix(slides): avoid splitting Unicode surrogate pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.21.15 - Unreleased
 
 - Security: backport the adm-zip destination-symlink extraction fix (GHSA-vwc7-r8mq-g2x9) while its new release completes the seven-day stabilization hold.
+- Slide text: avoid splitting Unicode surrogate pairs when shortening transcript or OCR text.
 - ONNX transcription: keep staged audio available until inference exits and discard interrupted model downloads so retries cannot reuse partial artifacts.
 - Refresh Free: honor `FORCE_COLOR=0` and use the same color-override precedence as the rest of the CLI.
 - Maintenance: refresh stabilized Pi AI, tokentally, Playwright, and Bun tooling, enforce formatting in CI, and reuse the installation build.

--- a/packages/core/src/slides/text-transcript.ts
+++ b/packages/core/src/slides/text-transcript.ts
@@ -49,7 +49,10 @@ function normalizeSlideText(value: string): string {
 
 export function truncateSlideText(value: string, limit: number): string {
   if (value.length <= limit) return value;
-  const truncated = value.slice(0, limit).trimEnd();
+  const prefix = value.slice(0, limit);
+  // A character budget can end between the UTF-16 units of an astral character.
+  const splitsSurrogatePair = (value.codePointAt(prefix.length - 1) ?? 0) > 0xffff;
+  const truncated = (splitsSurrogatePair ? prefix.slice(0, -1) : prefix).trimEnd();
   const clean = truncated.replace(/\s+\S*$/, "").trim();
   const result = clean.length > 0 ? clean : truncated.trim();
   return result.length > 0 ? `${result}...` : "";

--- a/tests/slides.text-unicode.test.ts
+++ b/tests/slides.text-unicode.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getTranscriptTextForSlide, truncateSlideText } from "../packages/core/src/slides/text.js";
+
+describe("slide text character budgets", () => {
+  it.each<[string, number, string]>([
+    ["a🦞bc", 2, "a..."],
+    ["🦞bc", 1, ""],
+    ["🦞bc", 2, "🦞..."],
+    ["abc defghi", 6, "abc..."],
+  ])("truncates %s at %i without splitting a surrogate pair", (text, limit, expected) => {
+    expect(truncateSlideText(text, limit)).toBe(expected);
+  });
+
+  it("keeps transcript fallback text well formed at the budget boundary", () => {
+    const prefix = "a".repeat(79);
+    expect(
+      getTranscriptTextForSlide({
+        slide: { index: 1, timestamp: 0 },
+        nextSlide: null,
+        segments: [{ startSeconds: 0, text: `${prefix}🦞tail` }],
+        budget: 80,
+        windowSeconds: 30,
+      }),
+    ).toBe(`${prefix}...`);
+  });
+});


### PR DESCRIPTION
A slide character budget could end between an astral character's UTF-16 units, producing a lone surrogate in transcript fallback or OCR text. Adjust the boundary in the shared helper before the existing word trimming and ellipsis logic. ASCII behavior, complete surrogate pairs, and the existing budget remain unchanged.

Three regressions failed before the fix, including the transcript fallback path; all five cases pass afterward. Full build/check, production extension build, and isolated Codex autoreview through P2 pass.

Live built-core clients in Node and real Chrome changed the synthetic `a🦞bc` / budget 2 result from a lone surrogate to `a...`, with `isWellFormed()` changing from false to true. The screenshots show the same synthetic fixture before and after. No runtime or browser floor changed.

![unicode-before-image](https://github.com/user-attachments/assets/93f0b0ec-62a0-4423-9eac-88c505a62407)

![unicode-after-image](https://github.com/user-attachments/assets/de72b789-9157-47c4-8736-1754cf1b173a)