### PR TITLE
fix(cli): preserve unrelated host logging globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Security: backport the adm-zip destination-symlink extraction fix (GHSA-vwc7-r8mq-g2x9) while its new release completes the seven-day stabilization hold.
 - ONNX transcription: keep staged audio available until inference exits and discard interrupted model downloads so retries cannot reuse partial artifacts.
+- CLI: preserve unrelated host logging globals, including read-only AI SDK settings.
 - Refresh Free: honor `FORCE_COLOR=0` and use the same color-override precedence as the rest of the CLI.
 - Maintenance: refresh stabilized Pi AI, tokentally, Playwright, and Bun tooling, enforce formatting in CI, and reuse the installation build.
 - Development: update stabilized Chrome typings, reuse Vitest source transforms between runs, and keep automatic worker counts within the available CPU budget.

--- a/src/run/runner.ts
+++ b/src/run/runner.ts
@@ -33,7 +33,6 @@ export async function runCli(
   argv: string[],
   { env: inputEnv, fetch, execFile: execFileOverride, stdin, stdout, stderr }: RunEnv,
 ): Promise<void> {
-  (globalThis as unknown as { AI_SDK_LOG_WARNINGS?: boolean }).AI_SDK_LOG_WARNINGS = false;
   const perfTrace = createPerfTrace({ env: inputEnv, stderr });
   const runStdout = perfTrace?.wrapStdout(stdout) ?? stdout;
 

--- a/tests/cli.json.test.ts
+++ b/tests/cli.json.test.ts
@@ -14,10 +14,14 @@ const htmlResponse = (html: string, status = 200) =>
 describe("cli --json", () => {
   const home = mkdtempSync(join(tmpdir(), "summarize-tests-json-"));
 
-  it("disables AI SDK warning logs (stdout must stay JSON)", async () => {
+  it("preserves read-only host logging settings while keeping stdout JSON", async () => {
     const globalObject = globalThis as unknown as { AI_SDK_LOG_WARNINGS?: boolean };
-    const previous = globalObject.AI_SDK_LOG_WARNINGS;
-    globalObject.AI_SDK_LOG_WARNINGS = true;
+    const previous = Object.getOwnPropertyDescriptor(globalObject, "AI_SDK_LOG_WARNINGS");
+    Object.defineProperty(globalObject, "AI_SDK_LOG_WARNINGS", {
+      value: true,
+      writable: false,
+      configurable: true,
+    });
 
     try {
       const html =
@@ -54,10 +58,11 @@ describe("cli --json", () => {
         },
       );
 
-      expect(globalObject.AI_SDK_LOG_WARNINGS).toBe(false);
+      expect(globalObject.AI_SDK_LOG_WARNINGS).toBe(true);
       expect(() => JSON.parse(stdoutText)).not.toThrow();
     } finally {
-      globalObject.AI_SDK_LOG_WARNINGS = previous;
+      if (previous) Object.defineProperty(globalObject, "AI_SDK_LOG_WARNINGS", previous);
+      else Reflect.deleteProperty(globalObject, "AI_SDK_LOG_WARNINGS");
     }
   });
 


### PR DESCRIPTION
The CLI still set an obsolete AI SDK global at startup even though the active provider stack does not consume it. This changed a host application's logging settings and crashed even `--version` when the host made that property read-only. Remove the unrelated global mutation.

The regression preserves a read-only host setting while still requiring valid JSON stdout; it failed with TypeError before the fix and passes afterward. Full build/check and isolated Codex autoreview through P2 pass. Live built CLI with a read-only-global prelude changed from exit 1 to exit 0 and printed its version normally. No owned configuration key or CLI option was removed.
