### PR TITLE
fix(extension): detect immediate User Scripts support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Security: backport the adm-zip destination-symlink extraction fix (GHSA-vwc7-r8mq-g2x9) while its new release completes the seven-day stabilization hold.
 - ONNX transcription: keep staged audio available until inference exits and discard interrupted model downloads so retries cannot reuse partial artifacts.
 - Refresh Free: honor `FORCE_COLOR=0` and use the same color-override precedence as the rest of the CLI.
+- Browser automation: detect immediate User Scripts execution support and give older Chrome versions an accurate upgrade requirement.
 - Cache statistics: close SQLite connections after failed reads and ignore invalid cache-kind names.
 - Maintenance: refresh stabilized Pi AI, tokentally, Playwright, and Bun tooling, enforce formatting in CI, and reuse the installation build.
 - Development: update stabilized Chrome typings, reuse Vitest source transforms between runs, and keep automatic worker counts within the available CPU budget.

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -105,7 +105,8 @@ access with Chrome policy; see [`docs/chrome-enterprise.md`](../../docs/chrome-e
 Summarization, chat, and browser media do not require Chrome's `userScripts` or `debugger`
 permissions. Website automation is off by default. **Options → Enable automation permissions**
 requests optional `userScripts` access from an explicit user click so user-requested `browserjs()` /
-REPL code can run in the page's main world.
+REPL code can run in the page context. Immediate `browserjs()` execution requires Chrome 135+;
+the extension installation minimum remains Chrome 120+.
 
 Chrome does not allow `debugger` to be declared optional. The standard Chrome build omits it and
 hides the debugger tool; `pnpm -C apps/chrome-extension build:automation` creates the separate

--- a/apps/chrome-extension/src/automation/userscripts.ts
+++ b/apps/chrome-extension/src/automation/userscripts.ts
@@ -1,3 +1,5 @@
+const MIN_EXECUTE_CHROME_VERSION = 135;
+
 export type UserScriptsStatus = {
   apiAvailable: boolean;
   permissionGranted: boolean;
@@ -11,7 +13,7 @@ export function getChromeVersion(): number | null {
 }
 
 export async function getUserScriptsStatus(): Promise<UserScriptsStatus> {
-  const apiAvailable = Boolean(chrome.userScripts);
+  const apiAvailable = typeof chrome.userScripts?.execute === "function";
   const permissionGranted = Boolean(
     await chrome.permissions?.contains?.({ permissions: ["userScripts"] }),
   );
@@ -22,7 +24,6 @@ export async function getUserScriptsStatus(): Promise<UserScriptsStatus> {
   };
 }
 
-// Returns a user-facing, actionable message for the current userScripts status.
 export function buildUserScriptsGuidance(status: UserScriptsStatus): string {
   const chromeVersion = status.chromeVersion ?? 0;
   const permissionHint = status.permissionGranted
@@ -38,6 +39,10 @@ export function buildUserScriptsGuidance(status: UserScriptsStatus): string {
       .join(" ");
   }
 
+  if (chromeVersion > 0 && chromeVersion < MIN_EXECUTE_CHROME_VERSION) {
+    return `Chrome ${chromeVersion} detected. Browser automation requires Chrome ${MIN_EXECUTE_CHROME_VERSION} or higher. Please update Chrome.`;
+  }
+
   if (chromeVersion >= 138) {
     return [
       permissionHint,
@@ -47,19 +52,10 @@ export function buildUserScriptsGuidance(status: UserScriptsStatus): string {
       .join("\n\n");
   }
 
-  if (chromeVersion >= 120) {
+  if (chromeVersion >= MIN_EXECUTE_CHROME_VERSION) {
     return [
       permissionHint,
       `Chrome ${chromeVersion} detected. Enable Developer mode in chrome://extensions, then reload the extension and try again.`,
-    ]
-      .filter(Boolean)
-      .join(" ");
-  }
-
-  if (chromeVersion > 0) {
-    return [
-      permissionHint,
-      `Chrome ${chromeVersion} detected. The userScripts API requires Chrome 120 or higher. Please update Chrome.`,
     ]
       .filter(Boolean)
       .join(" ");

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -57,7 +57,7 @@ Service installation keeps launchd, systemd, and Scheduled Task policy in separa
 
 Defined in `apps/chrome-extension/wxt.config.ts`:
 
-- `userScripts` – optional; requested via Options for `browserjs()` main-world script execution.
+- `userScripts` – optional; requested via Options for `browserjs()` page-context script execution.
 - `debugger` – required only in `build:automation` for **native input** and the **debugger** tool.
 
 Neither permission is needed for summarization. The standard Chrome build omits `debugger` because
@@ -65,6 +65,8 @@ Neither permission is needed for summarization. The standard Chrome build omits 
 and it hides debugger-backed tools. The separate automation build declares it as required.
 
 #### Chrome: enable User Scripts (if needed)
+
+Immediate `browserjs()` execution requires [Chrome 135+](https://developer.chrome.com/docs/extensions/reference/api/userScripts#method-execute). The extension installation minimum remains Chrome 120+.
 
 1. `chrome://extensions`
 2. Open extension details
@@ -206,7 +208,7 @@ REPL environment:
 
 - Runs in a **sandboxed iframe** (no DOM access to the panel).
 - `browserjs(fn, ...args)` runs the function **in the page context**.
-  - Uses `chrome.userScripts.execute` in the main world.
+  - Uses `chrome.userScripts.execute` (Chrome 135+) for page-context execution.
 - `navigate({ url })` available inside the REPL (always use for navigation).
 - `sleep(ms)` helper.
 - Console output is captured and returned; return values are appended as `=> value`.

--- a/tests/automation.userscripts.test.ts
+++ b/tests/automation.userscripts.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildUserScriptsGuidance,
+  getUserScriptsStatus,
+} from "../apps/chrome-extension/src/automation/userscripts.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const createStatus = (chromeVersion: number, apiAvailable = false, permissionGranted = true) => ({
+  chromeVersion,
+  apiAvailable,
+  permissionGranted,
+});
+
+describe("immediate User Scripts execution support", () => {
+  it.each([undefined, { register: () => {} }, { execute: "not callable" }])(
+    "does not report namespace-only or non-callable APIs as ready (%j)",
+    async (userScripts) => {
+      vi.stubGlobal("navigator", { userAgent: "Chrome/134.0.0.0" });
+      vi.stubGlobal("chrome", {
+        userScripts,
+        permissions: { contains: async () => true },
+      });
+      expect(await getUserScriptsStatus()).toEqual(createStatus(134));
+    },
+  );
+
+  it("detects callable execution independently of the permission grant", async () => {
+    const contains = vi.fn(async () => false);
+    vi.stubGlobal("navigator", { userAgent: "Chrome/135.0.0.0" });
+    vi.stubGlobal("chrome", {
+      userScripts: { execute: async () => [] },
+      permissions: { contains },
+    });
+    expect(await getUserScriptsStatus()).toEqual(createStatus(135, true, false));
+    expect(contains).toHaveBeenCalledWith({ permissions: ["userScripts"] });
+  });
+
+  it.each([120, 134])("gives Chrome %i the execution upgrade requirement", (version) => {
+    const guidance = buildUserScriptsGuidance(createStatus(version));
+    expect(guidance).toContain("Chrome 135");
+    expect(guidance).toContain("update Chrome");
+    expect(guidance).not.toContain("Enable Developer mode");
+    expect(guidance).not.toContain("permission is required");
+  });
+
+  it("retains Developer mode guidance for Chrome 135–137", () => {
+    expect(buildUserScriptsGuidance(createStatus(136))).toContain("Enable Developer mode");
+  });
+
+  it("retains permission and toggle guidance for current Chrome", () => {
+    const guidance = buildUserScriptsGuidance(createStatus(138, false, false));
+    expect(guidance).toContain("Enable automation permissions");
+    expect(guidance).toContain("Allow User Scripts");
+  });
+
+  it("prefers an available execution capability over the user-agent version", () => {
+    const guidance = buildUserScriptsGuidance(createStatus(134, true, false));
+    expect(guidance).toContain("Enable automation permissions");
+    expect(guidance).not.toContain("update Chrome");
+  });
+});


### PR DESCRIPTION
Chrome exposes the userScripts namespace before the immediate execute API exists. Checking only the namespace sent Chrome 120–134 users back to permission settings even when permission was already granted. Detect a callable execute method and report its existing Chrome 135 requirement. Available capabilities still take precedence over user-agent heuristics, and the Developer-mode/Allow User Scripts guidance remains version-specific.

Four regressions failed before the fix; all nine capability/guidance cases pass afterward. Full check, extension build, docs/link validation, and isolated Codex autoreview through P2 pass. A bundled production helper in real Chrome used a simulated pre-135 API surface with permission granted: the before/after screenshots show the corrected status and upgrade guidance. The official API reference confirms execute is Chrome 135+: https://developer.chrome.com/docs/extensions/reference/api/userScripts#method-execute.

This clarifies an existing feature requirement; the extension installation minimum remains Chrome 120. No permissions are newly requested.

![guidance-before-image](https://github.com/user-attachments/assets/75e025c5-5ab7-4217-9b56-8692a9b5c014)

![guidance-after-image](https://github.com/user-attachments/assets/7469f30a-37be-4282-a6c0-c4969d35d8dc)